### PR TITLE
chore: upgrade target frameworks from net8/net9 to net9/net10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          8.0.x
           9.0.x
+          10.0.x
         
     - name: Restore dependencies
       run: dotnet restore Daqifi.Core.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          8.0.x
           9.0.x
+          10.0.x
     
     - name: Set version
       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV

--- a/src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj
+++ b/src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Daqifi.Core/Daqifi.Core.csproj
+++ b/src/Daqifi.Core/Daqifi.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Summary

- Drops .NET 8 support, adds .NET 10 support to always track the latest two stable releases
- Updates `TargetFrameworks` in both `Daqifi.Core.csproj` and `Daqifi.Core.Tests.csproj` from `net8.0;net9.0` to `net9.0;net10.0`
- Updates `dotnet-version` in both `ci.yml` and `release.yml` from `8.0.x / 9.0.x` to `9.0.x / 10.0.x`

## Test plan

- [ ] CI build passes for both `net9.0` and `net10.0` targets
- [ ] Tests pass on both frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)