### PR TITLE
feat: SerialDeviceFinder probes ports to identify DAQiFi devices

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
@@ -235,20 +235,20 @@ public class DaqifiDeviceFactoryTests
     }
 
     [Fact]
-    public async Task ConnectSerialAsync_EmptyPortName_ThrowsArgumentNullException()
+    public async Task ConnectSerialAsync_EmptyPortName_ThrowsArgumentException()
     {
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
             () => DaqifiDeviceFactory.ConnectSerialAsync(""));
 
         Assert.Equal("portName", exception.ParamName);
     }
 
     [Fact]
-    public async Task ConnectSerialAsync_WhitespacePortName_ThrowsArgumentNullException()
+    public async Task ConnectSerialAsync_WhitespacePortName_ThrowsArgumentException()
     {
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
             () => DaqifiDeviceFactory.ConnectSerialAsync("   "));
 
         Assert.Equal("portName", exception.ParamName);
@@ -321,10 +321,10 @@ public class DaqifiDeviceFactoryTests
     }
 
     [Fact]
-    public void ConnectSerial_EmptyPortName_ThrowsArgumentNullException()
+    public void ConnectSerial_EmptyPortName_ThrowsArgumentException()
     {
         // Act & Assert
-        var exception = Assert.Throws<ArgumentNullException>(
+        var exception = Assert.Throws<ArgumentException>(
             () => DaqifiDeviceFactory.ConnectSerial(""));
 
         Assert.Equal("portName", exception.ParamName);

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -76,7 +76,7 @@ public class SerialDeviceFinderTests
     }
 
     [Fact]
-    public void SerialDeviceFinder_DefaultConstructor_Uses115200Baud()
+    public void SerialDeviceFinder_DefaultConstructor_Uses9600Baud()
     {
         // Arrange & Act
         using var finder = new SerialDeviceFinder();

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -120,7 +120,7 @@ public static class DaqifiDeviceFactory
     }
 
     /// <summary>
-    /// Connects to a DAQiFi device over a serial port asynchronously using the default baud rate (115200).
+    /// Connects to a DAQiFi device over a serial port asynchronously using the default baud rate (9600).
     /// </summary>
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
@@ -153,9 +153,14 @@ public static class DaqifiDeviceFactory
         DeviceConnectionOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        if (portName == null)
+        {
+            throw new ArgumentNullException(nameof(portName));
+        }
+
         if (string.IsNullOrWhiteSpace(portName))
         {
-            throw new ArgumentNullException(nameof(portName), "Port name cannot be null or empty.");
+            throw new ArgumentException("Port name cannot be empty or whitespace.", nameof(portName));
         }
 
         if (baudRate <= 0)
@@ -173,7 +178,7 @@ public static class DaqifiDeviceFactory
     }
 
     /// <summary>
-    /// Connects to a DAQiFi device over a serial port synchronously using the default baud rate (115200).
+    /// Connects to a DAQiFi device over a serial port synchronously using the default baud rate (9600).
     /// </summary>
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Ports;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Daqifi.Core.Communication.Consumers;
@@ -327,10 +328,10 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             .Where(port => !excludePatterns.Any(pattern =>
                 port.Contains(pattern, StringComparison.OrdinalIgnoreCase)));
 
-        // On macOS, prefer /dev/cu.* ports (for outgoing connections) over /dev/tty.* ports
+        // On macOS/Linux, prefer /dev/cu.* ports (for outgoing connections) over /dev/tty.* ports
         // If we have both cu and tty versions of the same port, only use cu
-        if (Environment.OSVersion.Platform == PlatformID.Unix ||
-            Environment.OSVersion.Platform == PlatformID.MacOSX)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             var cuPorts = filteredPorts.Where(p => p.StartsWith("/dev/cu.")).ToList();
             var ttyPorts = filteredPorts.Where(p => p.StartsWith("/dev/tty.")).ToList();


### PR DESCRIPTION
### **User description**
## Summary

Previously `SerialDeviceFinder` just listed available serial ports without verifying if they were actually DAQiFi devices. Now it probes each port to identify genuine DAQiFi devices.

## Changes

### Port Probing Logic
- Opens serial port with DTR enabled
- Waits 1 second for device wake-up
- Sends initialization commands (DisableEcho, StopStreaming, TurnDeviceOn, SetProtobufStreamFormat)
- Sends `GetDeviceInfo` command with retry logic (up to 3 retries, 1 second apart)
- Waits up to 4 seconds for a protobuf status message response
- Extracts device info (serial number, firmware version, part number) from the response
- Returns `null` for ports that don't respond as DAQiFi devices
- Properly cleans up resources in all cases (port, producer, consumer)

### Port Filtering
Adds `FilterProbableDaqifiPorts()` to improve discovery efficiency:
- Excludes debug, Bluetooth, and wlan ports (unlikely to be DAQiFi devices)
- On macOS, prefers `/dev/cu.*` over `/dev/tty.*` ports (cu is for outgoing connections)

### Device Info Extraction
From the status message, extracts:
- **Name**: Device part number (e.g., "Nq1") or falls back to port name
- **SerialNumber**: Device serial number
- **FirmwareVersion**: Device firmware version
- **Type**: Detected via `DeviceTypeDetector.DetectFromPartNumber()`
- **PortName**: The serial port path
- **ConnectionType**: Serial

## Test Plan

- [x] All 7 existing `SerialDeviceFinder` tests pass
- [x] All 414 unit tests pass
- [x] Tested with physical Nq1 device on `/dev/cu.usbmodem101`:
  ```
  Discovered 1 DAQiFi device(s):
    - Nq1 (/dev/cu.usbmodem101) SN:9090539562006014104 FW:3.2.0
  ```
- [x] Verified streaming still works after discovery

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add serial port connection support to DaqifiDeviceFactory with ConnectSerialAsync and ConnectSerial methods

- Implement port probing in SerialDeviceFinder to identify genuine DAQiFi devices via SCPI commands

- Change default serial baud rate from 115200 to 9600 to match DAQiFi firmware initialization

- Add port filtering to exclude debug, Bluetooth, and wlan ports; prefer /dev/cu.* on macOS


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DaqifiDeviceFactory"] -->|"ConnectSerialAsync/Sync"| B["SerialStreamTransport"]
  C["SerialDeviceFinder"] -->|"FilterProbableDaqifiPorts"| D["Filtered Port List"]
  D -->|"TryGetDeviceInfoAsync"| E["Port Probing"]
  E -->|"Send SCPI Commands"| F["MessageProducer"]
  E -->|"Receive Protobuf Response"| G["StreamMessageConsumer"]
  G -->|"Extract Device Info"| H["DeviceInfo"]
  A -->|"ConnectFromDeviceInfoAsync"| I["ConnectSerialDeviceAsync"]
  I -->|"Uses PortName"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DaqifiDeviceFactoryTests.cs</strong><dd><code>Add serial connection factory tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs

<ul><li>Add 10 new test cases for ConnectSerialAsync with <br>null/empty/whitespace port names and invalid baud rates<br> <li> Add 3 new test cases for ConnectSerial sync methods with validation<br> <li> Update ConnectFromDeviceInfoAsync serial device tests to expect <br>ArgumentException instead of NotSupportedException<br> <li> Add test for ConnectFromDeviceInfoAsync with cancellation token <br>support</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/98/files#diff-a7b86b1a1ed312e4d627ee60b4cbd9d430c166d865398abaffc1efa02042eb03">+148/-8</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SerialStreamTransport.cs</strong><dd><code>Update default serial baud rate to 9600</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs

<ul><li>Change default baud rate parameter from 115200 to 9600 in constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/98/files#diff-273dda906cd427d8b97e100ebd089e7f9515591419c8c40c6fe3f3ce54bdd4b4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DaqifiDeviceFactory.cs</strong><dd><code>Add serial connection factory methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/DaqifiDeviceFactory.cs

<ul><li>Add SerialDefaults class with BaudRate constant set to 9600<br> <li> Add ConnectSerialAsync overloads for default and custom baud rates <br>with full validation<br> <li> Add ConnectSerial sync overloads for default and custom baud rates<br> <li> Implement ConnectSerialDeviceAsync private method to handle serial <br>device connections from device info<br> <li> Update ConnectFromDeviceInfoAsync to support Serial connection type <br>instead of throwing NotSupportedException<br> <li> Refactor ConnectWithTransportAsync to accept IStreamTransport instead <br>of TcpStreamTransport for transport-agnostic logic</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/98/files#diff-05873cec4c2d301b36c38ed00ef77ea7b60b5cda44b5dc3aa1906fc151ffd024">+131/-4</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SerialDeviceFinder.cs</strong><dd><code>Implement serial port probing and device discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs

<ul><li>Change DefaultBaudRate from 115200 to 9600<br> <li> Implement comprehensive port probing logic with SCPI command <br>initialization and protobuf response handling<br> <li> Add retry logic for GetDeviceInfo command with up to 3 retries at <br>1-second intervals<br> <li> Add FilterProbableDaqifiPorts method to exclude debug/Bluetooth/wlan <br>ports and prefer /dev/cu.* on macOS<br> <li> Extract device information (serial number, firmware version, part <br>number) from status message responses<br> <li> Add proper resource cleanup for serial port, producer, and consumer in <br>finally block<br> <li> Add ConvertDeviceType helper method to map between Device and <br>Discovery namespace enums</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/98/files#diff-f58f7413050a6c54be96844570067eb0c0a4fa4815fc4638e7a2fc74707f8f0a">+256/-39</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

