### PR TITLE
fix: protobuf parser resyncs past leading garbage instead of stalling

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserTests.cs
@@ -105,6 +105,45 @@ public class ProtobufMessageParserTests
     }
 
     [Fact]
+    public void ProtobufMessageParser_ParseMessages_RecoversFromLeadingGarbage()
+    {
+        // Reproduces the real-world failure where boot-time garbage on the serial port
+        // (DTR pulse on Microchip USB-to-Serial chips, partial frames, etc.) leaves
+        // unrecognizable bytes at the head of the consumer buffer. When a valid streaming
+        // frame eventually arrives, the parser must skip past the garbage and parse the
+        // valid frame instead of stalling forever.
+        //
+        // With the original 3-retry cap, the parser exits after 3 failed attempts and
+        // never advances past the garbage; subsequent reads keep stacking bytes onto a
+        // buffer the parser refuses to drain.
+
+        // Arrange
+        var parser = new ProtobufMessageParser();
+
+        // 20 bytes of 0x00 — each is a valid but zero-length varint. The parser
+        // should advance one byte per attempt and ultimately reach the valid frame.
+        // This exposes the old 3-retry cap, which exited after only 3 advances and
+        // left the buffer perpetually clogged with garbage.
+        var junk = Enumerable.Repeat((byte)0x00, 20).ToArray();
+
+        // Length-prefixed valid frame.
+        using var stream = new MemoryStream();
+        new DaqifiOutMessage { MsgTimeStamp = 42 }.WriteDelimitedTo(stream);
+        var validFrame = stream.ToArray();
+
+        var data = junk.Concat(validFrame).ToArray();
+
+        // Act
+        var messages = parser.ParseMessages(data, out var consumedBytes).ToList();
+
+        // Assert — parser must skip the 20 junk bytes and recover the valid frame.
+        Assert.Single(messages);
+        var parsed = Assert.IsType<DaqifiOutMessage>(messages[0].Data);
+        Assert.Equal(42UL, parsed.MsgTimeStamp);
+        Assert.Equal(data.Length, consumedBytes);
+    }
+
+    [Fact]
     public void ProtobufMessageParser_ParseMessages_ReturnsCorrectMessageType()
     {
         // Arrange

--- a/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
@@ -66,8 +66,10 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
 
             try
             {
-                var payload = remainingData.Slice(prefixBytes, messageLength).ToArray();
-                var message = DaqifiOutMessage.Parser.ParseFrom(payload);
+                // ParseFrom(ReadOnlySpan) avoids the per-attempt byte[] copy, which matters
+                // because byte-by-byte resync over a garbage buffer can call this many times
+                // before finding (or failing to find) a valid frame.
+                var message = DaqifiOutMessage.Parser.ParseFrom(remainingData.Slice(prefixBytes, messageLength));
                 currentIndex += prefixBytes + messageLength;
                 consumedBytes = currentIndex;
                 messages.Add(new ProtobufMessage(message));

--- a/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
@@ -9,10 +9,9 @@ namespace Daqifi.Core.Communication.Consumers;
 /// </summary>
 public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
 {
-    private const int MaxRetryAttempts = 3;
     private const int MaxVarint32Bytes = 5;
     private const int MaxMessageSizeBytes = 1024 * 1024;
-    
+
     /// <summary>
     /// Parses raw data into protobuf messages.
     /// </summary>
@@ -28,9 +27,8 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
             return messages;
 
         var currentIndex = 0;
-        var retryCount = 0;
 
-        while (currentIndex < data.Length && retryCount < MaxRetryAttempts)
+        while (currentIndex < data.Length)
         {
             var remainingData = new ReadOnlySpan<byte>(data, currentIndex, data.Length - currentIndex);
 
@@ -38,34 +36,32 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
             {
                 if (prefixIsMalformed)
                 {
-                    currentIndex += Math.Max(prefixBytes, 1);
+                    // Skip this byte and resync; advancing by 1 (not by prefixBytes) is
+                    // important because the malformed run may overlap a valid frame that
+                    // starts mid-way through it.
+                    currentIndex++;
                     consumedBytes = currentIndex;
-                    retryCount++;
                     continue;
                 }
 
-                break; // Not enough data for length prefix yet.
+                break; // Not enough data for length prefix yet — wait for the next read.
             }
 
-            if (messageLength <= 0)
+            if (messageLength <= 0 || messageLength > MaxMessageSizeBytes)
             {
-                currentIndex += Math.Max(prefixBytes, 1);
+                currentIndex++;
                 consumedBytes = currentIndex;
-                retryCount++;
-                continue;
-            }
-
-            if (messageLength > MaxMessageSizeBytes)
-            {
-                currentIndex += Math.Max(prefixBytes, 1);
-                consumedBytes = currentIndex;
-                retryCount++;
                 continue;
             }
 
             if (remainingData.Length < prefixBytes + messageLength)
             {
-                break; // Wait for more data.
+                // Not enough buffered data for this frame yet. It might be a real frame
+                // waiting on more bytes — bail and wait. If the prefix turns out to be
+                // garbage, the next read will append more data and we'll retry from the
+                // same position; once a real frame eventually appears we resync to it
+                // by advancing one byte at a time on parse failures above.
+                break;
             }
 
             try
@@ -75,13 +71,11 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
                 currentIndex += prefixBytes + messageLength;
                 consumedBytes = currentIndex;
                 messages.Add(new ProtobufMessage(message));
-                retryCount = 0;
             }
             catch (Exception)
             {
                 currentIndex++;
                 consumedBytes = currentIndex;
-                retryCount++;
             }
         }
 


### PR DESCRIPTION
## Summary
- Removes the `MaxRetryAttempts = 3` cap in `ProtobufMessageParser`. After 3 failed parse attempts the loop exited without advancing past unrecognizable bytes — the consumer buffer stayed clogged forever and downstream `MessageReceived` events stopped firing.
- Replaces the cap with single-byte resync on every failure (malformed varint, oversized length, parse exception). The parser now drains until either a real frame is recovered or the buffer is empty.
- Adds regression test `ProtobufMessageParser_ParseMessages_RecoversFromLeadingGarbage` that prepends 20 zero bytes to a valid `WriteDelimitedTo` frame and asserts the parser recovers `MsgTimeStamp = 42` and consumes the full input.

## Why this matters
This regression manifests as the desktop Live Graph receiving zero stream messages after `StartStreaming`. The DTR pulse on Microchip USB-to-Serial chips emits a few boot-time bytes when the port opens; those land at the head of the consumer buffer. Pre-fix, `QueuedMessageCount` (which is byte count, not message count) climbed from 66 → 8202 in 2 seconds while no frames were dispatched. Post-fix, the parser advances past the boot garbage and the first valid streaming frame is recovered.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ProtobufMessageParser" -f net9.0` — 8/8 pass (new test green)
- [x] `dotnet test --filter "FullyQualifiedName~Consumers" -f net9.0` — 41/41 pass (no regressions)
- [ ] Smoke test with desktop streaming flow against `/dev/cu.usbmodem101` after the new Core release lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)