### PR TITLE
feat: Add missing SD card SCPI commands (delete, format, stream interface)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Text;
+using Daqifi.Core.Communication;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
 
@@ -279,6 +281,115 @@ public class ScpiMessageProducerTests
     {
         var message = ScpiMessageProducer.SetUsbTransparencyMode(1);
         Assert.Equal("SYSTem:USB:SetTransparentMode 1", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void DeleteSdFile_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.DeleteSdFile("data.bin");
+        Assert.Equal("SYSTem:STORage:SD:DELete \"data.bin\"", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DeleteSdFile_WithNullOrEmptyFileName_Throws(string? fileName)
+    {
+        Assert.Throws<ArgumentException>(
+            () => ScpiMessageProducer.DeleteSdFile(fileName!));
+    }
+
+    [Fact]
+    public void FormatSdCard_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.FormatSdCard;
+        Assert.Equal("SYSTem:STORage:SD:FORmat", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetSdMaxFileSize_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetSdMaxFileSize(1073741824);
+        Assert.Equal("SYSTem:STORage:SD:MAXSize 1073741824", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetSdMaxFileSize_WithZero_ReturnsDefaultCommand()
+    {
+        var message = ScpiMessageProducer.SetSdMaxFileSize(0);
+        Assert.Equal("SYSTem:STORage:SD:MAXSize 0", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetSdMaxFileSize_WithNegativeValue_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ScpiMessageProducer.SetSdMaxFileSize(-1));
+    }
+
+    [Fact]
+    public void GetSdMaxFileSize_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetSdMaxFileSize;
+        Assert.Equal("SYSTem:STORage:SD:MAXSize?", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void RunSdBenchmark_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.RunSdBenchmark(1048576);
+        Assert.Equal("SYSTem:STORage:SD:BENCHmark 1048576", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void RunSdBenchmark_WithZeroOrNegative_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ScpiMessageProducer.RunSdBenchmark(0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ScpiMessageProducer.RunSdBenchmark(-1));
+    }
+
+    [Fact]
+    public void GetSdBenchmarkResults_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetSdBenchmarkResults;
+        Assert.Equal("SYSTem:STORage:SD:BENCHmark?", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Theory]
+    [InlineData(StreamInterface.Usb, 0)]
+    [InlineData(StreamInterface.WiFi, 1)]
+    [InlineData(StreamInterface.SdCard, 2)]
+    [InlineData(StreamInterface.All, 3)]
+    public void SetStreamInterface_ReturnsCorrectCommand(StreamInterface iface, int expectedValue)
+    {
+        var message = ScpiMessageProducer.SetStreamInterface(iface);
+        Assert.Equal($"SYSTem:STReam:INTerface {expectedValue}", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetStreamInterface_WithUndefinedValue_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ScpiMessageProducer.SetStreamInterface((StreamInterface)99));
+    }
+
+    [Fact]
+    public void GetStreamInterface_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetStreamInterface;
+        Assert.Equal("SYSTem:STReam:INTerface?", message.Data);
         AssertMessageFormat(message);
     }
 

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -1,3 +1,4 @@
+using System;
 using Daqifi.Core.Communication.Messages;
 
 namespace Daqifi.Core.Communication.Producers;
@@ -138,6 +139,115 @@ public class ScpiMessageProducer
     {
         return new ScpiMessage($"SYSTem:STORage:SD:LOGging \"{fileName}\"");
     }
+
+    /// <summary>
+    /// Creates a command message to delete a file from the SD card.
+    /// </summary>
+    /// <param name="fileName">The name of the file to delete.</param>
+    /// <remarks>
+    /// Command: SYSTem:STORage:SD:DELete "filename"
+    /// Example: messageProducer.Send(ScpiMessageProducer.DeleteSdFile("data.bin"));
+    /// </remarks>
+    public static IOutboundMessage<string> DeleteSdFile(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("Filename cannot be null or empty.", nameof(fileName));
+        }
+
+        return new ScpiMessage($"SYSTem:STORage:SD:DELete \"{fileName}\"");
+    }
+
+    /// <summary>
+    /// Creates a command message to format the entire SD card.
+    /// </summary>
+    /// <remarks>
+    /// Warning: This is a destructive operation that erases all data on the SD card.
+    /// Command: SYSTem:STORage:SD:FORmat
+    /// Example: messageProducer.Send(ScpiMessageProducer.FormatSdCard);
+    /// </remarks>
+    public static IOutboundMessage<string> FormatSdCard => new ScpiMessage("SYSTem:STORage:SD:FORmat");
+
+    /// <summary>
+    /// Creates a command message to set the maximum file size before auto-splitting on the SD card.
+    /// </summary>
+    /// <param name="bytes">The maximum file size in bytes. Use 0 for the default (3.9 GB).</param>
+    /// <remarks>
+    /// Command: SYSTem:STORage:SD:MAXSize bytes
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetSdMaxFileSize(1073741824)); // 1 GB
+    /// </remarks>
+    public static IOutboundMessage<string> SetSdMaxFileSize(long bytes)
+    {
+        if (bytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bytes), bytes, "Max file size cannot be negative.");
+        }
+
+        return new ScpiMessage($"SYSTem:STORage:SD:MAXSize {bytes}");
+    }
+
+    /// <summary>
+    /// Creates a query message to get the current maximum file size setting for the SD card.
+    /// </summary>
+    /// <remarks>
+    /// Command: SYSTem:STORage:SD:MAXSize?
+    /// Example: messageProducer.Send(ScpiMessageProducer.GetSdMaxFileSize);
+    /// </remarks>
+    public static IOutboundMessage<string> GetSdMaxFileSize => new ScpiMessage("SYSTem:STORage:SD:MAXSize?");
+
+    /// <summary>
+    /// Creates a command message to run an SD card write speed benchmark.
+    /// </summary>
+    /// <param name="size">The size in bytes to benchmark.</param>
+    /// <remarks>
+    /// Command: SYSTem:STORage:SD:BENCHmark size
+    /// Example: messageProducer.Send(ScpiMessageProducer.RunSdBenchmark(1048576)); // 1 MB
+    /// </remarks>
+    public static IOutboundMessage<string> RunSdBenchmark(long size)
+    {
+        if (size <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), size, "Benchmark size must be positive.");
+        }
+
+        return new ScpiMessage($"SYSTem:STORage:SD:BENCHmark {size}");
+    }
+
+    /// <summary>
+    /// Creates a query message to get the SD card benchmark results.
+    /// </summary>
+    /// <remarks>
+    /// Command: SYSTem:STORage:SD:BENCHmark?
+    /// Example: messageProducer.Send(ScpiMessageProducer.GetSdBenchmarkResults);
+    /// </remarks>
+    public static IOutboundMessage<string> GetSdBenchmarkResults => new ScpiMessage("SYSTem:STORage:SD:BENCHmark?");
+
+    /// <summary>
+    /// Creates a command message to set the streaming target interface.
+    /// </summary>
+    /// <param name="streamInterface">The target interface for streaming data.</param>
+    /// <remarks>
+    /// Command: SYSTem:STReam:INTerface value
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.SdCard));
+    /// </remarks>
+    public static IOutboundMessage<string> SetStreamInterface(StreamInterface streamInterface)
+    {
+        if (!Enum.IsDefined(typeof(StreamInterface), streamInterface))
+        {
+            throw new ArgumentOutOfRangeException(nameof(streamInterface), streamInterface, "Unknown stream interface.");
+        }
+
+        return new ScpiMessage($"SYSTem:STReam:INTerface {(int)streamInterface}");
+    }
+
+    /// <summary>
+    /// Creates a query message to get the current streaming target interface.
+    /// </summary>
+    /// <remarks>
+    /// Command: SYSTem:STReam:INTerface?
+    /// Example: messageProducer.Send(ScpiMessageProducer.GetStreamInterface);
+    /// </remarks>
+    public static IOutboundMessage<string> GetStreamInterface => new ScpiMessage("SYSTem:STReam:INTerface?");
 
     /// <summary>
     /// Creates a command message to start data streaming at the specified frequency.

--- a/src/Daqifi.Core/Communication/StreamInterface.cs
+++ b/src/Daqifi.Core/Communication/StreamInterface.cs
@@ -1,0 +1,31 @@
+namespace Daqifi.Core.Communication;
+
+/// <summary>
+/// Specifies the target interface for data streaming.
+/// </summary>
+/// <remarks>
+/// Controls where the device sends streaming data. Values correspond to firmware
+/// SCPI command <c>SYSTem:STReam:INTerface</c> parameter values.
+/// </remarks>
+public enum StreamInterface
+{
+    /// <summary>
+    /// Stream data over USB.
+    /// </summary>
+    Usb = 0,
+
+    /// <summary>
+    /// Stream data over WiFi.
+    /// </summary>
+    WiFi = 1,
+
+    /// <summary>
+    /// Stream data to the SD card.
+    /// </summary>
+    SdCard = 2,
+
+    /// <summary>
+    /// Stream data to all interfaces simultaneously.
+    /// </summary>
+    All = 3
+}

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -48,5 +48,23 @@ namespace Daqifi.Core.Device.SdCard
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected.</exception>
         Task StopSdCardLoggingAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a file from the SD card.
+        /// </summary>
+        /// <param name="fileName">The name of the file to delete.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected or is currently logging to SD card.</exception>
+        /// <exception cref="System.ArgumentException">Thrown when the filename is null, empty, or contains invalid characters.</exception>
+        Task DeleteSdCardFileAsync(string fileName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Formats the entire SD card, erasing all data.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected or is currently logging to SD card.</exception>
+        Task FormatSdCardAsync(CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
### **User description**
## Summary

- Add 8 missing SCPI commands to `ScpiMessageProducer`: delete, format, max file size, benchmark, and stream interface (set/get)
- Add `StreamInterface` enum (`Usb=0`, `WiFi=1`, `SdCard=2`, `All=3`)
- Extend `ISdCardOperations` with `DeleteSdCardFileAsync` and `FormatSdCardAsync`
- Implement both in `DaqifiStreamingDevice` with connection/logging guards and filename validation

## Test plan

- [x] 82 unit tests pass (both net8.0 and net9.0)
- [x] Hardware-verified via example app: delete, format, log, list all work on real device over serial

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add 8 missing SCPI commands for SD card operations and streaming interface control

- Implement DeleteSdCardFileAsync and FormatSdCardAsync methods with validation

- Create StreamInterface enum with USB, WiFi, SD card, and All options

- Add comprehensive unit tests covering all new commands and edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ScpiProducer["ScpiMessageProducer"]
  StreamEnum["StreamInterface Enum"]
  SdOps["ISdCardOperations"]
  Device["DaqifiStreamingDevice"]
  Tests["Unit Tests"]
  
  ScpiProducer -- "adds 8 commands" --> Commands["Delete, Format, MaxSize,<br/>Benchmark, StreamInterface"]
  StreamEnum -- "defines interface options" --> Device
  SdOps -- "extends with 2 methods" --> Device
  Device -- "implements with validation" --> Impl["DeleteSdCardFileAsync<br/>FormatSdCardAsync"]
  Commands --> Tests
  Impl --> Tests
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StreamInterface.cs</strong><dd><code>Create StreamInterface enum for data streaming targets</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Communication/StreamInterface.cs

<ul><li>New enum defining streaming target interfaces (USB, WiFi, SD card, <br>All)<br> <li> Includes comprehensive XML documentation for each enum value<br> <li> Maps to firmware SCPI command parameter values</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/114/files#diff-b2b400ce5adf3e9c390f7978bd2111673440d68306de810079d224a3268b18b3">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ScpiMessageProducer.cs</strong><dd><code>Add 8 missing SD card and streaming SCPI commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs

<ul><li>Add DeleteSdFile method for deleting SD card files<br> <li> Add FormatSdCard property for formatting entire SD card<br> <li> Add SetSdMaxFileSize and GetSdMaxFileSize for file size management<br> <li> Add RunSdBenchmark and GetSdBenchmarkResults for performance testing<br> <li> Add SetStreamInterface and GetStreamInterface for streaming target <br>control<br> <li> Include input validation for negative/zero values where appropriate</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/114/files#diff-22578ab5eab5e48988fa747077eeeaea93a8dc330c3bf2e38617afd9902d1fbb">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ISdCardOperations.cs</strong><dd><code>Extend ISdCardOperations with delete and format methods</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs

<ul><li>Extend interface with DeleteSdCardFileAsync method<br> <li> Extend interface with FormatSdCardAsync method<br> <li> Include comprehensive XML documentation with exception details</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/114/files#diff-4deb3f4536a776a1b8612877fd8691b9160627e0848b8f6a850241e0adaf0032">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DaqifiStreamingDevice.cs</strong><dd><code>Implement SD card delete and format operations with guards</code></dd></summary>
<hr>

src/Daqifi.Core/Device/DaqifiStreamingDevice.cs

<ul><li>Implement DeleteSdCardFileAsync with connection and logging state <br>validation<br> <li> Implement FormatSdCardAsync with connection and logging state <br>validation<br> <li> Add filename validation using existing ValidateSdCardFileName method<br> <li> Enable SD card storage before executing delete/format operations<br> <li> Include comprehensive XML documentation and exception handling</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/114/files#diff-5c062b9a4da023d8571b974617a8cb55b2a3a4f5f280022047de66bf640ca6ed">+63/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ScpiMessageProducerTests.cs</strong><dd><code>Add unit tests for new SCPI commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs

<ul><li>Add 11 unit tests for new SCPI commands (delete, format, max size, <br>benchmark, stream interface)<br> <li> Test correct command format generation for all new methods<br> <li> Test input validation with negative values and zero values<br> <li> Test StreamInterface enum mapping to numeric values<br> <li> Verify all messages pass AssertMessageFormat validation</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/114/files#diff-11b1ff9fb7ff7e88f7be4914e1da2d34eba8efef96aadb7551901a669c428f7f">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SdCardOperationsTests.cs</strong><dd><code>Add comprehensive tests for delete and format operations</code>&nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs

<ul><li>Add 8 unit tests for DeleteSdCardFileAsync covering success, <br>disconnected, and logging states<br> <li> Add 4 unit tests for filename validation (null, empty, whitespace, <br>invalid characters)<br> <li> Add 3 unit tests for FormatSdCardAsync covering success, disconnected, <br>and logging states<br> <li> Verify correct SCPI commands are sent in correct order<br> <li> Test all exception conditions and edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/114/files#diff-55ab50f4072a7674112e4519b86f7bcd77299afbf56cfec4757b2ba08ccbc930">+113/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

