### PR TITLE
fix: prevent spurious Lost status during intentional disconnect

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceWithTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceWithTransportTests.cs
@@ -189,7 +189,29 @@ public class DaqifiDeviceWithTransportTests
         Assert.Contains("SYSTem:SYSInfoPB?", streamContent);
     }
 
-    [Fact] 
+    [Fact]
+    public void DaqifiDevice_Disconnect_ShouldNotReportLostStatus()
+    {
+        // Arrange
+        using var transport = new MockStreamTransport();
+        using var device = new DaqifiDevice("Mock Device", transport);
+
+        device.Connect();
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+
+        var statusChanges = new List<ConnectionStatus>();
+        device.StatusChanged += (sender, args) => statusChanges.Add(args.Status);
+
+        // Act - Intentional disconnect
+        device.Disconnect();
+
+        // Assert - Should go straight to Disconnected, never Lost
+        Assert.DoesNotContain(ConnectionStatus.Lost, statusChanges);
+        Assert.Contains(ConnectionStatus.Disconnected, statusChanges);
+        Assert.Equal(ConnectionStatus.Disconnected, device.Status);
+    }
+
+    [Fact]
     public void DaqifiDevice_TransportConnectionLost_ShouldUpdateStatus()
     {
         // Arrange

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -76,6 +76,7 @@ namespace Daqifi.Core.Device
 
         private IProtocolHandler? _protocolHandler;
         private bool _disposed;
+        private bool _isDisconnecting;
         private bool _isInitialized;
         private readonly List<IChannel> _channels = new();
         
@@ -198,6 +199,7 @@ namespace Daqifi.Core.Device
         /// </summary>
         public void Disconnect()
         {
+            _isDisconnecting = true;
             try
             {
                 // Unsubscribe from message consumer events
@@ -218,6 +220,7 @@ namespace Daqifi.Core.Device
                 Status = ConnectionStatus.Disconnected;
                 State = DeviceState.Disconnected;
                 _isInitialized = false;
+                _isDisconnecting = false;
             }
         }
 
@@ -489,8 +492,9 @@ namespace Daqifi.Core.Device
             }
             else
             {
-                // Transport disconnected, update device status
-                if (Status == ConnectionStatus.Connected)
+                // Transport disconnected — only report Lost for unexpected drops,
+                // not during an intentional Disconnect() call
+                if (Status == ConnectionStatus.Connected && !_isDisconnecting)
                 {
                     Status = ConnectionStatus.Lost;
                 }


### PR DESCRIPTION
## Summary
- Adds `_isDisconnecting` flag to `DaqifiDevice` to distinguish intentional disconnects from unexpected transport drops
- Prevents the spurious `Connected → Lost → Disconnected` transition when calling `Disconnect()` — now goes straight to `Disconnected`
- Unexpected transport losses still correctly report `Lost` status

Closes #161

## Test plan
- [x] New test `DaqifiDevice_Disconnect_ShouldNotReportLostStatus` verifies no `Lost` status during intentional disconnect
- [x] Existing test `DaqifiDevice_TransportConnectionLost_ShouldUpdateStatus` still passes for unexpected drops
- [x] All 9 transport tests pass on both net8.0 and net9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)