### PR TITLE
fix: send defensive stop command before SD card operations

### DIFF
--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -259,11 +259,9 @@ namespace Daqifi.Core.Device
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Stop streaming if active
-            if (IsStreaming)
-            {
-                StopStreaming();
-            }
+            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
+            Send(ScpiMessageProducer.StopStreaming);
+            IsStreaming = false;
 
             IReadOnlyList<string> lines;
             try
@@ -409,11 +407,9 @@ namespace Daqifi.Core.Device
 
             ValidateSdCardFileName(fileName);
 
-            // Stop streaming if active
-            if (IsStreaming)
-            {
-                StopStreaming();
-            }
+            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
+            Send(ScpiMessageProducer.StopStreaming);
+            IsStreaming = false;
 
             IReadOnlyList<string> lines;
             try
@@ -481,6 +477,10 @@ namespace Daqifi.Core.Device
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
+            Send(ScpiMessageProducer.StopStreaming);
+            IsStreaming = false;
+
             Send(ScpiMessageProducer.EnableStorageSd);
             Send(ScpiMessageProducer.FormatSdCard);
 
@@ -530,11 +530,9 @@ namespace Daqifi.Core.Device
                 throw new InvalidOperationException("Cannot download files while logging to SD card.");
             }
 
-            // Stop streaming if active
-            if (IsStreaming)
-            {
-                StopStreaming();
-            }
+            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
+            Send(ScpiMessageProducer.StopStreaming);
+            IsStreaming = false;
 
             var stopwatch = Stopwatch.StartNew();
             long fileSize = 0;


### PR DESCRIPTION
### **User description**
## Summary

- Always send `SYSTem:StopStreamData` before SD card operations (`GetSdCardFilesAsync`, `DeleteSdCardFileAsync`, `DownloadSdCardFileAsync`, `FormatSdCardAsync`) regardless of the `IsStreaming` flag
- Fixes garbled responses when streaming was started outside Core's API (e.g., desktop sending the SCPI command directly), leaving `IsStreaming` stale at `false` while the device is actually streaming
- Uses `Send()` + `IsStreaming = false` directly instead of `StopStreaming()`, which has an early-return guard that skips the send when `IsStreaming` is already `false`

Closes #118

## Test plan

- [x] 4 new tests verify stop command is sent even when `IsStreaming == false` (get, delete, download, format)
- [x] Updated `FormatSdCardAsync_WhenConnected_SendsCorrectCommands` for new 3-command sequence
- [x] All 669 tests pass on both net8.0 and net9.0
- [x] Sanity-checked on real device over serial (`--sd-list` returned file list cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Always send defensive `SYSTem:StopStreamData` before SD card operations

- Fixes garbled responses when streaming started outside Core's API

- Replaces conditional `StopStreaming()` with unconditional `Send()` call

- Adds 4 new tests verifying stop command sent when `IsStreaming == false`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SD Card Operations<br/>GetSdCardFilesAsync<br/>DeleteSdCardFileAsync<br/>DownloadSdCardFileAsync<br/>FormatSdCardAsync"] -- "Always send" --> B["SYSTem:StopStreamData"]
  B -- "Set IsStreaming = false" --> C["Execute SD Operation"]
  D["Issue #118<br/>Stale IsStreaming flag"] -- "Causes" --> E["Garbled responses<br/>from mixed binary + SCPI"]
  D -- "Fixed by" --> A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DaqifiStreamingDevice.cs</strong><dd><code>Always send defensive stop before SD operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core/Device/DaqifiStreamingDevice.cs

<ul><li>Modified <code>GetSdCardFilesAsync()</code> to always send <code>SYSTem:StopStreamData</code> <br>before operations<br> <li> Modified <code>DeleteSdCardFileAsync()</code> to always send <code>SYSTem:StopStreamData</code> <br>before operations<br> <li> Modified <code>DownloadSdCardFileAsync()</code> to always send <br><code>SYSTem:StopStreamData</code> before operations<br> <li> Modified <code>FormatSdCardAsync()</code> to always send <code>SYSTem:StopStreamData</code> <br>before operations<br> <li> Replaced conditional <code>if (IsStreaming) { StopStreaming(); }</code> with <br>unconditional <code>Send(ScpiMessageProducer.StopStreaming)</code> and <code>IsStreaming </code><br><code>= false</code></ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/125/files#diff-5c062b9a4da023d8571b974617a8cb55b2a3a4f5f280022047de66bf640ca6ed">+13/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SdCardOperationsTests.cs</strong><dd><code>Add defensive stop command tests for SD operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs

<ul><li>Updated <code>FormatSdCardAsync_WhenConnected_SendsCorrectCommands</code> test to <br>expect 3 commands instead of 2<br> <li> Added <code>GetSdCardFilesAsync_WhenNotStreaming_StillSendsStopCommand</code> test<br> <li> Added <code>DeleteSdCardFileAsync_WhenNotStreaming_StillSendsStopCommand</code> <br>test<br> <li> Added <code>DownloadSdCardFileAsync_WhenNotStreaming_StillSendsStopCommand</code> <br>test<br> <li> Added <code>FormatSdCardAsync_WhenNotStreaming_StillSendsStopCommand</code> test<br> <li> All new tests verify defensive stop command is sent even when <br><code>IsStreaming == false</code></ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/125/files#diff-55ab50f4072a7674112e4519b86f7bcd77299afbf56cfec4757b2ba08ccbc930">+78/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

