### PR TITLE
fix: add interface-settle delay and retry for SD LIST operations

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
@@ -126,5 +126,53 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal("log_invalid.bin", result[0].FileName);
             Assert.Null(result[0].CreatedDate);
         }
+
+        [Fact]
+        public void ParseFileList_WithScpiError_SkipsErrorLines()
+        {
+            // Arrange - simulates the error response from issue #119
+            var lines = new[] { "**ERROR: -200, \"Execution error\"" };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ParseFileList_WithScpiErrorMixedWithFiles_OnlyReturnsFiles()
+        {
+            // Arrange
+            var lines = new[]
+            {
+                "**ERROR: -200, \"Execution error\"",
+                "Daqifi/log_20240115_103000.bin",
+                "**ERROR: -100, \"Command error\""
+            };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert
+            Assert.Single(result);
+            Assert.Equal("log_20240115_103000.bin", result[0].FileName);
+        }
+
+        [Theory]
+        [InlineData("**ERROR: -200, \"Execution error\"")]
+        [InlineData("**error: -200")]
+        [InlineData("  **ERROR: -100")]
+        public void ParseFileList_WithVariousScpiErrorFormats_SkipsAll(string errorLine)
+        {
+            // Arrange
+            var lines = new[] { errorLine };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert
+            Assert.Empty(result);
+        }
     }
 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -40,6 +40,12 @@ namespace Daqifi.Core.Device.SdCard
 
                 var path = line.Trim();
 
+                // Skip SCPI error responses (e.g., "**ERROR: -200, \"Execution error\"")
+                if (path.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 // If a file size is present after the path, keep only the first token.
                 var tokenEnd = path.IndexOfAny(new[] { ' ', '\t' });
                 if (tokenEnd > 0)


### PR DESCRIPTION
### **User description**
## Summary
Fixes #119

- Add 100ms settle delay between `PrepareSdInterface()` and subsequent SD commands to allow the device firmware to complete the SPI bus switch
- Add retry-once semantics when a transient SCPI error (`**ERROR: -200`) is detected in the response
- Filter SCPI error lines in `SdCardFileListParser` so they never become phantom file entries
- Apply fixes to both `GetSdCardFilesAsync` and `DeleteSdCardFileAsync`

## Test plan
- [x] New parser tests verify SCPI error lines are skipped (3 tests)
- [x] New retry tests verify error-then-success, persistent error, and no-error paths (4 tests)
- [x] All 68 SD card tests pass on both net8.0 and net9.0
- [ ] Hardware verification on `/dev/cu.usbmodem101` with format → log → list sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add 100ms settle delay after SD interface switch to allow firmware completion

- Implement retry-once semantics for transient SCPI -200 errors in SD operations

- Filter SCPI error lines in parser to prevent phantom file entries

- Add comprehensive tests for error handling and retry behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SD Command Issued"] --> B["PrepareSdInterface"]
  B --> C["100ms Settle Delay"]
  C --> D["Execute Command"]
  D --> E{"SCPI Error?"}
  E -->|Yes| F["Wait 100ms"]
  F --> G["Retry Once"]
  G --> H{"Success?"}
  H -->|Yes| I["Return Results"]
  H -->|No| I
  E -->|No| I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DaqifiStreamingDevice.cs</strong><dd><code>Add settle delay and retry for SD operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/DaqifiStreamingDevice.cs

<ul><li>Added <code>SD_INTERFACE_SETTLE_DELAY_MS</code> constant (100ms) for SPI bus switch <br>timing<br> <li> Added <code>SD_LIST_MAX_RETRIES</code> constant for retry attempts on transient <br>errors<br> <li> Implemented <code>ContainsScpiError()</code> helper method to detect SCPI error <br>responses<br> <li> Enhanced <code>GetSdCardFilesAsync()</code> with settle delay and retry-once logic<br> <li> Enhanced <code>DeleteSdCardFileAsync()</code> with settle delay and retry-once <br>logic</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/121/files#diff-5c062b9a4da023d8571b974617a8cb55b2a3a4f5f280022047de66bf640ca6ed">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SdCardFileListParser.cs</strong><dd><code>Filter SCPI error lines from file list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs

<ul><li>Added filter to skip lines starting with "**ERROR" (case-insensitive)<br> <li> Prevents SCPI error responses from becoming phantom file entries</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/121/files#diff-d9ec4c27a9f9c0d512d717daf80c4fd588a5ad544d4d093a316c80b47bd06fc4">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SdCardFileListParserTests.cs</strong><dd><code>Add SCPI error filtering tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs

<ul><li>Added test for single SCPI error line filtering<br> <li> Added test for mixed SCPI errors and valid files<br> <li> Added parameterized test for various SCPI error formats</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/121/files#diff-247d6ab3340ed46b826d15993af3f8286026fb6551aadd51d676a76d917e6395">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SdCardOperationsTests.cs</strong><dd><code>Add retry and error handling tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs

<ul><li>Added test for error-then-success retry scenario in <br><code>GetSdCardFilesAsync()</code><br> <li> Added test for persistent error handling in <code>GetSdCardFilesAsync()</code><br> <li> Added test for retry behavior in <code>DeleteSdCardFileAsync()</code><br> <li> Added test verifying no retry occurs on successful first attempt<br> <li> Created <code>RetryableSdCardStreamingDevice</code> test helper class with response <br>sequencing</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/121/files#diff-55ab50f4072a7674112e4519b86f7bcd77299afbf56cfec4757b2ba08ccbc930">+106/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

