### PR TITLE
chore: bump coverlet packages from 8.0.1 to 10.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       prefix: "chore"
       include: "scope"
     groups:
+      coverlet:
+        patterns:
+          - "coverlet.*"
       minor-and-patch:
         update-types:
           - "minor"

--- a/src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj
+++ b/src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

- Bumps `coverlet.msbuild` and `coverlet.collector` from 8.0.1 to 10.0.0 (combines dependabot PRs #171 and #172)
- Adds a `coverlet` group to `.github/dependabot.yml` so these packages are always updated together in future

## Closes
Closes #171
Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)