### PR TITLE
fix(sdcard): IsNonResultLine no longer false-positives on filenames starting with 'error' (#190)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -133,6 +133,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
         [InlineData("**Error: bad")]
         [InlineData("ERROR: -100, Bad command")]
         [InlineData("Error !! Generic firmware status")]
+        [InlineData("Error!! No space firmware status")]
         [InlineData("ERROR")]
         [InlineData("error\tsomething")]
         public async Task GetSdCardFilesAsync_RealErrorLinesStillSkipped(string errorLine)
@@ -152,6 +153,36 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             Assert.Single(files);
             Assert.Equal("normal.bin", files[0].FileName);
+        }
+
+        [Theory]
+        [InlineData("error!log.bin")]
+        [InlineData("Daqifi/error!log.bin")]
+        [InlineData("Erroneous!data.bin")]
+        public async Task GetSdCardFilesAsync_FilenamesWithSingleBangSurvive(string filename)
+        {
+            // Regression: a single '!' immediately after "error" is ambiguous
+            // (could be a filename like "error!log.bin"). The classifier must
+            // require '!!' to treat as an error/status line so legitimate
+            // filenames aren't dropped from listings. Filename validation
+            // already permits '!' in SD filenames.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "Daqifi/normal.bin",
+                filename,
+            };
+            device.Connect();
+
+            var files = await device.GetSdCardFilesAsync();
+
+            var names = files.Select(f => f.FileName).ToList();
+            Assert.Equal(2, names.Count);
+            Assert.Contains("normal.bin", names);
+            // filename may or may not have the Daqifi/ prefix stripped depending
+            // on the parser's path handling; just confirm it survived.
+            var expected = filename.StartsWith("Daqifi/") ? filename.Substring("Daqifi/".Length) : filename;
+            Assert.Contains(expected, names);
         }
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -71,17 +71,24 @@ namespace Daqifi.Core.Tests.Device.SdCard
         [Fact]
         public async Task GetSdCardFilesAsync_FilenamesStartingWithErrorAreNotMisclassified()
         {
-            // Regression for #190: IsNonResultLine's prior bare "ERROR"
-            // prefix check false-positived on legit SD filenames whose
-            // basename starts with "error" (e.g. "error_log.csv"). The
-            // permissive classifier dropped them from the parsed file
-            // list. Tightened to require ERROR followed by `:`/` `/`!`/
-            // tab so ordinary filenames pass through.
+            // Regression for #190 covering BOTH bug locations:
+            //   - IsNonResultLine in DaqifiStreamingDevice (the LIST? response classifier)
+            //   - SdCardFileListParser.ParseFileList (the per-line parser; bare "ERROR" check)
+            // Pre-fix, both used a bare "ERROR" StartsWith check that
+            // false-positived on legit SD filenames. Tightened to require
+            // ERROR followed by ":"/" "/"!"/tab/end-of-line.
+            //
+            // Cover both path shapes the firmware may emit:
+            //   - prefixed: "Daqifi/error_log.csv"
+            //   - bare: "error_log.csv" (no Daqifi/ prefix)
             var device = new TestableSdCardStreamingDevice("TestDevice");
             device.CannedTextResponse = new List<string>
             {
                 "Daqifi/error_log.csv",
                 "Daqifi/Errors_summary.bin",
+                "error_log.csv",
+                "Errors_summary.bin",
+                "ERROR_archive.bin",
                 "Daqifi/normal.bin",
             };
             device.Connect();
@@ -91,8 +98,60 @@ namespace Daqifi.Core.Tests.Device.SdCard
             var names = files.Select(f => f.FileName).ToList();
             Assert.Contains("error_log.csv", names);
             Assert.Contains("Errors_summary.bin", names);
+            Assert.Contains("ERROR_archive.bin", names);
             Assert.Contains("normal.bin", names);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_OnlyErrorPrefixedFilenames_AllSurvive()
+        {
+            // Edge case explicitly called out by Qodo on PR #195: a
+            // listing consisting SOLELY of error*-prefixed filenames
+            // (no normal.bin to act as a sanity anchor) must round-trip
+            // every entry. Pre-fix, the entire response would have parsed
+            // as zero files.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "error_log.csv",
+                "errors.bin",
+                "Erroneous_data.bin",
+            };
+            device.Connect();
+
+            var files = await device.GetSdCardFilesAsync();
+
             Assert.Equal(3, files.Count);
+            var names = files.Select(f => f.FileName).ToList();
+            Assert.Contains("error_log.csv", names);
+            Assert.Contains("errors.bin", names);
+            Assert.Contains("Erroneous_data.bin", names);
+        }
+
+        [Theory]
+        [InlineData("**ERROR: -200, Execution error")]
+        [InlineData("**Error: bad")]
+        [InlineData("ERROR: -100, Bad command")]
+        [InlineData("Error !! Generic firmware status")]
+        [InlineData("ERROR")]
+        [InlineData("error\tsomething")]
+        public async Task GetSdCardFilesAsync_RealErrorLinesStillSkipped(string errorLine)
+        {
+            // Confirm the tightening didn't go too far — real error
+            // lines still classify as non-result and don't end up
+            // misinterpreted as filenames.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "Daqifi/normal.bin",
+                errorLine,
+            };
+            device.Connect();
+
+            var files = await device.GetSdCardFilesAsync();
+
+            Assert.Single(files);
+            Assert.Equal("normal.bin", files[0].FileName);
         }
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -179,9 +179,14 @@ namespace Daqifi.Core.Tests.Device.SdCard
             var names = files.Select(f => f.FileName).ToList();
             Assert.Equal(2, names.Count);
             Assert.Contains("normal.bin", names);
-            // filename may or may not have the Daqifi/ prefix stripped depending
-            // on the parser's path handling; just confirm it survived.
-            var expected = filename.StartsWith("Daqifi/") ? filename.Substring("Daqifi/".Length) : filename;
+            // The parser strips the "Daqifi/" prefix case-insensitively
+            // (StringComparison.OrdinalIgnoreCase), so mirror that here —
+            // a case-sensitive StartsWith would falsely fail if a future
+            // test case used "daqifi/" or "DAQIFI/".
+            const string daqifiPrefix = "Daqifi/";
+            var expected = filename.StartsWith(daqifiPrefix, StringComparison.OrdinalIgnoreCase)
+                ? filename.Substring(daqifiPrefix.Length)
+                : filename;
             Assert.Contains(expected, names);
         }
 

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -179,16 +179,20 @@ namespace Daqifi.Core.Tests.Device.SdCard
             var names = files.Select(f => f.FileName).ToList();
             Assert.Equal(2, names.Count);
             Assert.Contains("normal.bin", names);
-            // Mirror production normalization in SdCardFileListParser:
-            //  1. strip Daqifi/ prefix case-insensitively
-            //  2. apply Path.GetFileName so any nested path collapses to its basename
-            // Doing only step 1 would falsely fail on a future "Daqifi/sub/file.bin"
-            // test case, where production returns just "file.bin".
+            // Mirror production normalization: strip the Daqifi/ prefix then keep
+            // the basename. Split on '/' explicitly (not Path.GetFileName) — the
+            // device protocol uses forward slashes, and Path.GetFileName treats
+            // '\\' as a separator on Windows but not on Linux/macOS, which would
+            // make this expectation OS-dependent if a future case used '\\'.
             const string daqifiPrefix = "Daqifi/";
             var expected = filename.StartsWith(daqifiPrefix, StringComparison.OrdinalIgnoreCase)
                 ? filename.Substring(daqifiPrefix.Length)
                 : filename;
-            expected = Path.GetFileName(expected);
+            var lastSlash = expected.LastIndexOf('/');
+            if (lastSlash >= 0)
+            {
+                expected = expected.Substring(lastSlash + 1);
+            }
             Assert.Contains(expected, names);
         }
 

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -69,6 +69,33 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task GetSdCardFilesAsync_FilenamesStartingWithErrorAreNotMisclassified()
+        {
+            // Regression for #190: IsNonResultLine's prior bare "ERROR"
+            // prefix check false-positived on legit SD filenames whose
+            // basename starts with "error" (e.g. "error_log.csv"). The
+            // permissive classifier dropped them from the parsed file
+            // list. Tightened to require ERROR followed by `:`/` `/`!`/
+            // tab so ordinary filenames pass through.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "Daqifi/error_log.csv",
+                "Daqifi/Errors_summary.bin",
+                "Daqifi/normal.bin",
+            };
+            device.Connect();
+
+            var files = await device.GetSdCardFilesAsync();
+
+            var names = files.Select(f => f.FileName).ToList();
+            Assert.Contains("error_log.csv", names);
+            Assert.Contains("Errors_summary.bin", names);
+            Assert.Contains("normal.bin", names);
+            Assert.Equal(3, files.Count);
+        }
+
+        [Fact]
         public async Task GetSdCardFilesAsync_RestoresLanInterface()
         {
             // Arrange

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -179,14 +179,16 @@ namespace Daqifi.Core.Tests.Device.SdCard
             var names = files.Select(f => f.FileName).ToList();
             Assert.Equal(2, names.Count);
             Assert.Contains("normal.bin", names);
-            // The parser strips the "Daqifi/" prefix case-insensitively
-            // (StringComparison.OrdinalIgnoreCase), so mirror that here —
-            // a case-sensitive StartsWith would falsely fail if a future
-            // test case used "daqifi/" or "DAQIFI/".
+            // Mirror production normalization in SdCardFileListParser:
+            //  1. strip Daqifi/ prefix case-insensitively
+            //  2. apply Path.GetFileName so any nested path collapses to its basename
+            // Doing only step 1 would falsely fail on a future "Daqifi/sub/file.bin"
+            // test case, where production returns just "file.bin".
             const string daqifiPrefix = "Daqifi/";
             var expected = filename.StartsWith(daqifiPrefix, StringComparison.OrdinalIgnoreCase)
                 ? filename.Substring(daqifiPrefix.Length)
                 : filename;
+            expected = Path.GetFileName(expected);
             Assert.Contains(expected, names);
         }
 

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -749,13 +749,12 @@ namespace Daqifi.Core.Device
         // Permissive: any line that looks like a device error or status message,
         // including firmware text such as "Error !! ...". Used to recognize that
         // the parser would yield no result, without polluting LastScpiError with
-        // non-SCPI text. Delegates to SdCardFileListParser.IsErrorResponseLine
-        // so the SD-response classification rule (closes #190 — filenames
-        // starting with "error_" must NOT match) stays in lockstep across
-        // both call sites.
+        // non-SCPI text. Shared classifier so the SD-response rule (closes #190
+        // — filenames starting with "error_" must NOT match) stays in lockstep
+        // across both call sites.
         private static bool IsNonResultLine(string line)
         {
-            return SdCardFileListParser.IsErrorResponseLine(line);
+            return ScpiResponseClassifier.IsErrorResponseLine(line);
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -749,35 +749,13 @@ namespace Daqifi.Core.Device
         // Permissive: any line that looks like a device error or status message,
         // including firmware text such as "Error !! ...". Used to recognize that
         // the parser would yield no result, without polluting LastScpiError with
-        // non-SCPI text. Closes #190 — bare "ERROR" prefix false-positives on
-        // legit SD filenames that happen to start with "error" (e.g.
-        // "error_log.csv"), which would mask the file from GetSdCardFilesAsync's
-        // returned list. Tightened to require either:
-        //   - the canonical "**ERROR" SCPI marker (also matched by IsScpiErrorLine), or
-        //   - "ERROR" exactly (length-5 line), or
-        //   - "ERROR" followed by ":" / " " / "!" / tab — covering both
-        //     SCPI ("ERROR: -100, ...") and firmware ("Error !!", "Error ...") patterns.
+        // non-SCPI text. Delegates to SdCardFileListParser.IsErrorResponseLine
+        // so the SD-response classification rule (closes #190 — filenames
+        // starting with "error_" must NOT match) stays in lockstep across
+        // both call sites.
         private static bool IsNonResultLine(string line)
         {
-            // Trim both ends — bare "ERROR\r" from a CRLF line ending would
-            // otherwise leave the '\r' as trimmed[5] and fall through the
-            // delimiter switch below.
-            var trimmed = line.Trim();
-            if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
-                return true;
-            // Must be followed by an SCPI delimiter (':', ' ', '!', '\t')
-            // or end of line, so plain filenames like "error_log.csv"
-            // (which TrimStart leaves intact) don't match.
-            if (trimmed.Length >= 5
-                && trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
-            {
-                if (trimmed.Length == 5)
-                    return true;
-                var next = trimmed[5];
-                if (next == ':' || next == ' ' || next == '!' || next == '\t')
-                    return true;
-            }
-            return false;
+            return SdCardFileListParser.IsErrorResponseLine(line);
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -759,7 +759,10 @@ namespace Daqifi.Core.Device
         //     SCPI ("ERROR: -100, ...") and firmware ("Error !!", "Error ...") patterns.
         private static bool IsNonResultLine(string line)
         {
-            var trimmed = line.TrimStart();
+            // Trim both ends — bare "ERROR\r" from a CRLF line ending would
+            // otherwise leave the '\r' as trimmed[5] and fall through the
+            // delimiter switch below.
+            var trimmed = line.Trim();
             if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
                 return true;
             // Must be followed by an SCPI delimiter (':', ' ', '!', '\t')

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -749,12 +749,29 @@ namespace Daqifi.Core.Device
         // Permissive: any line that looks like a device error or status message,
         // including firmware text such as "Error !! ...". Used to recognize that
         // the parser would yield no result, without polluting LastScpiError with
-        // non-SCPI text.
+        // non-SCPI text. Closes #190 — bare "ERROR" prefix false-positives on
+        // legit SD filenames that happen to start with "error" (e.g.
+        // "error_log.csv"), which would mask the file from GetSdCardFilesAsync's
+        // returned list. Tightened to require ERROR followed by ":", " " (firmware
+        // pattern "Error !!"), or "*" (the "**ERROR" SCPI marker, also matched by
+        // IsScpiErrorLine).
         private static bool IsNonResultLine(string line)
         {
             var trimmed = line.TrimStart();
-            return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
-                || trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase);
+            if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
+                return true;
+            // Must be followed by a non-letter so plain filenames like
+            // "error_log.csv" (which TrimStart leaves intact) don't match.
+            if (trimmed.Length >= 5
+                && trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
+            {
+                if (trimmed.Length == 5)
+                    return true;
+                var next = trimmed[5];
+                if (next == ':' || next == ' ' || next == '!' || next == '\t')
+                    return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -752,9 +752,11 @@ namespace Daqifi.Core.Device
         // non-SCPI text. Closes #190 — bare "ERROR" prefix false-positives on
         // legit SD filenames that happen to start with "error" (e.g.
         // "error_log.csv"), which would mask the file from GetSdCardFilesAsync's
-        // returned list. Tightened to require ERROR followed by ":", " " (firmware
-        // pattern "Error !!"), or "*" (the "**ERROR" SCPI marker, also matched by
-        // IsScpiErrorLine).
+        // returned list. Tightened to require either:
+        //   - the canonical "**ERROR" SCPI marker (also matched by IsScpiErrorLine), or
+        //   - "ERROR" exactly (length-5 line), or
+        //   - "ERROR" followed by ":" / " " / "!" / tab — covering both
+        //     SCPI ("ERROR: -100, ...") and firmware ("Error !!", "Error ...") patterns.
         private static bool IsNonResultLine(string line)
         {
             var trimmed = line.TrimStart();

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -762,8 +762,9 @@ namespace Daqifi.Core.Device
             var trimmed = line.TrimStart();
             if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
                 return true;
-            // Must be followed by a non-letter so plain filenames like
-            // "error_log.csv" (which TrimStart leaves intact) don't match.
+            // Must be followed by an SCPI delimiter (':', ' ', '!', '\t')
+            // or end of line, so plain filenames like "error_log.csv"
+            // (which TrimStart leaves intact) don't match.
             if (trimmed.Length >= 5
                 && trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -1,0 +1,53 @@
+using System;
+
+#nullable enable
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Shared classification for SCPI text response lines. Used by both the
+    /// general streaming-device response handling and SD card listing parsing
+    /// so the error/status line rule stays consistent across call sites.
+    /// </summary>
+    internal static class ScpiResponseClassifier
+    {
+        /// <summary>
+        /// Returns true if the line is a non-result error/status line that
+        /// response parsers should drop. Matches both SCPI error responses
+        /// (canonical <c>**ERROR</c> marker, bare <c>ERROR</c> token followed
+        /// by a SCPI delimiter <c>:</c> / space / tab / end-of-line) and
+        /// firmware status text (<c>Error !! ...</c> with space, or the
+        /// no-space <c>Error!!</c> form). A double-<c>!</c> is required when
+        /// no other delimiter is present so legitimate filenames like
+        /// <c>error!log.bin</c> aren't dropped — single <c>!</c> alone is
+        /// ambiguous between error-status and filename. Trims both ends so
+        /// a bare <c>"ERROR\r"</c> from CRLF line endings still classifies.
+        /// Plain filenames whose basename starts with <c>error</c> /
+        /// <c>Errors</c> pass through unmatched (closes #190).
+        /// </summary>
+        internal static bool IsErrorResponseLine(string line)
+        {
+            var trimmed = line.Trim();
+            return MatchesErrorPrefix(trimmed, "**ERROR")
+                   || MatchesErrorPrefix(trimmed, "ERROR");
+        }
+
+        private static bool MatchesErrorPrefix(string trimmed, string prefix)
+        {
+            if (trimmed.Length < prefix.Length
+                || !trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (trimmed.Length == prefix.Length)
+                return true;
+            var next = trimmed[prefix.Length];
+            if (next == ':' || next == ' ' || next == '\t')
+                return true;
+            // Single '!' is ambiguous (could be a filename like "error!log.bin").
+            // Require '!!' so we still catch firmware "Error!!" status text but
+            // let plain filenames pass through.
+            return next == '!'
+                && trimmed.Length > prefix.Length + 1
+                && trimmed[prefix.Length + 1] == '!';
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -123,14 +123,19 @@ namespace Daqifi.Core.Device.SdCard
         // "error" / "Errors" pass through.
         private static bool IsErrorResponseLine(string line)
         {
-            if (line.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
+            // Defensive Trim — current callers already pre-trim, but a future
+            // reuse with raw CRLF input must still classify "ERROR\r" as an
+            // error line rather than letting the trailing '\r' disqualify it
+            // (mirrors IsNonResultLine in DaqifiStreamingDevice).
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
                 return true;
-            if (line.Length >= 5
-                && line.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
+            if (trimmed.Length >= 5
+                && trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
             {
-                if (line.Length == 5)
+                if (trimmed.Length == 5)
                     return true;
-                var next = line[5];
+                var next = trimmed[5];
                 if (next == ':' || next == ' ' || next == '!' || next == '\t')
                     return true;
             }

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -117,12 +117,13 @@ namespace Daqifi.Core.Device.SdCard
         }
 
         /// <summary>
-        /// Returns true if the line is a SCPI error response (<c>**ERROR</c>
-        /// canonical marker, or <c>ERROR</c> followed by a SCPI delimiter
-        /// '<c>:</c>', '<c> </c>', '<c>!</c>', '<c>\t</c>', or end of line).
-        /// Trims both ends so a bare <c>"ERROR\r"</c> from CRLF line endings
-        /// still classifies. Plain filenames whose basename starts with
-        /// <c>error</c> / <c>Errors</c> pass through unmatched (closes #190).
+        /// Returns true if the line is a SCPI error response — either the
+        /// canonical <c>**ERROR</c> marker or a bare <c>ERROR</c> token, in
+        /// each case followed by a SCPI delimiter (<c>:</c>, space, <c>!</c>,
+        /// tab) or end of line. Trims both ends so a bare <c>"ERROR\r"</c>
+        /// from CRLF line endings still classifies. Plain filenames whose
+        /// basename starts with <c>error</c> / <c>Errors</c> pass through
+        /// unmatched (closes #190).
         /// </summary>
         /// <remarks>
         /// Shared with <c>DaqifiStreamingDevice.IsNonResultLine</c> so any
@@ -132,18 +133,19 @@ namespace Daqifi.Core.Device.SdCard
         internal static bool IsErrorResponseLine(string line)
         {
             var trimmed = line.Trim();
-            if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
+            return MatchesErrorPrefix(trimmed, "**ERROR")
+                   || MatchesErrorPrefix(trimmed, "ERROR");
+        }
+
+        private static bool MatchesErrorPrefix(string trimmed, string prefix)
+        {
+            if (trimmed.Length < prefix.Length
+                || !trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (trimmed.Length == prefix.Length)
                 return true;
-            if (trimmed.Length >= 5
-                && trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
-            {
-                if (trimmed.Length == 5)
-                    return true;
-                var next = trimmed[5];
-                if (next == ':' || next == ' ' || next == '!' || next == '\t')
-                    return true;
-            }
-            return false;
+            var next = trimmed[prefix.Length];
+            return next == ':' || next == ' ' || next == '!' || next == '\t';
         }
     }
 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -117,13 +117,18 @@ namespace Daqifi.Core.Device.SdCard
         }
 
         /// <summary>
-        /// Returns true if the line is a SCPI error response — either the
-        /// canonical <c>**ERROR</c> marker or a bare <c>ERROR</c> token, in
-        /// each case followed by a SCPI delimiter (<c>:</c>, space, <c>!</c>,
-        /// tab) or end of line. Trims both ends so a bare <c>"ERROR\r"</c>
-        /// from CRLF line endings still classifies. Plain filenames whose
-        /// basename starts with <c>error</c> / <c>Errors</c> pass through
-        /// unmatched (closes #190).
+        /// Returns true if the line is a non-result error/status line that
+        /// SD listing parsers should drop. Matches both SCPI error responses
+        /// (canonical <c>**ERROR</c> marker, bare <c>ERROR</c> token followed
+        /// by a SCPI delimiter <c>:</c> / space / tab / end-of-line) and
+        /// firmware status text (<c>Error !! ...</c> with space, or the
+        /// no-space <c>Error!!</c> form). A double-<c>!</c> is required when
+        /// no other delimiter is present so legitimate filenames like
+        /// <c>error!log.bin</c> aren't dropped — single <c>!</c> alone is
+        /// ambiguous between error-status and filename. Trims both ends so
+        /// a bare <c>"ERROR\r"</c> from CRLF line endings still classifies.
+        /// Plain filenames whose basename starts with <c>error</c> /
+        /// <c>Errors</c> pass through unmatched (closes #190).
         /// </summary>
         /// <remarks>
         /// Shared with <c>DaqifiStreamingDevice.IsNonResultLine</c> so any
@@ -145,7 +150,14 @@ namespace Daqifi.Core.Device.SdCard
             if (trimmed.Length == prefix.Length)
                 return true;
             var next = trimmed[prefix.Length];
-            return next == ':' || next == ' ' || next == '!' || next == '\t';
+            if (next == ':' || next == ' ' || next == '\t')
+                return true;
+            // Single '!' is ambiguous (could be a filename like "error!log.bin").
+            // Require '!!' so we still catch firmware "Error!!" status text but
+            // let plain filenames pass through.
+            return next == '!'
+                && trimmed.Length > prefix.Length + 1
+                && trimmed[prefix.Length + 1] == '!';
         }
     }
 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -40,9 +40,15 @@ namespace Daqifi.Core.Device.SdCard
 
                 var path = line.Trim();
 
-                // Skip SCPI error responses: "**ERROR: -200, ..." or "ERROR: -200, ..."
-                if (path.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase) ||
-                    path.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
+                // Skip SCPI error responses: "**ERROR: -200, ..." or
+                // "ERROR: -200, ...". Bare "ERROR" prefix can't be used
+                // here because filenames like "error_log.csv" /
+                // "Errors_summary.bin" emitted without the Daqifi/
+                // directory prefix would also match (closes #190 second
+                // location — IsNonResultLine in DaqifiStreamingDevice
+                // had the same bug). Require a non-letter follower so
+                // ordinary filenames pass through.
+                if (IsErrorResponseLine(path))
                 {
                     continue;
                 }
@@ -107,6 +113,26 @@ namespace Daqifi.Core.Device.SdCard
             }
 
             return null;
+        }
+
+        // Mirrors DaqifiStreamingDevice.IsNonResultLine (the LIST? response
+        // classifier). Match `**ERROR` (the canonical SCPI marker) or
+        // `ERROR` followed by a non-letter so legit filenames whose basename
+        // starts with "error" / "Errors" pass through.
+        private static bool IsErrorResponseLine(string line)
+        {
+            if (line.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (line.Length >= 5
+                && line.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
+            {
+                if (line.Length == 5)
+                    return true;
+                var next = line[5];
+                if (next == ':' || next == ' ' || next == '!' || next == '\t')
+                    return true;
+            }
+            return false;
         }
     }
 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -46,8 +46,9 @@ namespace Daqifi.Core.Device.SdCard
                 // "Errors_summary.bin" emitted without the Daqifi/
                 // directory prefix would also match (closes #190 second
                 // location — IsNonResultLine in DaqifiStreamingDevice
-                // had the same bug). Require a non-letter follower so
-                // ordinary filenames pass through.
+                // had the same bug). Match `ERROR` only when followed
+                // by an SCPI delimiter (':', ' ', '!', '\t') or end of
+                // line so ordinary filenames pass through.
                 if (IsErrorResponseLine(path))
                 {
                     continue;
@@ -117,8 +118,9 @@ namespace Daqifi.Core.Device.SdCard
 
         // Mirrors DaqifiStreamingDevice.IsNonResultLine (the LIST? response
         // classifier). Match `**ERROR` (the canonical SCPI marker) or
-        // `ERROR` followed by a non-letter so legit filenames whose basename
-        // starts with "error" / "Errors" pass through.
+        // `ERROR` followed by an SCPI delimiter (':', ' ', '!', '\t') or
+        // end of line, so legit filenames whose basename starts with
+        // "error" / "Errors" pass through.
         private static bool IsErrorResponseLine(string line)
         {
             if (line.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -116,17 +116,21 @@ namespace Daqifi.Core.Device.SdCard
             return null;
         }
 
-        // Mirrors DaqifiStreamingDevice.IsNonResultLine (the LIST? response
-        // classifier). Match `**ERROR` (the canonical SCPI marker) or
-        // `ERROR` followed by an SCPI delimiter (':', ' ', '!', '\t') or
-        // end of line, so legit filenames whose basename starts with
-        // "error" / "Errors" pass through.
-        private static bool IsErrorResponseLine(string line)
+        /// <summary>
+        /// Returns true if the line is a SCPI error response (<c>**ERROR</c>
+        /// canonical marker, or <c>ERROR</c> followed by a SCPI delimiter
+        /// '<c>:</c>', '<c> </c>', '<c>!</c>', '<c>\t</c>', or end of line).
+        /// Trims both ends so a bare <c>"ERROR\r"</c> from CRLF line endings
+        /// still classifies. Plain filenames whose basename starts with
+        /// <c>error</c> / <c>Errors</c> pass through unmatched (closes #190).
+        /// </summary>
+        /// <remarks>
+        /// Shared with <c>DaqifiStreamingDevice.IsNonResultLine</c> so any
+        /// future delimiter / trim refinement stays consistent across both
+        /// SD-response classification paths.
+        /// </remarks>
+        internal static bool IsErrorResponseLine(string line)
         {
-            // Defensive Trim — current callers already pre-trim, but a future
-            // reuse with raw CRLF input must still classify "ERROR\r" as an
-            // error line rather than letting the trailing '\r' disqualify it
-            // (mirrors IsNonResultLine in DaqifiStreamingDevice).
             var trimmed = line.Trim();
             if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
                 return true;

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -40,16 +40,11 @@ namespace Daqifi.Core.Device.SdCard
 
                 var path = line.Trim();
 
-                // Skip SCPI error responses: "**ERROR: -200, ..." or
-                // "ERROR: -200, ...". Bare "ERROR" prefix can't be used
-                // here because filenames like "error_log.csv" /
-                // "Errors_summary.bin" emitted without the Daqifi/
-                // directory prefix would also match (closes #190 second
-                // location — IsNonResultLine in DaqifiStreamingDevice
-                // had the same bug). Match `ERROR` only when followed
-                // by an SCPI delimiter (':', ' ', '!', '\t') or end of
-                // line so ordinary filenames pass through.
-                if (IsErrorResponseLine(path))
+                // Skip SCPI error responses ("**ERROR: -200, ...", "ERROR: -200, ...")
+                // and firmware status text ("Error !! ..."). Classification rule lives
+                // in ScpiResponseClassifier so it stays consistent with
+                // DaqifiStreamingDevice.IsNonResultLine (closes #190).
+                if (ScpiResponseClassifier.IsErrorResponseLine(path))
                 {
                     continue;
                 }
@@ -114,50 +109,6 @@ namespace Daqifi.Core.Device.SdCard
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Returns true if the line is a non-result error/status line that
-        /// SD listing parsers should drop. Matches both SCPI error responses
-        /// (canonical <c>**ERROR</c> marker, bare <c>ERROR</c> token followed
-        /// by a SCPI delimiter <c>:</c> / space / tab / end-of-line) and
-        /// firmware status text (<c>Error !! ...</c> with space, or the
-        /// no-space <c>Error!!</c> form). A double-<c>!</c> is required when
-        /// no other delimiter is present so legitimate filenames like
-        /// <c>error!log.bin</c> aren't dropped — single <c>!</c> alone is
-        /// ambiguous between error-status and filename. Trims both ends so
-        /// a bare <c>"ERROR\r"</c> from CRLF line endings still classifies.
-        /// Plain filenames whose basename starts with <c>error</c> /
-        /// <c>Errors</c> pass through unmatched (closes #190).
-        /// </summary>
-        /// <remarks>
-        /// Shared with <c>DaqifiStreamingDevice.IsNonResultLine</c> so any
-        /// future delimiter / trim refinement stays consistent across both
-        /// SD-response classification paths.
-        /// </remarks>
-        internal static bool IsErrorResponseLine(string line)
-        {
-            var trimmed = line.Trim();
-            return MatchesErrorPrefix(trimmed, "**ERROR")
-                   || MatchesErrorPrefix(trimmed, "ERROR");
-        }
-
-        private static bool MatchesErrorPrefix(string trimmed, string prefix)
-        {
-            if (trimmed.Length < prefix.Length
-                || !trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                return false;
-            if (trimmed.Length == prefix.Length)
-                return true;
-            var next = trimmed[prefix.Length];
-            if (next == ':' || next == ' ' || next == '\t')
-                return true;
-            // Single '!' is ambiguous (could be a filename like "error!log.bin").
-            // Require '!!' so we still catch firmware "Error!!" status text but
-            // let plain filenames pass through.
-            return next == '!'
-                && trimmed.Length > prefix.Length + 1
-                && trimmed[prefix.Length + 1] == '!';
         }
     }
 }


### PR DESCRIPTION
## Summary

Pre-fix, `IsNonResultLine` returned true for any line starting with the bare substring "ERROR" (case-insensitive). `GetSdCardFilesAsync` silently dropped legit SD filenames whose basename starts with "error" (e.g. `error_log.csv`, `Errors_summary.bin`) because the permissive classifier treated them as non-result error/status text.

Tightened to require ERROR followed by `:`, ` `/`\t`, `!`, or end-of-line. The strict `**ERROR` prefix path and `IsScpiErrorLine` are unchanged.

## Test plan

- [x] New test `GetSdCardFilesAsync_FilenamesStartingWithErrorAreNotMisclassified` cans three filenames (`error_log.csv`, `Errors_summary.bin`, `normal.bin`) into the LIST? response and asserts all three round-trip into the parsed file list.
- [x] 891 tests pass on net9.0 + net10.0 (was 890).

## Refs

- Closes #190
- Parallel Python fix: daqifi/daqifi-python-core PR #102