### PR TITLE
feat: Add SD card file download over USB transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The DAQiFi Core Library is a .NET library designed to simplify interaction with 
 - **Device Discovery**: Find DAQiFi devices connected via WiFi, USB/Serial, or HID bootloader mode
 - **Easy Connection**: Single-call device connection with `DaqifiDeviceFactory`
 - **Data Streaming**: Stream data from devices in real-time with event-driven API
-- **SD Card Operations**: List SD card files and start/stop SD logging over USB/Serial connections (not available over WiFi)
+- **SD Card Operations**: List, download, delete, and format SD card files; start/stop SD logging over USB/Serial connections (not available over WiFi)
 - **Transport Layer**: TCP, UDP, and Serial communication with async/await patterns
 - **Protocol Buffers**: Efficient binary message serialization for device communication
 - **Cross-Platform**: Compatible with .NET 8.0 and .NET 9.0

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
@@ -1,0 +1,402 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Device.SdCard;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+public class SdCardFileReceiverTests
+{
+    private static readonly byte[] EofMarker = Encoding.ASCII.GetBytes("__END_OF_FILE__");
+
+    [Fact]
+    public async Task ReceiveAsync_CompleteFileWithEofMarker_WritesCorrectBytes()
+    {
+        // Arrange
+        var fileData = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 };
+        var sourceData = Combine(fileData, EofMarker);
+        using var sourceStream = new MemoryStream(sourceData);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        // Act
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "test.bin");
+
+        // Assert
+        Assert.Equal(fileData.Length, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_EofMarkerIsStrippedFromOutput()
+    {
+        // Arrange
+        var fileData = Encoding.ASCII.GetBytes("Hello, World!");
+        var sourceData = Combine(fileData, EofMarker);
+        using var sourceStream = new MemoryStream(sourceData);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        // Act
+        await receiver.ReceiveAsync(destinationStream, "test.bin");
+
+        // Assert — output should NOT contain the EOF marker
+        var output = destinationStream.ToArray();
+        Assert.Equal(fileData.Length, output.Length);
+        Assert.DoesNotContain("__END_OF_FILE__", Encoding.ASCII.GetString(output));
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_EofMarkerSplitAcrossChunks_DetectedCorrectly()
+    {
+        // Arrange — use a buffer size that will split the EOF marker across reads
+        var fileData = new byte[10];
+        for (var i = 0; i < fileData.Length; i++) fileData[i] = (byte)(i + 1);
+
+        var sourceData = Combine(fileData, EofMarker);
+
+        // Use a chunked stream that delivers data in small pieces
+        using var sourceStream = new ChunkedMemoryStream(sourceData, chunkSize: 5);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream, bufferSize: 5);
+
+        // Act
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "test.bin");
+
+        // Assert
+        Assert.Equal(fileData.Length, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_TimeoutWhenEofNeverArrives_ThrowsTimeoutException()
+    {
+        // Arrange — stream that never contains EOF marker and eventually returns 0
+        var dataWithoutEof = new byte[] { 0x01, 0x02, 0x03 };
+        using var sourceStream = new MemoryStream(dataWithoutEof);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        // Act & Assert — stream ends without EOF marker, should throw TimeoutException
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => receiver.ReceiveAsync(destinationStream, "test.bin", timeout: TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_CancellationTokenRespected_ThrowsOperationCanceledException()
+    {
+        // Arrange — stream that blocks (never returns data)
+        using var sourceStream = new NeverEndingStream();
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        // Act & Assert — TaskCanceledException inherits from OperationCanceledException
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => receiver.ReceiveAsync(
+                destinationStream, "test.bin",
+                timeout: TimeSpan.FromMinutes(5),
+                cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_ProgressReporting_BytesReceivedIncreases()
+    {
+        // Arrange
+        var fileData = new byte[1000];
+        new Random(42).NextBytes(fileData);
+        var sourceData = Combine(fileData, EofMarker);
+
+        using var sourceStream = new ChunkedMemoryStream(sourceData, chunkSize: 100);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream, bufferSize: 100);
+
+        var progressReports = new System.Collections.Generic.List<SdCardTransferProgress>();
+        var progress = new Progress<SdCardTransferProgress>(p => progressReports.Add(p));
+
+        // Act
+        await receiver.ReceiveAsync(destinationStream, "test.bin", progress);
+
+        // Allow progress callbacks to fire (they're posted to the sync context)
+        await Task.Delay(100);
+
+        // Assert — we should have received at least one progress report
+        Assert.NotEmpty(progressReports);
+        Assert.All(progressReports, p =>
+        {
+            Assert.Equal("test.bin", p.FileName);
+            Assert.True(p.BytesReceived >= 0);
+        });
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_EmptyFile_JustEofMarker_OutputIsEmpty()
+    {
+        // Arrange — only the EOF marker, no file data
+        using var sourceStream = new MemoryStream(EofMarker);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        // Act
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "empty.bin");
+
+        // Assert
+        Assert.Equal(0, bytesReceived);
+        Assert.Empty(destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_LargeFile_AllDataReceivedCorrectly()
+    {
+        // Arrange — 64KB of data (larger than the 16KB default buffer and 32KB firmware buffer)
+        var fileData = new byte[65536];
+        new Random(42).NextBytes(fileData);
+        var sourceData = Combine(fileData, EofMarker);
+
+        using var sourceStream = new MemoryStream(sourceData);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        // Act
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "large.bin");
+
+        // Assert
+        Assert.Equal(fileData.Length, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_LargeFileWithSmallChunks_AllDataReceivedCorrectly()
+    {
+        // Arrange — simulate USB CDC chunks
+        var fileData = new byte[50000];
+        new Random(123).NextBytes(fileData);
+        var sourceData = Combine(fileData, EofMarker);
+
+        using var sourceStream = new ChunkedMemoryStream(sourceData, chunkSize: 512);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream, bufferSize: 1024);
+
+        // Act
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "chunked.bin");
+
+        // Assert
+        Assert.Equal(fileData.Length, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_DataContainingPartialEofMarkerBytes_NotFalsePositive()
+    {
+        // Arrange — file data that contains bytes similar to the EOF marker but not the full marker
+        var partialMarker = Encoding.ASCII.GetBytes("__END_OF_");
+        var fileData = Combine(new byte[] { 0x01, 0x02 }, partialMarker, new byte[] { 0x03, 0x04 });
+        var sourceData = Combine(fileData, EofMarker);
+
+        using var sourceStream = new MemoryStream(sourceData);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        // Act
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "test.bin");
+
+        // Assert — all file data should be received, partial marker is data not the terminator
+        Assert.Equal(fileData.Length, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    #region FindEndOfFileMarker Tests
+
+    [Fact]
+    public void FindEndOfFileMarker_MarkerInNewData_ReturnsCorrectPosition()
+    {
+        // Arrange
+        var trailing = new byte[0];
+        var newData = Combine(new byte[] { 0x01, 0x02 }, EofMarker);
+
+        // Act
+        var (found, position) = SdCardFileReceiver.FindEndOfFileMarker(trailing, 0, newData, newData.Length);
+
+        // Assert
+        Assert.True(found);
+        Assert.Equal(2, position);
+    }
+
+    [Fact]
+    public void FindEndOfFileMarker_MarkerSpanningBoundary_ReturnsCorrectPosition()
+    {
+        // Arrange — first 5 bytes of marker in trailing, rest in new data
+        var trailing = new byte[EofMarker.Length];
+        Array.Copy(EofMarker, 0, trailing, 0, 5);
+        var trailingCount = 5;
+
+        var newData = new byte[EofMarker.Length - 5];
+        Array.Copy(EofMarker, 5, newData, 0, newData.Length);
+
+        // Act
+        var (found, position) = SdCardFileReceiver.FindEndOfFileMarker(trailing, trailingCount, newData, newData.Length);
+
+        // Assert
+        Assert.True(found);
+        Assert.Equal(0, position);
+    }
+
+    [Fact]
+    public void FindEndOfFileMarker_NoMarker_ReturnsFalse()
+    {
+        // Arrange
+        var trailing = new byte[] { 0x01, 0x02, 0x03 };
+        var newData = new byte[] { 0x04, 0x05, 0x06 };
+
+        // Act
+        var (found, _) = SdCardFileReceiver.FindEndOfFileMarker(trailing, trailing.Length, newData, newData.Length);
+
+        // Assert
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void FindEndOfFileMarker_DataTooShort_ReturnsFalse()
+    {
+        // Arrange
+        var trailing = new byte[0];
+        var newData = new byte[] { 0x01 };
+
+        // Act
+        var (found, _) = SdCardFileReceiver.FindEndOfFileMarker(trailing, 0, newData, newData.Length);
+
+        // Assert
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void FindEndOfFileMarker_MarkerEntirelyInTrailing_NotDetected()
+    {
+        // The search starts at max(0, trailingCount - markerLen + 1) to avoid
+        // re-detecting markers that were already fully in the trailing buffer.
+        // Here the marker is at position 0 but trailing has 16 bytes (14 marker + 2 extra),
+        // so searchStart = max(0, 16 - 14 + 1) = 3, skipping position 0.
+        var trailing = new byte[EofMarker.Length + 2];
+        Array.Copy(EofMarker, 0, trailing, 0, EofMarker.Length);
+        trailing[EofMarker.Length] = 0xFF;
+        trailing[EofMarker.Length + 1] = 0xFF;
+        var newData = new byte[] { 0xAA };
+
+        var (found, _) = SdCardFileReceiver.FindEndOfFileMarker(trailing, trailing.Length, newData, newData.Length);
+
+        // The marker is entirely in the old trailing data — not found in the new scan
+        Assert.False(found);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static byte[] Combine(params byte[][] arrays)
+    {
+        var totalLength = 0;
+        foreach (var arr in arrays) totalLength += arr.Length;
+
+        var result = new byte[totalLength];
+        var offset = 0;
+        foreach (var arr in arrays)
+        {
+            Array.Copy(arr, 0, result, offset, arr.Length);
+            offset += arr.Length;
+        }
+
+        return result;
+    }
+
+    #endregion
+
+    #region Helper Streams
+
+    /// <summary>
+    /// A MemoryStream wrapper that returns data in fixed-size chunks to simulate
+    /// real transport behavior where data arrives incrementally.
+    /// </summary>
+    private sealed class ChunkedMemoryStream : Stream
+    {
+        private readonly byte[] _data;
+        private readonly int _chunkSize;
+        private int _position;
+
+        public ChunkedMemoryStream(byte[] data, int chunkSize)
+        {
+            _data = data;
+            _chunkSize = chunkSize;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _data.Length;
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var available = _data.Length - _position;
+            if (available <= 0) return 0;
+
+            var toRead = Math.Min(Math.Min(count, _chunkSize), available);
+            Array.Copy(_data, _position, buffer, offset, toRead);
+            _position += toRead;
+            return toRead;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(Read(buffer, offset, count));
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A stream that blocks on read until cancellation is requested.
+    /// Used to test cancellation behavior.
+    /// </summary>
+    private sealed class NeverEndingStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Thread.Sleep(Timeout.Infinite);
+            return 0;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return 0;
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core/Daqifi.Core.csproj
+++ b/src/Daqifi.Core/Daqifi.Core.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.33.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All"/>
     <PackageReference Include="System.IO.Ports" Version="10.0.2" />
+    <InternalsVisibleTo Include="Daqifi.Core.Tests" />
   </ItemGroup>
 
 

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -66,5 +68,35 @@ namespace Daqifi.Core.Device.SdCard
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected or is currently logging to SD card.</exception>
         Task FormatSdCardAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Downloads a file from the device's SD card over USB.
+        /// </summary>
+        /// <param name="fileName">The name of the file to download.</param>
+        /// <param name="destinationStream">The stream to write file contents to.</param>
+        /// <param name="progress">Optional progress reporting.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Metadata about the downloaded file.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected or is not using a USB/serial transport.</exception>
+        /// <exception cref="System.ArgumentException">Thrown when the filename is null, empty, or contains invalid characters.</exception>
+        Task<SdCardDownloadResult> DownloadSdCardFileAsync(
+            string fileName,
+            Stream destinationStream,
+            IProgress<SdCardTransferProgress>? progress = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Downloads a file from the device's SD card over USB to a temporary file.
+        /// </summary>
+        /// <param name="fileName">The name of the file to download.</param>
+        /// <param name="progress">Optional progress reporting.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Metadata about the downloaded file, including the local <see cref="SdCardDownloadResult.FilePath"/>.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected or is not using a USB/serial transport.</exception>
+        /// <exception cref="System.ArgumentException">Thrown when the filename is null, empty, or contains invalid characters.</exception>
+        Task<SdCardDownloadResult> DownloadSdCardFileAsync(
+            string fileName,
+            IProgress<SdCardTransferProgress>? progress = null,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardDownloadResult.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardDownloadResult.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Result of an SD card file download operation.
+/// </summary>
+/// <param name="FileName">The name of the downloaded file.</param>
+/// <param name="FileSize">The size of the downloaded file in bytes.</param>
+/// <param name="Duration">How long the download took.</param>
+/// <param name="FilePath">The local file path, if the file was downloaded to disk.</param>
+public sealed record SdCardDownloadResult(
+    string FileName,
+    long FileSize,
+    TimeSpan Duration,
+    string? FilePath = null);

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
@@ -1,0 +1,273 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Receives raw bytes from a transport stream during an SD card file download.
+/// Accumulates data and writes it to a destination stream, detecting the
+/// <c>__END_OF_FILE__</c> marker that signals transfer completion.
+/// </summary>
+public sealed class SdCardFileReceiver
+{
+    /// <summary>
+    /// The ASCII marker appended by the firmware after all file data has been sent.
+    /// </summary>
+    internal static readonly byte[] EndOfFileMarker =
+        Encoding.ASCII.GetBytes("__END_OF_FILE__");
+
+    private readonly Stream _sourceStream;
+    private readonly int _bufferSize;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SdCardFileReceiver"/> class.
+    /// </summary>
+    /// <param name="sourceStream">The transport stream to read raw bytes from.</param>
+    /// <param name="bufferSize">Read buffer size in bytes. Defaults to 16384 (16 KB).</param>
+    public SdCardFileReceiver(Stream sourceStream, int bufferSize = 16384)
+    {
+        _sourceStream = sourceStream ?? throw new ArgumentNullException(nameof(sourceStream));
+
+        if (bufferSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer size must be greater than zero.");
+        }
+
+        _bufferSize = bufferSize;
+    }
+
+    /// <summary>
+    /// Reads bytes from the source stream until the <c>__END_OF_FILE__</c> marker is detected,
+    /// writing all file content (minus the marker) to the destination stream.
+    /// </summary>
+    /// <param name="destinationStream">The stream to write file data to.</param>
+    /// <param name="fileName">The file name, used for progress reporting.</param>
+    /// <param name="progress">Optional progress reporter.</param>
+    /// <param name="timeout">
+    /// Maximum time to wait for the complete file transfer.
+    /// If the timeout elapses before the EOF marker is received, a <see cref="TimeoutException"/> is thrown.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The total number of file bytes written (excluding the EOF marker).</returns>
+    /// <exception cref="TimeoutException">Thrown when the EOF marker is not received within the timeout period.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+    public async Task<long> ReceiveAsync(
+        Stream destinationStream,
+        string fileName,
+        IProgress<SdCardTransferProgress>? progress = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(destinationStream);
+        ArgumentNullException.ThrowIfNull(fileName);
+
+        var effectiveTimeout = timeout ?? TimeSpan.FromMinutes(30);
+        using var timeoutCts = new CancellationTokenSource(effectiveTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+        var token = linkedCts.Token;
+
+        var buffer = new byte[_bufferSize];
+        long totalBytesReceived = 0;
+
+        // We keep a trailing window of the last N bytes to detect the EOF marker
+        // even when it's split across chunk boundaries.
+        var trailingBytes = new byte[EndOfFileMarker.Length];
+        var trailingCount = 0;
+
+        try
+        {
+            while (true)
+            {
+                int bytesRead;
+                try
+                {
+                    bytesRead = await _sourceStream.ReadAsync(buffer, 0, buffer.Length, token)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"SD card file download timed out after {effectiveTimeout.TotalSeconds:F0} seconds. " +
+                        $"Received {totalBytesReceived} bytes before timeout.");
+                }
+
+                if (bytesRead == 0)
+                {
+                    // Stream ended without EOF marker — treat as timeout/error
+                    throw new TimeoutException(
+                        $"Transport stream closed before receiving the EOF marker. " +
+                        $"Received {totalBytesReceived} bytes.");
+                }
+
+                // Check if the EOF marker is contained in or spans the new data
+                var (foundEof, eofPosition) = FindEndOfFileMarker(
+                    trailingBytes, trailingCount, buffer, bytesRead);
+
+                if (foundEof)
+                {
+                    // Write only the data bytes before the marker
+                    // eofPosition is relative to the combined [trailing + new] buffer.
+                    // The data we haven't written yet from trailing is trailingCount bytes,
+                    // so we need to figure out how much of the new data is actual file content.
+                    var newDataFileBytes = eofPosition - trailingCount;
+
+                    if (newDataFileBytes < 0)
+                    {
+                        // The marker started within the trailing bytes. We only need to
+                        // write the portion of the trailing buffer before the marker.
+                        var trailingToWrite = eofPosition;
+                        if (trailingToWrite > 0)
+                        {
+                            await destinationStream.WriteAsync(trailingBytes, 0, trailingToWrite, token)
+                                .ConfigureAwait(false);
+                            totalBytesReceived += trailingToWrite;
+                        }
+                    }
+                    else
+                    {
+                        // Write deferred trailing bytes
+                        if (trailingCount > 0)
+                        {
+                            await destinationStream.WriteAsync(trailingBytes, 0, trailingCount, token)
+                                .ConfigureAwait(false);
+                            totalBytesReceived += trailingCount;
+                        }
+
+                        // Write the portion of new data before the marker
+                        if (newDataFileBytes > 0)
+                        {
+                            await destinationStream.WriteAsync(buffer, 0, newDataFileBytes, token)
+                                .ConfigureAwait(false);
+                            totalBytesReceived += newDataFileBytes;
+                        }
+                    }
+
+                    progress?.Report(new SdCardTransferProgress(totalBytesReceived, fileName));
+                    return totalBytesReceived;
+                }
+
+                // No EOF marker found — combine trailing + new data, write
+                // everything except the last markerLength bytes (the new trailing window).
+                var combinedLen = trailingCount + bytesRead;
+
+                if (combinedLen >= EndOfFileMarker.Length)
+                {
+                    // How many bytes can we safely write (not part of potential marker)?
+                    var safeCount = combinedLen - EndOfFileMarker.Length;
+
+                    if (safeCount > 0)
+                    {
+                        // Write from the trailing portion first
+                        var fromTrailing = Math.Min(safeCount, trailingCount);
+                        if (fromTrailing > 0)
+                        {
+                            await destinationStream.WriteAsync(trailingBytes, 0, fromTrailing, token)
+                                .ConfigureAwait(false);
+                            totalBytesReceived += fromTrailing;
+                        }
+
+                        // Write from the new data
+                        var fromNew = safeCount - fromTrailing;
+                        if (fromNew > 0)
+                        {
+                            await destinationStream.WriteAsync(buffer, 0, fromNew, token)
+                                .ConfigureAwait(false);
+                            totalBytesReceived += fromNew;
+                        }
+                    }
+
+                    // Build the new trailing window from the last markerLength bytes of [trailing + new]
+                    var newTrailingCount = EndOfFileMarker.Length;
+                    var fromNewData = Math.Min(bytesRead, newTrailingCount);
+                    var fromTrailingData = newTrailingCount - fromNewData;
+
+                    if (fromTrailingData > 0)
+                    {
+                        Array.Copy(trailingBytes, trailingCount - fromTrailingData, trailingBytes, 0, fromTrailingData);
+                    }
+
+                    if (fromNewData > 0)
+                    {
+                        Array.Copy(buffer, bytesRead - fromNewData, trailingBytes, fromTrailingData, fromNewData);
+                    }
+
+                    trailingCount = newTrailingCount;
+                }
+                else
+                {
+                    // Combined data is still shorter than the marker — just accumulate
+                    Array.Copy(buffer, 0, trailingBytes, trailingCount, bytesRead);
+                    trailingCount = combinedLen;
+                }
+
+                progress?.Report(new SdCardTransferProgress(totalBytesReceived, fileName));
+            }
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"SD card file download timed out after {effectiveTimeout.TotalSeconds:F0} seconds. " +
+                $"Received {totalBytesReceived} bytes before timeout.");
+        }
+    }
+
+    /// <summary>
+    /// Searches for the EOF marker in the combined view of trailing bytes and new data.
+    /// The marker could span the boundary between the two buffers.
+    /// </summary>
+    /// <returns>
+    /// A tuple of (found, position) where position is the start index of the marker
+    /// in the virtual combined buffer [trailing..new].
+    /// </returns>
+    internal static (bool Found, int Position) FindEndOfFileMarker(
+        byte[] trailing, int trailingCount, byte[] newData, int newDataLength)
+    {
+        if (trailingCount + newDataLength < EndOfFileMarker.Length)
+        {
+            return (false, -1);
+        }
+
+        // Build a search window that covers the overlap zone.
+        // The marker can start at any position from (trailingCount - markerLength + 1)
+        // to (trailingCount + newDataLength - markerLength).
+        // But we only need to scan positions that include new data to avoid re-scanning.
+        var markerLen = EndOfFileMarker.Length;
+        var searchStart = Math.Max(0, trailingCount - markerLen + 1);
+        var searchEnd = trailingCount + newDataLength - markerLen;
+
+        for (var pos = searchStart; pos <= searchEnd; pos++)
+        {
+            var match = true;
+            for (var j = 0; j < markerLen; j++)
+            {
+                var idx = pos + j;
+                byte b;
+                if (idx < trailingCount)
+                {
+                    b = trailing[idx];
+                }
+                else
+                {
+                    b = newData[idx - trailingCount];
+                }
+
+                if (b != EndOfFileMarker[j])
+                {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match)
+            {
+                return (true, pos);
+            }
+        }
+
+        return (false, -1);
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardTransferProgress.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTransferProgress.cs
@@ -1,0 +1,8 @@
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Progress information reported during an SD card file download.
+/// </summary>
+/// <param name="BytesReceived">Total bytes received from the device so far.</param>
+/// <param name="FileName">The name of the file being downloaded.</param>
+public sealed record SdCardTransferProgress(long BytesReceived, string FileName);


### PR DESCRIPTION
### **User description**
## Summary
- Add `SdCardFileReceiver` for raw byte accumulation with `__END_OF_FILE__` marker detection, handling marker splits across chunk boundaries via a sliding trailing window
- Add `ExecuteRawCaptureAsync` to `DaqifiDevice` for pausing the protobuf consumer during raw byte capture (follows the existing `ExecuteTextCommandAsync` pattern)
- Add `DownloadSdCardFileAsync` to `ISdCardOperations` and `DaqifiStreamingDevice` with stream and temp-file overloads, USB validation, streaming stop, and LAN interface restoration
- Add `SdCardTransferProgress` and `SdCardDownloadResult` records
- Add `InternalsVisibleTo` for test access to `FindEndOfFileMarker`

## Test plan
- [x] 12 unit tests for `SdCardFileReceiver` (complete file, EOF stripping, split across chunks, timeout, cancellation, progress, empty file, large file, chunked transport, partial marker false positive, boundary detection)
- [x] 8 integration tests for `DownloadSdCardFileAsync` (disconnected, non-USB, null/empty filename, invalid chars, logging active, correct commands, temp file path, streaming stop)
- [x] All 649 tests pass on both net8.0 and net9.0
- [x] Tested end-to-end with real hardware over USB serial — successfully downloaded a 2,033 byte log file

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `SdCardFileReceiver` for raw byte accumulation with `__END_OF_FILE__` marker detection

- Add `ExecuteRawCaptureAsync` to `DaqifiDevice` for pausing protobuf consumer during raw capture

- Add `DownloadSdCardFileAsync` to `ISdCardOperations` and `DaqifiStreamingDevice` with stream and temp-file overloads

- Add `SdCardTransferProgress` and `SdCardDownloadResult` records for download metadata

- Add comprehensive unit and integration tests with 20 test cases covering edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DaqifiStreamingDevice"] -->|calls| B["ExecuteRawCaptureAsync"]
  B -->|pauses| C["MessageConsumer"]
  B -->|provides stream to| D["SdCardFileReceiver"]
  D -->|detects| E["__END_OF_FILE__ Marker"]
  E -->|writes to| F["DestinationStream"]
  D -->|reports| G["SdCardTransferProgress"]
  F -->|returns| H["SdCardDownloadResult"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>SdCardFileReceiver.cs</strong><dd><code>New receiver for raw byte accumulation with EOF detection</code></dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-b33abc7b1e7a1cfc5a6ba16c525a112e54fec69c6f7395f6650087afc0594359">+271/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardTransferProgress.cs</strong><dd><code>New record for download progress reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-bcb47215374c610db5ce827097542cf8f7f1dd3ba560f7e37c907719e90492de">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardDownloadResult.cs</strong><dd><code>New record for download operation results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-354f40244caf5342d93b04bac0d14e28a397a1f1cef4cc781eea7864a99d4804">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DaqifiDevice.cs</strong><dd><code>Add ExecuteRawCaptureAsync for pausing protobuf consumer</code>&nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-d10202f27691c4d66ba60d145619feaad5886e70fd297dc0ed284a99cd154699">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DaqifiStreamingDevice.cs</strong><dd><code>Add DownloadSdCardFileAsync with USB validation and LAN restoration</code></dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-5c062b9a4da023d8571b974617a8cb55b2a3a4f5f280022047de66bf640ca6ed">+134/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ISdCardOperations.cs</strong><dd><code>Add DownloadSdCardFileAsync interface methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-4deb3f4536a776a1b8612877fd8691b9160627e0848b8f6a850241e0adaf0032">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>SdCardFileReceiverTests.cs</strong><dd><code>Add 12 unit tests for SdCardFileReceiver functionality</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-3ed55f2964dfda308f9b80d90da7f7cd22b576769fa0dd61a8af3eaed09686f9">+402/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardOperationsTests.cs</strong><dd><code>Add 8 integration tests for DownloadSdCardFileAsync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-55ab50f4072a7674112e4519b86f7bcd77299afbf56cfec4757b2ba08ccbc930">+230/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Daqifi.Core.csproj</strong><dd><code>Add InternalsVisibleTo for test access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/115/files#diff-452b92a268fa425b0b0d6a6bc4e3c81dffd25a00cbff8e827d044d903a4c16ae">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

