### PR TITLE
feat: distinguish SD card error states in GetSdCardFilesAsync

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -681,6 +681,54 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task GetSdCardFilesAsync_LastScpiError_ContainsOnlyScpiFormattedLine()
+        {
+            // Arrange — firmware emits both "Error !! ..." status text AND a SCPI error.
+            // LastScpiError must only carry the SCPI-formatted line so callers can
+            // parse it; the status text is preserved in RawDeviceResponse.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var response = new List<string>
+            {
+                "Error !! No SD Card Detected",
+                "**ERROR: -200, \"Execution error\""
+            };
+            device.ResponseSequence.Enqueue(response);
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.Connect();
+
+            // Act
+            var ex = await Assert.ThrowsAsync<SdCardNotPresentException>(
+                () => device.GetSdCardFilesAsync());
+
+            // Assert — LastScpiError must be the SCPI line, never the firmware text
+            Assert.NotNull(ex.LastScpiError);
+            Assert.StartsWith("**ERROR", ex.LastScpiError);
+            Assert.DoesNotContain("Error !!", ex.LastScpiError);
+            Assert.Contains("Error !! No SD Card Detected", ex.RawDeviceResponse);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WithFirmwareTextOnly_ThrowsWithNullLastScpiError()
+        {
+            // Arrange — defensive: hypothetical firmware response with status text
+            // but no SCPI error line. Shouldn't happen for known paths, but the
+            // classifier must not silently return an empty list.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var response = new List<string> { "Error !! Some unfamiliar firmware error" };
+            device.ResponseSequence.Enqueue(response);
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.Connect();
+
+            // Act
+            var ex = await Assert.ThrowsAsync<SdCardOperationException>(
+                () => device.GetSdCardFilesAsync());
+
+            // Assert
+            Assert.Null(ex.LastScpiError);
+            Assert.Contains("Some unfamiliar firmware error", ex.Message);
+        }
+
+        [Fact]
         public async Task GetSdCardFilesAsync_OnError_StillRestoresLanInterface()
         {
             // Arrange - persistent error path must still restore the LAN interface

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -552,20 +552,151 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
-        public async Task GetSdCardFilesAsync_WithPersistentScpiError_ReturnsEmptyAfterRetries()
+        public async Task GetSdCardFilesAsync_WithPersistentScpiError_ThrowsSdCardOperationException()
         {
-            // Arrange - simulate persistent error
+            // Arrange - simulate persistent bare SCPI error (card busy / timeout territory).
+            // Previous behavior returned an empty list, which made real failures look
+            // identical to "directory is empty". Issue #181 surfaces this as a typed
+            // exception so callers can show actionable detail.
             var device = new RetryableSdCardStreamingDevice("TestDevice");
             device.ResponseSequence.Enqueue(new List<string> { "**ERROR: -200, \"Execution error\"" });
             device.ResponseSequence.Enqueue(new List<string> { "**ERROR: -200, \"Execution error\"" });
             device.Connect();
 
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<SdCardOperationException>(
+                () => device.GetSdCardFilesAsync());
+            Assert.Equal(2, device.ExecuteTextCommandCallCount);
+            Assert.Contains("**ERROR", ex.LastScpiError);
+            Assert.NotEmpty(ex.RawDeviceResponse);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WithNoSdCardDetected_ThrowsSdCardNotPresentException()
+        {
+            // Arrange - matches the firmware response when no SD card is installed:
+            // \r\nError !! No SD Card Detected\r\n + **ERROR: -200, "Execution error"
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var response = new List<string>
+            {
+                "Error !! No SD Card Detected",
+                "**ERROR: -200, \"Execution error\""
+            };
+            device.ResponseSequence.Enqueue(response);
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.Connect();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<SdCardNotPresentException>(
+                () => device.GetSdCardFilesAsync());
+            Assert.Contains("**ERROR", ex.LastScpiError);
+            Assert.NotEmpty(ex.RawDeviceResponse);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WithFilesystemError_ThrowsSdCardFilesystemException()
+        {
+            // Arrange - matches the firmware response when the directory cannot be opened
+            // (corrupt FS, unformatted card, etc): "[Error:N]Failed to open directory ..."
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var response = new List<string>
+            {
+                "[Error:3]Failed to open directory /Daqifi"
+            };
+            device.ResponseSequence.Enqueue(response);
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.Connect();
+
+            // Act & Assert
+            // Note: there is no SCPI error line in this response, but there are also
+            // no file lines, so the classifier treats it as a filesystem error.
+            var ex = await Assert.ThrowsAsync<SdCardFilesystemException>(
+                () => device.GetSdCardFilesAsync());
+            Assert.Contains("Failed to open directory", ex.DeviceMessage);
+            Assert.Contains("Failed to open directory", ex.Message);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WithFilesystemErrorAndScpi_ThrowsSdCardFilesystemException()
+        {
+            // Arrange - filesystem error accompanied by an SCPI error line
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var response = new List<string>
+            {
+                "[Error:3]Failed to open directory /Daqifi",
+                "**ERROR: -200, \"Execution error\""
+            };
+            device.ResponseSequence.Enqueue(response);
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.Connect();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<SdCardFilesystemException>(
+                () => device.GetSdCardFilesAsync());
+            Assert.Contains("Failed to open directory", ex.DeviceMessage);
+            Assert.Contains("**ERROR", ex.LastScpiError);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WithFilesAndInterleavedError_ReturnsFiles()
+        {
+            // Arrange - response contains both files and an SCPI error line.
+            // The presence of any error line triggers a retry (existing behavior),
+            // so we enqueue the same mixed payload twice. After all retries exhaust,
+            // because file lines are present, we still hand off to the parser and
+            // ignore the stray error line — issue #181 keeps this behavior intact.
+            var mixed = new List<string>
+            {
+                "Daqifi/log_20240115_103000.bin",
+                "**ERROR: -200, \"Execution error\""
+            };
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            device.ResponseSequence.Enqueue(new List<string>(mixed));
+            device.ResponseSequence.Enqueue(new List<string>(mixed));
+            device.Connect();
+
             // Act
             var files = await device.GetSdCardFilesAsync();
 
-            // Assert - should be empty since all responses were errors
+            // Assert
+            Assert.Single(files);
+            Assert.Equal("log_20240115_103000.bin", files[0].FileName);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WithEmptyDirectory_ReturnsEmptyList()
+        {
+            // Arrange - device returns no lines (empty directory, no errors). This is
+            // the legitimate "0 files" case and must keep its existing behavior.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            device.ResponseSequence.Enqueue(new List<string>());
+            device.Connect();
+
+            // Act
+            var files = await device.GetSdCardFilesAsync();
+
+            // Assert
             Assert.Empty(files);
-            Assert.Equal(2, device.ExecuteTextCommandCallCount);
+            Assert.Equal(1, device.ExecuteTextCommandCallCount);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_OnError_StillRestoresLanInterface()
+        {
+            // Arrange - persistent error path must still restore the LAN interface
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            device.ResponseSequence.Enqueue(new List<string> { "Error !! No SD Card Detected", "**ERROR: -200" });
+            device.ResponseSequence.Enqueue(new List<string> { "Error !! No SD Card Detected", "**ERROR: -200" });
+            device.Connect();
+
+            // Act
+            await Assert.ThrowsAsync<SdCardNotPresentException>(
+                () => device.GetSdCardFilesAsync());
+
+            // Assert - LAN restore commands must have been sent even though we threw
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:STORage:SD:ENAble 0", sentCommands);
+            Assert.Contains("SYSTem:COMMunicate:LAN:ENAbled 1", sentCommands);
         }
 
         [Fact]

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -732,15 +732,25 @@ namespace Daqifi.Core.Device
         /// <returns>True if any line contains a SCPI error, false otherwise.</returns>
         private static bool ContainsScpiError(IReadOnlyList<string> lines)
         {
-            return lines.Any(line =>
-            {
-                var trimmed = line.TrimStart();
-                return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
-                    || trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase);
-            });
+            return lines.Any(IsScpiErrorLine);
         }
 
+        // Strict SCPI error format: "**ERROR..." or "ERROR: ...". The colon (or **
+        // prefix) distinguishes a true SCPI error from firmware status text like
+        // "Error !! No SD Card Detected", which should not be surfaced as
+        // SdCardOperationException.LastScpiError.
         private static bool IsScpiErrorLine(string line)
+        {
+            var trimmed = line.TrimStart();
+            return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
+                || trimmed.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Permissive: any line that looks like a device error or status message,
+        // including firmware text such as "Error !! ...". Used to recognize that
+        // the parser would yield no result, without polluting LastScpiError with
+        // non-SCPI text.
+        private static bool IsNonResultLine(string line)
         {
             var trimmed = line.TrimStart();
             return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
@@ -757,6 +767,9 @@ namespace Daqifi.Core.Device
         /// </summary>
         private static void ThrowIfSdCardListError(IReadOnlyList<string> lines)
         {
+            // LastScpiError must only carry a real SCPI-formatted error so callers
+            // can rely on its shape. Firmware status text ("Error !! ...") is
+            // surfaced via the exception's Message and RawDeviceResponse instead.
             var lastScpiError = lines.LastOrDefault(IsScpiErrorLine)?.Trim();
 
             // Specific firmware-emitted error markers take precedence over generic
@@ -775,10 +788,11 @@ namespace Daqifi.Core.Device
                 throw new SdCardFilesystemException(lines, lastScpiError, filesystemErrorLine.Trim());
             }
 
-            // If any line looks like a real result (non-empty, non-SCPI-error),
-            // hand off to the parser even if SCPI error lines are interleaved.
+            // If any line looks like a real result (non-empty, not an error or
+            // firmware status line), hand off to the parser. Stray interleaved
+            // error lines are still parsed away by SdCardFileListParser.
             var hasContentLine = lines.Any(line =>
-                !string.IsNullOrWhiteSpace(line) && !IsScpiErrorLine(line));
+                !string.IsNullOrWhiteSpace(line) && !IsNonResultLine(line));
             if (hasContentLine)
             {
                 return;
@@ -790,6 +804,20 @@ namespace Daqifi.Core.Device
                     "The SD card list operation failed: " + lastScpiError,
                     lines,
                     lastScpiError);
+            }
+
+            // Defensive fallback: firmware status text ("Error !! ...") with no
+            // SCPI error and no recognized marker. Shouldn't happen for known
+            // firmware paths, but surfacing it as a typed exception is far
+            // better than silently returning an empty list.
+            var nonResultLine = lines.FirstOrDefault(l =>
+                !string.IsNullOrWhiteSpace(l) && IsNonResultLine(l))?.Trim();
+            if (nonResultLine != null)
+            {
+                throw new SdCardOperationException(
+                    "The SD card list operation failed: " + nonResultLine,
+                    lines,
+                    lastScpiError: null);
             }
 
             // No error lines and no content lines — empty directory. Caller continues.

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -291,6 +291,9 @@ namespace Daqifi.Core.Device
         /// <returns>A task that represents the asynchronous operation, containing the list of files.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the device is not connected.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        /// <exception cref="SdCardNotPresentException">Thrown when no SD card is installed in the device.</exception>
+        /// <exception cref="SdCardFilesystemException">Thrown when the SD card filesystem cannot satisfy the request (corrupt card, unreadable directory).</exception>
+        /// <exception cref="SdCardOperationException">Thrown when the device returned an SCPI error that did not match a more specific condition. Empty directories return an empty list rather than throwing.</exception>
         public async Task<IReadOnlyList<SdCardFileInfo>> GetSdCardFilesAsync(CancellationToken cancellationToken = default)
         {
             if (!IsConnected)
@@ -351,6 +354,8 @@ namespace Daqifi.Core.Device
                     PrepareLanInterface();
                 }
             }
+
+            ThrowIfSdCardListError(lines);
 
             var files = SdCardFileListParser.ParseFileList(lines);
             _sdCardFiles = files;
@@ -733,6 +738,61 @@ namespace Daqifi.Core.Device
                 return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
                     || trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase);
             });
+        }
+
+        private static bool IsScpiErrorLine(string line)
+        {
+            var trimmed = line.TrimStart();
+            return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
+                || trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Inspects the final response from a <c>SYSTem:STORage:SD:LISt?</c> exchange
+        /// and throws a typed <see cref="SdCardOperationException"/> when the device
+        /// reported a real failure (no SD card, filesystem error, generic SCPI error).
+        /// If any non-error/non-empty line is present, callers proceed to parse — even
+        /// if SCPI error lines are interleaved — so a successful directory listing is
+        /// never masked by stray transient errors.
+        /// </summary>
+        private static void ThrowIfSdCardListError(IReadOnlyList<string> lines)
+        {
+            var lastScpiError = lines.LastOrDefault(IsScpiErrorLine)?.Trim();
+
+            // Specific firmware-emitted error markers take precedence over generic
+            // content/error checks. They're plain text (not SCPI-shaped), so a
+            // simple "is there any content line?" check would otherwise miss them
+            // and pass garbage to the parser.
+            if (lines.Any(l => l.IndexOf("No SD Card Detected", StringComparison.OrdinalIgnoreCase) >= 0))
+            {
+                throw new SdCardNotPresentException(lines, lastScpiError);
+            }
+
+            var filesystemErrorLine = lines.FirstOrDefault(l =>
+                l.IndexOf("Failed to open directory", StringComparison.OrdinalIgnoreCase) >= 0);
+            if (filesystemErrorLine != null)
+            {
+                throw new SdCardFilesystemException(lines, lastScpiError, filesystemErrorLine.Trim());
+            }
+
+            // If any line looks like a real result (non-empty, non-SCPI-error),
+            // hand off to the parser even if SCPI error lines are interleaved.
+            var hasContentLine = lines.Any(line =>
+                !string.IsNullOrWhiteSpace(line) && !IsScpiErrorLine(line));
+            if (hasContentLine)
+            {
+                return;
+            }
+
+            if (lastScpiError != null)
+            {
+                throw new SdCardOperationException(
+                    "The SD card list operation failed: " + lastScpiError,
+                    lines,
+                    lastScpiError);
+            }
+
+            // No error lines and no content lines — empty directory. Caller continues.
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -29,6 +29,9 @@ namespace Daqifi.Core.Device.SdCard
         /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation, containing the list of files.</returns>
         /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected.</exception>
+        /// <exception cref="SdCardNotPresentException">Thrown when no SD card is installed in the device.</exception>
+        /// <exception cref="SdCardFilesystemException">Thrown when the SD card filesystem cannot satisfy the request (e.g. corrupt card, unreadable directory).</exception>
+        /// <exception cref="SdCardOperationException">Thrown when the device returned an SCPI error that did not match a more specific condition. An empty directory returns an empty list rather than throwing.</exception>
         Task<IReadOnlyList<SdCardFileInfo>> GetSdCardFilesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardBusyException.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardBusyException.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// Thrown when an SD card operation cannot proceed because the SD card is busy
+    /// (for example, the device is actively logging to it).
+    /// </summary>
+    public class SdCardBusyException : SdCardOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SdCardBusyException"/> class.
+        /// </summary>
+        public SdCardBusyException(
+            IReadOnlyList<string> rawDeviceResponse,
+            string? lastScpiError = null)
+            : base(
+                "The SD card is busy and cannot complete the requested operation.",
+                rawDeviceResponse,
+                lastScpiError)
+        {
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardFilesystemException.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFilesystemException.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// Thrown when the device's SD card filesystem cannot satisfy a request — for
+    /// example, the directory cannot be opened because the card is unformatted,
+    /// the filesystem is corrupt, or the path does not exist.
+    /// Detected from the firmware's <c>"[Error:N]Failed to open directory ..."</c>
+    /// response.
+    /// </summary>
+    public class SdCardFilesystemException : SdCardOperationException
+    {
+        /// <summary>
+        /// Gets the raw filesystem error line emitted by the device firmware,
+        /// for example <c>"[Error:3]Failed to open directory /Daqifi"</c>.
+        /// </summary>
+        public string DeviceMessage { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SdCardFilesystemException"/> class.
+        /// </summary>
+        public SdCardFilesystemException(
+            IReadOnlyList<string> rawDeviceResponse,
+            string? lastScpiError,
+            string deviceMessage)
+            : base(
+                BuildMessage(deviceMessage),
+                rawDeviceResponse,
+                lastScpiError)
+        {
+            DeviceMessage = deviceMessage;
+        }
+
+        private static string BuildMessage(string deviceMessage)
+        {
+            return string.IsNullOrWhiteSpace(deviceMessage)
+                ? "The SD card filesystem reported an error."
+                : $"The SD card filesystem reported an error: {deviceMessage}";
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardNotPresentException.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardNotPresentException.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// Thrown when an SD card operation fails because no SD card is installed in the device.
+    /// Detected from the firmware's <c>"No SD Card Detected"</c> response.
+    /// </summary>
+    public class SdCardNotPresentException : SdCardOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SdCardNotPresentException"/> class.
+        /// </summary>
+        public SdCardNotPresentException(
+            IReadOnlyList<string> rawDeviceResponse,
+            string? lastScpiError = null)
+            : base(
+                "No SD card is installed in the device.",
+                rawDeviceResponse,
+                lastScpiError)
+        {
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperationException.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperationException.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// Represents an error returned by the device while performing an SD card operation.
+    /// Carries the raw response lines so callers can surface the underlying device output
+    /// to users or logs without having to re-parse the wire data.
+    /// </summary>
+    public class SdCardOperationException : Exception
+    {
+        /// <summary>
+        /// Gets the raw response lines that were captured from the device when the error
+        /// was classified. Useful for diagnostics and for surfacing actionable detail in
+        /// higher-level UIs.
+        /// </summary>
+        public IReadOnlyList<string> RawDeviceResponse { get; }
+
+        /// <summary>
+        /// Gets the last SCPI error line observed in the response (e.g.
+        /// <c>**ERROR: -200, "Execution error"</c>), or <c>null</c> if none was present.
+        /// </summary>
+        public string? LastScpiError { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SdCardOperationException"/> class.
+        /// </summary>
+        public SdCardOperationException(
+            string message,
+            IReadOnlyList<string> rawDeviceResponse,
+            string? lastScpiError = null,
+            Exception? innerException = null)
+            : base(message, innerException)
+        {
+            RawDeviceResponse = rawDeviceResponse ?? Array.Empty<string>();
+            LastScpiError = lastScpiError;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #181.

`GetSdCardFilesAsync` silently swallowed SCPI errors and returned an empty list, making real failures (no card, corrupt FS, busy SD subsystem) indistinguishable from \"directory is empty.\" A corrupt SD card on firmware 3.4.4 sent multiple debug sessions chasing phantom firmware bugs before someone thought to swap the card.

This adds a typed exception hierarchy and classifies the response after the existing retry loop so callers can show actionable detail.

### What changed

- **New exception hierarchy** in `Daqifi.Core.Device.SdCard`:
  - `SdCardOperationException` — base; carries `RawDeviceResponse` and `LastScpiError`
  - `SdCardNotPresentException` — \"No SD Card Detected\"
  - `SdCardFilesystemException` — \"Failed to open directory\" with the device's raw error text in `DeviceMessage`
  - `SdCardBusyException` — defined for completeness (firmware cannot distinguish busy from timeout on the wire, so this currently surfaces as the base type)
- **`DaqifiStreamingDevice.GetSdCardFilesAsync`** now calls a private `ThrowIfSdCardListError` classifier after the retry loop. Specific firmware markers take precedence over the generic content/error check; an empty directory still returns an empty list.
- **`ISdCardOperations`** xmldoc updated to document the new exceptions.

### Behavior preserved

- Empty directory (no errors, no content lines) → returns empty list (unchanged).
- File lines present, even with stray interleaved `**ERROR` lines → returns parsed files (unchanged).
- LAN interface is still restored in the `finally` block on the throwing path.

### Hardware verification

Tested on `/dev/cu.usbmodem2101` via the example app:
- Card with files → returns files (no exception)
- No card → throws `SdCardNotPresentException` (previously silently returned 0 files)
- A \"corrupt\" card available for testing returned an empty `SD:LISt?` response at the firmware level (i.e. firmware mounted it and saw 0 files), so the `SdCardFilesystemException` and bare-`**ERROR` paths are exercised by unit tests against the firmware wire formats from the issue.

## Test plan

- [x] Unit tests pass on net9.0 + net10.0 (878 passing, 0 failing)
- [x] New tests cover: not-present, filesystem-error (with and without SCPI co-error), persistent-SCPI-error, files-with-interleaved-error, empty-directory, LAN-restore-on-error
- [x] Updated test that previously asserted empty list on persistent SCPI error now asserts `SdCardOperationException`
- [x] Manual verification on physical device for happy path and not-present path

🤖 Generated with [Claude Code](https://claude.com/claude-code)