### PR TITLE
feat: expose TimestampFrequency, filter plain ERROR and control-char filenames

### DIFF
--- a/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
@@ -685,4 +685,46 @@ public class ChannelPopulationTests
     }
 
     #endregion
+
+    #region TimestampFrequency Tests
+
+    [Fact]
+    public void TimestampFrequency_DefaultsToZero()
+    {
+        // Arrange & Act
+        var device = new DaqifiDevice("TestDevice");
+
+        // Assert
+        Assert.Equal(0u, device.TimestampFrequency);
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_WithTimestampFreq_PopulatesTimestampFrequency()
+    {
+        // Arrange
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage { TimestampFreq = 48000000 };
+
+        // Act
+        device.PopulateChannelsFromStatus(message);
+
+        // Assert
+        Assert.Equal(48000000u, device.TimestampFrequency);
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_WithZeroTimestampFreq_DoesNotOverwriteExistingValue()
+    {
+        // Arrange
+        var device = new DaqifiDevice("TestDevice");
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage { TimestampFreq = 48000000 });
+
+        // Act — message with TimestampFreq = 0 should not reset the value
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage { TimestampFreq = 0 });
+
+        // Assert
+        Assert.Equal(48000000u, device.TimestampFrequency);
+    }
+
+    #endregion
 }

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
@@ -222,5 +222,86 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal(expected, result[0].FileName);
             Assert.NotNull(result[0].CreatedDate);
         }
+
+        [Fact]
+        public void ParseFileList_WithPlainErrorLine_SkipsErrorLine()
+        {
+            // Arrange
+            var lines = new[] { "ERROR: -200, \"Execution error\"" };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ParseFileList_WithPlainErrorMixedWithFiles_OnlyReturnsFiles()
+        {
+            // Arrange
+            var lines = new[]
+            {
+                "ERROR: -200, \"Execution error\"",
+                "Daqifi/log_20240115_103000.bin",
+                "ERROR: -100, \"Command error\""
+            };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert
+            Assert.Single(result);
+            Assert.Equal("log_20240115_103000.bin", result[0].FileName);
+        }
+
+        [Theory]
+        [InlineData("ERROR: -200, \"Execution error\"")]
+        [InlineData("error: -200")]
+        [InlineData("  ERROR: -100")]
+        public void ParseFileList_WithVariousPlainErrorFormats_SkipsAll(string errorLine)
+        {
+            // Arrange
+            var lines = new[] { errorLine };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ParseFileList_WithControlCharacterInFilename_SkipsFile()
+        {
+            // Arrange
+            var lines = new[] { "log_\x01corrupt.bin" };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ParseFileList_WithControlCharMixedWithValidFiles_OnlyReturnsCleanFiles()
+        {
+            // Arrange
+            var lines = new[]
+            {
+                "log_20240115_103000.bin",
+                "log_\x01corrupt.bin",
+                "log_20240116_120000.bin"
+            };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal("log_20240115_103000.bin", result[0].FileName);
+            Assert.Equal("log_20240116_120000.bin", result[1].FileName);
+        }
     }
 }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -52,6 +52,14 @@ namespace Daqifi.Core.Device
         public IReadOnlyList<IChannel> Channels => _channels.AsReadOnly();
 
         /// <summary>
+        /// Gets the device's timestamp clock frequency in Hz.
+        /// Populated from the <c>TimestampFreq</c> field of the status message.
+        /// Used as the fallback frequency for SD card log file parsing when no
+        /// per-message timestamp frequency is available.
+        /// </summary>
+        public uint TimestampFrequency { get; private set; }
+
+        /// <summary>
         /// Gets or sets the current operational state of the device.
         /// </summary>
         public DeviceState State { get; private set; } = DeviceState.Disconnected;
@@ -627,6 +635,12 @@ namespace Daqifi.Core.Device
             if (message == null)
             {
                 throw new ArgumentNullException(nameof(message));
+            }
+
+            // Update timestamp frequency if present
+            if (message.TimestampFreq != 0)
+            {
+                TimestampFrequency = message.TimestampFreq;
             }
 
             // Clear existing channels before repopulating

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -656,7 +656,12 @@ namespace Daqifi.Core.Device
         /// <returns>True if any line contains a SCPI error, false otherwise.</returns>
         private static bool ContainsScpiError(IReadOnlyList<string> lines)
         {
-            return lines.Any(line => line.TrimStart().StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase));
+            return lines.Any(line =>
+            {
+                var trimmed = line.TrimStart();
+                return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
+                    || trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase);
+            });
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -40,8 +40,9 @@ namespace Daqifi.Core.Device.SdCard
 
                 var path = line.Trim();
 
-                // Skip SCPI error responses (e.g., "**ERROR: -200, \"Execution error\"")
-                if (path.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
+                // Skip SCPI error responses: "**ERROR: -200, ..." or "ERROR: -200, ..."
+                if (path.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase) ||
+                    path.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
@@ -62,6 +63,12 @@ namespace Daqifi.Core.Device.SdCard
                 // Extract just the filename from the path
                 var fileName = Path.GetFileName(path);
                 if (string.IsNullOrWhiteSpace(fileName))
+                {
+                    continue;
+                }
+
+                // Skip filenames with control characters (corrupted SD card directory entries)
+                if (fileName.Any(char.IsControl))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Closes #137

- **`DaqifiDevice.TimestampFrequency`** — new `uint` property populated from `TimestampFreq` in the status protobuf (via `PopulateChannelsFromStatus`). Zero values are ignored to preserve any previously received frequency. Downstream consumers (e.g. SD card import) can use this as `SdCardParseOptions.FallbackTimestampFrequency` without re-parsing the protobuf.

- **`SdCardFileListParser.ParseFileList`** — now skips plain `ERROR: ...` lines (previously only `**ERROR: ...` was filtered) and rejects filenames containing control characters (which can appear from corrupted SD card directory entries).

- **`DaqifiStreamingDevice.ContainsScpiError`** — updated to match both `**ERROR` and `ERROR` prefixes so the retry-on-transient-error logic fires correctly for both device error formats.

## Test plan

- [ ] `ChannelPopulationTests` — three new cases: default value is 0, populated from status message, zero in message does not overwrite existing value
- [ ] `SdCardFileListParserTests` — six new cases: plain `ERROR` line skipped, plain `ERROR` mixed with files, theory for `error:` / `  ERROR:` variants, control-char filename skipped, control-char mixed with valid files
- [ ] `dotnet test` passes (833 total, 831 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)