### PR TITLE
fix: resolve all compilation warnings for clean build

### DIFF
--- a/src/Daqifi.Core.Tests/Channel/AnalogChannelTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/AnalogChannelTests.cs
@@ -140,7 +140,7 @@ public class AnalogChannelTests
     }
 
     [Fact]
-    public void SetActiveSample_IsThreadSafe()
+    public async Task SetActiveSample_IsThreadSafe()
     {
         // Arrange
         var channel = new AnalogChannel(0);
@@ -153,7 +153,7 @@ public class AnalogChannelTests
             tasks.Add(Task.Run(() => channel.SetActiveSample(value, DateTime.UtcNow)));
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks.ToArray());
 
         // Assert
         Assert.NotNull(channel.ActiveSample);

--- a/src/Daqifi.Core.Tests/Channel/DigitalChannelTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/DigitalChannelTests.cs
@@ -120,7 +120,7 @@ public class DigitalChannelTests
     }
 
     [Fact]
-    public void SetActiveSample_IsThreadSafe()
+    public async Task SetActiveSample_IsThreadSafe()
     {
         // Arrange
         var channel = new DigitalChannel(0);
@@ -133,7 +133,7 @@ public class DigitalChannelTests
             tasks.Add(Task.Run(() => channel.SetActiveSample(value, DateTime.UtcNow)));
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks.ToArray());
 
         // Assert
         Assert.NotNull(channel.ActiveSample);

--- a/src/Daqifi.Core.Tests/Communication/Transport/UdpTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/UdpTransportTests.cs
@@ -2,6 +2,7 @@ using Daqifi.Core.Communication.Transport;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Daqifi.Core.Tests.Communication.Transport;
 
@@ -188,11 +189,11 @@ public class UdpTransportTests
     }
 
     [Fact]
-    public void Dispose_ShouldCloseTransport()
+    public async Task Dispose_ShouldCloseTransport()
     {
         // Arrange
         var transport = new UdpTransport(0);
-        transport.OpenAsync().Wait();
+        await transport.OpenAsync();
 
         // Act
         transport.Dispose();
@@ -202,7 +203,7 @@ public class UdpTransportTests
     }
 
     [Fact]
-    public void ConnectionInfo_ShouldReflectStatus()
+    public async Task ConnectionInfo_ShouldReflectStatus()
     {
         // Arrange - use dynamic port to avoid conflicts in parallel test runs
         using var transport = new UdpTransport(0);
@@ -210,7 +211,7 @@ public class UdpTransportTests
         // Act & Assert
         Assert.Contains("Closed", transport.ConnectionInfo);
 
-        transport.OpenAsync().Wait();
+        await transport.OpenAsync();
         Assert.Contains("Open", transport.ConnectionInfo);
     }
 }

--- a/src/Daqifi.Core.Tests/Device/DeviceTypeDetectorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceTypeDetectorTests.cs
@@ -31,7 +31,7 @@ public class DeviceTypeDetectorTests
     [InlineData("")]
     [InlineData(" ")]
     [InlineData(null)]
-    public void DetectFromPartNumber_EmptyOrNull_ReturnsUnknown(string partNumber)
+    public void DetectFromPartNumber_EmptyOrNull_ReturnsUnknown(string? partNumber)
     {
         // Act
         var result = DeviceTypeDetector.DetectFromPartNumber(partNumber);

--- a/src/Daqifi.Core.Tests/Device/Protocol/ProtobufProtocolHandlerTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Protocol/ProtobufProtocolHandlerTests.cs
@@ -38,11 +38,11 @@ public class ProtobufProtocolHandlerTests
     }
 
     [Fact]
-    public async void HandleAsync_WithStatusMessage_CallsStatusHandler()
+    public async Task HandleAsync_WithStatusMessage_CallsStatusHandler()
     {
         // Arrange
         var statusHandlerCalled = false;
-        DaqifiOutMessage receivedMessage = null;
+        DaqifiOutMessage? receivedMessage = null;
 
         var handler = new ProtobufProtocolHandler(
             statusMessageHandler: msg =>
@@ -69,11 +69,11 @@ public class ProtobufProtocolHandlerTests
     }
 
     [Fact]
-    public async void HandleAsync_WithStreamMessage_CallsStreamHandler()
+    public async Task HandleAsync_WithStreamMessage_CallsStreamHandler()
     {
         // Arrange
         var streamHandlerCalled = false;
-        DaqifiOutMessage receivedMessage = null;
+        DaqifiOutMessage? receivedMessage = null;
 
         var handler = new ProtobufProtocolHandler(
             streamMessageHandler: msg =>
@@ -102,7 +102,7 @@ public class ProtobufProtocolHandlerTests
     }
 
     [Fact]
-    public async void HandleAsync_WithNonProtobufMessage_DoesNotCallHandlers()
+    public async Task HandleAsync_WithNonProtobufMessage_DoesNotCallHandlers()
     {
         // Arrange
         var statusHandlerCalled = false;
@@ -127,7 +127,7 @@ public class ProtobufProtocolHandlerTests
     {
         // Arrange - USB firmware sends pre-scaled float values (AnalogInDataFloat)
         var streamHandlerCalled = false;
-        DaqifiOutMessage receivedMessage = null;
+        DaqifiOutMessage? receivedMessage = null;
 
         var handler = new ProtobufProtocolHandler(
             streamMessageHandler: msg =>

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
@@ -180,8 +180,8 @@ public sealed class SdCardCsvFileParserTests
         Assert.Single(samples);
         Assert.NotNull(samples[0].AnalogTimestamps);
         Assert.Equal(2, samples[0].AnalogTimestamps!.Count);
-        Assert.Equal(1000u, samples[0].AnalogTimestamps[0]);
-        Assert.Equal(1001u, samples[0].AnalogTimestamps[1]);
+        Assert.Equal(1000u, samples[0].AnalogTimestamps![0]);
+        Assert.Equal(1001u, samples[0].AnalogTimestamps![1]);
     }
 
     [Fact]
@@ -201,9 +201,9 @@ public sealed class SdCardCsvFileParserTests
         Assert.NotNull(samples[0].AnalogTimestamps);
         Assert.Equal(3, samples[0].AnalogTimestamps!.Count);
         // All channels share the same timestamp in shared-ts mode
-        Assert.Equal(1746522255u, samples[0].AnalogTimestamps[0]);
-        Assert.Equal(1746522255u, samples[0].AnalogTimestamps[1]);
-        Assert.Equal(1746522255u, samples[0].AnalogTimestamps[2]);
+        Assert.Equal(1746522255u, samples[0].AnalogTimestamps![0]);
+        Assert.Equal(1746522255u, samples[0].AnalogTimestamps![1]);
+        Assert.Equal(1746522255u, samples[0].AnalogTimestamps![2]);
     }
 
     // -------------------------------------------------------------------------
@@ -443,7 +443,7 @@ public sealed class SdCardCsvFileParserTests
             "TestDevice", "SN001", 100u, rows);
 
         var progressCalls = 0;
-        var lastProgress = default(global::Daqifi.Core.Device.SdCard.SdCardParseProgress);
+        global::Daqifi.Core.Device.SdCard.SdCardParseProgress? lastProgress = null;
         var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
         var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
         {
@@ -459,7 +459,8 @@ public sealed class SdCardCsvFileParserTests
 
         Assert.Equal(250, samples.Count);
         Assert.True(progressCalls >= 2, $"Expected ≥2 progress callbacks, got {progressCalls}");
-        Assert.Equal(250, lastProgress.MessagesRead);
+        Assert.NotNull(lastProgress);
+        Assert.Equal(250, lastProgress!.MessagesRead);
         Assert.True(lastProgress.BytesRead > 0);
     }
 

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
@@ -253,7 +253,7 @@ public sealed class SdCardJsonFileParserTests
         );
 
         var progressCalls = 0;
-        var lastProgress = default(global::Daqifi.Core.Device.SdCard.SdCardParseProgress);
+        global::Daqifi.Core.Device.SdCard.SdCardParseProgress? lastProgress = null;
         var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
         var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
         {
@@ -273,7 +273,8 @@ public sealed class SdCardJsonFileParserTests
         // Assert
         Assert.Equal(250, samples.Count);
         Assert.True(progressCalls >= 2);  // At least 2 progress updates (100-line batches + final)
-        Assert.Equal(250, lastProgress.MessagesRead);
+        Assert.NotNull(lastProgress);
+        Assert.Equal(250, lastProgress!.MessagesRead);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/TimestampProcessorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/TimestampProcessorTests.cs
@@ -330,7 +330,7 @@ public class TimestampProcessorTests
     #region Thread Safety Tests
 
     [Fact]
-    public void ProcessTimestamp_IsThreadSafe()
+    public async Task ProcessTimestamp_IsThreadSafe()
     {
         // Arrange
         var processor = new TimestampProcessor();
@@ -348,15 +348,15 @@ public class TimestampProcessorTests
             }));
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks.ToArray());
 
         // Assert - All tasks completed without exception
         Assert.Equal(100, results.Count);
-        Assert.Single(results.Where(r => r.IsFirstMessage)); // Only one first message
+        Assert.Single(results, r => r.IsFirstMessage); // Only one first message
     }
 
     [Fact]
-    public void ProcessTimestamp_MultipleDevicesInParallel_IsThreadSafe()
+    public async Task ProcessTimestamp_MultipleDevicesInParallel_IsThreadSafe()
     {
         // Arrange
         var processor = new TimestampProcessor();
@@ -384,7 +384,7 @@ public class TimestampProcessorTests
             }
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks.ToArray());
 
         // Assert - All devices have 10 results
         Assert.Equal(10, results.Count);

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -125,7 +125,7 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                 var tempBuffer = new byte[_buffer.Length];
                 while (networkStream.DataAvailable)
                 {
-                    _stream.Read(tempBuffer, 0, tempBuffer.Length);
+                    _ = _stream.Read(tempBuffer, 0, tempBuffer.Length);
                 }
             }
         }

--- a/src/Daqifi.Core/Device/DeviceTypeDetector.cs
+++ b/src/Daqifi.Core/Device/DeviceTypeDetector.cs
@@ -10,7 +10,7 @@ public static class DeviceTypeDetector
     /// </summary>
     /// <param name="partNumber">The device part number (e.g., "Nq1", "Nq2", "Nq3").</param>
     /// <returns>The detected DeviceType, or DeviceType.Unknown if not recognized.</returns>
-    public static DeviceType DetectFromPartNumber(string partNumber)
+    public static DeviceType DetectFromPartNumber(string? partNumber)
     {
         if (string.IsNullOrWhiteSpace(partNumber))
         {


### PR DESCRIPTION
## Summary
- Fixes all 21 unique compilation warning locations (42 total across net8.0/net9.0 TFMs) to achieve a zero-warning build
- Production code: fixed CA2022 inexact `Stream.Read` in `StreamMessageConsumer` and made `DeviceTypeDetector.DetectFromPartNumber` accept nullable string to match its actual contract
- Test code: converted `async void` → `async Task`, `Task.WaitAll` → `await Task.WhenAll`, added nullable annotations, and used `Assert.Single` predicate overload

## Test plan
- [x] `dotnet build` produces 0 warnings, 0 errors
- [x] All 820 tests pass on both net8.0 and net9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)