### PR TITLE
fix: correct EnableAdcChannels docs from binary to decimal bitmask

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ device.MessageReceived += (sender, e) =>
 };
 
 // Configure channels and start streaming
-device.Send(ScpiMessageProducer.EnableAdcChannels("0000000011")); // Enable first 2 channels
+device.Send(ScpiMessageProducer.EnableAdcChannels("3")); // Enable first 2 channels (bitmask 0b11 = 3)
 device.Send(ScpiMessageProducer.StartStreaming(100)); // 100 Hz sample rate
 
 await Task.Delay(TimeSpan.FromSeconds(10)); // Stream for 10 seconds

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -28,7 +28,7 @@ device.MessageReceived += (sender, e) =>
 };
 
 // Configure channels and start streaming
-device.Send(ScpiMessageProducer.EnableAdcChannels("0000000011")); // Enable first 2 channels
+device.Send(ScpiMessageProducer.EnableAdcChannels("3")); // Enable first 2 channels (bitmask 0b11 = 3)
 device.Send(ScpiMessageProducer.StartStreaming(100)); // 100 Hz sample rate
 
 await Task.Delay(TimeSpan.FromSeconds(10)); // Stream for 10 seconds
@@ -226,8 +226,8 @@ device.MessageReceived += (sender, e) =>
     }
 };
 
-// Enable channels (binary mask: 1 = enabled)
-device.Send(ScpiMessageProducer.EnableAdcChannels("0000000011")); // Channels 0 and 1
+// Enable channels (decimal bitmask: each bit enables a channel)
+device.Send(ScpiMessageProducer.EnableAdcChannels("3")); // Channels 0 and 1 (bitmask 0b11 = 3)
 
 // Start streaming at 100 Hz
 device.Send(ScpiMessageProducer.StartStreaming(100));
@@ -255,7 +255,7 @@ device.Send(ScpiMessageProducer.StartStreaming(1000));  // Start at 1000 Hz
 device.Send(ScpiMessageProducer.StopStreaming);
 
 // Channel configuration
-device.Send(ScpiMessageProducer.EnableAdcChannels("11111111")); // Enable 8 channels
+device.Send(ScpiMessageProducer.EnableAdcChannels("255")); // Enable 8 channels (bitmask 0xFF = 255)
 device.Send(ScpiMessageProducer.DisableDeviceEcho);
 device.Send(ScpiMessageProducer.SetProtobufStreamFormat);
 ```

--- a/docs/simulator/GITHUB_ISSUES.md
+++ b/docs/simulator/GITHUB_ISSUES.md
@@ -261,7 +261,7 @@ Implement TCP server for data connections and SCPI command processing, enabling 
   - `SYSTem:ECHO <-1|1>`
   - `SYSTem:StartStreamData <freq>`
   - `SYSTem:StopStreamData`
-  - `ENAble:VOLTage:DC <binary_string>`
+  - `ENAble:VOLTage:DC <decimal_bitmask>`
 - [ ] Integrate TCP server with `DeviceSimulator.StartAsync()`
 - [ ] Write integration tests with `DaqifiDevice` and `TcpStreamTransport`
 
@@ -279,7 +279,7 @@ Implement TCP server for data connections and SCPI command processing, enabling 
 
 **Example**:
 ```
-Client: "ENAble:VOLTage:DC 0000000011\r\n"
+Client: "ENAble:VOLTage:DC 3\r\n"
 Server: (no response)
 
 Client: "SYSTem:SYSInfoPB?\r\n"

--- a/docs/simulator/SIMULATOR_DESIGN.md
+++ b/docs/simulator/SIMULATOR_DESIGN.md
@@ -151,7 +151,7 @@ SYSTem:STReam:FORmat <0|1|2>
 SYSTem:STReam:FORmat?
 
 # Configuration
-ENAble:VOLTage:DC <binary_string>
+ENAble:VOLTage:DC <decimal_bitmask>
 
 # Digital I/O
 DIO:PORt:DIRection <ch>,<dir>
@@ -282,7 +282,7 @@ Length-delimited DaqifiOutMessage containing:
 
 **Example Exchange**:
 ```
-Client -> Server: "ENAble:VOLTage:DC 0000000011\r\n"
+Client -> Server: "ENAble:VOLTage:DC 3\r\n"
 Server -> Client: (no response)
 
 Client -> Server: "SYSTem:StartStreamData 100\r\n"
@@ -412,7 +412,7 @@ public async Task CanConnectAndStreamData()
     device.Connect();
 
     // Configure channels
-    device.Send(ScpiMessageProducer.EnableAnalogChannels("0000000011"));
+    device.Send(ScpiMessageProducer.EnableAdcChannels("3")); // 0b11 = channels 0,1
 
     // Start streaming
     var messagesReceived = new List<DaqifiOutMessage>();

--- a/docs/simulator/SIMULATOR_IMPLEMENTATION_PLAN.md
+++ b/docs/simulator/SIMULATOR_IMPLEMENTATION_PLAN.md
@@ -583,8 +583,8 @@ internal class ScpiCommandProcessor
         // Channel configuration
         else if (command.StartsWith("enable:voltage:dc "))
         {
-            var binaryString = command.Split(' ')[1];
-            var mask = Convert.ToUInt32(binaryString, 2);
+            var maskString = command.Split(' ')[1];
+            var mask = Convert.ToUInt32(maskString);
             _device.SetChannelMask(mask);
             return null;
         }

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -151,8 +151,8 @@ public class ScpiMessageProducerTests
     [Fact]
     public void EnableAdcChannels_ReturnsCorrectCommand()
     {
-        var message = ScpiMessageProducer.EnableAdcChannels("0001010100");
-        Assert.Equal("ENAble:VOLTage:DC 0001010100", message.Data);
+        var message = ScpiMessageProducer.EnableAdcChannels("84");
+        Assert.Equal("ENAble:VOLTage:DC 84", message.Data);
         AssertMessageFormat(message);
     }
 

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -316,24 +316,23 @@ public class ScpiMessageProducer
     public static IOutboundMessage<string> GetStreamFormat => new ScpiMessage("SYSTem:STReam:FORmat?");
 
     /// <summary>
-    /// Creates a command message to enable ADC channels using a binary string.
+    /// Creates a command message to enable ADC channels using a decimal bitmask.
     /// </summary>
-    /// <param name="channelSetString">A binary string where each character represents a channel (0 = disabled, 1 = enabled), right-to-left. For example, "0001010100" enables channels 2, 4, and 6.</param>
+    /// <param name="channelSetString">A decimal integer string representing a bitmask where each bit enables a channel. For example, "84" (0b1010100) enables channels 2, 4, and 6.</param>
     /// <remarks>
-    /// The binary string is read from right to left, where position 0 is the rightmost bit:
-    /// - Position 0: Channel 0
-    /// - Position 1: Channel 1
-    /// - Position 2: Channel 2
+    /// The firmware parses this value as a decimal integer and interprets it as a bitmask:
+    /// - Bit 0 (value 1): Channel 0
+    /// - Bit 1 (value 2): Channel 1
+    /// - Bit 2 (value 4): Channel 2
     /// etc.
-    /// 
-    /// Command: ENAble:VOLTage:DC binaryString
-    /// Example: 
+    ///
+    /// Command: ENAble:VOLTage:DC decimalMask
     /// <code>
-    /// // Enable channels 2, 4, and 6
-    /// messageProducer.Send(ScpiMessageProducer.EnableAdcChannels("0001010100"));
-    /// 
-    /// // Enable channels 0 and 1
-    /// messageProducer.Send(ScpiMessageProducer.EnableAdcChannels("0000000011"));
+    /// // Enable channels 2, 4, and 6 (bitmask = 4 + 16 + 64 = 84)
+    /// device.Send(ScpiMessageProducer.EnableAdcChannels("84"));
+    ///
+    /// // Enable channels 0 and 1 (bitmask = 1 + 2 = 3)
+    /// device.Send(ScpiMessageProducer.EnableAdcChannels("3"));
     /// </code>
     /// </remarks>
     public static IOutboundMessage<string> EnableAdcChannels(string channelSetString)

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -366,7 +366,8 @@ namespace Daqifi.Core.Device
         /// (.bin for Protobuf, .json for JSON, .dat for TestData).
         /// </param>
         /// <param name="channelMask">
-        /// Optional binary string mask to enable specific ADC channels (e.g. "0000000011" enables channels 0 and 1).
+        /// Optional decimal bitmask string to enable specific ADC channels (e.g. "3" enables channels 0 and 1).
+        /// The firmware parses this as a decimal integer where each bit enables a channel.
         /// If null or empty, the current device channel configuration is used.
         /// </param>
         /// <param name="format">The logging format to use. Defaults to <see cref="SdCardLogFormat.Protobuf"/>.</param>

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -40,7 +40,8 @@ namespace Daqifi.Core.Device.SdCard
         /// (.bin for Protobuf, .json for JSON, .dat for TestData).
         /// </param>
         /// <param name="channelMask">
-        /// Optional binary string mask to enable specific ADC channels (e.g. "0000000011" enables channels 0 and 1).
+        /// Optional decimal bitmask string to enable specific ADC channels (e.g. "3" enables channels 0 and 1).
+        /// The firmware parses this as a decimal integer where each bit enables a channel.
         /// If null or empty, the current device channel configuration is used.
         /// </param>
         /// <param name="format">The logging format to use. Defaults to <see cref="SdCardLogFormat.Protobuf"/>.</param>


### PR DESCRIPTION
## Summary

- The firmware's `SCPI_ADCChanEnableSet` parses the `ENAble:VOLTage:DC` parameter as a **decimal integer** via `SCPI_ParamInt32`, but the `EnableAdcChannels` XML docs, README, and DEVICE_INTERFACES.md all showed binary strings like `"0000000011"`.
- This mismatch meant callers following the documented examples would send the wrong channel configuration (e.g. firmware parses `"11"` as decimal 11 = channels 0,1,3 instead of intended channels 0,1).
- Updated all docs and the test to use correct decimal bitmask values (e.g. `"3"` for channels 0+1, `"84"` for channels 2,4,6).

Related: daqifi/daqifi-desktop#439

**Note:** The `daqifi-core-example-app` also has this issue — its `IsValidChannelMask()` validates for binary strings and `--channels` help text likely shows binary format. That's a separate repo and should be fixed separately.

## Test plan

- [x] All 818 core tests pass on both net8.0 and net9.0
- [ ] Manual test: use example app with `--channels 3` to enable channels 0+1

🤖 Generated with [Claude Code](https://claude.com/claude-code)