### PR TITLE
fix: bind UDP discovery per-NIC and skip virtual adapters (#179)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -114,6 +114,10 @@ public class WiFiDeviceFinderTests
     [InlineData("VirtualBox Host-Only Network", "VirtualBox Host-Only Ethernet Adapter")]
     [InlineData("VMware Network Adapter VMnet1", "VMware Virtual Ethernet Adapter for VMnet1")]
     [InlineData("OpenVPN TAP-Windows6", "TAP-Windows Adapter V9")]
+    // Keyword present only in name (not description) — both fields must be checked.
+    [InlineData("vEthernet (Default Switch)", "")]
+    [InlineData("WSL Bridge", "Generic Adapter")]
+    [InlineData("VMware NAT", "Generic Adapter")]
     public void IsVirtualOrTunnelInterface_VirtualAdapters_ReturnsTrue(string name, string description)
     {
         Assert.True(WiFiDeviceFinder.IsVirtualOrTunnelInterface(name, description));

--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -99,4 +99,37 @@ public class WiFiDeviceFinderTests
         // Assert
         Assert.NotNull(finder);
     }
+
+    // Virtual / tunnel adapter filter — issue #179.
+    // WSL2 mirrored networking, Hyper-V vEthernet, VPN/TAP adapters frequently share a /24
+    // subnet with the real WiFi/Ethernet NIC and cause Windows routing to pick the wrong egress
+    // for broadcasts, silently breaking discovery.
+    [Theory]
+    [InlineData("vEthernet (WSL)", "Hyper-V Virtual Ethernet Adapter")]
+    [InlineData("vEthernet (Default Switch)", "Hyper-V Virtual Ethernet Adapter")]
+    [InlineData("Ethernet 3", "Hyper-V Virtual Ethernet Adapter #2")]
+    [InlineData("Ethernet 4", "WSL Virtual Ethernet Adapter")]
+    [InlineData("VirtualBox Host-Only Network", "VirtualBox Host-Only Ethernet Adapter")]
+    [InlineData("VMware Network Adapter VMnet1", "VMware Virtual Ethernet Adapter for VMnet1")]
+    [InlineData("OpenVPN TAP-Windows6", "TAP-Windows Adapter V9")]
+    public void IsVirtualOrTunnelInterface_VirtualAdapters_ReturnsTrue(string name, string description)
+    {
+        Assert.True(WiFiDeviceFinder.IsVirtualOrTunnelInterface(name, description));
+    }
+
+    [Theory]
+    [InlineData("Wi-Fi", "Intel(R) Wi-Fi 6 AX201 160MHz")]
+    [InlineData("Ethernet", "Realtek PCIe GbE Family Controller")]
+    [InlineData("Ethernet 2", "Intel(R) Ethernet Connection I219-LM")]
+    [InlineData("WLAN", "Qualcomm Atheros QCA9377 Wireless Network Adapter")]
+    public void IsVirtualOrTunnelInterface_PhysicalAdapters_ReturnsFalse(string name, string description)
+    {
+        Assert.False(WiFiDeviceFinder.IsVirtualOrTunnelInterface(name, description));
+    }
+
+    [Fact]
+    public void IsVirtualOrTunnelInterface_NullInputs_ReturnsFalse()
+    {
+        Assert.False(WiFiDeviceFinder.IsVirtualOrTunnelInterface(null, null));
+    }
 }

--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 using Daqifi.Core.Device.Discovery;
@@ -131,5 +133,39 @@ public class WiFiDeviceFinderTests
     public void IsVirtualOrTunnelInterface_NullInputs_ReturnsFalse()
     {
         Assert.False(WiFiDeviceFinder.IsVirtualOrTunnelInterface(null, null));
+    }
+
+    // Mixed-NIC selection — issue #179.
+    // Simulates the realistic Windows multi-NIC scenario: physical WiFi + physical Ethernet +
+    // WSL2 vEthernet + Hyper-V vEthernet + a down NIC + a non-IPv4 NIC + an unsupported
+    // interface type. The filter must keep only the eligible physical adapters.
+    [Fact]
+    public void ShouldIncludeInterface_MixedNicList_ExcludesVirtualAndIneligible()
+    {
+        var nics = new (string Name, string Description, OperationalStatus Status, NetworkInterfaceType Type, bool IPv4, bool Expected)[]
+        {
+            ("Wi-Fi", "Intel(R) Wi-Fi 6 AX201", OperationalStatus.Up, NetworkInterfaceType.Wireless80211, true, true),
+            ("Ethernet", "Realtek PCIe GbE", OperationalStatus.Up, NetworkInterfaceType.Ethernet, true, true),
+            ("vEthernet (WSL)", "Hyper-V Virtual Ethernet Adapter", OperationalStatus.Up, NetworkInterfaceType.Ethernet, true, false),
+            ("vEthernet (Default Switch)", "Hyper-V Virtual Ethernet Adapter", OperationalStatus.Up, NetworkInterfaceType.Ethernet, true, false),
+            ("VirtualBox Host-Only", "VirtualBox Host-Only Ethernet Adapter", OperationalStatus.Up, NetworkInterfaceType.Ethernet, true, false),
+            ("Ethernet 2", "Disconnected adapter", OperationalStatus.Down, NetworkInterfaceType.Ethernet, true, false),
+            ("Loopback", "Software Loopback", OperationalStatus.Up, NetworkInterfaceType.Loopback, true, false),
+            ("Tunnel", "Teredo Tunneling", OperationalStatus.Up, NetworkInterfaceType.Tunnel, true, false),
+            ("Ethernet 3", "Some IPv6-only adapter", OperationalStatus.Up, NetworkInterfaceType.Ethernet, false, false),
+        };
+
+        var included = nics
+            .Where(n => WiFiDeviceFinder.ShouldIncludeInterface(n.Name, n.Description, n.Status, n.Type, n.IPv4))
+            .Select(n => n.Name)
+            .ToList();
+
+        Assert.Equal(new[] { "Wi-Fi", "Ethernet" }, included);
+
+        foreach (var nic in nics)
+        {
+            var actual = WiFiDeviceFinder.ShouldIncludeInterface(nic.Name, nic.Description, nic.Status, nic.Type, nic.IPv4);
+            Assert.True(actual == nic.Expected, $"NIC '{nic.Name}' expected {nic.Expected} but got {actual}");
+        }
     }
 }

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -244,7 +244,17 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                 discoveredDevices.Add(deviceInfo);
             }
 
-            OnDeviceDiscovered(deviceInfo);
+            // Subscriber exceptions must not fault the receive task — with parallel per-NIC
+            // loops awaited via Task.WhenAll under an infinite-timeout overload, a single
+            // faulted task would hang DiscoverAsync indefinitely.
+            try
+            {
+                OnDeviceDiscovered(deviceInfo);
+            }
+            catch
+            {
+                // Swallow subscriber exceptions; continue receiving on this NIC.
+            }
         }
     }
 
@@ -333,18 +343,12 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
 
         foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
         {
-            if (networkInterface.OperationalStatus != OperationalStatus.Up ||
-                !networkInterface.Supports(NetworkInterfaceComponent.IPv4) ||
-                (networkInterface.NetworkInterfaceType != NetworkInterfaceType.Ethernet &&
-                 networkInterface.NetworkInterfaceType != NetworkInterfaceType.Wireless80211))
-            {
-                continue;
-            }
-
-            // Skip virtual/tunnel adapters (WSL2 mirrored vEthernet, Hyper-V, VirtualBox, VMware, TAP)
-            // that frequently share a subnet with the real adapter and cause Windows routing to pick
-            // the wrong egress NIC for broadcasts. See issue #179.
-            if (IsVirtualOrTunnelInterface(networkInterface.Name, networkInterface.Description))
+            if (!ShouldIncludeInterface(
+                    networkInterface.Name,
+                    networkInterface.Description,
+                    networkInterface.OperationalStatus,
+                    networkInterface.NetworkInterfaceType,
+                    networkInterface.Supports(NetworkInterfaceComponent.IPv4)))
             {
                 continue;
             }
@@ -389,6 +393,46 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         }
 
         return interfaces;
+    }
+
+    /// <summary>
+    /// Returns true if a NIC matching the given metadata should be included in discovery.
+    /// Centralizes the filter — Up + IPv4-capable + Ethernet/Wireless80211 + non-virtual —
+    /// so a mixed-NIC list can be exercised in unit tests without instantiating real
+    /// <see cref="NetworkInterface"/> objects. Internal for testing.
+    /// </summary>
+    internal static bool ShouldIncludeInterface(
+        string? name,
+        string? description,
+        OperationalStatus operationalStatus,
+        NetworkInterfaceType interfaceType,
+        bool supportsIPv4)
+    {
+        if (operationalStatus != OperationalStatus.Up)
+        {
+            return false;
+        }
+
+        if (!supportsIPv4)
+        {
+            return false;
+        }
+
+        if (interfaceType != NetworkInterfaceType.Ethernet &&
+            interfaceType != NetworkInterfaceType.Wireless80211)
+        {
+            return false;
+        }
+
+        // Skip virtual/tunnel adapters (WSL2 mirrored vEthernet, Hyper-V, VirtualBox, VMware, TAP)
+        // that frequently share a subnet with the real adapter and cause Windows routing to pick
+        // the wrong egress NIC for broadcasts. See issue #179.
+        if (IsVirtualOrTunnelInterface(name, description))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -153,6 +153,7 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                 foreach (var interfaceInfo in networkInterfaces)
                 {
                     UdpClient? udp = null;
+                    var added = false;
                     try
                     {
                         // Bind to the discovery port (with ReuseAddress) rather than an ephemeral
@@ -168,10 +169,19 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                         udp.Client.Bind(new IPEndPoint(interfaceInfo.LocalAddress, _discoveryPort));
                         await udp.SendAsync(_queryCommandBytes, _queryCommandBytes.Length, interfaceInfo.BroadcastEndpoint);
                         perNicClients.Add((udp, interfaceInfo.LocalAddress));
+                        added = true;
                     }
-                    catch (SocketException)
+                    catch
                     {
-                        udp?.Dispose();
+                        // Skip this NIC; continue with others. Any setup or send failure is
+                        // recoverable at the discovery level.
+                    }
+                    finally
+                    {
+                        if (!added)
+                        {
+                            udp?.Dispose();
+                        }
                     }
                 }
 
@@ -230,37 +240,38 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                 break;
             }
 
-            var receivedText = Encoding.ASCII.GetString(result.Buffer);
-            if (!IsValidDiscoveryMessage(receivedText))
+            // Defense-in-depth: any unexpected exception in payload processing or subscriber
+            // dispatch must not fault this receive task. With parallel per-NIC loops awaited
+            // via Task.WhenAll under the infinite-timeout overload, a single faulted task would
+            // hang DiscoverAsync indefinitely.
+            try
             {
-                continue;
-            }
-
-            var deviceInfo = ParseDeviceInfo(result.Buffer, result.RemoteEndPoint, localAddress);
-            if (deviceInfo == null)
-            {
-                continue;
-            }
-
-            lock (discoveredDevices)
-            {
-                if (discoveredDevices.Any(d => IsDuplicateDevice(d, deviceInfo)))
+                var receivedText = Encoding.ASCII.GetString(result.Buffer);
+                if (!IsValidDiscoveryMessage(receivedText))
                 {
                     continue;
                 }
-                discoveredDevices.Add(deviceInfo);
-            }
 
-            // Subscriber exceptions must not fault the receive task — with parallel per-NIC
-            // loops awaited via Task.WhenAll under an infinite-timeout overload, a single
-            // faulted task would hang DiscoverAsync indefinitely.
-            try
-            {
+                var deviceInfo = ParseDeviceInfo(result.Buffer, result.RemoteEndPoint, localAddress);
+                if (deviceInfo == null)
+                {
+                    continue;
+                }
+
+                lock (discoveredDevices)
+                {
+                    if (discoveredDevices.Any(d => IsDuplicateDevice(d, deviceInfo)))
+                    {
+                        continue;
+                    }
+                    discoveredDevices.Add(deviceInfo);
+                }
+
                 OnDeviceDiscovered(deviceInfo);
             }
             catch
             {
-                // Swallow subscriber exceptions; continue receiving on this NIC.
+                // Swallow malformed payloads and subscriber exceptions; keep receiving.
             }
         }
     }
@@ -448,16 +459,21 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
     /// </summary>
     internal static bool IsVirtualOrTunnelInterface(string? name, string? description)
     {
-        var n = name ?? string.Empty;
-        var d = description ?? string.Empty;
+        var n = (name ?? string.Empty).Trim();
+        var d = (description ?? string.Empty).Trim();
 
+        // Use specific TAP prefixes ("TAP-Windows", "TAP-", "TAP " with trailing space) rather
+        // than a generic "TAP" substring to avoid false positives on legitimate physical NIC
+        // descriptions that happen to contain those three letters.
         return n.StartsWith("vEthernet", StringComparison.OrdinalIgnoreCase) ||
                d.IndexOf("vEthernet", StringComparison.OrdinalIgnoreCase) >= 0 ||
                d.IndexOf("Hyper-V", StringComparison.OrdinalIgnoreCase) >= 0 ||
                d.IndexOf("WSL", StringComparison.OrdinalIgnoreCase) >= 0 ||
                d.IndexOf("VirtualBox", StringComparison.OrdinalIgnoreCase) >= 0 ||
                d.IndexOf("VMware", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               d.IndexOf("TAP", StringComparison.OrdinalIgnoreCase) >= 0;
+               d.IndexOf("TAP-Windows", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               d.IndexOf("TAP-", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               d.IndexOf("TAP ", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -155,10 +155,17 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                     UdpClient? udp = null;
                     try
                     {
-                        udp = new UdpClient(new IPEndPoint(interfaceInfo.LocalAddress, 0))
+                        // Bind to the discovery port (with ReuseAddress) rather than an ephemeral
+                        // port so devices that target the well-known port for replies still reach
+                        // us. Per-NIC sockets coexist on the same port via distinct (LocalAddress,
+                        // port) tuples + SO_REUSEADDR.
+                        udp = new UdpClient
                         {
-                            EnableBroadcast = true
+                            EnableBroadcast = true,
+                            ExclusiveAddressUse = false
                         };
+                        udp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                        udp.Client.Bind(new IPEndPoint(interfaceInfo.LocalAddress, _discoveryPort));
                         await udp.SendAsync(_queryCommandBytes, _queryCommandBytes.Length, interfaceInfo.BroadcastEndpoint);
                         perNicClients.Add((udp, interfaceInfo.LocalAddress));
                     }

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -239,6 +239,12 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
             {
                 break;
             }
+            catch
+            {
+                // Catch-all so an unexpected exception type cannot fault this receive task
+                // and hang DiscoverAsync via Task.WhenAll under the infinite-timeout overload.
+                break;
+            }
 
             // Defense-in-depth: any unexpected exception in payload processing or subscriber
             // dispatch must not fault this receive task. With parallel per-NIC loops awaited
@@ -462,18 +468,21 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         var n = (name ?? string.Empty).Trim();
         var d = (description ?? string.Empty).Trim();
 
-        // Use specific TAP prefixes ("TAP-Windows", "TAP-", "TAP " with trailing space) rather
-        // than a generic "TAP" substring to avoid false positives on legitimate physical NIC
-        // descriptions that happen to contain those three letters.
-        return n.StartsWith("vEthernet", StringComparison.OrdinalIgnoreCase) ||
-               d.IndexOf("vEthernet", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               d.IndexOf("Hyper-V", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               d.IndexOf("WSL", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               d.IndexOf("VirtualBox", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               d.IndexOf("VMware", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               d.IndexOf("TAP-Windows", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               d.IndexOf("TAP-", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               d.IndexOf("TAP ", StringComparison.OrdinalIgnoreCase) >= 0;
+        static bool Contains(string haystack, string needle) =>
+            haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+
+        // Match keywords against BOTH name and description — virtualization markers can show
+        // up in either field depending on platform/locale. Use specific TAP prefixes to avoid
+        // false positives on legitimate physical NICs whose description happens to contain
+        // those three letters.
+        return Contains(n, "vEthernet") || Contains(d, "vEthernet") ||
+               Contains(n, "Hyper-V") || Contains(d, "Hyper-V") ||
+               Contains(n, "WSL") || Contains(d, "WSL") ||
+               Contains(n, "VirtualBox") || Contains(d, "VirtualBox") ||
+               Contains(n, "VMware") || Contains(d, "VMware") ||
+               Contains(n, "TAP-Windows") || Contains(d, "TAP-Windows") ||
+               Contains(n, "TAP-") || Contains(d, "TAP-") ||
+               Contains(n, "TAP ") || Contains(d, "TAP ");
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -166,7 +166,17 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                             ExclusiveAddressUse = false
                         };
                         udp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-                        udp.Client.Bind(new IPEndPoint(interfaceInfo.LocalAddress, _discoveryPort));
+                        try
+                        {
+                            udp.Client.Bind(new IPEndPoint(interfaceInfo.LocalAddress, _discoveryPort));
+                        }
+                        catch (SocketException)
+                        {
+                            // Fall back to an ephemeral port if the well-known discovery port
+                            // can't be acquired on this platform/NIC (e.g. another process holds
+                            // it). Devices that reply to source-port still reach us either way.
+                            udp.Client.Bind(new IPEndPoint(interfaceInfo.LocalAddress, 0));
+                        }
                         await udp.SendAsync(_queryCommandBytes, _queryCommandBytes.Length, interfaceInfo.BroadcastEndpoint);
                         perNicClients.Add((udp, interfaceInfo.LocalAddress));
                         added = true;
@@ -271,9 +281,12 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                         continue;
                     }
                     discoveredDevices.Add(deviceInfo);
-                }
 
-                OnDeviceDiscovered(deviceInfo);
+                    // Invoke under the lock so DeviceDiscovered fires sequentially across the
+                    // parallel per-NIC receive loops, matching the original (single-socket)
+                    // sequential-callback contract that subscribers may depend on.
+                    OnDeviceDiscovered(deviceInfo);
+                }
             }
             catch
             {

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -9,7 +9,6 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device.Network;
 
 namespace Daqifi.Core.Device.Discovery;
@@ -45,11 +44,6 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         /// The local interface address.
         /// </summary>
         public IPAddress LocalAddress { get; init; }
-
-        /// <summary>
-        /// The subnet mask for this interface.
-        /// </summary>
-        public IPAddress SubnetMask { get; init; }
     }
 
     #endregion
@@ -144,68 +138,54 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                 return discoveredDevices;
             }
 
-            using var udpTransport = new UdpTransport(_discoveryPort);
-            await udpTransport.OpenAsync();
-
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             if (timeout != Timeout.InfiniteTimeSpan)
             {
                 cts.CancelAfter(timeout);
             }
 
+            // Bind a separate UdpClient per NIC so the OS routes each broadcast out the intended adapter
+            // and replies arrive on the socket whose bound IP is the actual local interface — avoiding
+            // misrouting on hosts where virtual NICs (WSL2 mirrored, Hyper-V) share a subnet with the real one.
+            var perNicClients = new List<(UdpClient Client, IPAddress LocalAddress)>();
             try
             {
-                // Send broadcast query to all network interfaces
                 foreach (var interfaceInfo in networkInterfaces)
                 {
+                    UdpClient? udp = null;
                     try
                     {
-                        await udpTransport.SendBroadcastAsync(_queryCommandBytes, interfaceInfo.BroadcastEndpoint);
+                        udp = new UdpClient(new IPEndPoint(interfaceInfo.LocalAddress, 0))
+                        {
+                            EnableBroadcast = true
+                        };
+                        await udp.SendAsync(_queryCommandBytes, _queryCommandBytes.Length, interfaceInfo.BroadcastEndpoint);
+                        perNicClients.Add((udp, interfaceInfo.LocalAddress));
                     }
                     catch (SocketException)
                     {
-                        // Continue with other endpoints if one fails
+                        udp?.Dispose();
                     }
                 }
 
-                // Listen for responses until timeout or cancellation
-                while (!cts.Token.IsCancellationRequested)
+                if (perNicClients.Count == 0)
                 {
-                    try
-                    {
-                        var result = await udpTransport.ReceiveAsync(TimeSpan.FromMilliseconds(100), cts.Token);
-
-                        if (result.HasValue)
-                        {
-                            var (data, remoteEndPoint) = result.Value;
-                            var receivedText = Encoding.ASCII.GetString(data);
-
-                            if (IsValidDiscoveryMessage(receivedText))
-                            {
-                                // Determine which local interface discovered this device
-                                var localInterfaceAddress = FindLocalInterfaceForRemoteAddress(remoteEndPoint.Address, networkInterfaces);
-                                var deviceInfo = ParseDeviceInfo(data, remoteEndPoint, localInterfaceAddress);
-                                if (deviceInfo != null)
-                                {
-                                    // Check for duplicates based on MAC address or serial number
-                                    if (!discoveredDevices.Any(d => IsDuplicateDevice(d, deviceInfo)))
-                                    {
-                                        discoveredDevices.Add(deviceInfo);
-                                        OnDeviceDiscovered(deviceInfo);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        break;
-                    }
+                    OnDiscoveryCompleted();
+                    return discoveredDevices;
                 }
+
+                var receiveTasks = perNicClients
+                    .Select(c => ReceiveLoopAsync(c.Client, c.LocalAddress, discoveredDevices, cts.Token))
+                    .ToArray();
+
+                await Task.WhenAll(receiveTasks);
             }
             finally
             {
-                await udpTransport.CloseAsync();
+                foreach (var (client, _) in perNicClients)
+                {
+                    try { client.Dispose(); } catch { /* ignore */ }
+                }
             }
 
             OnDiscoveryCompleted();
@@ -214,6 +194,57 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         finally
         {
             _discoverySemaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Receives discovery responses on a single NIC-bound socket until cancellation.
+    /// The socket's bound IP is the authoritative LocalInterfaceAddress for any reply it receives.
+    /// </summary>
+    private async Task ReceiveLoopAsync(UdpClient udp, IPAddress localAddress, List<IDeviceInfo> discoveredDevices, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            UdpReceiveResult result;
+            try
+            {
+                result = await udp.ReceiveAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (SocketException)
+            {
+                break;
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+
+            var receivedText = Encoding.ASCII.GetString(result.Buffer);
+            if (!IsValidDiscoveryMessage(receivedText))
+            {
+                continue;
+            }
+
+            var deviceInfo = ParseDeviceInfo(result.Buffer, result.RemoteEndPoint, localAddress);
+            if (deviceInfo == null)
+            {
+                continue;
+            }
+
+            lock (discoveredDevices)
+            {
+                if (discoveredDevices.Any(d => IsDuplicateDevice(d, deviceInfo)))
+                {
+                    continue;
+                }
+                discoveredDevices.Add(deviceInfo);
+            }
+
+            OnDeviceDiscovered(deviceInfo);
         }
     }
 
@@ -310,6 +341,14 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                 continue;
             }
 
+            // Skip virtual/tunnel adapters (WSL2 mirrored vEthernet, Hyper-V, VirtualBox, VMware, TAP)
+            // that frequently share a subnet with the real adapter and cause Windows routing to pick
+            // the wrong egress NIC for broadcasts. See issue #179.
+            if (IsVirtualOrTunnelInterface(networkInterface.Name, networkInterface.Description))
+            {
+                continue;
+            }
+
             var ipProperties = networkInterface.GetIPProperties();
             if (ipProperties == null)
             {
@@ -344,8 +383,7 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                 interfaces.Add(new NetworkInterfaceInfo
                 {
                     BroadcastEndpoint = endpoint,
-                    LocalAddress = ipAddress,
-                    SubnetMask = subnetMask
+                    LocalAddress = ipAddress
                 });
             }
         }
@@ -354,52 +392,21 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
     }
 
     /// <summary>
-    /// Finds the local interface address that is on the same subnet as the remote address.
+    /// Returns true if the adapter looks like a virtual/tunnel interface that should be skipped
+    /// (WSL2 mirrored vEthernet, Hyper-V, VirtualBox, VMware, TAP). Internal for testing.
     /// </summary>
-    /// <param name="remoteAddress">The remote device's IP address.</param>
-    /// <param name="networkInterfaces">The list of available network interfaces.</param>
-    /// <returns>The local interface address, or null if no matching interface is found.</returns>
-    private static IPAddress? FindLocalInterfaceForRemoteAddress(IPAddress remoteAddress, List<NetworkInterfaceInfo> networkInterfaces)
+    internal static bool IsVirtualOrTunnelInterface(string? name, string? description)
     {
-        if (remoteAddress.AddressFamily != AddressFamily.InterNetwork)
-        {
-            return null;
-        }
+        var n = name ?? string.Empty;
+        var d = description ?? string.Empty;
 
-        var remoteBytes = remoteAddress.GetAddressBytes();
-        if (remoteBytes.Length != 4)
-        {
-            return null;
-        }
-
-        foreach (var interfaceInfo in networkInterfaces)
-        {
-            var localBytes = interfaceInfo.LocalAddress.GetAddressBytes();
-            var maskBytes = interfaceInfo.SubnetMask.GetAddressBytes();
-
-            if (localBytes.Length != 4 || maskBytes.Length != 4)
-            {
-                continue;
-            }
-
-            // Check if remote address is on the same subnet as this interface
-            var isOnSameSubnet = true;
-            for (var i = 0; i < 4; i++)
-            {
-                if ((remoteBytes[i] & maskBytes[i]) != (localBytes[i] & maskBytes[i]))
-                {
-                    isOnSameSubnet = false;
-                    break;
-                }
-            }
-
-            if (isOnSameSubnet)
-            {
-                return interfaceInfo.LocalAddress;
-            }
-        }
-
-        return null;
+        return n.StartsWith("vEthernet", StringComparison.OrdinalIgnoreCase) ||
+               d.IndexOf("vEthernet", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               d.IndexOf("Hyper-V", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               d.IndexOf("WSL", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               d.IndexOf("VirtualBox", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               d.IndexOf("VMware", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               d.IndexOf("TAP", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #179.

## Summary
- `WiFiDeviceFinder` now binds **one `UdpClient` per NIC** at `(LocalAddress, 0)` for both send and receive. The OS routes each broadcast out the intended adapter; replies arrive on the same socket; the socket's bound IP becomes the authoritative `LocalInterfaceAddress` (no more subnet-match guessing across virtual NICs that share a subnet).
- `GetAllNetworkInterfaces` now skips virtual/tunnel adapters by Name/Description (`vEthernet`, `Hyper-V`, `WSL`, `VirtualBox`, `VMware`, `TAP`).
- Removed the now-dead `FindLocalInterfaceForRemoteAddress` helper and unused `SubnetMask` field on `NetworkInterfaceInfo`.
- Added `IsVirtualOrTunnelInterface` (`internal static`, `InternalsVisibleTo` already in place) plus xUnit `Theory` cases covering common virtual-adapter shapes and physical-adapter negatives.

## Why
On Windows hosts with WSL2 mirrored networking (or Hyper-V/VPN/TAP) the virtual NIC frequently shares a `/24` with the real WiFi/Ethernet adapter. Sending broadcasts from a single `UdpClient` bound to `IPAddress.Any` lets Windows pick the wrong egress NIC, and the subnet-match reply heuristic could attribute a reply to the virtual NIC. Discovery would silently return zero devices even though the device was reachable via TCP from the same host.

## Behavior note
`DeviceDiscovered` may now be invoked **concurrently** from multiple per-NIC receive loops (was strictly sequential before). The existing public contract did not guarantee single-threaded invocation; subscribers should already be thread-safe.

## Test plan
- [x] `dotnet build Daqifi.Core.sln` — clean (net8.0 + net9.0), 0 warnings
- [x] `dotnet test Daqifi.Core.sln` — 830 passed / 0 failed / 2 skipped (both target frameworks)
- [x] New tests `IsVirtualOrTunnelInterface_*` cover vEthernet (WSL), vEthernet (Default Switch), `Ethernet 3` w/ Hyper-V description, `Ethernet 4` w/ WSL description, VirtualBox, VMware, TAP-Windows — plus Wi-Fi/Ethernet/WLAN negatives and null inputs
- [x] Manually verified on a Windows host (Hyper-V `vEthernet (Default Switch)` 172.25.176.1 + Intel 10G `Ethernet 3` 192.168.1.133): DAQiFi-95A7 at 192.168.1.160 was discovered and `LocalInterfaceAddress` correctly populated as `192.168.1.133` (the real NIC, not the Hyper-V adapter)
- [ ] Strict WSL2-mirrored-on-same-subnet repro is best-validated by issue reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)