### PR TITLE
perf: optimize unit test execution speed

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerTests.cs
@@ -67,7 +67,7 @@ public class StreamMessageConsumerTests
         
         // Act
         consumer.Start();
-        Thread.Sleep(200); // Give time for processing
+        Thread.Sleep(20); // Give time for processing
         consumer.Stop();
         
         // Assert
@@ -88,7 +88,7 @@ public class StreamMessageConsumerTests
         
         // Act
         consumer.Start();
-        Thread.Sleep(300); // Give time for processing
+        Thread.Sleep(30); // Give time for processing
         consumer.Stop();
         
         // Assert

--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
@@ -62,14 +62,12 @@ public class MessageProducerTests
         // Act
         producer.Send(message);
         
-        // Wait for background thread to process the message
-        Thread.Sleep(200);
+        // Stop safely to ensure all messages are processed
+        producer.StopSafely();
         
         // Assert
         var written = Encoding.UTF8.GetString(stream.ToArray());
         Assert.Contains("TEST:COMMAND", written);
-        
-        producer.StopSafely();
     }
 
     [Fact]
@@ -132,14 +130,12 @@ public class MessageProducerTests
         // Act
         producer.Send(message);
         
-        // Give the background thread time to process
-        Thread.Sleep(200);
+        // Stop safely to ensure all messages are processed
+        producer.StopSafely();
         
         // Assert
         var written = Encoding.UTF8.GetString(stream.ToArray());
         Assert.Contains("ASYNC:TEST", written);
-        
-        producer.StopSafely();
     }
 
     [Fact]
@@ -158,7 +154,7 @@ public class MessageProducerTests
         }
         
         // Wait for processing
-        Thread.Sleep(300);
+        Thread.Sleep(50);
         producer.StopSafely();
         
         // Assert - All messages should be written
@@ -185,7 +181,7 @@ public class MessageProducerTests
         
         // Should work normally
         producer.Send(new ScpiMessage("TEST"));
-        Thread.Sleep(100);
+        Thread.Sleep(20);
         
         producer.StopSafely();
         

--- a/src/Daqifi.Core.Tests/Integration/Desktop/BackwardCompatibilityTests.cs
+++ b/src/Daqifi.Core.Tests/Integration/Desktop/BackwardCompatibilityTests.cs
@@ -191,8 +191,8 @@ public class BackwardCompatibilityTests
     {
         // This test simulates the exact pattern used in existing desktop applications
         
-        // Arrange - Typical desktop application usage
-        using var device = CoreDeviceAdapter.CreateTcpAdapter("192.168.1.100", 12345);
+        // Arrange - Use localhost with unopened port for fast failure
+        using var device = CoreDeviceAdapter.CreateTcpAdapter("127.0.0.1", 1); // localhost:1 should fail immediately
         
         // Subscribe to events (this is how desktop apps get device responses)
         device.MessageReceived += (sender, args) =>

--- a/src/Daqifi.Core.Tests/Integration/Desktop/CoreDeviceAdapterTests.cs
+++ b/src/Daqifi.Core.Tests/Integration/Desktop/CoreDeviceAdapterTests.cs
@@ -100,8 +100,8 @@ public class CoreDeviceAdapterTests
     [Fact] 
     public void CoreDeviceAdapter_Connect_WithInvalidAddress_ShouldReturnFalse()
     {
-        // Arrange
-        using var adapter = CoreDeviceAdapter.CreateTcpAdapter("192.0.2.1", 1); // TEST-NET-1 address that should fail fast
+        // Arrange - Use localhost with unopened port for fast failure
+        using var adapter = CoreDeviceAdapter.CreateTcpAdapter("127.0.0.1", 1); // localhost:1 should fail immediately
         
         // Act
         var result = adapter.Connect();
@@ -114,8 +114,8 @@ public class CoreDeviceAdapterTests
     [Fact]
     public async Task CoreDeviceAdapter_ConnectAsync_WithInvalidAddress_ShouldReturnFalse()
     {
-        // Arrange
-        using var adapter = CoreDeviceAdapter.CreateTcpAdapter("192.0.2.1", 1); // TEST-NET-1 address that should fail fast
+        // Arrange - Use localhost with unopened port for fast failure
+        using var adapter = CoreDeviceAdapter.CreateTcpAdapter("127.0.0.1", 1); // localhost:1 should fail immediately
         
         // Act
         var result = await adapter.ConnectAsync();
@@ -169,8 +169,8 @@ public class CoreDeviceAdapterTests
     [Fact]
     public void CoreDeviceAdapter_ConnectionStatusChanged_ShouldFireOnConnectionAttempt()
     {
-        // Arrange
-        using var adapter = CoreDeviceAdapter.CreateTcpAdapter("192.0.2.1", 1); // TEST-NET-1 address that should fail fast
+        // Arrange - Use localhost with unopened port for fast failure
+        using var adapter = CoreDeviceAdapter.CreateTcpAdapter("127.0.0.1", 1); // localhost:1 should fail immediately
         TransportStatusEventArgs? capturedArgs = null;
         
         adapter.ConnectionStatusChanged += (sender, args) => capturedArgs = args;


### PR DESCRIPTION
### **User description**
## Summary
- Reduced Thread.Sleep durations in test files from 200-300ms to 20-50ms for faster execution
- Replaced Thread.Sleep with StopSafely() calls in MessageProducerTests for better synchronization  
- Changed test connection addresses from unreachable IPs to localhost:1 for immediate connection failures
- Added connection timeout to TcpStreamTransport to prevent long waits in tests and production

## Test plan
- [x] Run existing unit tests to ensure they still pass with reduced timing
- [x] Verify test execution time improvement
- [x] Test connection timeout functionality in TcpStreamTransport
- [ ] Run full test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Reduced Thread.Sleep durations from 200-300ms to 20-50ms

- Replaced Thread.Sleep with StopSafely() for better synchronization

- Changed test addresses to localhost:1 for faster failures

- Added 5-second connection timeout to TcpStreamTransport


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Sleep Times"] -- "reduced 200-300ms to 20-50ms" --> B["Faster Tests"]
  C["Thread.Sleep"] -- "replaced with" --> D["StopSafely()"]
  E["Unreachable IPs"] -- "changed to" --> F["localhost:1"]
  G["TcpStreamTransport"] -- "added 5s timeout" --> H["Faster Failures"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StreamMessageConsumerTests.cs</strong><dd><code>Reduced sleep times for faster test execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerTests.cs

<ul><li>Reduced Thread.Sleep from 200ms to 20ms in message processing test<br> <li> Reduced Thread.Sleep from 300ms to 30ms in multiple messages test</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/37/files#diff-d3032523726dc1e6066ccdc4fe5d95d10b8163d9787ce7775e8bacb97d60bbd1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MessageProducerTests.cs</strong><dd><code>Improved synchronization and reduced sleep times</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs

<ul><li>Replaced Thread.Sleep(200ms) with StopSafely() calls for better <br>synchronization<br> <li> Reduced Thread.Sleep from 300ms to 50ms in multiple messages test<br> <li> Reduced Thread.Sleep from 100ms to 20ms in start test</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/37/files#diff-595a6ec1c54e7c957b70cea68cdb420dd610cdeea3b31d93030c98b4f1b6cc2c">+6/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BackwardCompatibilityTests.cs</strong><dd><code>Changed to localhost for faster connection failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Integration/Desktop/BackwardCompatibilityTests.cs

<ul><li>Changed test connection address from 192.168.1.100:12345 to <br>localhost:1<br> <li> Updated comment to explain fast failure expectation</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/37/files#diff-8d94f08d0ae3f65c369c5c54231dde498bc5afbcc239002c79b2d0add3015b75">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CoreDeviceAdapterTests.cs</strong><dd><code>Updated test addresses to localhost for speed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Integration/Desktop/CoreDeviceAdapterTests.cs

<ul><li>Changed test connection addresses from 192.0.2.1:1 to localhost:1<br> <li> Updated comments to explain localhost fast failure behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/37/files#diff-1419d59bb7753ee52ea1b9af848f1d4a868d5a4c640497f3232d133a42eb039f">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TcpStreamTransport.cs</strong><dd><code>Added connection timeout to prevent long waits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs

<ul><li>Added 5-second connection timeout using CancellationTokenSource<br> <li> Refactored connection logic to use WaitAsync with timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/37/files#diff-d0f6a74a508748b254425ac97f3dbcd76e610ab5049219fcd8f60f3427444606">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

