### PR TITLE
refactor(scpi)!: update producers for firmware SCPI breaking renames

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -77,14 +77,6 @@ public class ScpiMessageProducerTests
     }
 
     [Fact]
-    public void GetSdLoggingState_ReturnsCorrectCommand()
-    {
-        var message = ScpiMessageProducer.GetSdLoggingState;
-        Assert.Equal("SYSTem:STORage:SD:LOGging?", message.Data);
-        AssertMessageFormat(message);
-    }
-
-    [Fact]
     public void GetSdFileList_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.GetSdFileList;
@@ -104,7 +96,7 @@ public class ScpiMessageProducerTests
     public void SetSdLoggingFileName_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.SetSdLoggingFileName("log.bin");
-        Assert.Equal("SYSTem:STORage:SD:LOGging \"log.bin\"", message.Data);
+        Assert.Equal("SYSTem:STORage:SD:FILE \"log.bin\"", message.Data);
         AssertMessageFormat(message);
     }
 
@@ -112,7 +104,7 @@ public class ScpiMessageProducerTests
     public void StartStreaming_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.StartStreaming(100);
-        Assert.Equal("SYSTem:StartStreamData 100", message.Data);
+        Assert.Equal("SYSTem:STReam:START 100", message.Data);
         AssertMessageFormat(message);
     }
 
@@ -120,7 +112,7 @@ public class ScpiMessageProducerTests
     public void StopStreaming_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.StopStreaming;
-        Assert.Equal("SYSTem:StopStreamData", message.Data);
+        Assert.Equal("SYSTem:STReam:STOP", message.Data);
         AssertMessageFormat(message);
     }
 
@@ -280,7 +272,7 @@ public class ScpiMessageProducerTests
     public void SetUsbTransparencyMode_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.SetUsbTransparencyMode(1);
-        Assert.Equal("SYSTem:USB:SetTransparentMode 1", message.Data);
+        Assert.Equal("SYSTem:USB:TRANSparent:MODE 1", message.Data);
         AssertMessageFormat(message);
     }
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -28,7 +28,7 @@ namespace Daqifi.Core.Tests.Device
             var sentData = device.DirectSentMessages.Select(m => m.Data).ToList();
 
             Assert.Contains(sentData, d => d.Contains("SYSTem:ECHO -1"));
-            Assert.Contains(sentData, d => d.Contains("SYSTem:StopStreamData"));
+            Assert.Contains(sentData, d => d.Contains("SYSTem:STReam:STOP"));
             Assert.Contains(sentData, d => d.Contains("SYSTem:POWer:STATe 1"));
             Assert.Contains(sentData, d => d.Contains("SYSTem:STReam:FORmat 0"));
             Assert.Contains(sentData, d => d.Contains("SYSTem:SYSInfoPB?"));

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -117,9 +117,9 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal("SYSTem:COMMunicate:LAN:ENAbled 0", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 1", sentCommands[1]);
             Assert.Equal("SYSTem:STReam:INTerface 2", sentCommands[2]);
-            Assert.Equal("SYSTem:STORage:SD:LOGging \"mylog.bin\"", sentCommands[3]);
+            Assert.Equal("SYSTem:STORage:SD:FILE \"mylog.bin\"", sentCommands[3]);
             Assert.Equal("SYSTem:STReam:FORmat 0", sentCommands[4]);
-            Assert.Equal("SYSTem:StartStreamData 100", sentCommands[5]);
+            Assert.Equal("SYSTem:STReam:START 100", sentCommands[5]);
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Contains("SYSTem:STORage:SD:LOGging \"custom_data.bin\"", sentCommands);
+            Assert.Contains("SYSTem:STORage:SD:FILE \"custom_data.bin\"", sentCommands);
         }
 
         [Fact]
@@ -162,7 +162,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
             Assert.Contains(".bin", loggingCommand);
@@ -198,7 +198,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
             Assert.Equal(4, sentCommands.Count);
-            Assert.Equal("SYSTem:StopStreamData", sentCommands[0]);
+            Assert.Equal("SYSTem:STReam:STOP", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 0", sentCommands[1]);
             Assert.Equal("SYSTem:STReam:INTerface 0", sentCommands[2]); // Restore USB
             Assert.Equal("SYSTem:COMMunicate:LAN:ENAbled 1", sentCommands[3]); // Re-enable LAN
@@ -219,7 +219,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert - stop command should still be sent defensively
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Contains("SYSTem:StopStreamData", sentCommands);
+            Assert.Contains("SYSTem:STReam:STOP", sentCommands);
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
         }
@@ -287,7 +287,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
         }
@@ -324,9 +324,9 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal("SYSTem:COMMunicate:LAN:ENAbled 0", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 1", sentCommands[1]);
             Assert.Equal("SYSTem:STReam:INTerface 2", sentCommands[2]);
-            Assert.Equal("SYSTem:STORage:SD:LOGging \"mylog.json\"", sentCommands[3]);
+            Assert.Equal("SYSTem:STORage:SD:FILE \"mylog.json\"", sentCommands[3]);
             Assert.Equal("SYSTem:STReam:FORmat 1", sentCommands[4]);
-            Assert.Equal("SYSTem:StartStreamData 100", sentCommands[5]);
+            Assert.Equal("SYSTem:STReam:START 100", sentCommands[5]);
         }
 
         [Fact]
@@ -345,9 +345,9 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal("SYSTem:COMMunicate:LAN:ENAbled 0", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 1", sentCommands[1]);
             Assert.Equal("SYSTem:STReam:INTerface 2", sentCommands[2]);
-            Assert.Equal("SYSTem:STORage:SD:LOGging \"mylog.csv\"", sentCommands[3]);
+            Assert.Equal("SYSTem:STORage:SD:FILE \"mylog.csv\"", sentCommands[3]);
             Assert.Equal("SYSTem:STReam:FORmat 2", sentCommands[4]);
-            Assert.Equal("SYSTem:StartStreamData 100", sentCommands[5]);
+            Assert.Equal("SYSTem:STReam:START 100", sentCommands[5]);
         }
 
         [Fact]
@@ -362,7 +362,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
             Assert.Contains(".json", loggingCommand);
@@ -381,7 +381,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
             Assert.Contains(".csv", loggingCommand);
@@ -615,7 +615,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
             // Assert — defensive stop is always sent first (issue #118)
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
             Assert.Equal(3, sentCommands.Count);
-            Assert.Equal("SYSTem:StopStreamData", sentCommands[0]);
+            Assert.Equal("SYSTem:STReam:STOP", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 1", sentCommands[1]);
             Assert.Equal("SYSTem:STORage:SD:FORmat", sentCommands[2]);
         }
@@ -660,7 +660,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert — stop command should still be sent defensively
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Contains("SYSTem:StopStreamData", sentCommands);
+            Assert.Contains("SYSTem:STReam:STOP", sentCommands);
         }
 
         [Fact]
@@ -677,7 +677,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert — stop command should still be sent defensively
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Contains("SYSTem:StopStreamData", sentCommands);
+            Assert.Contains("SYSTem:STReam:STOP", sentCommands);
         }
 
         [Fact]
@@ -696,7 +696,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert — stop command should still be sent defensively
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Contains("SYSTem:StopStreamData", sentCommands);
+            Assert.Contains("SYSTem:STReam:STOP", sentCommands);
         }
 
         [Fact]
@@ -712,7 +712,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert — stop command should still be sent defensively
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Contains("SYSTem:StopStreamData", sentCommands);
+            Assert.Contains("SYSTem:STReam:STOP", sentCommands);
         }
 
         #endregion
@@ -890,7 +890,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert — stop streaming command should be sent before the download commands
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Equal("SYSTem:StopStreamData", sentCommands[0]);
+            Assert.Equal("SYSTem:STReam:STOP", sentCommands[0]);
         }
 
         #endregion

--- a/src/Daqifi.Core.Tests/Integration/EndToEndTests.cs
+++ b/src/Daqifi.Core.Tests/Integration/EndToEndTests.cs
@@ -45,8 +45,8 @@ public class EndToEndTests
         var transportContent = mockTransport.GetWrittenContent();
         Assert.Contains("SYSTem:SYSInfoPB?", transportContent);
         Assert.Contains("SYSTem:REboot", transportContent);
-        Assert.Contains("SYSTem:StartStreamData 1000", transportContent);
-        Assert.Contains("SYSTem:StopStreamData", transportContent);
+        Assert.Contains("SYSTem:STReam:START 1000", transportContent);
+        Assert.Contains("SYSTem:STReam:STOP", transportContent);
     }
 
     [Fact]  

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -96,15 +96,6 @@ public class ScpiMessageProducer
     public static IOutboundMessage<string> DisableStorageSd => new ScpiMessage("SYSTem:STORage:SD:ENAble 0");
 
     /// <summary>
-    /// Creates a query message to get the current SD card logging state.
-    /// </summary>
-    /// <remarks>
-    /// Command: SYSTem:STORage:SD:LOGging?
-    /// Example: messageProducer.Send(ScpiMessageProducer.GetSdLoggingState);
-    /// </remarks>
-    public static IOutboundMessage<string> GetSdLoggingState => new ScpiMessage("SYSTem:STORage:SD:LOGging?");
-
-    /// <summary>
     /// Creates a query message to get the list of files on the SD card.
     /// </summary>
     /// <remarks>
@@ -132,12 +123,12 @@ public class ScpiMessageProducer
     /// <param name="fileName">The name of the file to create or append to. Must be enclosed in quotes.</param>
     /// <remarks>
     /// The specified file will be created if it doesn't exist, or appended to if it already exists.
-    /// Command: SYSTem:STORage:SD:LOGging "filename.bin"
+    /// Command: SYSTem:STORage:SD:FILE "filename.bin"
     /// Example: messageProducer.Send(ScpiMessageProducer.SetSdLoggingFileName("data.bin"));
     /// </remarks>
     public static IOutboundMessage<string> SetSdLoggingFileName(string fileName)
     {
-        return new ScpiMessage($"SYSTem:STORage:SD:LOGging \"{fileName}\"");
+        return new ScpiMessage($"SYSTem:STORage:SD:FILE \"{fileName}\"");
     }
 
     /// <summary>
@@ -255,22 +246,22 @@ public class ScpiMessageProducer
     /// <param name="frequency">The streaming frequency in Hz (1-1000).</param>
     /// <remarks>
     /// Starts streaming data from enabled channels at the specified frequency.
-    /// Command: SYSTem:StartStreamData frequency
+    /// Command: SYSTem:STReam:START frequency
     /// Example: messageProducer.Send(ScpiMessageProducer.StartStreaming(100)); // Stream at 100Hz
     /// </remarks>
     public static IOutboundMessage<string> StartStreaming(int frequency)
     {
-        return new ScpiMessage($"SYSTem:StartStreamData {frequency}");
+        return new ScpiMessage($"SYSTem:STReam:START {frequency}");
     }
 
     /// <summary>
     /// Creates a command message to stop data streaming.
     /// </summary>
     /// <remarks>
-    /// Command: SYSTem:StopStreamData
+    /// Command: SYSTem:STReam:STOP
     /// Example: messageProducer.Send(ScpiMessageProducer.StopStreaming);
     /// </remarks>
-    public static IOutboundMessage<string> StopStreaming => new ScpiMessage("SYSTem:StopStreamData");
+    public static IOutboundMessage<string> StopStreaming => new ScpiMessage("SYSTem:STReam:STOP");
 
     /// <summary>
     /// Creates a command message to set the stream format to Protocol Buffer.
@@ -494,11 +485,11 @@ public class ScpiMessageProducer
     /// </summary>
     /// <param name="mode">The transparency mode (0 = disabled, 1 = enabled).</param>
     /// <remarks>
-    /// Command: SYSTem:USB:SetTransparentMode mode
+    /// Command: SYSTem:USB:TRANSparent:MODE mode
     /// </remarks>
     public static IOutboundMessage<string> SetUsbTransparencyMode(int mode)
     {
-        return new ScpiMessage($"SYSTem:USB:SetTransparentMode {mode}");
+        return new ScpiMessage($"SYSTem:USB:TRANSparent:MODE {mode}");
     }
 
     /// <summary>


### PR DESCRIPTION
Coordinates with daqifi-nyquist-firmware #311. Groups the 4 SCPI renames that affect .NET consumers into one PR for clean version compatibility. Merge after firmware #324 lands.