### PR TITLE
feat: add LAN chip info query and WiFi version check before flashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ The core library exposes `IFirmwareUpdateService` for update orchestration:
 - `UpdateFirmwareAsync(...)` for PIC32 firmware flashing from a local Intel HEX file
 - `UpdateWifiModuleAsync(...)` for WiFi module flashing through an external tool runner
 
+`UpdateWifiModuleAsync` automatically queries the device's current WiFi chip firmware version via `ILanChipInfoProvider` and compares it against the latest GitHub release. If the device is already up to date, the flash is skipped and the service reports `Complete` immediately — no unnecessary reflashing.
+
 The service emits explicit state transitions and `IProgress<FirmwareUpdateProgress>` updates for UI/CLI telemetry.
 
 Note: the default WiFi flash tool configuration uses `winc_flash_tool.cmd` conventions. If you run on macOS/Linux, provide a compatible executable/script and argument template via `FirmwareUpdateServiceOptions`.

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -347,6 +347,150 @@ public class FirmwareUpdateServiceTests
         }
     }
 
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenDeviceVersionMatchesLatest_SkipsFlashAndReportsComplete()
+    {
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 5, 4, null, 0),
+            TagName = "19.5.4",
+            IsPreRelease = false
+        };
+
+        var downloadService = new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease };
+        var device = new FakeLanChipInfoStreamingDevice("COM9", chipInfo: new LanChipInfo
+        {
+            ChipId = 1234,
+            FwVersion = "19.5.4",
+            BuildDate = "Jan  8 2019"
+        });
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            downloadService,
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            CreateFastOptions());
+
+        var progressEvents = new List<FirmwareUpdateProgress>();
+        var progress = new CapturingProgress<FirmwareUpdateProgress>(progressEvents);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(device, firmwareDir, progress);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        // Device should NOT have been put into firmware update mode
+        Assert.DoesNotContain("SYSTem:COMMUnicate:LAN:FWUpdate", device.SentCommands);
+        // Progress should contain a Complete event at 100%
+        var completeEvent = Assert.Single(progressEvents, p => p.State == FirmwareUpdateState.Complete);
+        Assert.Equal(100, completeEvent.PercentComplete);
+        Assert.Contains("already up to date", completeEvent.CurrentOperation, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenDeviceVersionIsOlder_ProceedsWithFlash()
+    {
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 6, 1, null, 0),
+            TagName = "19.6.1",
+            IsPreRelease = false
+        };
+
+        var downloadService = new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease };
+        var device = new FakeLanChipInfoStreamingDevice("COM10", chipInfo: new LanChipInfo
+        {
+            ChipId = 1234,
+            FwVersion = "19.5.4",
+            BuildDate = "Jan  8 2019"
+        });
+
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), [], [])
+        };
+
+        var options = CreateFastOptions();
+        options.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(5);
+        options.PostWifiReconnectDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            downloadService,
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(device, firmwareDir);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        // Device SHOULD have been put into firmware update mode
+        Assert.Contains("SYSTem:COMMUnicate:LAN:FWUpdate", device.SentCommands);
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenDeviceDoesNotSupportLanQuery_ProceedsWithFlash()
+    {
+        // FakeStreamingDevice does NOT implement ILanChipInfoProvider — version check is skipped
+        var device = new FakeStreamingDevice("COM11");
+
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), [], [])
+        };
+
+        var options = CreateFastOptions();
+        options.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(5);
+        options.PostWifiReconnectDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(device, firmwareDir);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Contains("SYSTem:COMMUnicate:LAN:FWUpdate", device.SentCommands);
+    }
+
     private static FirmwareUpdateServiceOptions CreateFastOptions()
     {
         return new FirmwareUpdateServiceOptions
@@ -451,6 +595,65 @@ public class FirmwareUpdateServiceTests
         public void StopStreaming()
         {
             IsStreaming = false;
+        }
+    }
+
+    private sealed class FakeLanChipInfoStreamingDevice : IStreamingDevice, ILanChipInfoProvider
+    {
+        private readonly LanChipInfo? _chipInfo;
+        private ConnectionStatus _status = ConnectionStatus.Connected;
+
+        public FakeLanChipInfoStreamingDevice(string name, LanChipInfo? chipInfo)
+        {
+            Name = name;
+            _chipInfo = chipInfo;
+            IsConnected = true;
+        }
+
+        public string Name { get; }
+        public IPAddress? IpAddress => null;
+        public bool IsConnected { get; private set; }
+        public ConnectionStatus Status => _status;
+        public int StreamingFrequency { get; set; }
+        public bool IsStreaming { get; private set; }
+
+        public List<string> SentCommands { get; } = [];
+
+        public event EventHandler<DeviceStatusEventArgs>? StatusChanged;
+        public event EventHandler<MessageReceivedEventArgs>? MessageReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public void Connect()
+        {
+            IsConnected = true;
+            _status = ConnectionStatus.Connected;
+            StatusChanged?.Invoke(this, new DeviceStatusEventArgs(_status));
+        }
+
+        public void Disconnect()
+        {
+            IsConnected = false;
+            _status = ConnectionStatus.Disconnected;
+            StatusChanged?.Invoke(this, new DeviceStatusEventArgs(_status));
+        }
+
+        public void Send<T>(IOutboundMessage<T> message)
+        {
+            if (message is IOutboundMessage<string> textMessage)
+            {
+                SentCommands.Add(textMessage.Data);
+            }
+        }
+
+        public void StartStreaming() => IsStreaming = true;
+        public void StopStreaming() => IsStreaming = false;
+
+        public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_chipInfo);
         }
     }
 
@@ -668,6 +871,8 @@ public class FirmwareUpdateServiceTests
 
     private sealed class FakeFirmwareDownloadService : IFirmwareDownloadService
     {
+        public FirmwareReleaseInfo? LatestWifiRelease { get; set; }
+
         public Task<FirmwareReleaseInfo?> GetLatestReleaseAsync(bool includePreRelease = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<FirmwareReleaseInfo?>(null);
@@ -694,6 +899,11 @@ public class FirmwareUpdateServiceTests
         public Task<(string ExtractedPath, string Version)?> DownloadWifiFirmwareAsync(string destinationDirectory, IProgress<int>? progress = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<(string ExtractedPath, string Version)?>(null);
+        }
+
+        public Task<FirmwareReleaseInfo?> GetLatestWifiReleaseAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(LatestWifiRelease);
         }
 
         public void InvalidateCache()

--- a/src/Daqifi.Core.Tests/Firmware/LanChipInfoParserTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/LanChipInfoParserTests.cs
@@ -1,0 +1,114 @@
+using Daqifi.Core.Firmware;
+
+namespace Daqifi.Core.Tests.Firmware;
+
+public class LanChipInfoParserTests
+{
+    [Fact]
+    public void TryParse_ValidJson_ReturnsChipInfo()
+    {
+        const string json = """{"ChipId":5596,"FwVersion":"19.5.4","BuildDate":"Jan  8 2019 Time 12:38:49"}""";
+
+        Assert.True(LanChipInfoParser.TryParse(json, out var result));
+        Assert.NotNull(result);
+        Assert.Equal(5596, result.ChipId);
+        Assert.Equal("19.5.4", result.FwVersion);
+        Assert.Equal("Jan  8 2019 Time 12:38:49", result.BuildDate);
+    }
+
+    [Fact]
+    public void TryParse_JsonMissingBuildDate_UsesEmptyString()
+    {
+        const string json = """{"ChipId":1234,"FwVersion":"19.5.4"}""";
+
+        Assert.True(LanChipInfoParser.TryParse(json, out var result));
+        Assert.NotNull(result);
+        Assert.Equal("19.5.4", result.FwVersion);
+        Assert.Equal(string.Empty, result.BuildDate);
+    }
+
+    [Fact]
+    public void TryParse_JsonMissingChipId_UsesZero()
+    {
+        const string json = """{"FwVersion":"19.5.4","BuildDate":"Jan  8 2019"}""";
+
+        Assert.True(LanChipInfoParser.TryParse(json, out var result));
+        Assert.NotNull(result);
+        Assert.Equal(0, result.ChipId);
+        Assert.Equal("19.5.4", result.FwVersion);
+    }
+
+    [Fact]
+    public void TryParse_JsonMissingFwVersion_ReturnsFalse()
+    {
+        const string json = """{"ChipId":1234,"BuildDate":"Jan  8 2019"}""";
+
+        Assert.False(LanChipInfoParser.TryParse(json, out var result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParse_JsonEmptyFwVersion_ReturnsFalse()
+    {
+        const string json = """{"ChipId":1234,"FwVersion":"","BuildDate":"Jan  8 2019"}""";
+
+        Assert.False(LanChipInfoParser.TryParse(json, out var result));
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryParse_NullOrWhitespace_ReturnsFalse(string? input)
+    {
+        Assert.False(LanChipInfoParser.TryParse(input, out var result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParse_MalformedJson_ReturnsFalse()
+    {
+        Assert.False(LanChipInfoParser.TryParse("{not valid json", out var result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParse_NonJsonString_ReturnsFalse()
+    {
+        Assert.False(LanChipInfoParser.TryParse("plain text response", out var result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParseLines_FindsFirstValidLine()
+    {
+        var lines = new[]
+        {
+            "",
+            "some preamble",
+            """{"ChipId":5596,"FwVersion":"19.5.4","BuildDate":"Jan  8 2019"}""",
+            "trailing text"
+        };
+
+        Assert.True(LanChipInfoParser.TryParseLines(lines, out var result));
+        Assert.NotNull(result);
+        Assert.Equal("19.5.4", result.FwVersion);
+    }
+
+    [Fact]
+    public void TryParseLines_NoValidLines_ReturnsFalse()
+    {
+        var lines = new[] { "", "not json", "also not json" };
+
+        Assert.False(LanChipInfoParser.TryParseLines(lines, out var result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParseLines_EmptySequence_ReturnsFalse()
+    {
+        Assert.False(LanChipInfoParser.TryParseLines([], out var result));
+        Assert.Null(result);
+    }
+}

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -501,4 +501,15 @@ public class ScpiMessageProducer
     {
         return new ScpiMessage($"SYSTem:USB:SetTransparentMode {mode}");
     }
+
+    /// <summary>
+    /// Creates a query message to get LAN chip information including the WiFi module firmware version.
+    /// </summary>
+    /// <remarks>
+    /// The device returns a JSON response:
+    /// <c>{"ChipId":&lt;id&gt;,"FwVersion":"&lt;version&gt;","BuildDate":"&lt;date&gt;"}</c>
+    /// Command: SYSTem:COMMunicate:LAN:GETChipInfo?
+    /// Example: messageProducer.Send(ScpiMessageProducer.GetLanChipInfo);
+    /// </remarks>
+    public static IOutboundMessage<string> GetLanChipInfo => new ScpiMessage("SYSTem:COMMunicate:LAN:GETChipInfo?");
 }

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -3,6 +3,7 @@ using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device.Network;
 using Daqifi.Core.Device.SdCard;
+using Daqifi.Core.Firmware;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -20,7 +21,7 @@ namespace Daqifi.Core.Device
     /// Represents a DAQiFi device that supports data streaming functionality.
     /// Extends the base DaqifiDevice with streaming-specific operations.
     /// </summary>
-    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, INetworkConfigurable, ISdCardOperations
+    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider
     {
         /// <summary>
         /// The delay in milliseconds to wait for the WiFi module to restart after applying configuration.
@@ -677,6 +678,23 @@ namespace Daqifi.Core.Device
                     "Filename contains invalid characters. Quotes, newlines, and semicolons are not allowed.",
                     nameof(fileName));
             }
+        }
+
+        /// <inheritdoc />
+        public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            var lines = await ExecuteTextCommandAsync(
+                () => Send(ScpiMessageProducer.GetLanChipInfo),
+                responseTimeoutMs: 2000,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            LanChipInfoParser.TryParseLines(lines, out var info);
+            return info;
         }
     }
 }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -23,6 +23,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             [FirmwareUpdateState.Idle] = new HashSet<FirmwareUpdateState>
             {
                 FirmwareUpdateState.PreparingDevice,
+                FirmwareUpdateState.Complete,
                 FirmwareUpdateState.Failed
             },
             [FirmwareUpdateState.PreparingDevice] = new HashSet<FirmwareUpdateState>
@@ -335,6 +336,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
         try
         {
+            if (await IsWifiFirmwareUpToDateAsync(device, progress, cancellationToken).ConfigureAwait(false))
+            {
+                return;
+            }
+
             TransitionToState(FirmwareUpdateState.PreparingDevice, "Preparing device for WiFi module update.");
             ReportProgress(progress, FirmwareUpdateState.PreparingDevice, 0, _currentOperation, 0, totalBytes);
 
@@ -420,6 +426,77 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
             throw CreateFirmwareUpdateException(failedState, failedOperation, ex);
         }
+    }
+
+    private async Task<bool> IsWifiFirmwareUpToDateAsync(
+        IStreamingDevice device,
+        IProgress<FirmwareUpdateProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        if (device is not ILanChipInfoProvider lanChipInfoProvider)
+        {
+            return false;
+        }
+
+        LanChipInfo? chipInfo;
+        try
+        {
+            chipInfo = await lanChipInfoProvider.GetLanChipInfoAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Failed to query LAN chip info; proceeding with WiFi firmware update.");
+            return false;
+        }
+
+        if (chipInfo == null)
+        {
+            return false;
+        }
+
+        FirmwareReleaseInfo? latestWifi;
+        try
+        {
+            latestWifi = await FirmwareDownloadService
+                .GetLatestWifiReleaseAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Failed to query latest WiFi firmware release; proceeding with update.");
+            return false;
+        }
+
+        if (latestWifi == null)
+        {
+            return false;
+        }
+
+        if (!IsWifiVersionCurrent(chipInfo.FwVersion, latestWifi.TagName))
+        {
+            _logger.LogInformation(
+                "WiFi firmware update available: device has {DeviceVersion}, latest is {LatestVersion}.",
+                chipInfo.FwVersion,
+                latestWifi.TagName);
+            return false;
+        }
+
+        var message = $"WiFi firmware is already up to date (device: {chipInfo.FwVersion}, latest: {latestWifi.TagName}).";
+        _logger.LogInformation(message);
+        TransitionToState(FirmwareUpdateState.Complete, message);
+        ReportProgress(progress, FirmwareUpdateState.Complete, 100, message, 100, 100);
+        return true;
+    }
+
+    private static bool IsWifiVersionCurrent(string deviceVersion, string latestTagName)
+    {
+        if (!FirmwareVersion.TryParse(deviceVersion, out var device) ||
+            !FirmwareVersion.TryParse(latestTagName, out var latest))
+        {
+            return false;
+        }
+
+        return device >= latest;
     }
 
     private ExternalProcessRequest BuildWifiProcessRequest(

--- a/src/Daqifi.Core/Firmware/GitHubFirmwareDownloadService.cs
+++ b/src/Daqifi.Core/Firmware/GitHubFirmwareDownloadService.cs
@@ -129,6 +129,14 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
     }
 
     /// <inheritdoc />
+    public async Task<FirmwareReleaseInfo?> GetLatestWifiReleaseAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var releases = await GetWifiReleasesAsync(cancellationToken);
+        return FindLatestRelease(releases, includePreRelease: false, assetExtension: null);
+    }
+
+    /// <inheritdoc />
     public async Task<(string ExtractedPath, string Version)?> DownloadWifiFirmwareAsync(
         string destinationDirectory,
         IProgress<int>? progress = null,

--- a/src/Daqifi.Core/Firmware/IFirmwareDownloadService.cs
+++ b/src/Daqifi.Core/Firmware/IFirmwareDownloadService.cs
@@ -67,6 +67,14 @@ public interface IFirmwareDownloadService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the latest WiFi firmware release information without downloading.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The latest WiFi release info, or null if none found.</returns>
+    Task<FirmwareReleaseInfo?> GetLatestWifiReleaseAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Invalidates the cached release data, forcing the next call to query the API.
     /// </summary>
     void InvalidateCache();

--- a/src/Daqifi.Core/Firmware/ILanChipInfoProvider.cs
+++ b/src/Daqifi.Core/Firmware/ILanChipInfoProvider.cs
@@ -1,0 +1,19 @@
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// Optional capability for querying the WiFi LAN chip information from a device.
+/// Implement this interface on a device class to enable WiFi firmware version checks
+/// before flashing.
+/// </summary>
+public interface ILanChipInfoProvider
+{
+    /// <summary>
+    /// Queries the device for its current WiFi module chip information.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The parsed <see cref="LanChipInfo"/>, or <see langword="null"/> if the device
+    /// did not return a recognizable response.
+    /// </returns>
+    Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Daqifi.Core/Firmware/LanChipInfo.cs
+++ b/src/Daqifi.Core/Firmware/LanChipInfo.cs
@@ -1,0 +1,22 @@
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// WiFi LAN chip information returned by the <c>SYSTem:COMMunicate:LAN:GETChipInfo?</c> SCPI query.
+/// </summary>
+public sealed record LanChipInfo
+{
+    /// <summary>
+    /// Gets the chip hardware identifier.
+    /// </summary>
+    public required int ChipId { get; init; }
+
+    /// <summary>
+    /// Gets the WiFi module firmware version string (e.g. "19.5.4").
+    /// </summary>
+    public required string FwVersion { get; init; }
+
+    /// <summary>
+    /// Gets the firmware build date string.
+    /// </summary>
+    public required string BuildDate { get; init; }
+}

--- a/src/Daqifi.Core/Firmware/LanChipInfoParser.cs
+++ b/src/Daqifi.Core/Firmware/LanChipInfoParser.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// Parses the JSON response from the <c>SYSTem:COMMunicate:LAN:GETChipInfo?</c> SCPI command.
+/// </summary>
+public static class LanChipInfoParser
+{
+    /// <summary>
+    /// Attempts to parse a single JSON response string into a <see cref="LanChipInfo"/>.
+    /// </summary>
+    /// <param name="json">The JSON string to parse, e.g. <c>{"ChipId":1234,"FwVersion":"19.5.4","BuildDate":"Jan  8 2019"}</c>.</param>
+    /// <param name="result">The parsed chip info, or <see langword="null"/> if parsing failed.</param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(string? json, [NotNullWhen(true)] out LanChipInfo? result)
+    {
+        result = null;
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("FwVersion", out var fwVersionProp))
+            {
+                return false;
+            }
+
+            var fwVersion = fwVersionProp.GetString();
+            if (string.IsNullOrEmpty(fwVersion))
+            {
+                return false;
+            }
+
+            var chipId = root.TryGetProperty("ChipId", out var chipIdProp) &&
+                         chipIdProp.ValueKind == JsonValueKind.Number
+                ? chipIdProp.GetInt32()
+                : 0;
+
+            var buildDate = root.TryGetProperty("BuildDate", out var buildDateProp)
+                ? buildDateProp.GetString() ?? string.Empty
+                : string.Empty;
+
+            result = new LanChipInfo
+            {
+                ChipId = chipId,
+                FwVersion = fwVersion,
+                BuildDate = buildDate
+            };
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to parse <see cref="LanChipInfo"/> from a sequence of text response lines,
+    /// trying each non-empty line in order until one succeeds.
+    /// </summary>
+    /// <param name="lines">Response lines from the device.</param>
+    /// <param name="result">The parsed chip info, or <see langword="null"/> if no line could be parsed.</param>
+    /// <returns><see langword="true"/> if any line was successfully parsed; otherwise <see langword="false"/>.</returns>
+    public static bool TryParseLines(IEnumerable<string> lines, [NotNullWhen(true)] out LanChipInfo? result)
+    {
+        result = null;
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (TryParse(line, out result))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Implements [#139](https://github.com/daqifi/daqifi-core/issues/139).

- **`GetLanChipInfo` SCPI command** — added to `ScpiMessageProducer` (`SYSTem:COMMunicate:LAN:GETChipInfo?`)
- **`LanChipInfo` record + `LanChipInfoParser`** — parses the JSON response `{"ChipId":<id>,"FwVersion":"<version>","BuildDate":"<date>"}` from the device; `FwVersion` is required, others default gracefully
- **`ILanChipInfoProvider` interface** — optional-capability pattern so `FirmwareUpdateService` can cast `device is ILanChipInfoProvider` without changing `IStreamingDevice`
- **`DaqifiStreamingDevice.GetLanChipInfoAsync`** — sends the SCPI command via `ExecuteTextCommandAsync`, parses the response lines
- **`IFirmwareDownloadService.GetLatestWifiReleaseAsync`** — metadata-only query (no download) to get the latest WiFi firmware tag from GitHub
- **`FirmwareUpdateService` version check** — before flashing WiFi firmware, queries the device and compares versions; if device is already current, transitions directly to `Complete` and reports 100% progress (no unnecessary reflash)
- **11 new `LanChipInfoParser` tests** and **3 new `FirmwareUpdateService` tests** for the version-check behavior

Hardware-validated against a physical Nyquist 1 over serial (`ChipId: 1377184, FwVersion: 19.7.7, BuildDate: Mar 30 2022`).

## Test plan

- [x] All 847 existing tests pass (both net8.0 and net9.0)
- [x] 11 new `LanChipInfoParserTests` cover valid JSON, optional fields, malformed input, null/whitespace, and `TryParseLines`
- [x] 3 new `FirmwareUpdateServiceTests` cover: device already up to date (skips flash), device is older (proceeds), device doesn't support `ILanChipInfoProvider` (proceeds)
- [x] End-to-end validated on hardware via `daqifi-core-example-app --lan-chip-info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)