### PR TITLE
fix: isolate ParseFileAsync test to prevent parallel CI race

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserTests.cs
@@ -521,7 +521,10 @@ public class SdCardFileParserTests
                 timestamp: 500,
                 analogFloatValues: new[] { 42.0f }));
 
-        var tempPath = Path.Combine(Path.GetTempPath(), "log_20240115_103000.bin");
+        // Use a unique temp directory so parallel multi-TFM test runs don't share the same path
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        var tempPath = Path.Combine(tempDir, "log_20240115_103000.bin");
         try
         {
             await File.WriteAllBytesAsync(tempPath, builder.Build().ToArray());
@@ -541,7 +544,7 @@ public class SdCardFileParserTests
         }
         finally
         {
-            File.Delete(tempPath);
+            Directory.Delete(tempDir, recursive: true);
         }
     }
 


### PR DESCRIPTION
### **User description**
## Summary

Fixes the flaky test failure blocking the v0.16.0 publish.

`ParseFileAsync_ParsesLocalFile` used a hardcoded temp path (`/tmp/log_20240115_103000.bin`). The CI runs `net8.0` and `net9.0` test targets in parallel — one run's `finally` block deleted the file while the other was still reading it, causing a `FileNotFoundException`.

**Fix:** create a unique temp directory per run with `Path.GetRandomFileName()`. The filename itself (`log_20240115_103000.bin`) is preserved inside the directory so the date-parsing assertion still works.

## Test plan

- [x] One-line change, no logic affected
- [x] Date-parsing assertion unchanged — filename stays `log_20240115_103000.bin`
- [x] `Directory.Delete(tempDir, recursive: true)` cleans up both file and directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Isolate ParseFileAsync test with unique temp directory per run

- Prevent parallel CI race condition between net8.0 and net9.0 targets

- Preserve filename for date-parsing assertion validation

- Use recursive directory deletion for proper cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded temp path<br/>/tmp/log_20240115_103000.bin"] -->|"Race condition<br/>in parallel CI"| B["File deleted by<br/>one TFM while<br/>other reads it"]
  C["Unique temp dir<br/>per test run"] -->|"Path.GetRandomFileName()"| D["Isolated test<br/>execution"]
  D -->|"Preserves filename<br/>in subdirectory"| E["Date assertion<br/>still works"]
  D -->|"Recursive cleanup"| F["Both file and<br/>directory deleted"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SdCardFileParserTests.cs</strong><dd><code>Isolate test with unique temp directory per run</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserTests.cs

<ul><li>Replace hardcoded temp path with unique directory using <br><code>Path.GetRandomFileName()</code><br> <li> Create temp directory before writing test file<br> <li> Preserve original filename <code>log_20240115_103000.bin</code> inside unique <br>directory<br> <li> Change cleanup from <code>File.Delete()</code> to <code>Directory.Delete(tempDir, </code><br><code>recursive: true)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/129/files#diff-1c1d2186e847ea2f7652dbc53a930a1af75ed9a09d6e201a2ba91ac793a708f8">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

