### PR TITLE
Phase 7.1: Network Configuration Implementation

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Configuration/NetworkConfigurationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Configuration/NetworkConfigurationTests.cs
@@ -1,0 +1,116 @@
+using Daqifi.Core.Device.Configuration;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.Configuration;
+
+/// <summary>
+/// Tests for NetworkConfiguration model.
+/// </summary>
+public class NetworkConfigurationTests
+{
+    [Fact]
+    public void NetworkConfiguration_DefaultValues_AreCorrect()
+    {
+        // Arrange & Act
+        var config = new NetworkConfiguration();
+
+        // Assert
+        // Default value for enum is 0, which doesn't match any defined enum value
+        Assert.Equal((WifiMode)0, config.Mode);
+        Assert.Equal(WifiSecurityType.None, config.SecurityType);
+        Assert.Null(config.Ssid);
+        Assert.Null(config.Password);
+        Assert.Null(config.IpAddress);
+        Assert.Null(config.MacAddress);
+        Assert.Null(config.Gateway);
+        Assert.Null(config.SubnetMask);
+    }
+
+    [Fact]
+    public void NetworkConfiguration_SetProperties_WorksCorrectly()
+    {
+        // Arrange
+        var config = new NetworkConfiguration();
+
+        // Act
+        config.Mode = WifiMode.SelfHosted;
+        config.SecurityType = WifiSecurityType.WpaPskPhrase;
+        config.Ssid = "TestNetwork";
+        config.Password = "TestPassword123";
+        config.IpAddress = "192.168.1.100";
+        config.MacAddress = "00:11:22:33:44:55";
+
+        // Assert
+        Assert.Equal(WifiMode.SelfHosted, config.Mode);
+        Assert.Equal(WifiSecurityType.WpaPskPhrase, config.SecurityType);
+        Assert.Equal("TestNetwork", config.Ssid);
+        Assert.Equal("TestPassword123", config.Password);
+        Assert.Equal("192.168.1.100", config.IpAddress);
+        Assert.Equal("00:11:22:33:44:55", config.MacAddress);
+    }
+
+    [Theory]
+    [InlineData(WifiMode.ExistingNetwork, 1)]
+    [InlineData(WifiMode.SelfHosted, 4)]
+    public void WifiMode_EnumValues_AreCorrect(WifiMode mode, int expectedValue)
+    {
+        // Assert
+        Assert.Equal(expectedValue, (int)mode);
+    }
+
+    [Theory]
+    [InlineData(WifiSecurityType.None, 0)]
+    [InlineData(WifiSecurityType.WpaPskPhrase, 3)]
+    public void WifiSecurityType_EnumValues_AreCorrect(WifiSecurityType securityType, int expectedValue)
+    {
+        // Assert
+        Assert.Equal(expectedValue, (int)securityType);
+    }
+}
+
+/// <summary>
+/// Tests for NetworkStatus model.
+/// </summary>
+public class NetworkStatusTests
+{
+    [Fact]
+    public void NetworkStatus_DefaultValues_AreCorrect()
+    {
+        // Arrange & Act
+        var status = new NetworkStatus();
+
+        // Assert
+        Assert.False(status.IsConnected);
+        Assert.Null(status.IpAddress);
+        Assert.Null(status.MacAddress);
+        Assert.Null(status.Ssid);
+        Assert.Null(status.SignalStrength);
+        Assert.Null(status.Gateway);
+        Assert.Null(status.SubnetMask);
+    }
+
+    [Fact]
+    public void NetworkStatus_SetProperties_WorksCorrectly()
+    {
+        // Arrange
+        var status = new NetworkStatus();
+
+        // Act
+        status.IsConnected = true;
+        status.IpAddress = "192.168.1.100";
+        status.MacAddress = "00:11:22:33:44:55";
+        status.Ssid = "TestNetwork";
+        status.SignalStrength = -45;
+        status.Gateway = "192.168.1.1";
+        status.SubnetMask = "255.255.255.0";
+
+        // Assert
+        Assert.True(status.IsConnected);
+        Assert.Equal("192.168.1.100", status.IpAddress);
+        Assert.Equal("00:11:22:33:44:55", status.MacAddress);
+        Assert.Equal("TestNetwork", status.Ssid);
+        Assert.Equal(-45, status.SignalStrength);
+        Assert.Equal("192.168.1.1", status.Gateway);
+        Assert.Equal("255.255.255.0", status.SubnetMask);
+    }
+}

--- a/src/Daqifi.Core/Device/Configuration/INetworkConfigurable.cs
+++ b/src/Daqifi.Core/Device/Configuration/INetworkConfigurable.cs
@@ -1,0 +1,102 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Configuration
+{
+    /// <summary>
+    /// Interface for devices that support network configuration.
+    /// </summary>
+    public interface INetworkConfigurable
+    {
+        /// <summary>
+        /// Gets the current network configuration of the device.
+        /// </summary>
+        NetworkConfiguration NetworkConfiguration { get; }
+
+        /// <summary>
+        /// Retrieves the current network configuration from the device.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// <returns>The current network configuration.</returns>
+        Task<NetworkConfiguration> GetNetworkConfigAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sets the network configuration on the device without applying it.
+        /// Configuration must be applied using <see cref="ApplyNetworkConfigAsync"/> to take effect.
+        /// </summary>
+        /// <param name="config">The network configuration to set.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        Task SetNetworkConfigAsync(NetworkConfiguration config, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Applies the network configuration to the device.
+        /// This will restart the WiFi module, which may take up to 2 seconds.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        Task ApplyNetworkConfigAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Saves the network configuration to non-volatile memory on the device.
+        /// Configuration will persist across device reboots.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        Task SaveNetworkConfigAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets the current WiFi signal strength from the device.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// <returns>The WiFi signal strength (RSSI) in dBm, or null if not available.</returns>
+        Task<int?> GetWifiSignalStrengthAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets the comprehensive network status from the device.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// <returns>The network status including IP, MAC, signal strength, etc.</returns>
+        Task<NetworkStatus> GetNetworkStatusAsync(CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Represents the comprehensive network status of a device.
+    /// </summary>
+    public class NetworkStatus
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the network is connected.
+        /// </summary>
+        public bool IsConnected { get; set; }
+
+        /// <summary>
+        /// Gets or sets the IP address of the device.
+        /// </summary>
+        public string? IpAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MAC address of the device.
+        /// </summary>
+        public string? MacAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SSID of the connected network.
+        /// </summary>
+        public string? Ssid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the WiFi signal strength (RSSI) in dBm.
+        /// </summary>
+        public int? SignalStrength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the gateway address.
+        /// </summary>
+        public string? Gateway { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subnet mask.
+        /// </summary>
+        public string? SubnetMask { get; set; }
+    }
+}

--- a/src/Daqifi.Core/Device/Configuration/NetworkConfiguration.cs
+++ b/src/Daqifi.Core/Device/Configuration/NetworkConfiguration.cs
@@ -1,0 +1,86 @@
+using System;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Configuration
+{
+    /// <summary>
+    /// Represents the network configuration for a DAQiFi device.
+    /// </summary>
+    public class NetworkConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the WiFi mode (Existing Network or Self-Hosted).
+        /// </summary>
+        public WifiMode Mode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the WiFi security type (None or WPA2-PSK).
+        /// </summary>
+        public WifiSecurityType SecurityType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SSID (network name).
+        /// </summary>
+        public string? Ssid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the network password. Required when SecurityType is WPA2-PSK.
+        /// </summary>
+        public string? Password { get; set; }
+
+        // Read-only properties (from device)
+
+        /// <summary>
+        /// Gets or sets the IP address assigned to the device (read-only, retrieved from device).
+        /// </summary>
+        public string? IpAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MAC address of the device (read-only, retrieved from device).
+        /// </summary>
+        public string? MacAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the gateway address (read-only, retrieved from device).
+        /// </summary>
+        public string? Gateway { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subnet mask (read-only, retrieved from device).
+        /// </summary>
+        public string? SubnetMask { get; set; }
+    }
+
+    /// <summary>
+    /// Specifies the WiFi operation mode.
+    /// </summary>
+    public enum WifiMode
+    {
+        /// <summary>
+        /// Connect to an existing WiFi network.
+        /// </summary>
+        ExistingNetwork = 1,
+
+        /// <summary>
+        /// Create a self-hosted access point.
+        /// </summary>
+        SelfHosted = 4
+    }
+
+    /// <summary>
+    /// Specifies the WiFi security type.
+    /// </summary>
+    public enum WifiSecurityType
+    {
+        /// <summary>
+        /// No security (open network).
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// WPA2-PSK (Pre-Shared Key) security with passphrase.
+        /// </summary>
+        WpaPskPhrase = 3
+    }
+}

--- a/src/Daqifi.Core/Device/DeviceMetadata.cs
+++ b/src/Daqifi.Core/Device/DeviceMetadata.cs
@@ -71,6 +71,11 @@ public class DeviceMetadata
     public uint WifiInfrastructureMode { get; set; }
 
     /// <summary>
+    /// Gets or sets the WiFi signal strength (RSSI) in dBm.
+    /// </summary>
+    public int? SignalStrength { get; set; }
+
+    /// <summary>
     /// Updates the device metadata from a protobuf message.
     /// </summary>
     /// <param name="message">The protobuf message containing device information.</param>
@@ -148,6 +153,11 @@ public class DeviceMetadata
         if (message.DigitalPortNum > 0)
         {
             Capabilities.DigitalChannels = (int)message.DigitalPortNum;
+        }
+
+        if (message.SsidStrength > 0)
+        {
+            SignalStrength = (int)message.SsidStrength;
         }
     }
 }


### PR DESCRIPTION
### **User description**
## Summary

Implements **Phase 7.1: Network Configuration** from PHASE_7_PLAN.md, adding comprehensive WiFi and network management capabilities to daqifi-core.

This PR introduces network configuration support for DAQiFi devices, enabling WiFi setup, configuration persistence, and network status monitoring through a clean, async API.

## Features Implemented

### ✅ Network Configuration Models
- `NetworkConfiguration` - WiFi configuration (mode, SSID, security, password)
- `NetworkStatus` - Comprehensive network state (IP, MAC, SSID, signal strength)
- `WifiMode` enum - ExistingNetwork (1) or SelfHosted (4)
- `WifiSecurityType` enum - None (0) or WpaPskPhrase (3)

### ✅ INetworkConfigurable Interface
Complete async API for network operations:
- `GetNetworkConfigAsync()` - Retrieve current configuration
- `SetNetworkConfigAsync()` - Configure WiFi settings
- `ApplyNetworkConfigAsync()` - Apply with WiFi module restart
- `SaveNetworkConfigAsync()` - Persist to device NVM
- `GetWifiSignalStrengthAsync()` - WiFi RSSI monitoring
- `GetNetworkStatusAsync()` - Comprehensive status

### ✅ DaqifiDevice Implementation
- Implements `INetworkConfigurable` interface
- SCPI command sequence for WiFi configuration
- Automatic validation (SSID required, password for WPA)
- 2-second WiFi module restart delay
- Signal strength from protobuf field 59

### ✅ DeviceMetadata Enhancement
- Added `SignalStrength` property
- Parses `SsidStrength` from DaqifiOutMessage

## Technical Details

### SCPI Command Sequence
1. SetNetworkWifiMode (Existing=1, SelfHosted=4)
2. SetNetworkWifiSsid (with quotes)
3. SetNetworkWifiSecurity (None=0, WPA=3)
4. SetNetworkWifiPassword (if WPA security)
5. ApplyNetworkLan (triggers 2s WiFi restart)
6. SaveNetworkLan (persist to NVM)

### Validation Rules
- SSID cannot be empty
- Password required when using WPA security
- Device must be connected for all operations

## Testing

### Unit Tests (6/6 passing)
- ✅ NetworkConfiguration default values
- ✅ NetworkConfiguration property setters
- ✅ WifiMode enum values (1, 4)
- ✅ WifiSecurityType enum values (0, 3)
- ✅ NetworkStatus default values
- ✅ NetworkStatus property setters

### Test Coverage
```bash
dotnet test --filter "FullyQualifiedName~NetworkConfiguration"
Total tests: 6
     Passed: 6
     Failed: 0
```

## PHASE_7_PLAN.md Coverage

| Task | Status | Description |
|------|--------|-------------|
| 1.1 | ✅ | Create Network Configuration Models |
| 1.2 | ✅ | Create Network Configuration Interface |
| 1.3 | ✅ | Implement Network Configuration in DaqifiDevice |
| 1.4 | ✅ | Add Network Status Queries |

## Example Usage

```csharp
// Configure WiFi to connect to existing network
var config = new NetworkConfiguration
{
    Mode = WifiMode.ExistingNetwork,
    SecurityType = WifiSecurityType.WpaPskPhrase,
    Ssid = "MyNetwork",
    Password = "password123"
};

await device.SetNetworkConfigAsync(config);
await device.ApplyNetworkConfigAsync(); // Triggers WiFi restart
await device.SaveNetworkConfigAsync();  // Persist to NVM

// Query network status
var status = await device.GetNetworkStatusAsync();
Console.WriteLine($"IP: {status.IpAddress}");
Console.WriteLine($"Signal: {status.SignalStrength} dBm");
```

## Files Changed

### New Files
- `src/Daqifi.Core/Device/Configuration/NetworkConfiguration.cs`
- `src/Daqifi.Core/Device/Configuration/INetworkConfigurable.cs`
- `src/Daqifi.Core.Tests/Device/Configuration/NetworkConfigurationTests.cs`

### Modified Files
- `src/Daqifi.Core/Device/DaqifiDevice.cs` - Implements INetworkConfigurable
- `src/Daqifi.Core/Device/DeviceMetadata.cs` - Added SignalStrength property

## Build Status
✅ Build: Success (warnings only - missing XML docs)  
✅ Tests: 6/6 passing  
✅ Integration: Compatible with existing code  

## Migration Impact
This is a **non-breaking change** - adds new interfaces and implementations without modifying existing APIs.

## Next Steps
After merge, remaining Phase 7 tasks:
- 7.2: SD Card Operations
- 7.3: Device Configuration Persistence
- 7.4: Firmware Update Support
- 7.5: Logging and Diagnostics

## Related
- Implements: PHASE_7_PLAN.md Section 7.1
- Depends on: Phase 6 (Protocol Implementation) ✓

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Implements Phase 7.1 Network Configuration with WiFi management capabilities

- Adds INetworkConfigurable interface with async methods for configuration and status

- Implements network configuration in DaqifiDevice with SCPI command sequences

- Adds NetworkConfiguration and NetworkStatus models with WiFi enums

- Enhances DeviceMetadata with SignalStrength property for RSSI tracking

- Includes comprehensive unit tests validating models and enum values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NetworkConfiguration<br/>Model"] -->|implements| B["INetworkConfigurable<br/>Interface"]
  C["NetworkStatus<br/>Model"] -->|returned by| B
  D["WifiMode &<br/>WifiSecurityType<br/>Enums"] -->|used by| A
  B -->|implemented by| E["DaqifiDevice"]
  E -->|sends| F["SCPI Commands<br/>via ScpiMessageProducer"]
  E -->|updates from| G["DeviceMetadata<br/>+ SignalStrength"]
  H["Unit Tests<br/>6/6 passing"] -->|validates| A
  H -->|validates| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkConfiguration.cs</strong><dd><code>Network configuration models and WiFi enums</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/Configuration/NetworkConfiguration.cs

<ul><li>Introduces NetworkConfiguration class with WiFi mode, security type, <br>SSID, and password properties<br> <li> Adds read-only properties for IP address, MAC address, gateway, and <br>subnet mask<br> <li> Defines WifiMode enum with ExistingNetwork (1) and SelfHosted (4) <br>values<br> <li> Defines WifiSecurityType enum with None (0) and WpaPskPhrase (3) <br>values</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/73/files#diff-b00e88ed2f7cb7815395c277160d2fce07cc5512e081889dfcb9660c806e60cf">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>INetworkConfigurable.cs</strong><dd><code>Network configuration interface and status model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/Configuration/INetworkConfigurable.cs

<ul><li>Defines INetworkConfigurable interface with async methods for network <br>operations<br> <li> Includes GetNetworkConfigAsync, SetNetworkConfigAsync, <br>ApplyNetworkConfigAsync, SaveNetworkConfigAsync<br> <li> Adds GetWifiSignalStrengthAsync and GetNetworkStatusAsync for status <br>queries<br> <li> Defines NetworkStatus class with connection state, IP, MAC, SSID, <br>signal strength, gateway, and subnet mask</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/73/files#diff-3b7a450bf3e6389adc8b412504a3effeac0d73f43c11ef6ffbb83cf63ad2a396">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DaqifiDevice.cs</strong><dd><code>Network configuration implementation in DaqifiDevice</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/DaqifiDevice.cs

<ul><li>Implements INetworkConfigurable interface in DaqifiDevice class<br> <li> Adds NetworkConfiguration property to store current configuration <br>state<br> <li> Implements GetNetworkConfigAsync to retrieve configuration from device <br>metadata<br> <li> Implements SetNetworkConfigAsync with SCPI command sequence for WiFi <br>setup<br> <li> Implements ApplyNetworkConfigAsync with 2-second WiFi restart delay<br> <li> Implements SaveNetworkConfigAsync to persist configuration to NVM<br> <li> Implements GetWifiSignalStrengthAsync to query RSSI from device <br>metadata<br> <li> Implements GetNetworkStatusAsync to aggregate comprehensive network <br>status<br> <li> Adds ValidateNetworkConfiguration method ensuring SSID and password <br>requirements<br> <li> Adds UpdateNetworkConfigurationFromMetadata helper method</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/73/files#diff-d10202f27691c4d66ba60d145619feaad5886e70fd297dc0ed284a99cd154699">+223/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DeviceMetadata.cs</strong><dd><code>Add WiFi signal strength tracking to metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/DeviceMetadata.cs

<ul><li>Adds SignalStrength property to store WiFi RSSI in dBm<br> <li> Updates UpdateFromProtobuf method to parse SsidStrength field from <br>protobuf message<br> <li> Enables signal strength tracking from device responses</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/73/files#diff-265a6df205c109f9e9f42460c89bac22a5dff92f74d6b5219ab77985dd1aa953">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkConfigurationTests.cs</strong><dd><code>Unit tests for network configuration models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Device/Configuration/NetworkConfigurationTests.cs

<ul><li>Adds NetworkConfigurationTests class with 4 test methods validating <br>model behavior<br> <li> Tests default values for NetworkConfiguration properties<br> <li> Tests property setters for all configuration fields<br> <li> Validates WifiMode enum values (ExistingNetwork=1, SelfHosted=4)<br> <li> Validates WifiSecurityType enum values (None=0, WpaPskPhrase=3)<br> <li> Adds NetworkStatusTests class with 2 test methods for status model<br> <li> Tests default values and property setters for NetworkStatus</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/73/files#diff-13f9445ec0857b540843b6a9591bb82e77929dee24ebc9d6a54a4fc7554fb42f">+116/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

