### PR TITLE
feat: add JSON and CSV SD card log file parsers

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -1,0 +1,118 @@
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class DaqifiDeviceInitializeTests
+    {
+        [Fact]
+        public async Task InitializeAsync_SendsAllConfigCommands()
+        {
+            // Arrange
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            await device.InitializeAsync();
+
+            // Assert — the 5 commands are sent directly via Send()
+            var sentData = device.DirectSentMessages.Select(m => m.Data).ToList();
+
+            Assert.Contains(sentData, d => d.Contains("SYSTem:ECHO -1"));
+            Assert.Contains(sentData, d => d.Contains("SYSTem:StopStreamData"));
+            Assert.Contains(sentData, d => d.Contains("SYSTem:POWer:STATe 1"));
+            Assert.Contains(sentData, d => d.Contains("SYSTem:STReam:FORmat 0"));
+            Assert.Contains(sentData, d => d.Contains("SYSTem:SYSInfoPB?"));
+        }
+
+        [Fact]
+        public async Task InitializeAsync_SendsGetDeviceInfo()
+        {
+            // Arrange
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            await device.InitializeAsync();
+
+            // Assert — GetDeviceInfo is sent as a direct Send
+            var directSends = device.DirectSentMessages.Select(m => m.Data).ToList();
+            Assert.Contains(directSends, d => d.Contains("SYSTem:SYSInfoPB?"));
+        }
+
+        [Fact]
+        public async Task InitializeAsync_SetsStateToReady()
+        {
+            // Arrange
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            await device.InitializeAsync();
+
+            // Assert
+            Assert.Equal(DeviceState.Ready, device.State);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenAlreadyInitialized_DoesNotSendCommandsAgain()
+        {
+            // Arrange
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+            await device.InitializeAsync();
+            var firstCallCount = device.DirectSentMessages.Count;
+
+            // Act — second call
+            await device.InitializeAsync();
+
+            // Assert — no additional commands sent on second call
+            Assert.Equal(firstCallCount, device.DirectSentMessages.Count);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenDisconnected_Throws()
+        {
+            // Arrange
+            var device = new TestableDaqifiDevice("TestDevice");
+            // Not connected
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.InitializeAsync());
+            Assert.Equal("Device must be connected before initialization.", ex.Message);
+        }
+
+        /// <summary>
+        /// A testable DaqifiDevice that captures sent messages without needing a real transport.
+        /// </summary>
+        private class TestableDaqifiDevice : DaqifiDevice
+        {
+            /// <summary>
+            /// All messages sent via direct Send() calls.
+            /// </summary>
+            public List<IOutboundMessage<string>> DirectSentMessages { get; } = new();
+
+            public TestableDaqifiDevice(string name, IPAddress? ipAddress = null)
+                : base(name, ipAddress)
+            {
+            }
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    DirectSentMessages.Add(stringMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
@@ -1,0 +1,494 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+public sealed class SdCardCsvFileParserTests
+{
+    // -------------------------------------------------------------------------
+    // Basic parsing
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseAsync_ValidFirmwareCsvLines_ReturnsCorrectSamples()
+    {
+        // Arrange — real firmware format: shared timestamp per row, 2 channels
+        // Tick freq = 100 Hz → delta of 100 ticks = 1 second
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nyquist 1", "AABBCCDDEEFF0011", 100u,
+            (1000u, new[] { 1.5, 2.5 }),
+            (1100u, new[] { 3.5, 4.5 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            SessionStartTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "log_20240101_120000.csv", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal("log_20240101_120000.csv", session.FileName);
+        Assert.Equal(2, samples.Count);
+
+        // First sample — at anchor time
+        Assert.Equal(new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), samples[0].Timestamp);
+        Assert.Equal(2, samples[0].AnalogValues.Count);
+        Assert.Equal(1.5, samples[0].AnalogValues[0], precision: 5);
+        Assert.Equal(2.5, samples[0].AnalogValues[1], precision: 5);
+
+        // Second sample — 1 second later (100 ticks / 100 Hz = 1 s)
+        Assert.Equal(new DateTime(2024, 1, 1, 12, 0, 1, DateTimeKind.Utc), samples[1].Timestamp);
+        Assert.Equal(3.5, samples[1].AnalogValues[0], precision: 5);
+        Assert.Equal(4.5, samples[1].AnalogValues[1], precision: 5);
+    }
+
+    [Fact]
+    public async Task ParseAsync_DigitalDataIsAlwaysZero_BecauseFirmwareCsvHasNoDigitalColumn()
+    {
+        // Arrange — real firmware CSV has no digital data column
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nyquist 1", "SN123", 50_000_000u,
+            (1000u, new[] { 10.0, 20.0 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        // DigitalData is always 0 in the firmware CSV format
+        Assert.Single(samples);
+        Assert.Equal(0u, samples[0].DigitalData);
+    }
+
+    // -------------------------------------------------------------------------
+    // Header parsing
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseAsync_ExtractsDeviceConfigFromCommentHeaders()
+    {
+        // Arrange — real firmware embeds all config in # comment lines
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nyquist 1", "7E2815916200E898", 50_000_000u,
+            (1746522255u, new[] { 0.0, 21.0, 0.0 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+
+        // Assert
+        Assert.NotNull(session.DeviceConfig);
+        Assert.Equal("Nyquist 1", session.DeviceConfig.DevicePartNumber);
+        Assert.Equal("7E2815916200E898", session.DeviceConfig.DeviceSerialNumber);
+        Assert.Equal(50_000_000u, session.DeviceConfig.TimestampFrequency);
+        Assert.Equal(3, session.DeviceConfig.AnalogPortCount);
+        Assert.Equal(0, session.DeviceConfig.DigitalPortCount);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ChannelCountInferredFromColumnHeader()
+    {
+        // Arrange — 3 channels → 6 column headers (ch0_ts,ch0_val,ch1_ts,ch1_val,ch2_ts,ch2_val)
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "TestDevice", "SN001", 1000u,
+            (500u, new[] { 1.0, 2.0, 3.0 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+
+        Assert.NotNull(session.DeviceConfig);
+        Assert.Equal(3, session.DeviceConfig.AnalogPortCount);
+    }
+
+    [Fact]
+    public async Task ParseAsync_NoCommentHeaders_UsesDefaultsAndParsesData()
+    {
+        // Arrange — column header + data rows only (no # comments)
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileNoHeaders(
+            (1000u, new[] { 5.0, 10.0 }),
+            (2000u, new[] { 6.0, 11.0 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 1000u
+        };
+
+        var session = await parser.ParseAsync(stream, "test.csv", options);
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+        Assert.Equal(5.0, samples[0].AnalogValues[0], precision: 5);
+        Assert.Equal(10.0, samples[0].AnalogValues[1], precision: 5);
+    }
+
+    [Fact]
+    public async Task ParseAsync_FallbackTimestampFrequencyUsedWhenNoHeader()
+    {
+        // Arrange — no # Timestamp Tick Rate comment, falls back to options.FallbackTimestampFrequency
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileNoHeaders(
+            (0u, new[] { 1.0 }),
+            (500u, new[] { 2.0 })  // 500 ticks @ 500 Hz = 1 second
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            SessionStartTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            FallbackTimestampFrequency = 500u
+        };
+
+        var session = await parser.ParseAsync(stream, "test.csv", options);
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), samples[0].Timestamp);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 1, DateTimeKind.Utc), samples[1].Timestamp);
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-channel timestamps
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseAsync_PerChannelTimestamps_PopulatedFromFirmwareFormat()
+    {
+        // Arrange — real firmware CSV stores per-channel timestamps; each channel can have a different ts
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFile(
+            channelCount: 2,
+            deviceName: "TestDevice",
+            serialNumber: "SN001",
+            timestampFreq: 1000u,
+            new[] { (1000u, 5.0), (1001u, 10.0) }  // ch0 ts=1000, ch1 ts=1001
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Single(samples);
+        Assert.NotNull(samples[0].AnalogTimestamps);
+        Assert.Equal(2, samples[0].AnalogTimestamps!.Count);
+        Assert.Equal(1000u, samples[0].AnalogTimestamps[0]);
+        Assert.Equal(1001u, samples[0].AnalogTimestamps[1]);
+    }
+
+    [Fact]
+    public async Task ParseAsync_SharedTimestampPerRow_PerChannelTimestampsAllEqual()
+    {
+        // Arrange — in practice, firmware writes the same timestamp for every channel in a row
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nyquist 1", "SN001", 50_000_000u,
+            (1746522255u, new[] { 0.0, 21.0, 0.0 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Single(samples);
+        Assert.NotNull(samples[0].AnalogTimestamps);
+        Assert.Equal(3, samples[0].AnalogTimestamps!.Count);
+        // All channels share the same timestamp in shared-ts mode
+        Assert.Equal(1746522255u, samples[0].AnalogTimestamps[0]);
+        Assert.Equal(1746522255u, samples[0].AnalogTimestamps[1]);
+        Assert.Equal(1746522255u, samples[0].AnalogTimestamps[2]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Timestamp arithmetic
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseAsync_TimestampRollover_HandledCorrectly()
+    {
+        // Arrange — tick counter wraps from near-max to a small value
+        var nearMax = uint.MaxValue - 50;
+
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "TestDevice", "SN001", 100u,
+            (nearMax, new[] { 1.0 }),
+            (100u,    new[] { 2.0 })   // rollover
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            SessionStartTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var session = await parser.ParseAsync(stream, "test.csv", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // delta = (uint.MaxValue - nearMax) + 100 + 1 = 51 + 100 = 151 ticks @ 100 Hz = 1.51 s
+        Assert.Equal(2, samples.Count);
+        var expectedDelta = 151.0 / 100.0;
+        Assert.Equal(
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(expectedDelta),
+            samples[1].Timestamp);
+    }
+
+    [Fact]
+    public async Task ParseAsync_MonotonicallyIncreasingTimestamps_AdvanceCorrectly()
+    {
+        // Arrange — simulate real device data (50 MHz tick, ~5 ms between rows = 250 000 ticks)
+        const uint freq = 50_000_000u;
+        const uint delta = 250_000u;  // 5 ms worth of ticks
+
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nyquist 1", "SN001", freq,
+            (1_000_000u, new[] { 1.0 }),
+            (1_000_000u + delta, new[] { 2.0 }),
+            (1_000_000u + delta * 2, new[] { 3.0 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            SessionStartTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var session = await parser.ParseAsync(stream, "test.csv", options);
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(3, samples.Count);
+        Assert.True(samples[1].Timestamp > samples[0].Timestamp);
+        Assert.True(samples[2].Timestamp > samples[1].Timestamp);
+
+        var dt = (samples[1].Timestamp - samples[0].Timestamp).TotalSeconds;
+        Assert.Equal(0.005, dt, precision: 6);  // 5 ms
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge cases
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseAsync_EmptyFile_ReturnsEmptySession()
+    {
+        await using var stream = new MemoryStream();
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Empty(samples);
+        Assert.Null(session.DeviceConfig);
+    }
+
+    [Fact]
+    public async Task ParseAsync_HeaderOnlyNoDataRows_ReturnsEmptySamples()
+    {
+        // Arrange — only comment lines + column header, no data
+        var content = "# Device: Nyquist 1\n# Serial Number: SN001\n# Timestamp Tick Rate: 50000000 Hz\nch0_ts,ch0_val\n";
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Empty(samples);
+        Assert.NotNull(session.DeviceConfig);  // Config extracted from headers
+        Assert.Equal("Nyquist 1", session.DeviceConfig!.DevicePartNumber);
+    }
+
+    [Fact]
+    public async Task ParseAsync_MalformedDataRow_SkipsAndContinues()
+    {
+        // Arrange — embed a malformed row between valid ones
+        var content =
+            "# Device: TestDevice\n" +
+            "# Serial Number: SN001\n" +
+            "# Timestamp Tick Rate: 100 Hz\n" +
+            "ch0_ts,ch0_val\n" +
+            "1000,5.0\n" +
+            "not_a_number,bad\n" +   // should be skipped
+            "2000,6.0\n";
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+        Assert.Equal(5.0, samples[0].AnalogValues[0], precision: 5);
+        Assert.Equal(6.0, samples[1].AnalogValues[0], precision: 5);
+    }
+
+    [Fact]
+    public async Task ParseAsync_OddColumnCount_SkipsMalformedRow()
+    {
+        // Arrange — a row with an odd number of columns (not ts+val pairs) should be skipped
+        var content =
+            "# Device: TestDevice\n" +
+            "# Serial Number: SN001\n" +
+            "# Timestamp Tick Rate: 100 Hz\n" +
+            "ch0_ts,ch0_val,ch1_ts,ch1_val\n" +
+            "1000,5.0,1001,10.0\n" +  // valid: 2 channels
+            "2000,6.0,2001\n" +        // odd column count — skip
+            "3000,7.0,3001,12.0\n";   // valid
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "test.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+        Assert.Equal(5.0, samples[0].AnalogValues[0], precision: 5);
+        Assert.Equal(7.0, samples[1].AnalogValues[0], precision: 5);
+    }
+
+    // -------------------------------------------------------------------------
+    // Date / config extraction
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseAsync_FileNameDateExtraction_SetsFileCreatedDate()
+    {
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "TestDevice", "SN001", 100u,
+            (1000u, new[] { 1.0 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var session = await parser.ParseAsync(stream, "log_20240315_143022.csv");
+
+        Assert.NotNull(session.FileCreatedDate);
+        Assert.Equal(new DateTime(2024, 3, 15, 14, 30, 22), session.FileCreatedDate.Value);
+    }
+
+    [Fact]
+    public async Task ParseAsync_SessionStartTimeOverride_TakesPrecedenceOverFileName()
+    {
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "TestDevice", "SN001", 100u,
+            (1000u, new[] { 1.0 })
+        );
+
+        var overrideTime = new DateTime(2025, 6, 1, 8, 0, 0, DateTimeKind.Utc);
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            SessionStartTime = overrideTime
+        };
+
+        var session = await parser.ParseAsync(stream, "log_20240315_143022.csv", options);
+
+        // SessionStartTime wins over filename-derived date
+        Assert.Equal(overrideTime, session.FileCreatedDate);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ConfigurationOverride_OverridesEmbeddedHeaders()
+    {
+        // Arrange — even though the file has # comment headers, ConfigurationOverride wins
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nyquist 1", "7E2815916200E898", 50_000_000u,
+            (1000u, new[] { 1.0, 2.0 })
+        );
+
+        var overrideConfig = new global::Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration(
+            AnalogPortCount: 4,
+            DigitalPortCount: 1,
+            TimestampFrequency: 1_000_000u,
+            DeviceSerialNumber: "OVERRIDE_SN",
+            DevicePartNumber: "OVERRIDE_DEVICE",
+            FirmwareRevision: "9.9.9",
+            CalibrationValues: null
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            ConfigurationOverride = overrideConfig
+        };
+
+        var session = await parser.ParseAsync(stream, "test.csv", options);
+
+        Assert.NotNull(session.DeviceConfig);
+        Assert.Equal("OVERRIDE_SN", session.DeviceConfig.DeviceSerialNumber);
+        Assert.Equal("OVERRIDE_DEVICE", session.DeviceConfig.DevicePartNumber);
+        Assert.Equal(1_000_000u, session.DeviceConfig.TimestampFrequency);
+    }
+
+    // -------------------------------------------------------------------------
+    // Progress reporting & cancellation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseAsync_ProgressReporting_CallsCallback()
+    {
+        // Arrange — 250 rows to trigger intermediate progress reports (every 100 lines)
+        var rows = Enumerable.Range(0, 250)
+            .Select(i => ((uint)(i * 100), new[] { (double)i }))
+            .ToArray();
+
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "TestDevice", "SN001", 100u, rows);
+
+        var progressCalls = 0;
+        var lastProgress = default(global::Daqifi.Core.Device.SdCard.SdCardParseProgress);
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            Progress = new Progress<global::Daqifi.Core.Device.SdCard.SdCardParseProgress>(p =>
+            {
+                progressCalls++;
+                lastProgress = p;
+            })
+        };
+
+        var session = await parser.ParseAsync(stream, "test.csv", options);
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(250, samples.Count);
+        Assert.True(progressCalls >= 2, $"Expected ≥2 progress callbacks, got {progressCalls}");
+        Assert.Equal(250, lastProgress.MessagesRead);
+        Assert.True(lastProgress.BytesRead > 0);
+    }
+
+    [Fact]
+    public async Task ParseAsync_CancellationDuringRead_ThrowsOperationCanceled()
+    {
+        // Pre-cancelled token → should throw during the ReadLineAsync phase
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "TestDevice", "SN001", 100u,
+            Enumerable.Range(0, 1000).Select(i => ((uint)i, new[] { (double)i })).ToArray());
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await parser.ParseAsync(stream, "test.csv", ct: cts.Token);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var list = new List<T>();
+        await foreach (var item in source)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserFactoryTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+public sealed class SdCardFileParserFactoryTests
+{
+    [Theory]
+    [InlineData("log.bin", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf)]
+    [InlineData("log.BIN", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf)]
+    [InlineData("log.json", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Json)]
+    [InlineData("log.JSON", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Json)]
+    [InlineData("log.csv", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Csv)]
+    [InlineData("log.CSV", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Csv)]
+    public void DetectFormat_ValidExtensions_ReturnsCorrectFormat(string fileName, global::Daqifi.Core.Device.SdCard.SdCardLogFormat expectedFormat)
+    {
+        // Act
+        var format = global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.DetectFormat(fileName);
+
+        // Assert
+        Assert.Equal(expectedFormat, format);
+    }
+
+    [Theory]
+    [InlineData("log.txt")]
+    [InlineData("log.dat")]
+    [InlineData("log")]
+    [InlineData("log.")]
+    public void DetectFormat_UnsupportedExtension_ThrowsArgumentException(string fileName)
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentException>(() =>
+            global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.DetectFormat(fileName));
+
+        Assert.Contains("Unsupported file extension", exception.Message);
+    }
+
+    [Fact]
+    public void DetectFormat_NullFileName_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.DetectFormat(null!));
+    }
+
+    [Fact]
+    public async Task ParseAsync_JsonFile_RoutesToJsonParser()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0, 2.0 }, "")
+        );
+
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 100
+        };
+
+        // Act
+        var session = await global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.ParseAsync(
+            stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Single(samples);
+        Assert.Equal(2, samples[0].AnalogValues.Count);
+    }
+
+    [Fact]
+    public async Task ParseAsync_CsvFile_RoutesToCsvParser()
+    {
+        // Arrange — real firmware CSV format with 2 channels
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "TestDevice", "SN001", 100u,
+            (100u, new[] { 1.0, 2.0 })
+        );
+
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 100
+        };
+
+        // Act
+        var session = await global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.ParseAsync(
+            stream, "test.csv", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Single(samples);
+        Assert.Equal(2, samples[0].AnalogValues.Count);
+    }
+
+    [Fact]
+    public async Task ParseWithFormatAsync_ExplicitJsonFormat_UsesJsonParser()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 3.0 }, "01")
+        );
+
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 100
+        };
+
+        // Act
+        var session = await global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.ParseWithFormatAsync(
+            stream,
+            "anyname.dat",  // Extension doesn't matter when format is explicit
+            global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Json,
+            options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Single(samples);
+        Assert.Equal(3.0, samples[0].AnalogValues[0]);
+        Assert.Equal(0x01u, samples[0].DigitalData);
+    }
+
+    [Fact]
+    public async Task ParseWithFormatAsync_ExplicitCsvFormat_UsesCsvParser()
+    {
+        // Arrange — real firmware CSV format (no digital column; DigitalData is always 0)
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "TestDevice", "SN001", 100u,
+            (100u, new[] { 5.0 })
+        );
+
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 100
+        };
+
+        // Act
+        var session = await global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.ParseWithFormatAsync(
+            stream,
+            "anyname.dat",  // Extension doesn't matter when format is explicit
+            global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Csv,
+            options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Single(samples);
+        Assert.Equal(5.0, samples[0].AnalogValues[0]);
+        // Real firmware CSV has no digital column — always 0
+        Assert.Equal(0u, samples[0].DigitalData);
+    }
+
+    [Fact]
+    public async Task ParseWithFormatAsync_InvalidFormat_ThrowsArgumentException()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0 }, "")
+        );
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.ParseWithFormatAsync(
+                stream,
+                "test.json",
+                (global::Daqifi.Core.Device.SdCard.SdCardLogFormat)999,
+                null));
+    }
+
+    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var list = new List<T>();
+        await foreach (var item in source)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+public sealed class SdCardJsonFileParserTests
+{
+    [Fact]
+    public async Task ParseAsync_ValidJsonLines_ReturnsCorrectSamples()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.234567, 2.345678 }, "01-02"),
+            (200u, new[] { 3.456789, 4.567890 }, "03-04")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            SessionStartTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            FallbackTimestampFrequency = 100  // 100 Hz for easy math
+        };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "log_20240101_120000.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal("log_20240101_120000.json", session.FileName);
+        Assert.Equal(2, samples.Count);
+
+        // First sample at anchor time
+        Assert.Equal(new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc), samples[0].Timestamp);
+        Assert.Equal(2, samples[0].AnalogValues.Count);
+        Assert.Equal(1.234567, samples[0].AnalogValues[0], precision: 6);
+        Assert.Equal(2.345678, samples[0].AnalogValues[1], precision: 6);
+        Assert.Equal(0x0201u, samples[0].DigitalData);  // Little-endian: 01-02
+
+        // Second sample 1 second later (delta=100 ticks / 100 Hz = 1 second)
+        Assert.Equal(new DateTime(2024, 1, 1, 12, 0, 1, DateTimeKind.Utc), samples[1].Timestamp);
+        Assert.Equal(3.456789, samples[1].AnalogValues[0], precision: 6);
+        Assert.Equal(0x0403u, samples[1].DigitalData);  // Little-endian: 03-04
+    }
+
+    [Fact]
+    public async Task ParseAsync_TimestampRollover_HandlesCorrectly()
+    {
+        // Arrange
+        var nearMax = uint.MaxValue - 50;
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (nearMax, new[] { 1.0 }, ""),
+            (100u, new[] { 2.0 }, "")  // Rollover
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            SessionStartTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            FallbackTimestampFrequency = 100
+        };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal(2, samples.Count);
+        // Delta = (uint.MaxValue - nearMax) + 100 + 1 = 51 + 100 = 151 ticks
+        var expectedDelta = 151.0 / 100.0;  // 1.51 seconds
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(expectedDelta),
+                     samples[1].Timestamp);
+    }
+
+    [Fact]
+    public async Task ParseAsync_IntegerAnalogValues_ParsesCorrectly()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFileWithIntegers(
+            (100u, new[] { 1234, 5678 }, "")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions { FallbackTimestampFrequency = 100 };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Single(samples);
+        Assert.Equal(1234.0, samples[0].AnalogValues[0]);
+        Assert.Equal(5678.0, samples[0].AnalogValues[1]);
+    }
+
+    [Fact]
+    public async Task ParseAsync_EmptyDigitalField_ReturnsZero()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0 }, "")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions { FallbackTimestampFrequency = 100 };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Single(samples);
+        Assert.Equal(0u, samples[0].DigitalData);
+    }
+
+    [Fact]
+    public async Task ParseAsync_DigitalHexString_ParsesLittleEndian()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0 }, "01-02-03-04")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions { FallbackTimestampFrequency = 100 };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Single(samples);
+        // Little-endian: byte0=01, byte1=02, byte2=03, byte3=04
+        // Result = 0x04030201
+        Assert.Equal(0x04030201u, samples[0].DigitalData);
+    }
+
+    [Fact]
+    public async Task ParseAsync_MalformedLine_SkipsAndContinues()
+    {
+        // Arrange
+        using var stream = new System.IO.MemoryStream();
+        using var writer = new System.IO.StreamWriter(stream, leaveOpen: true);
+        writer.WriteLine("{\"ts\":100,\"analog\":[1.0],\"digital\":\"\"}");
+        writer.WriteLine("this is not valid json");
+        writer.WriteLine("{\"ts\":200,\"analog\":[2.0],\"digital\":\"\"}");
+        writer.Flush();
+        stream.Position = 0;
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions { FallbackTimestampFrequency = 100 };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal(2, samples.Count);  // Malformed line skipped
+        Assert.Equal(1.0, samples[0].AnalogValues[0]);
+        Assert.Equal(2.0, samples[1].AnalogValues[0]);
+    }
+
+    [Fact]
+    public async Task ParseAsync_EmptyFile_ReturnsEmptySamples()
+    {
+        // Arrange
+        await using var stream = new System.IO.MemoryStream();
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions();
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Empty(samples);
+        Assert.Null(session.DeviceConfig);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ConfigurationOverride_UsesProvidedConfig()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0, 2.0 }, "")
+        );
+
+        var overrideConfig = new global::Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration(
+            AnalogPortCount: 2,
+            DigitalPortCount: 1,
+            TimestampFrequency: 1000,
+            DeviceSerialNumber: "TEST123",
+            DevicePartNumber: "NQ1",
+            FirmwareRevision: "1.0.0",
+            CalibrationValues: null
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            ConfigurationOverride = overrideConfig
+        };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+
+        // Assert
+        Assert.NotNull(session.DeviceConfig);
+        Assert.Equal("TEST123", session.DeviceConfig.DeviceSerialNumber);
+        Assert.Equal(1000u, session.DeviceConfig.TimestampFrequency);
+    }
+
+    [Fact]
+    public async Task ParseAsync_InfersAnalogChannelCount()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0, 2.0, 3.0 }, "")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 50_000_000
+        };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+
+        // Assert
+        Assert.NotNull(session.DeviceConfig);
+        Assert.Equal(3, session.DeviceConfig.AnalogPortCount);
+        Assert.Equal(50_000_000u, session.DeviceConfig.TimestampFrequency);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ProgressReporting_CallsCallback()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            Enumerable.Range(0, 250).Select(i => ((uint)i, new[] { (double)i }, "")).ToArray()
+        );
+
+        var progressCalls = 0;
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 100,
+            Progress = new Progress<global::Daqifi.Core.Device.SdCard.SdCardParseProgress>(p =>
+            {
+                progressCalls++;
+                Assert.True(p.BytesRead >= 0);
+                Assert.Equal(250, p.MessagesRead);
+            })
+        };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal(250, samples.Count);
+        Assert.True(progressCalls >= 2);  // At least 2 progress updates (100-line batches + final)
+    }
+
+    [Fact]
+    public async Task ParseAsync_FileNameDateExtraction_SetsFileCreatedDate()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0 }, "")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 100
+        };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "log_20240315_143022.json", options);
+
+        // Assert
+        Assert.NotNull(session.FileCreatedDate);
+        Assert.Equal(new DateTime(2024, 3, 15, 14, 30, 22), session.FileCreatedDate.Value);
+    }
+
+    [Fact]
+    public async Task ParseAsync_CancellationToken_ThrowsOnCancel()
+    {
+        // Arrange — pre-cancelled token; the parser checks it during the ReadLineAsync loop
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            Enumerable.Range(0, 1000).Select(i => ((uint)i, new[] { (double)i }, "")).ToArray()
+        );
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 100
+        };
+
+        // Act & Assert — ParseAsync reads all lines upfront and throws when the token is already cancelled
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await parser.ParseAsync(stream, "test.json", options, cts.Token);
+        });
+    }
+
+    [Fact]
+    public async Task ParseAsync_PerChannelTimestamps_ReturnsNull()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0 }, "")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions { FallbackTimestampFrequency = 100 };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Single(samples);
+        Assert.Null(samples[0].AnalogTimestamps);  // JSON/CSV formats don't support per-channel timestamps
+    }
+
+    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var list = new List<T>();
+        await foreach (var item in source)
+        {
+            list.Add(item);
+        }
+        return list;
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardTestTextFileBuilders.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardTestTextFileBuilders.cs
@@ -1,0 +1,169 @@
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+/// <summary>
+/// Helper class for building test JSON log files for unit tests.
+/// </summary>
+internal static class SdCardTestJsonFileBuilder
+{
+    /// <summary>
+    /// Builds a JSON log file stream from sample data.
+    /// </summary>
+    /// <param name="lines">Array of tuples containing (timestamp, analog values, digital hex string).</param>
+    /// <returns>A <see cref="MemoryStream"/> positioned at the beginning containing the JSON data.</returns>
+    public static MemoryStream BuildJsonFile(params (uint ts, double[] analog, string digital)[] lines)
+    {
+        var ms = new MemoryStream();
+        var writer = new StreamWriter(ms, new UTF8Encoding(false), leaveOpen: true);
+
+        foreach (var (ts, analog, digital) in lines)
+        {
+            var analogStr = string.Join(",", analog.Select(v => v.ToString("F6", CultureInfo.InvariantCulture)));
+            var line = $"{{\"ts\":{ts.ToString(CultureInfo.InvariantCulture)},\"analog\":[{analogStr}],\"digital\":\"{digital}\"}}";
+            writer.WriteLine(line);
+        }
+
+        writer.Flush();
+        ms.Position = 0;
+        return ms;
+    }
+
+    /// <summary>
+    /// Builds a JSON log file with integer analog values instead of floats.
+    /// </summary>
+    public static MemoryStream BuildJsonFileWithIntegers(params (uint ts, int[] analog, string digital)[] lines)
+    {
+        var ms = new MemoryStream();
+        var writer = new StreamWriter(ms, new UTF8Encoding(false), leaveOpen: true);
+
+        foreach (var (ts, analog, digital) in lines)
+        {
+            var analogStr = string.Join(",", analog.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+            var line = $"{{\"ts\":{ts.ToString(CultureInfo.InvariantCulture)},\"analog\":[{analogStr}],\"digital\":\"{digital}\"}}";
+            writer.WriteLine(line);
+        }
+
+        writer.Flush();
+        ms.Position = 0;
+        return ms;
+    }
+}
+
+/// <summary>
+/// Helper class for building test CSV log files in the real DAQiFi firmware format.
+/// <para>
+/// The firmware CSV format is:
+/// <list type="bullet">
+///   <item><description># Device: {deviceName}</description></item>
+///   <item><description># Serial Number: {serialNumber}</description></item>
+///   <item><description># Timestamp Tick Rate: {freq} Hz</description></item>
+///   <item><description>ch0_ts,ch0_val,ch1_ts,ch1_val,...</description></item>
+///   <item><description>Data rows: interleaved per-channel (timestamp_ticks, adc_raw_value) pairs</description></item>
+/// </list>
+/// </para>
+/// </summary>
+internal static class SdCardTestCsvFileBuilder
+{
+    /// <summary>
+    /// Builds a CSV log file stream from sample data in the real DAQiFi firmware format.
+    /// </summary>
+    /// <param name="channelCount">Number of analog channels.</param>
+    /// <param name="deviceName">Device name for header (e.g. "Nyquist 1").</param>
+    /// <param name="serialNumber">Serial number for header (e.g. "AABBCCDDEEFF0011").</param>
+    /// <param name="timestampFreq">Timestamp tick rate in Hz for header.</param>
+    /// <param name="rows">
+    /// Array of rows, each containing per-channel (timestamp_ticks, adc_raw_value) pairs.
+    /// e.g. new[] { (1000u, 15.0), (1000u, 22.0) } means ch0 ts=1000 val=15, ch1 ts=1000 val=22.
+    /// </param>
+    /// <returns>A <see cref="MemoryStream"/> positioned at the beginning containing the CSV data.</returns>
+    public static MemoryStream BuildCsvFile(
+        int channelCount,
+        string deviceName,
+        string serialNumber,
+        uint timestampFreq,
+        params (uint ts, double val)[][] rows)
+    {
+        var ms = new MemoryStream();
+        var writer = new StreamWriter(ms, new UTF8Encoding(false), leaveOpen: true);
+
+        // Comment header lines
+        writer.WriteLine($"# Device: {deviceName}");
+        writer.WriteLine($"# Serial Number: {serialNumber}");
+        writer.WriteLine($"# Timestamp Tick Rate: {timestampFreq} Hz");
+
+        // Column header
+        var headerCols = Enumerable.Range(0, channelCount)
+            .SelectMany(ch => new[] { $"ch{ch}_ts", $"ch{ch}_val" });
+        writer.WriteLine(string.Join(",", headerCols));
+
+        // Data rows
+        foreach (var row in rows)
+        {
+            var cols = row.SelectMany(pair => new[]
+            {
+                pair.ts.ToString(CultureInfo.InvariantCulture),
+                pair.val.ToString("F6", CultureInfo.InvariantCulture)
+            });
+            writer.WriteLine(string.Join(",", cols));
+        }
+
+        writer.Flush();
+        ms.Position = 0;
+        return ms;
+    }
+
+    /// <summary>
+    /// Builds a CSV log file with a simplified signature for single-timestamp-per-row data
+    /// where all channels share the same timestamp (common in firmware output).
+    /// </summary>
+    /// <param name="deviceName">Device name.</param>
+    /// <param name="serialNumber">Serial number.</param>
+    /// <param name="timestampFreq">Tick rate in Hz.</param>
+    /// <param name="rows">Array of (sharedTimestamp, analogValues[]) tuples.</param>
+    public static MemoryStream BuildCsvFileSharedTimestamp(
+        string deviceName,
+        string serialNumber,
+        uint timestampFreq,
+        params (uint ts, double[] analog)[] rows)
+    {
+        var channelCount = rows.Length > 0 ? rows[0].analog.Length : 0;
+        var perChannelRows = rows
+            .Select(r => r.analog.Select((v, i) => (r.ts, v)).ToArray())
+            .ToArray();
+        return BuildCsvFile(channelCount, deviceName, serialNumber, timestampFreq, perChannelRows);
+    }
+
+    /// <summary>
+    /// Builds a minimal CSV file (no comment headers) with raw data rows only,
+    /// for testing format fallback / graceful degradation.
+    /// </summary>
+    public static MemoryStream BuildCsvFileNoHeaders(params (uint ts, double[] analog)[] rows)
+    {
+        var channelCount = rows.Length > 0 ? rows[0].analog.Length : 0;
+        var ms = new MemoryStream();
+        var writer = new StreamWriter(ms, new UTF8Encoding(false), leaveOpen: true);
+
+        // Column header only (no # comment lines)
+        var headerCols = Enumerable.Range(0, channelCount)
+            .SelectMany(ch => new[] { $"ch{ch}_ts", $"ch{ch}_val" });
+        writer.WriteLine(string.Join(",", headerCols));
+
+        foreach (var (ts, analog) in rows)
+        {
+            var cols = analog.SelectMany((v, i) => new[]
+            {
+                ts.ToString(CultureInfo.InvariantCulture),
+                v.ToString("F6", CultureInfo.InvariantCulture)
+            });
+            writer.WriteLine(string.Join(",", cols));
+        }
+
+        writer.Flush();
+        ms.Position = 0;
+        return ms;
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Parses SD card log <c>.csv</c> files produced by DAQiFi firmware.
+/// <para>
+/// The firmware CSV format consists of:
+/// <list type="bullet">
+///   <item><description>Up to three <c>#</c>-prefixed comment lines containing device metadata
+///   (device name, serial number, and timestamp tick rate).</description></item>
+///   <item><description>A column header row: <c>ch0_ts,ch0_val,ch1_ts,ch1_val,...</c></description></item>
+///   <item><description>Data rows with interleaved per-channel timestamp/value pairs.</description></item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class SdCardCsvFileParser
+{
+    /// <summary>
+    /// Parses an SD card CSV log file from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="fileStream">A readable stream containing the CSV log data.</param>
+    /// <param name="fileName">The file name (used for metadata and date extraction).</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    public async Task<SdCardLogSession> ParseAsync(
+        Stream fileStream,
+        string fileName,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileStream);
+        ArgumentNullException.ThrowIfNull(fileName);
+
+        options ??= new SdCardParseOptions();
+
+        var fileCreatedDate = options.SessionStartTime
+                              ?? SdCardFileListParser.TryParseDateFromLogFileName(fileName);
+
+        // Read all lines into memory (similar to protobuf parser reading all messages)
+        var lines = new List<string>();
+        using (var reader = new StreamReader(fileStream, leaveOpen: true))
+        {
+            while (!reader.EndOfStream)
+            {
+                ct.ThrowIfCancellationRequested();
+                var line = await reader.ReadLineAsync(ct);
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    lines.Add(line);
+                }
+            }
+        }
+
+        if (lines.Count == 0)
+        {
+            // Empty file
+            return new SdCardLogSession(
+                fileName,
+                fileCreatedDate,
+                null,
+                EmptySamples());
+        }
+
+        var config = options.ConfigurationOverride ?? ParseHeader(lines, options);
+
+        // Find the index of the first data row (after comments and column header)
+        var dataStartIndex = FindDataStartIndex(lines);
+
+        if (dataStartIndex >= lines.Count)
+        {
+            // Only header, no data
+            return new SdCardLogSession(
+                fileName,
+                fileCreatedDate,
+                config,
+                EmptySamples());
+        }
+
+        var samples = ParseCsvLines(
+            lines,
+            dataStartIndex,
+            config,
+            fileCreatedDate,
+            options);
+
+        return new SdCardLogSession(fileName, fileCreatedDate, config, samples);
+    }
+
+    /// <summary>
+    /// Parses an SD card CSV log file from a file path.
+    /// </summary>
+    /// <param name="filePath">The path to the CSV log file.</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    public async Task<SdCardLogSession> ParseFileAsync(
+        string filePath,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        await using var fileStream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: options?.BufferSize ?? 64 * 1024,
+            useAsync: true);
+
+        return await ParseAsync(fileStream, Path.GetFileName(filePath), options, ct);
+    }
+
+    /// <summary>
+    /// Parses device metadata from the comment header lines.
+    /// </summary>
+    private static SdCardDeviceConfiguration ParseHeader(List<string> lines, SdCardParseOptions options)
+    {
+        string? deviceName = null;
+        string? serialNumber = null;
+        var timestampFreq = options.FallbackTimestampFrequency;
+        var analogChannelCount = 0;
+
+        foreach (var line in lines)
+        {
+            if (line.StartsWith('#'))
+            {
+                // # Device: Nyquist 1
+                // # Serial Number: 7E2815916200E898
+                // # Timestamp Tick Rate: 50000000 Hz
+                var content = line[1..].Trim();
+                if (content.StartsWith("Device:", StringComparison.OrdinalIgnoreCase))
+                {
+                    deviceName = content["Device:".Length..].Trim();
+                }
+                else if (content.StartsWith("Serial Number:", StringComparison.OrdinalIgnoreCase))
+                {
+                    serialNumber = content["Serial Number:".Length..].Trim();
+                }
+                else if (content.StartsWith("Timestamp Tick Rate:", StringComparison.OrdinalIgnoreCase))
+                {
+                    var rateStr = content["Timestamp Tick Rate:".Length..].Trim();
+                    // Remove " Hz" suffix if present
+                    var spaceIdx = rateStr.IndexOf(' ');
+                    if (spaceIdx > 0)
+                    {
+                        rateStr = rateStr[..spaceIdx];
+                    }
+
+                    if (uint.TryParse(rateStr, NumberStyles.None, CultureInfo.InvariantCulture, out var rate))
+                    {
+                        timestampFreq = rate;
+                    }
+                }
+            }
+            else if (line.Contains("_ts,", StringComparison.OrdinalIgnoreCase) ||
+                     line.StartsWith("ch", StringComparison.OrdinalIgnoreCase))
+            {
+                // Column header: ch0_ts,ch0_val,ch1_ts,ch1_val,...
+                // Count channel pairs (every 2 columns = 1 channel)
+                var cols = line.Split(',');
+                analogChannelCount = cols.Length / 2;
+                break;
+            }
+            else
+            {
+                // First data row reached without finding column header
+                break;
+            }
+        }
+
+        if (timestampFreq == 0)
+        {
+            timestampFreq = 50_000_000;  // Default for Nyquist devices
+        }
+
+        return new SdCardDeviceConfiguration(
+            AnalogPortCount: analogChannelCount,
+            DigitalPortCount: 0,
+            TimestampFrequency: timestampFreq,
+            DeviceSerialNumber: serialNumber,
+            DevicePartNumber: deviceName,
+            FirmwareRevision: null,
+            CalibrationValues: null);
+    }
+
+    /// <summary>
+    /// Finds the index of the first data row (skipping comments and the column header).
+    /// </summary>
+    private static int FindDataStartIndex(List<string> lines)
+    {
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var line = lines[i];
+            if (line.StartsWith('#'))
+            {
+                continue;  // Comment line
+            }
+
+            // Check if it's the column header (contains "_ts," or starts with "ch")
+            if (line.Contains("_ts,", StringComparison.OrdinalIgnoreCase) ||
+                (line.StartsWith("ch", StringComparison.OrdinalIgnoreCase) && !char.IsDigit(line[2])))
+            {
+                continue;  // Column header line
+            }
+
+            return i;  // First data row
+        }
+
+        return lines.Count;  // No data found
+    }
+
+    private static async IAsyncEnumerable<SdCardLogEntry> ParseCsvLines(
+        List<string> lines,
+        int dataStartIndex,
+        SdCardDeviceConfiguration config,
+        DateTime? fileCreatedDate,
+        SdCardParseOptions options)
+    {
+        var baseTime = fileCreatedDate ?? DateTime.UtcNow;
+        var timestampFreq = config.TimestampFrequency;
+        var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
+
+        uint? previousTimestamp = null;
+        var elapsedSeconds = 0.0;
+        var linesProcessed = 0;
+        var bytesRead = 0L;
+
+        var progress = options.Progress;
+        var dataLines = lines.Count - dataStartIndex;
+        var totalBytes = lines.Sum(l => l.Length + 1); // +1 for newline
+
+        for (var i = dataStartIndex; i < lines.Count; i++)
+        {
+            var line = lines[i];
+            linesProcessed++;
+            bytesRead += line.Length + 1;
+
+            var parsed = TryParseCsvDataRow(line);
+            if (parsed == null)
+            {
+                // Skip malformed lines
+                continue;
+            }
+
+            var (rowTimestamp, analogValues, perChannelTimestamps) = parsed.Value;
+
+            // Reconstruct absolute timestamp using first channel timestamp
+            var absoluteTime = baseTime;
+            if (tickPeriod > 0)
+            {
+                if (previousTimestamp == null)
+                {
+                    previousTimestamp = rowTimestamp;
+                }
+                else
+                {
+                    var delta = ComputeTickDelta(previousTimestamp.Value, rowTimestamp);
+                    elapsedSeconds += delta * tickPeriod;
+                    previousTimestamp = rowTimestamp;
+                }
+
+                absoluteTime = baseTime.AddSeconds(elapsedSeconds);
+            }
+
+            yield return new SdCardLogEntry(absoluteTime, analogValues, 0u, perChannelTimestamps);
+
+            // Report progress every 100 lines for efficiency
+            if (linesProcessed % 100 == 0 && progress != null)
+            {
+                progress.Report(new SdCardParseProgress(bytesRead, totalBytes, linesProcessed));
+            }
+        }
+
+        // Final progress report
+        progress?.Report(new SdCardParseProgress(bytesRead, totalBytes, linesProcessed));
+
+        await Task.CompletedTask; // keep the method async-compatible
+    }
+
+    /// <summary>
+    /// Parses a firmware CSV data row with interleaved per-channel timestamp/value pairs.
+    /// Format: ch0_ts,ch0_val,ch1_ts,ch1_val,...
+    /// </summary>
+    private static (uint rowTimestamp, IReadOnlyList<double> analogValues, IReadOnlyList<uint> perChannelTimestamps)? TryParseCsvDataRow(string line)
+    {
+        try
+        {
+            var columns = line.Split(',');
+            // Must have at least one channel pair (2 columns: ts + val)
+            if (columns.Length < 2 || columns.Length % 2 != 0)
+            {
+                return null;
+            }
+
+            var channelCount = columns.Length / 2;
+            var analogValues = new List<double>(channelCount);
+            var perChannelTimestamps = new List<uint>(channelCount);
+
+            for (var ch = 0; ch < channelCount; ch++)
+            {
+                var tsCol = columns[ch * 2];
+                var valCol = columns[ch * 2 + 1];
+
+                if (!uint.TryParse(tsCol, NumberStyles.None, CultureInfo.InvariantCulture, out var ts))
+                {
+                    return null;
+                }
+
+                if (!double.TryParse(valCol, NumberStyles.Float | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var val))
+                {
+                    return null;
+                }
+
+                perChannelTimestamps.Add(ts);
+                analogValues.Add(val);
+            }
+
+            // Use first channel's timestamp as the row timestamp
+            return (perChannelTimestamps[0], analogValues, perChannelTimestamps);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Computes the tick delta between two uint32 timestamps, handling rollover.
+    /// </summary>
+    private static long ComputeTickDelta(uint previous, uint current)
+    {
+        if (current >= previous)
+        {
+            return current - previous;
+        }
+
+        // Rollover: ticks remaining to max + current
+        return (long)(uint.MaxValue - previous) + current + 1;
+    }
+
+    private static async IAsyncEnumerable<SdCardLogEntry> EmptySamples()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Factory for creating SD card log file parsers based on file format.
+/// Supports auto-detection via file extension (.bin, .json, .csv).
+/// </summary>
+public static class SdCardFileParserFactory
+{
+    /// <summary>
+    /// Parses an SD card log file with format auto-detection from file extension.
+    /// </summary>
+    /// <param name="filePath">The path to the log file.</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    public static async Task<SdCardLogSession> ParseFileAsync(
+        string filePath,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        var format = DetectFormat(filePath);
+        await using var stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: options?.BufferSize ?? 64 * 1024,
+            useAsync: true);
+
+        return await ParseWithFormatAsync(stream, Path.GetFileName(filePath), format, options, ct);
+    }
+
+    /// <summary>
+    /// Parses an SD card log file from a stream with format auto-detection from file name.
+    /// </summary>
+    /// <param name="fileStream">A readable stream containing the log data.</param>
+    /// <param name="fileName">The file name (used for format detection and metadata).</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    public static async Task<SdCardLogSession> ParseAsync(
+        Stream fileStream,
+        string fileName,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileStream);
+        ArgumentNullException.ThrowIfNull(fileName);
+
+        var format = DetectFormat(fileName);
+        return await ParseWithFormatAsync(fileStream, fileName, format, options, ct);
+    }
+
+    /// <summary>
+    /// Parses an SD card log file using an explicitly specified format.
+    /// </summary>
+    /// <param name="fileStream">A readable stream containing the log data.</param>
+    /// <param name="fileName">The file name (used for metadata and date extraction).</param>
+    /// <param name="format">The log file format.</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    public static Task<SdCardLogSession> ParseWithFormatAsync(
+        Stream fileStream,
+        string fileName,
+        SdCardLogFormat format,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        return format switch
+        {
+            SdCardLogFormat.Protobuf => new SdCardFileParser().ParseAsync(fileStream, fileName, options, ct),
+            SdCardLogFormat.Json => new SdCardJsonFileParser().ParseAsync(fileStream, fileName, options, ct),
+            SdCardLogFormat.Csv => new SdCardCsvFileParser().ParseAsync(fileStream, fileName, options, ct),
+            _ => throw new ArgumentException($"Unsupported format: {format}", nameof(format))
+        };
+    }
+
+    /// <summary>
+    /// Detects the SD card log file format from the file extension.
+    /// </summary>
+    /// <param name="fileName">The file name or path.</param>
+    /// <returns>The detected <see cref="SdCardLogFormat"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when the file extension is not supported.</exception>
+    public static SdCardLogFormat DetectFormat(string fileName)
+    {
+        ArgumentNullException.ThrowIfNull(fileName);
+
+        return Path.GetExtension(fileName).ToLowerInvariant() switch
+        {
+            ".bin" => SdCardLogFormat.Protobuf,
+            ".json" => SdCardLogFormat.Json,
+            ".csv" => SdCardLogFormat.Csv,
+            var ext => throw new ArgumentException($"Unsupported file extension: {ext}. Supported extensions are .bin, .json, .csv", nameof(fileName))
+        };
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Parses SD card log <c>.json</c> files containing JSONL-formatted sample data.
+/// Each line is a JSON object: {"ts":timestamp,"analog":[...],"digital":"hex"}.
+/// </summary>
+public sealed class SdCardJsonFileParser
+{
+    /// <summary>
+    /// Parses an SD card JSON log file from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="fileStream">A readable stream containing the JSON log data.</param>
+    /// <param name="fileName">The file name (used for metadata and date extraction).</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    public async Task<SdCardLogSession> ParseAsync(
+        Stream fileStream,
+        string fileName,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileStream);
+        ArgumentNullException.ThrowIfNull(fileName);
+
+        options ??= new SdCardParseOptions();
+
+        var fileCreatedDate = options.SessionStartTime
+                              ?? SdCardFileListParser.TryParseDateFromLogFileName(fileName);
+
+        // Read all lines into memory (similar to protobuf parser reading all messages)
+        var lines = new List<string>();
+        using (var reader = new StreamReader(fileStream, leaveOpen: true))
+        {
+            while (!reader.EndOfStream)
+            {
+                ct.ThrowIfCancellationRequested();
+                var line = await reader.ReadLineAsync(ct);
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    lines.Add(line);
+                }
+            }
+        }
+
+        if (lines.Count == 0)
+        {
+            // Empty file
+            return new SdCardLogSession(
+                fileName,
+                fileCreatedDate,
+                null,
+                EmptySamples());
+        }
+
+        var config = InferConfiguration(lines[0], options);
+
+        var samples = ParseJsonLines(
+            lines,
+            config,
+            fileCreatedDate,
+            options);
+
+        return new SdCardLogSession(fileName, fileCreatedDate, config, samples);
+    }
+
+    /// <summary>
+    /// Parses an SD card JSON log file from a file path.
+    /// </summary>
+    /// <param name="filePath">The path to the JSON log file.</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    public async Task<SdCardLogSession> ParseFileAsync(
+        string filePath,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        await using var fileStream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: options?.BufferSize ?? 64 * 1024,
+            useAsync: true);
+
+        return await ParseAsync(fileStream, Path.GetFileName(filePath), options, ct);
+    }
+
+    private static async IAsyncEnumerable<SdCardLogEntry> ParseJsonLines(
+        List<string> lines,
+        SdCardDeviceConfiguration config,
+        DateTime? fileCreatedDate,
+        SdCardParseOptions options)
+    {
+        var baseTime = fileCreatedDate ?? DateTime.UtcNow;
+        var timestampFreq = config.TimestampFrequency;
+        var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
+
+        uint? previousTimestamp = null;
+        var elapsedSeconds = 0.0;
+        var linesProcessed = 0;
+        var bytesRead = 0L;
+
+        var progress = options.Progress;
+        var totalBytes = lines.Sum(l => l.Length + 1); // +1 for newline
+
+        foreach (var line in lines)
+        {
+            linesProcessed++;
+            bytesRead += line.Length + 1;
+
+            var parsed = TryParseJsonLine(line);
+            if (parsed == null)
+            {
+                // Skip malformed lines
+                continue;
+            }
+
+            var (timestamp, analogValues, digitalData) = parsed.Value;
+
+            // Reconstruct absolute timestamp
+            var absoluteTime = baseTime;
+            if (tickPeriod > 0)
+            {
+                if (previousTimestamp == null)
+                {
+                    previousTimestamp = timestamp;
+                }
+                else
+                {
+                    var delta = ComputeTickDelta(previousTimestamp.Value, timestamp);
+                    elapsedSeconds += delta * tickPeriod;
+                    previousTimestamp = timestamp;
+                }
+
+                absoluteTime = baseTime.AddSeconds(elapsedSeconds);
+            }
+
+            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, null);
+
+            // Report progress every 100 lines for efficiency
+            if (linesProcessed % 100 == 0 && progress != null)
+            {
+                progress.Report(new SdCardParseProgress(bytesRead, totalBytes, linesProcessed));
+            }
+        }
+
+        // Final progress report
+        progress?.Report(new SdCardParseProgress(bytesRead, totalBytes, linesProcessed));
+
+        await Task.CompletedTask; // keep the method async-compatible
+    }
+
+    private static (uint timestamp, IReadOnlyList<double> analog, uint digital)? TryParseJsonLine(string line)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(line);
+            var root = doc.RootElement;
+
+            // Parse timestamp
+            if (!root.TryGetProperty("ts", out var tsElement) || !tsElement.TryGetUInt32(out var timestamp))
+            {
+                return null;
+            }
+
+            // Parse analog array
+            if (!root.TryGetProperty("analog", out var analogElement) || analogElement.ValueKind != JsonValueKind.Array)
+            {
+                return null;
+            }
+
+            var analogList = new List<double>();
+            foreach (var item in analogElement.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.Number)
+                {
+                    analogList.Add(item.GetDouble());
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            // Parse digital hex string
+            var digitalData = 0u;
+            if (root.TryGetProperty("digital", out var digitalElement) && digitalElement.ValueKind == JsonValueKind.String)
+            {
+                var hexString = digitalElement.GetString();
+                if (!string.IsNullOrEmpty(hexString))
+                {
+                    digitalData = ParseDigitalHexString(hexString);
+                }
+            }
+
+            return (timestamp, analogList, digitalData);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static uint ParseDigitalHexString(string hexString)
+    {
+        if (string.IsNullOrEmpty(hexString))
+        {
+            return 0;
+        }
+
+        var hexBytes = hexString.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        var result = 0u;
+
+        for (var i = 0; i < hexBytes.Length && i < 4; i++)  // Max 4 bytes for uint32
+        {
+            if (byte.TryParse(hexBytes[i], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var byteValue))
+            {
+                result |= (uint)byteValue << (i * 8);  // Little-endian packing
+            }
+        }
+
+        return result;
+    }
+
+    private static SdCardDeviceConfiguration InferConfiguration(string firstLine, SdCardParseOptions options)
+    {
+        // Use override if provided
+        if (options.ConfigurationOverride != null)
+        {
+            return options.ConfigurationOverride;
+        }
+
+        // Parse first line to infer analog channel count
+        var parsed = TryParseJsonLine(firstLine);
+        var analogCount = parsed?.analog.Count ?? 0;
+
+        var timestampFreq = options.FallbackTimestampFrequency;
+        if (timestampFreq == 0)
+        {
+            timestampFreq = 50_000_000;  // Default for Nyquist devices
+        }
+
+        return new SdCardDeviceConfiguration(
+            AnalogPortCount: analogCount,
+            DigitalPortCount: 0,  // Cannot infer from data
+            TimestampFrequency: timestampFreq,
+            DeviceSerialNumber: null,
+            DevicePartNumber: null,
+            FirmwareRevision: null,
+            CalibrationValues: null);
+    }
+
+    /// <summary>
+    /// Computes the tick delta between two uint32 timestamps, handling rollover.
+    /// </summary>
+    private static long ComputeTickDelta(uint previous, uint current)
+    {
+        if (current >= previous)
+        {
+            return current - previous;
+        }
+
+        // Rollover: ticks remaining to max + current
+        return (long)(uint.MaxValue - previous) + current + 1;
+    }
+
+    private static async IAsyncEnumerable<SdCardLogEntry> EmptySamples()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardParseOptions.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardParseOptions.cs
@@ -37,4 +37,11 @@ public sealed class SdCardParseOptions
     /// </para>
     /// </summary>
     public uint FallbackTimestampFrequency { get; set; }
+
+    /// <summary>
+    /// Gets or sets a device configuration override for formats that don't embed
+    /// config metadata (JSON/CSV). When set, this config is used instead of inference.
+    /// For Protobuf files, this is ignored since config is embedded in the file.
+    /// </summary>
+    public SdCardDeviceConfiguration? ConfigurationOverride { get; set; }
 }


### PR DESCRIPTION
### **User description**
## Summary

Implements [issue #124](https://github.com/daqifi/daqifi-core/issues/124) — support for all three DAQiFi firmware SD card log formats.

- **`SdCardJsonFileParser`** — parses JSONL format: `{"ts":uint,"analog":[...],"digital":"hex"}`
- **`SdCardCsvFileParser`** — parses the real firmware CSV format discovered from a live Nyquist 1 device (FW 3.2.0):
  - `#`-prefixed comment headers: device name, serial number, timestamp tick rate
  - `ch0_ts,ch0_val,ch1_ts,ch1_val,...` column header
  - Data rows: interleaved per-channel `(uint32_ticks, adc_raw_value)` pairs
  - Populates `SdCardLogEntry.AnalogTimestamps` with per-channel timestamps
- **`SdCardFileParserFactory`** — auto-detects format by extension (`.bin` → Protobuf, `.json` → JSON, `.csv` → CSV); also supports explicit format override via `ParseWithFormatAsync`
- **`SdCardParseOptions`** — adds `ConfigurationOverride` property for formats where the caller wants to supply config externally

## Test plan

- [x] 87 new unit tests across `SdCardJsonFileParserTests`, `SdCardCsvFileParserTests`, `SdCardFileParserFactoryTests`, and `SdCardTestTextFileBuilders` (174 total across net8.0 + net9.0)
- [x] All 732 tests pass on both net8.0 and net9.0
- [x] CSV parser validated against a real CSV file downloaded from a Nyquist 1 device (FW 3.2.0) — correct device config extracted from headers, 100 samples parsed with advancing timestamps (~100ms apart at 50 MHz tick rate)
- [x] JSON format: real device writes empty `{}` objects in FW 3.2.0 (firmware limitation); parser is correct but output is empty until firmware populates JSON fields
- [x] Format auto-detection correctly rejects unsupported extensions with a clear error message

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements JSON and CSV SD card log file parsers for DAQiFi firmware

- Adds SdCardFileParserFactory for auto-detection by file extension

- Supports per-channel timestamps in CSV format and digital data parsing

- Includes 87 new unit tests validating parsers against real device data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SD Card Log Files<br/>.bin/.json/.csv"] -->|DetectFormat| B["SdCardFileParserFactory"]
  B -->|.bin| C["SdCardFileParser<br/>Protobuf"]
  B -->|.json| D["SdCardJsonFileParser<br/>JSONL Format"]
  B -->|.csv| E["SdCardCsvFileParser<br/>Firmware CSV"]
  C --> F["SdCardLogSession<br/>with Samples"]
  D --> F
  E --> F
  G["SdCardParseOptions<br/>ConfigurationOverride"] -.->|optional| D
  G -.->|optional| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>SdCardJsonFileParser.cs</strong><dd><code>JSON JSONL log file parser implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-d0b2d5d77669cb741be831c3b39f4bb7ed2366e4627f3066b65028735d884f24">+285/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardCsvFileParser.cs</strong><dd><code>CSV firmware log file parser with per-channel timestamps</code>&nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-00f7278708fa66698bc32f0bf0460398f303ab9dceb9757fc038ceee2dc22bec">+355/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardFileParserFactory.cs</strong><dd><code>Factory for format auto-detection and routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-59ff8e797b53538d485a3a567c684f5e85bf08b83d443eaff718daecc4707a57">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardParseOptions.cs</strong><dd><code>Add ConfigurationOverride property for external config</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-9ffb0efc5bc295a6d18f36cf35a1cbfbd48155530f8555c1d8505bae8f5d2225">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>SdCardJsonFileParserTests.cs</strong><dd><code>Unit tests for JSON parser with 11 test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-bd3a0bd8884017fe730c6b02f2401254e14b6d6f1361fca446903e9d3dab21fb">+345/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardCsvFileParserTests.cs</strong><dd><code>Unit tests for CSV parser with 20 test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-77916e26d5d82b820253d2e0425a26b8980126e4fb50fc4bb36119ad13575ea5">+494/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardFileParserFactoryTests.cs</strong><dd><code>Unit tests for factory format detection and routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-1a11b1399987139c444fa054939f918831e3b015008ce7a7f48d9a230a586da7">+178/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SdCardTestTextFileBuilders.cs</strong><dd><code>Test helper builders for JSON and CSV files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-8ab34824eb24c20abc01c57f4ff1db12406207112568b5d5c960628ccf834a1a">+169/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DaqifiDeviceInitializeTests.cs</strong><dd><code>Unit tests for device initialization sequence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-core/pull/132/files#diff-89c4f2af36c318cfa66bb49aa977161fe6a0d9ba5371763024b879e848fda2e5">+118/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

