### PR TITLE
fix: honor LocalInterfaceAddress when connecting WiFi devices

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/TcpStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/TcpStreamTransportTests.cs
@@ -136,6 +136,65 @@ public class TcpStreamTransportTests
         Assert.Contains("127.0.0.1:5000", disconnectedInfo);
     }
 
+    [Fact]
+    public void TcpStreamTransport_Constructor_WithLocalInterface_ExposesIt()
+    {
+        // Arrange & Act
+        using var transport = new TcpStreamTransport(IPAddress.Loopback, 5000, IPAddress.Loopback);
+
+        // Assert
+        Assert.Equal(IPAddress.Loopback, transport.LocalInterface);
+    }
+
+    [Fact]
+    public void TcpStreamTransport_Constructor_WithoutLocalInterface_LocalInterfaceIsNull()
+    {
+        // Arrange & Act
+        using var transport = new TcpStreamTransport(IPAddress.Loopback, 5000);
+
+        // Assert
+        Assert.Null(transport.LocalInterface);
+    }
+
+    [Fact]
+    public async Task TcpStreamTransport_ConnectAsync_WithUnassignedLocalInterface_ThrowsSocketException()
+    {
+        // Arrange - 192.0.2.1 is in TEST-NET-1 (RFC 5737) and is not assigned to any local
+        // interface, so binding the outbound socket to it must fail with EADDRNOTAVAIL.
+        // This proves the local-interface argument actually drives the socket bind.
+        var bogusLocal = IPAddress.Parse("192.0.2.1");
+        using var transport = new TcpStreamTransport(IPAddress.Loopback, 1, bogusLocal);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<SocketException>(() => transport.ConnectAsync());
+        Assert.False(transport.IsConnected);
+    }
+
+    [Fact]
+    public async Task TcpStreamTransport_ConnectAsync_WithLoopbackLocalInterface_ConnectsAndReportsBoundLocal()
+    {
+        // Arrange - real listener on loopback so the connection actually completes
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            using var transport = new TcpStreamTransport(IPAddress.Loopback, port, IPAddress.Loopback);
+
+            // Act
+            await transport.ConnectAsync();
+
+            // Assert
+            Assert.True(transport.IsConnected);
+            Assert.Contains("127.0.0.1", transport.ConnectionInfo);
+            await transport.DisconnectAsync();
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
     // Integration test that requires a real server - marked as integration test
     [Fact(Skip = "Integration test - requires external server")]
     public async Task TcpStreamTransport_RealConnection_ShouldWorkEndToEnd()

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Discovery;
@@ -477,6 +478,47 @@ public class DaqifiDeviceFactoryTests
         // Act & Assert
         await Assert.ThrowsAsync<OperationCanceledException>(
             () => DaqifiDeviceFactory.ConnectFromDeviceInfoAsync(deviceInfo, null, cts.Token));
+    }
+
+    [Fact]
+    public async Task ConnectFromDeviceInfoAsync_WiFiWithLocalInterface_BindsOutboundSocketToIt()
+    {
+        // Arrange - 192.0.2.1 is in TEST-NET-1 (RFC 5737) and is not assigned to any local
+        // interface. If the factory threads LocalInterfaceAddress into the TCP transport,
+        // the bind will fail with EADDRNOTAVAIL (SocketException) before connect is attempted.
+        // If the factory ignores LocalInterfaceAddress, the connection to 127.0.0.1 would
+        // proceed and fail with a different error (or succeed against the listener), so a
+        // SocketException at bind time is the signal that the wiring is correct.
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var deviceInfo = new TestDeviceInfo
+            {
+                ConnectionType = ConnectionType.WiFi,
+                IPAddress = IPAddress.Loopback,
+                Port = port,
+                LocalInterfaceAddress = IPAddress.Parse("192.0.2.1")
+            };
+            var options = new DeviceConnectionOptions
+            {
+                ConnectionRetry = new ConnectionRetryOptions
+                {
+                    Enabled = false,
+                    ConnectionTimeout = TimeSpan.FromSeconds(1)
+                },
+                InitializeDevice = false
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<SocketException>(
+                () => DaqifiDeviceFactory.ConnectFromDeviceInfoAsync(deviceInfo, options));
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 
     #endregion

--- a/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
@@ -11,6 +11,7 @@ namespace Daqifi.Core.Communication.Transport;
 public class TcpStreamTransport : IStreamTransport
 {
     private readonly IPEndPoint _endPoint;
+    private readonly IPAddress? _localInterface;
     private TcpClient? _tcpClient;
     private NetworkStream? _networkStream;
     private bool _disposed;
@@ -20,9 +21,15 @@ public class TcpStreamTransport : IStreamTransport
     /// </summary>
     /// <param name="ipAddress">The IP address to connect to.</param>
     /// <param name="port">The port to connect to.</param>
-    public TcpStreamTransport(IPAddress ipAddress, int port)
+    /// <param name="localInterface">
+    /// Optional local interface address to bind the outbound socket to. When supplied, the TCP
+    /// connection egresses on the specified NIC; required for multi-homed hosts where the OS
+    /// would otherwise pick the wrong interface for the route.
+    /// </param>
+    public TcpStreamTransport(IPAddress ipAddress, int port, IPAddress? localInterface = null)
     {
         _endPoint = new IPEndPoint(ipAddress, port);
+        _localInterface = localInterface;
     }
 
     /// <summary>
@@ -30,7 +37,12 @@ public class TcpStreamTransport : IStreamTransport
     /// </summary>
     /// <param name="host">The hostname to connect to.</param>
     /// <param name="port">The port to connect to.</param>
-    public TcpStreamTransport(string host, int port)
+    /// <param name="localInterface">
+    /// Optional local interface address to bind the outbound socket to. When supplied, the TCP
+    /// connection egresses on the specified NIC; required for multi-homed hosts where the OS
+    /// would otherwise pick the wrong interface for the route.
+    /// </param>
+    public TcpStreamTransport(string host, int port, IPAddress? localInterface = null)
     {
         if (IPAddress.TryParse(host, out var ipAddress))
         {
@@ -42,12 +54,18 @@ public class TcpStreamTransport : IStreamTransport
             _endPoint = new IPEndPoint(IPAddress.None, port);
             Hostname = host;
         }
+        _localInterface = localInterface;
     }
 
     /// <summary>
     /// Gets the hostname if provided instead of IP address.
     /// </summary>
     public string? Hostname { get; }
+
+    /// <summary>
+    /// Gets the local interface address the outbound socket will bind to, or null to let the OS choose.
+    /// </summary>
+    public IPAddress? LocalInterface => _localInterface;
 
     /// <summary>
     /// Gets the underlying stream for read/write operations.
@@ -126,7 +144,9 @@ public class TcpStreamTransport : IStreamTransport
                     }
                 }
 
-                _tcpClient = new TcpClient();
+                _tcpClient = _localInterface != null
+                    ? new TcpClient(new IPEndPoint(_localInterface, 0))
+                    : new TcpClient();
 
                 // Set timeouts from retry options or use defaults
                 var timeout = (int)options.ConnectionTimeout.TotalMilliseconds;

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -306,11 +306,15 @@ public static class DaqifiDeviceFactory
             InitializeDevice = effectiveOptions.InitializeDevice
         };
 
-        return await ConnectTcpAsync(
+        // Honor LocalInterfaceAddress so multi-homed hosts egress on the NIC that
+        // discovered the device, not whichever NIC the OS routing table prefers.
+        var transport = new TcpStreamTransport(
             deviceInfo.IPAddress,
             deviceInfo.Port.Value,
-            modifiedOptions,
-            cancellationToken).ConfigureAwait(false);
+            deviceInfo.LocalInterfaceAddress);
+
+        return await ConnectWithTransportAsync(transport, modifiedOptions, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -291,6 +291,8 @@ public static class DaqifiDeviceFactory
                 nameof(deviceInfo));
         }
 
+        ValidatePort(deviceInfo.Port.Value);
+
         var effectiveOptions = options ?? DeviceConnectionOptions.Default;
 
         // Use the device name from the discovery info if not overridden in options


### PR DESCRIPTION
## Summary
- `TcpStreamTransport` now takes an optional `localInterface` and, when supplied, binds the outbound socket to that address before connecting (multi-homed hosts can't otherwise control egress NIC).
- `DaqifiDeviceFactory.ConnectFromDeviceInfoAsync` threads `deviceInfo.LocalInterfaceAddress` into the transport for the WiFi path; serial/HID paths and existing `ConnectTcpAsync` callers are unchanged.
- Adds focused tests: transport-level bind verification (loopback succeeds, unassigned address fails with `SocketException`) plus a factory-level test that proves `LocalInterfaceAddress` is threaded through end-to-end.

Closes #147.

## Test plan
- [x] `dotnet build src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj` — clean
- [x] `dotnet test --filter "FullyQualifiedName~LocalInterface"` — 8 passed on net9.0 and net10.0
- [x] Full suite: 895 passed / 0 failed / 2 skipped on both target frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)