### PR TITLE
fix: re-enable LAN after stopping SD card logging

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -197,10 +197,11 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Equal(3, sentCommands.Count);
+            Assert.Equal(4, sentCommands.Count);
             Assert.Equal("SYSTem:StopStreamData", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 0", sentCommands[1]);
             Assert.Equal("SYSTem:STReam:INTerface 0", sentCommands[2]); // Restore USB
+            Assert.Equal("SYSTem:COMMunicate:LAN:ENAbled 1", sentCommands[3]); // Re-enable LAN
         }
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -205,6 +205,24 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task StopSdCardLoggingAsync_SendsStopCommandEvenWhenIsStreamingIsFalse()
+        {
+            // Arrange - simulate stale IsStreaming state (see issue #118)
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.Connect();
+            await device.StartSdCardLoggingAsync("test.bin");
+            device.StopStreaming(); // Sets IsStreaming = false
+            device.SentMessages.Clear();
+
+            // Act
+            await device.StopSdCardLoggingAsync();
+
+            // Assert - stop command should still be sent defensively
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:StopStreamData", sentCommands);
+        }
+
+        [Fact]
         public async Task StopSdCardLoggingAsync_SetsIsLoggingToFalse()
         {
             // Arrange

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -461,6 +461,10 @@ namespace Daqifi.Core.Device
                 Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.Usb));
             }
 
+            // Re-enable LAN interface. StartSdCardLoggingAsync disables LAN because
+            // the SD card and WiFi/LAN share the SPI bus on the hardware.
+            Send(ScpiMessageProducer.EnableNetworkLan);
+
             _isLoggingToSdCard = false;
 
             return Task.CompletedTask;

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -452,7 +452,10 @@ namespace Daqifi.Core.Device
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            StopStreaming();
+            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
+            Send(ScpiMessageProducer.StopStreaming);
+            IsStreaming = false;
+
             Send(ScpiMessageProducer.DisableStorageSd);
 
             // Restore stream interface to USB so subsequent non-SD operations work.


### PR DESCRIPTION
## Summary

- `StopSdCardLoggingAsync()` never re-enabled the LAN interface after stopping SD card logging. `StartSdCardLoggingAsync()` disables LAN because the SD card and WiFi share the SPI bus, but the stop method only disabled SD storage and restored the stream interface to USB — it never sent `SYSTem:COMMunicate:LAN:ENAbled 1`.
- This left WiFi/LAN silently disabled after every SD logging session. Every other SD operation (`GetSdCardFilesAsync`, `DeleteSdCardFileAsync`, `DownloadSdCardFileAsync`) correctly restored LAN via `PrepareLanInterface()` in their `finally` blocks.
- The existing test `StopSdCardLoggingAsync_SendsCorrectCommands` asserted only 3 commands (matching the buggy behavior). Updated to assert 4 commands including the LAN re-enable.

## Test plan

- [x] All 195 SD card tests pass on both net8.0 and net9.0
- [ ] Manual test: connect over serial, start SD logging, stop SD logging, verify device is reachable over WiFi

🤖 Generated with [Claude Code](https://claude.com/claude-code)