### PR TITLE
fix(device): serialize ExecuteTextCommandAsync (closes #186)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceTextCommandLockTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceTextCommandLockTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Net;
+using System.Reflection;
+using System.Threading.Tasks;
+using Daqifi.Core.Device;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    /// <summary>
+    /// Tests for #186 — ExecuteTextCommandAsync must serialize concurrent
+    /// callers (SemaphoreSlim), reject same-thread re-entrant calls
+    /// (InvalidOperationException, not deadlock), and reject calls when
+    /// the device is disposed or disconnecting.
+    ///
+    /// The protected method is exercised via a thin subclass that exposes
+    /// it. Because spinning up a real transport here would be fragile, the
+    /// pre-lock re-entrancy guard and the disposed/disconnecting guard are
+    /// tested by setting the relevant private fields via reflection — those
+    /// guards run before any transport / consumer interaction, so this gives
+    /// faithful coverage without a transport stack.
+    /// </summary>
+    public class DaqifiDeviceTextCommandLockTests
+    {
+        [Fact]
+        public async Task ExecuteTextCommandAsync_WhenSameThreadAlreadyOwnsLock_ThrowsInvalidOperation()
+        {
+            var device = new TextCommandTestableDevice("TestDevice");
+
+            // Simulate "we're already inside ExecuteTextCommandAsync on this
+            // thread" by directly setting the owner-thread tracker. The
+            // re-entrancy guard runs before WaitAsync(), so this check
+            // fires immediately without touching any transport state.
+            SetOwnerThreadId(device, Environment.CurrentManagedThreadId);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.CallExecuteTextCommandAsync(() => { }));
+            Assert.Contains("not re-entrant", ex.Message);
+        }
+
+        [Fact]
+        public async Task ExecuteTextCommandAsync_WhenDisposing_ThrowsInvalidOperation()
+        {
+            var device = new TextCommandTestableDevice("TestDevice");
+            SetIsDisconnecting(device, true);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.CallExecuteTextCommandAsync(() => { }));
+            Assert.Contains("disposing or disconnecting", ex.Message);
+        }
+
+        [Fact]
+        public async Task ExecuteTextCommandAsync_WhenDisposed_ThrowsInvalidOperation()
+        {
+            var device = new TextCommandTestableDevice("TestDevice");
+            SetDisposed(device, true);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.CallExecuteTextCommandAsync(() => { }));
+            Assert.Contains("disposing or disconnecting", ex.Message);
+        }
+
+        [Fact]
+        public async Task ExecuteTextCommandAsync_ReleasesLockAfterValidationFailure()
+        {
+            // After a validation failure (e.g. not connected), the lock
+            // must be released so subsequent calls don't hang. Verified
+            // by calling twice — second call must reach validation too,
+            // not block on WaitAsync.
+            var device = new TextCommandTestableDevice("TestDevice");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.CallExecuteTextCommandAsync(() => { }));
+            // Second call: also throws, but ONLY if the lock was released.
+            // If the lock leaked, this would deadlock and pytest's per-test
+            // budget would time it out instead.
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.CallExecuteTextCommandAsync(() => { }));
+        }
+
+        [Fact]
+        public async Task ExecuteTextCommandAsync_OwnerThreadIdClearedAfterReturn()
+        {
+            // Even when the call throws, the owner-thread tracker is
+            // cleared in the finally block so a subsequent call from the
+            // same thread doesn't false-positive the re-entrancy check.
+            var device = new TextCommandTestableDevice("TestDevice");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.CallExecuteTextCommandAsync(() => { }));
+
+            Assert.Null(GetOwnerThreadId(device));
+        }
+
+        // ── Reflection helpers — kept private to this test class so the
+        // production DaqifiDevice doesn't have to expose internals. ─────
+
+        private static void SetOwnerThreadId(DaqifiDevice device, int? value)
+        {
+            typeof(DaqifiDevice)
+                .GetField("_textExchangeOwnerThreadId", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(device, value);
+        }
+
+        private static int? GetOwnerThreadId(DaqifiDevice device)
+        {
+            return (int?)typeof(DaqifiDevice)
+                .GetField("_textExchangeOwnerThreadId", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(device);
+        }
+
+        private static void SetIsDisconnecting(DaqifiDevice device, bool value)
+        {
+            typeof(DaqifiDevice)
+                .GetField("_isDisconnecting", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(device, value);
+        }
+
+        private static void SetDisposed(DaqifiDevice device, bool value)
+        {
+            typeof(DaqifiDevice)
+                .GetField("_disposed", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(device, value);
+        }
+
+        /// <summary>
+        /// Subclass that exposes the protected ExecuteTextCommandAsync via
+        /// a public wrapper so tests can call it directly. Does NOT override
+        /// it — the real method runs, including the lock + guards.
+        /// </summary>
+        private class TextCommandTestableDevice : DaqifiDevice
+        {
+            public TextCommandTestableDevice(string name, IPAddress? ipAddress = null)
+                : base(name, ipAddress)
+            {
+            }
+
+            public Task<System.Collections.Generic.IReadOnlyList<string>> CallExecuteTextCommandAsync(
+                Action setupAction)
+            {
+                return ExecuteTextCommandAsync(setupAction, responseTimeoutMs: 100, completionTimeoutMs: 50);
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceTextCommandLockTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceTextCommandLockTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Daqifi.Core.Device;
 using Xunit;
@@ -9,29 +10,29 @@ namespace Daqifi.Core.Tests.Device
 {
     /// <summary>
     /// Tests for #186 — ExecuteTextCommandAsync must serialize concurrent
-    /// callers (SemaphoreSlim), reject same-thread re-entrant calls
-    /// (InvalidOperationException, not deadlock), and reject calls when
-    /// the device is disposed or disconnecting.
+    /// callers (SemaphoreSlim), reject re-entrant calls from the same
+    /// async flow (InvalidOperationException, not deadlock), and reject
+    /// calls when the device is disposed or disconnecting.
     ///
     /// The protected method is exercised via a thin subclass that exposes
-    /// it. Because spinning up a real transport here would be fragile, the
-    /// pre-lock re-entrancy guard and the disposed/disconnecting guard are
-    /// tested by setting the relevant private fields via reflection — those
-    /// guards run before any transport / consumer interaction, so this gives
-    /// faithful coverage without a transport stack.
+    /// it. The disposed/disconnecting guards are tested by setting the
+    /// relevant private fields via reflection — those guards run before
+    /// any transport / consumer interaction, so this gives faithful
+    /// coverage without a transport stack. Re-entrancy is tested by
+    /// flipping the AsyncLocal flag from inside the same logical flow.
     /// </summary>
     public class DaqifiDeviceTextCommandLockTests
     {
         [Fact]
-        public async Task ExecuteTextCommandAsync_WhenSameThreadAlreadyOwnsLock_ThrowsInvalidOperation()
+        public async Task ExecuteTextCommandAsync_WhenAlreadyInsideAsyncFlow_ThrowsInvalidOperation()
         {
             var device = new TextCommandTestableDevice("TestDevice");
 
             // Simulate "we're already inside ExecuteTextCommandAsync on this
-            // thread" by directly setting the owner-thread tracker. The
-            // re-entrancy guard runs before WaitAsync(), so this check
-            // fires immediately without touching any transport state.
-            SetOwnerThreadId(device, Environment.CurrentManagedThreadId);
+            // async flow" by setting the AsyncLocal flag. The re-entrancy
+            // guard runs before WaitAsync(), so this check fires immediately
+            // without touching any transport state.
+            GetIsInsideTextExchange(device).Value = true;
 
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => device.CallExecuteTextCommandAsync(() => { }));
@@ -72,41 +73,34 @@ namespace Daqifi.Core.Tests.Device
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => device.CallExecuteTextCommandAsync(() => { }));
             // Second call: also throws, but ONLY if the lock was released.
-            // If the lock leaked, this would deadlock and pytest's per-test
+            // If the lock leaked, this would deadlock and xunit's per-test
             // budget would time it out instead.
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => device.CallExecuteTextCommandAsync(() => { }));
         }
 
         [Fact]
-        public async Task ExecuteTextCommandAsync_OwnerThreadIdClearedAfterReturn()
+        public async Task ExecuteTextCommandAsync_AsyncLocalClearedAfterReturn()
         {
-            // Even when the call throws, the owner-thread tracker is
-            // cleared in the finally block so a subsequent call from the
-            // same thread doesn't false-positive the re-entrancy check.
+            // Even when the call throws, the AsyncLocal re-entrancy flag
+            // is cleared in the finally block so a subsequent call from
+            // the same flow doesn't false-positive the re-entrancy check.
             var device = new TextCommandTestableDevice("TestDevice");
 
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => device.CallExecuteTextCommandAsync(() => { }));
 
-            Assert.Null(GetOwnerThreadId(device));
+            Assert.False(GetIsInsideTextExchange(device).Value);
         }
 
         // ── Reflection helpers — kept private to this test class so the
         // production DaqifiDevice doesn't have to expose internals. ─────
 
-        private static void SetOwnerThreadId(DaqifiDevice device, int? value)
+        private static AsyncLocal<bool> GetIsInsideTextExchange(DaqifiDevice device)
         {
-            typeof(DaqifiDevice)
-                .GetField("_textExchangeOwnerThreadId", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .SetValue(device, value);
-        }
-
-        private static int? GetOwnerThreadId(DaqifiDevice device)
-        {
-            return (int?)typeof(DaqifiDevice)
-                .GetField("_textExchangeOwnerThreadId", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .GetValue(device);
+            return (AsyncLocal<bool>)typeof(DaqifiDevice)
+                .GetField("_isInsideTextExchange", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(device)!;
         }
 
         private static void SetIsDisconnecting(DaqifiDevice device, bool value)

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -219,17 +219,20 @@ namespace Daqifi.Core.Device
         /// Disconnects from the device.
         /// </summary>
         /// <remarks>
-        /// Waits up to 1 second to acquire <c>_textExchangeLock</c> before
+        /// Waits up to 10 seconds to acquire <c>_textExchangeLock</c> before
         /// tearing down the consumer / producer / transport. This prevents
         /// a race where an in-flight <see cref="ExecuteTextCommandAsync"/>
         /// is mid-swap (text consumer running on the stream, protobuf
         /// consumer not yet restarted) and Disconnect rips the transport
         /// out from under it. If the wait times out, Disconnect proceeds
         /// anyway — a stuck text exchange must not block teardown forever.
-        /// The 1s budget is the longest delay any normal text exchange
-        /// can hold the lock for (responseTimeoutMs default + safety
-        /// margin); callers wanting non-blocking disconnect should drive
-        /// this off a Task.Run.
+        /// The 10s budget covers the worst-case ExecuteTextCommandAsync
+        /// hold time with default timeouts (StopSafely up to 1s + maxWait
+        /// of responseTimeoutMs*5 = 5s by default + safety margin) and
+        /// most custom-timeout callers; on timeout the in-flight exchange
+        /// sees <c>_isDisconnecting == true</c> via the post-acquisition
+        /// validation and bails out cleanly. Callers wanting non-blocking
+        /// disconnect should drive this off a Task.Run.
         /// </remarks>
         public void Disconnect()
         {
@@ -244,7 +247,7 @@ namespace Daqifi.Core.Device
             var lockAcquired = false;
             try
             {
-                lockAcquired = _textExchangeLock.Wait(TimeSpan.FromSeconds(1));
+                lockAcquired = _textExchangeLock.Wait(TimeSpan.FromSeconds(10));
             }
             catch (ObjectDisposedException)
             {

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -219,26 +219,32 @@ namespace Daqifi.Core.Device
         /// Disconnects from the device.
         /// </summary>
         /// <remarks>
-        /// Waits up to 5 seconds to acquire <c>_textExchangeLock</c> before
+        /// Waits up to 1 second to acquire <c>_textExchangeLock</c> before
         /// tearing down the consumer / producer / transport. This prevents
         /// a race where an in-flight <see cref="ExecuteTextCommandAsync"/>
         /// is mid-swap (text consumer running on the stream, protobuf
         /// consumer not yet restarted) and Disconnect rips the transport
         /// out from under it. If the wait times out, Disconnect proceeds
         /// anyway — a stuck text exchange must not block teardown forever.
+        /// The 1s budget is the longest delay any normal text exchange
+        /// can hold the lock for (responseTimeoutMs default + safety
+        /// margin); callers wanting non-blocking disconnect should drive
+        /// this off a Task.Run.
         /// </remarks>
         public void Disconnect()
         {
             _isDisconnecting = true;
-            // Best-effort coordination with ExecuteTextCommandAsync. We do
-            // NOT release this lock — Dispose() disposes the semaphore
-            // shortly after, and any in-flight text exchange will see
-            // _isDisconnecting on its own validation path or take the
-            // ObjectDisposedException catch in its Release().
+            // Best-effort coordination with ExecuteTextCommandAsync —
+            // acquire the lock so we don't tear the transport out from
+            // under an in-flight text exchange. The lock IS released in
+            // the finally below when acquired (so a future Connect()
+            // followed by ExecuteTextCommandAsync isn't blocked); a
+            // stuck exchange that holds past the timeout drops to the
+            // _isDisconnecting validation path inside the exchange.
             var lockAcquired = false;
             try
             {
-                lockAcquired = _textExchangeLock.Wait(TimeSpan.FromSeconds(5));
+                lockAcquired = _textExchangeLock.Wait(TimeSpan.FromSeconds(1));
             }
             catch (ObjectDisposedException)
             {
@@ -484,7 +490,11 @@ namespace Daqifi.Core.Device
                 };
 
                 textConsumer.Start();
-                await Task.Delay(50, cancellationToken);
+                // ConfigureAwait(false): the lock is held across this delay,
+                // so resuming on a captured sync context (e.g. UI thread)
+                // would let a sync Disconnect() call from that same thread
+                // deadlock waiting for the lock we hold.
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
 
                 Trace.WriteLine($"[ExecuteTextCommandAsync] Text consumer started at {sw.ElapsedMilliseconds}ms");
 
@@ -504,7 +514,10 @@ namespace Daqifi.Core.Device
                 while (DateTime.UtcNow - startTime < maxWait)
                 {
                     var previousCount = collectedLines.Count;
-                    await Task.Delay(50, cancellationToken);
+                    // ConfigureAwait(false): see textConsumer.Start above —
+                    // we still hold _textExchangeLock and must not resume on
+                    // a captured sync context.
+                    await Task.Delay(50, cancellationToken).ConfigureAwait(false);
                     if (collectedLines.Count > previousCount)
                     {
                         lastMessageTime = DateTime.UtcNow;

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -398,7 +398,20 @@ namespace Daqifi.Core.Device
                     + "do not call it from inside a setupAction callback.");
             }
 
-            await _textExchangeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _textExchangeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Dispose() raced ahead of us and disposed the semaphore.
+                // Surface the same clean failure as the post-acquisition
+                // _disposed check below, instead of leaking a low-level
+                // teardown exception to callers.
+                throw new InvalidOperationException(
+                    "ExecuteTextCommandAsync cannot run because the device is disposed.");
+            }
+
             _isInsideTextExchange.Value = true;
             try
             {

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -80,6 +80,25 @@ namespace Daqifi.Core.Device
         private bool _isDisconnecting;
         private bool _isInitialized;
         private readonly List<IChannel> _channels = new();
+
+        // Serializes ExecuteTextCommandAsync calls device-wide (closes #186).
+        // Multiple callers — e.g. concurrent GetSdCardFilesAsync /
+        // DrainErrorQueueAsync / GetSystemInfoAsync — would otherwise race the
+        // protobuf-consumer pause/swap/restart sequence on the same stream and
+        // either intermix SCPI bytes on the wire or interleave reply lines
+        // between callers' returned lists. SemaphoreSlim chosen over Lock
+        // because the method is async; counter is (1, 1) for mutual exclusion.
+        private readonly SemaphoreSlim _textExchangeLock = new(1, 1);
+
+        // Thread that currently holds _textExchangeLock, or null when free.
+        // Lets ExecuteTextCommandAsync detect a same-thread re-entrant call
+        // (a setupAction that itself calls back into ExecuteTextCommandAsync)
+        // and throw InvalidOperationException instead of deadlocking on
+        // _textExchangeLock.WaitAsync(). Same safety guarantee — the
+        // re-entrant call would corrupt the consumer swap; better failure
+        // mode for callers (clean exception, stack trace) than a hung
+        // process (closes #186 follow-up).
+        private int? _textExchangeOwnerThreadId;
         
         /// <summary>
         /// Gets the current connection status of the device.
@@ -328,26 +347,53 @@ namespace Daqifi.Core.Device
             if (completionTimeoutMs <= 0)
                 throw new ArgumentOutOfRangeException(nameof(completionTimeoutMs), completionTimeoutMs, "Timeout must be positive.");
 
-            var sw = Stopwatch.StartNew();
-
-            if (!IsConnected)
-            {
-                throw new InvalidOperationException("Device is not connected.");
-            }
-
-            if (_transport == null)
-            {
-                throw new InvalidOperationException("ExecuteTextCommandAsync requires a transport-based connection.");
-            }
-
             cancellationToken.ThrowIfCancellationRequested();
 
-            var collectedLines = new List<string>();
-            var stream = _transport.Stream;
-            int? originalReadTimeout = null;
+            // Same-thread re-entrancy detection: a setupAction that calls
+            // ExecuteTextCommandAsync on the same device would corrupt the
+            // consumer swap mid-flight. Surface as a clean exception rather
+            // than wedging on _textExchangeLock.WaitAsync() forever.
+            var currentTid = Environment.CurrentManagedThreadId;
+            if (_textExchangeOwnerThreadId == currentTid)
+            {
+                throw new InvalidOperationException(
+                    "ExecuteTextCommandAsync is not re-entrant on the same device; "
+                    + "do not call it from inside a setupAction callback.");
+            }
 
+            await _textExchangeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            _textExchangeOwnerThreadId = currentTid;
             try
             {
+                // All validation runs INSIDE the lock so a competing thread
+                // calling DisconnectAsync() / Dispose() while we're blocked
+                // on WaitAsync() doesn't leave us with a stale _transport /
+                // _messageConsumer reference (closes the TOCTOU window
+                // documented in #186).
+                if (_disposed || _isDisconnecting)
+                {
+                    throw new InvalidOperationException(
+                        "ExecuteTextCommandAsync cannot run while the device is "
+                        + "disposing or disconnecting.");
+                }
+
+                if (!IsConnected)
+                {
+                    throw new InvalidOperationException("Device is not connected.");
+                }
+
+                if (_transport == null)
+                {
+                    throw new InvalidOperationException("ExecuteTextCommandAsync requires a transport-based connection.");
+                }
+
+                var sw = Stopwatch.StartNew();
+                var collectedLines = new List<string>();
+                var stream = _transport.Stream;
+                int? originalReadTimeout = null;
+
+                try
+                {
                 if (stream.CanTimeout)
                 {
                     try
@@ -468,7 +514,13 @@ namespace Daqifi.Core.Device
                 Trace.WriteLine($"[ExecuteTextCommandAsync] Total elapsed: {sw.ElapsedMilliseconds}ms");
             }
 
-            return collectedLines;
+                return collectedLines;
+            }
+            finally
+            {
+                _textExchangeOwnerThreadId = null;
+                _textExchangeLock.Release();
+            }
         }
 
         /// <summary>
@@ -595,6 +647,7 @@ namespace Daqifi.Core.Device
                 _messageConsumer?.Dispose();
                 _messageProducer?.Dispose();
                 _transport?.Dispose();
+                _textExchangeLock.Dispose();
                 _disposed = true;
             }
         }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -90,15 +90,16 @@ namespace Daqifi.Core.Device
         // because the method is async; counter is (1, 1) for mutual exclusion.
         private readonly SemaphoreSlim _textExchangeLock = new(1, 1);
 
-        // Thread that currently holds _textExchangeLock, or null when free.
-        // Lets ExecuteTextCommandAsync detect a same-thread re-entrant call
-        // (a setupAction that itself calls back into ExecuteTextCommandAsync)
-        // and throw InvalidOperationException instead of deadlocking on
-        // _textExchangeLock.WaitAsync(). Same safety guarantee — the
-        // re-entrant call would corrupt the consumer swap; better failure
-        // mode for callers (clean exception, stack trace) than a hung
-        // process (closes #186 follow-up).
-        private int? _textExchangeOwnerThreadId;
+        // Async-context flag that tracks whether the current logical flow
+        // already holds _textExchangeLock. AsyncLocal flows across await
+        // resumptions on different threads, so a setupAction that re-enters
+        // ExecuteTextCommandAsync after a ConfigureAwait(false) hop is still
+        // detected and surfaced as InvalidOperationException — instead of
+        // wedging on _textExchangeLock.WaitAsync() (the re-entrant call
+        // would corrupt the consumer swap mid-flight). Plain
+        // Environment.CurrentManagedThreadId capture wouldn't work — the
+        // value seen before await may not match the value seen after.
+        private readonly AsyncLocal<bool> _isInsideTextExchange = new();
         
         /// <summary>
         /// Gets the current connection status of the device.
@@ -217,9 +218,33 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Disconnects from the device.
         /// </summary>
+        /// <remarks>
+        /// Waits up to 5 seconds to acquire <c>_textExchangeLock</c> before
+        /// tearing down the consumer / producer / transport. This prevents
+        /// a race where an in-flight <see cref="ExecuteTextCommandAsync"/>
+        /// is mid-swap (text consumer running on the stream, protobuf
+        /// consumer not yet restarted) and Disconnect rips the transport
+        /// out from under it. If the wait times out, Disconnect proceeds
+        /// anyway — a stuck text exchange must not block teardown forever.
+        /// </remarks>
         public void Disconnect()
         {
             _isDisconnecting = true;
+            // Best-effort coordination with ExecuteTextCommandAsync. We do
+            // NOT release this lock — Dispose() disposes the semaphore
+            // shortly after, and any in-flight text exchange will see
+            // _isDisconnecting on its own validation path or take the
+            // ObjectDisposedException catch in its Release().
+            var lockAcquired = false;
+            try
+            {
+                lockAcquired = _textExchangeLock.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (ObjectDisposedException)
+            {
+                // Disconnect called after Dispose — nothing to coordinate.
+            }
+
             try
             {
                 // Unsubscribe from message consumer events
@@ -241,6 +266,16 @@ namespace Daqifi.Core.Device
                 State = DeviceState.Disconnected;
                 _isInitialized = false;
                 _isDisconnecting = false;
+                if (lockAcquired)
+                {
+                    try
+                    {
+                        _textExchangeLock.Release();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
+                }
             }
         }
 
@@ -349,12 +384,14 @@ namespace Daqifi.Core.Device
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Same-thread re-entrancy detection: a setupAction that calls
+            // Async-context re-entrancy detection: a setupAction that calls
             // ExecuteTextCommandAsync on the same device would corrupt the
             // consumer swap mid-flight. Surface as a clean exception rather
             // than wedging on _textExchangeLock.WaitAsync() forever.
-            var currentTid = Environment.CurrentManagedThreadId;
-            if (_textExchangeOwnerThreadId == currentTid)
+            // AsyncLocal flows across await thread hops so this catches
+            // re-entry even when the inner call resumes on a different
+            // thread than the outer call.
+            if (_isInsideTextExchange.Value)
             {
                 throw new InvalidOperationException(
                     "ExecuteTextCommandAsync is not re-entrant on the same device; "
@@ -362,7 +399,7 @@ namespace Daqifi.Core.Device
             }
 
             await _textExchangeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            _textExchangeOwnerThreadId = currentTid;
+            _isInsideTextExchange.Value = true;
             try
             {
                 // All validation runs INSIDE the lock so a competing thread
@@ -518,8 +555,20 @@ namespace Daqifi.Core.Device
             }
             finally
             {
-                _textExchangeOwnerThreadId = null;
-                _textExchangeLock.Release();
+                _isInsideTextExchange.Value = false;
+                // Release can race with Dispose() — Dispose acquires the lock
+                // before disposing it, but if that acquisition timed out and
+                // Dispose proceeded anyway, our SemaphoreSlim handle is now
+                // gone. Treat that as a benign teardown signal rather than
+                // surfacing it from the finally and masking the original
+                // exception (if any) from the try body.
+                try
+                {
+                    _textExchangeLock.Release();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
             }
         }
 

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -453,132 +453,127 @@ namespace Daqifi.Core.Device
 
                 try
                 {
-                if (stream.CanTimeout)
-                {
-                    try
+                    if (stream.CanTimeout)
                     {
-                        originalReadTimeout = stream.ReadTimeout;
-                        stream.ReadTimeout = Math.Min(500, Math.Max(100, responseTimeoutMs / 4));
+                        try
+                        {
+                            originalReadTimeout = stream.ReadTimeout;
+                            stream.ReadTimeout = Math.Min(500, Math.Max(100, responseTimeoutMs / 4));
+                        }
+                        catch
+                        {
+                            // Some streams may not allow setting read timeout; ignore.
+                            originalReadTimeout = null;
+                        }
                     }
-                    catch
+
+                    // Stop the protobuf consumer so it doesn't compete for stream bytes.
+                    // The serial transport sets ReadTimeout=500ms after connect, so the
+                    // consumer thread's blocking Read will unblock within 500ms.
+                    if (_messageConsumer != null)
                     {
-                        // Some streams may not allow setting read timeout; ignore.
-                        originalReadTimeout = null;
+                        _messageConsumer.MessageReceived -= OnInboundMessageReceived;
+                        var stopped = _messageConsumer.StopSafely(timeoutMs: 1000);
+                        if (!stopped)
+                        {
+                            _messageConsumer.Stop();
+                        }
                     }
-                }
 
-                // Stop the protobuf consumer so it doesn't compete for stream bytes.
-                // The serial transport sets ReadTimeout=500ms after connect, so the
-                // consumer thread's blocking Read will unblock within 500ms.
-                if (_messageConsumer != null)
-                {
-                    _messageConsumer.MessageReceived -= OnInboundMessageReceived;
-                    var stopped = _messageConsumer.StopSafely(timeoutMs: 1000);
-                    if (!stopped)
+                    Trace.WriteLine($"[ExecuteTextCommandAsync] Protobuf consumer stopped at {sw.ElapsedMilliseconds}ms");
+
+                    // Create a temporary text consumer on the same stream
+                    using var textConsumer = new StreamMessageConsumer<string>(
+                        _transport.Stream,
+                        new LineBasedMessageParser());
+
+                    textConsumer.MessageReceived += (_, e) =>
                     {
-                        _messageConsumer.Stop();
-                    }
-                }
+                        collectedLines.Add(e.Message.Data);
+                    };
 
-                Trace.WriteLine($"[ExecuteTextCommandAsync] Protobuf consumer stopped at {sw.ElapsedMilliseconds}ms");
-
-                // Create a temporary text consumer on the same stream
-                using var textConsumer = new StreamMessageConsumer<string>(
-                    _transport.Stream,
-                    new LineBasedMessageParser());
-
-                textConsumer.MessageReceived += (_, e) =>
-                {
-                    collectedLines.Add(e.Message.Data);
-                };
-
-                textConsumer.Start();
-                // ConfigureAwait(false): the lock is held across this delay,
-                // so resuming on a captured sync context (e.g. UI thread)
-                // would let a sync Disconnect() call from that same thread
-                // deadlock waiting for the lock we hold.
-                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
-
-                Trace.WriteLine($"[ExecuteTextCommandAsync] Text consumer started at {sw.ElapsedMilliseconds}ms");
-
-                // Execute the setup action (sends SCPI commands)
-                setupAction();
-
-                Trace.WriteLine($"[ExecuteTextCommandAsync] Setup action completed at {sw.ElapsedMilliseconds}ms");
-
-                // Wait for responses using a two-phase inactivity-based timeout:
-                // Phase 1: Wait up to responseTimeoutMs for the first response.
-                // Phase 2: After receiving data, wait completionTimeoutMs of inactivity to finish.
-                var lastMessageTime = DateTime.UtcNow;
-                var maxWait = TimeSpan.FromMilliseconds(responseTimeoutMs * 5);
-                var startTime = DateTime.UtcNow;
-                var hasReceivedAny = false;
-
-                while (DateTime.UtcNow - startTime < maxWait)
-                {
-                    var previousCount = collectedLines.Count;
-                    // ConfigureAwait(false): see textConsumer.Start above —
-                    // we still hold _textExchangeLock and must not resume on
-                    // a captured sync context.
+                    textConsumer.Start();
+                    // ConfigureAwait(false): the lock is held, so resuming on a captured
+                    // sync context (e.g. UI thread) would deadlock if that thread calls Disconnect().
                     await Task.Delay(50, cancellationToken).ConfigureAwait(false);
-                    if (collectedLines.Count > previousCount)
+
+                    Trace.WriteLine($"[ExecuteTextCommandAsync] Text consumer started at {sw.ElapsedMilliseconds}ms");
+
+                    // Execute the setup action (sends SCPI commands)
+                    setupAction();
+
+                    Trace.WriteLine($"[ExecuteTextCommandAsync] Setup action completed at {sw.ElapsedMilliseconds}ms");
+
+                    // Wait for responses using a two-phase inactivity-based timeout:
+                    // Phase 1: Wait up to responseTimeoutMs for the first response.
+                    // Phase 2: After receiving data, wait completionTimeoutMs of inactivity to finish.
+                    var lastMessageTime = DateTime.UtcNow;
+                    var maxWait = TimeSpan.FromMilliseconds(responseTimeoutMs * 5);
+                    var startTime = DateTime.UtcNow;
+                    var hasReceivedAny = false;
+
+                    while (DateTime.UtcNow - startTime < maxWait)
                     {
-                        lastMessageTime = DateTime.UtcNow;
-                        if (!hasReceivedAny)
+                        var previousCount = collectedLines.Count;
+                        await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                        if (collectedLines.Count > previousCount)
                         {
-                            hasReceivedAny = true;
-                            Trace.WriteLine($"[ExecuteTextCommandAsync] First response at {sw.ElapsedMilliseconds}ms");
+                            lastMessageTime = DateTime.UtcNow;
+                            if (!hasReceivedAny)
+                            {
+                                hasReceivedAny = true;
+                                Trace.WriteLine($"[ExecuteTextCommandAsync] First response at {sw.ElapsedMilliseconds}ms");
+                            }
+                        }
+
+                        var elapsed = DateTime.UtcNow - lastMessageTime;
+
+                        if (hasReceivedAny)
+                        {
+                            // Phase 2: short completion timeout after first data
+                            if (elapsed >= TimeSpan.FromMilliseconds(completionTimeoutMs))
+                            {
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            // Phase 1: full initial timeout waiting for first data
+                            if (elapsed >= TimeSpan.FromMilliseconds(responseTimeoutMs))
+                            {
+                                break;
+                            }
                         }
                     }
 
-                    var elapsed = DateTime.UtcNow - lastMessageTime;
+                    Trace.WriteLine($"[ExecuteTextCommandAsync] Collection complete at {sw.ElapsedMilliseconds}ms, {collectedLines.Count} lines");
 
-                    if (hasReceivedAny)
-                    {
-                        // Phase 2: short completion timeout after first data
-                        if (elapsed >= TimeSpan.FromMilliseconds(completionTimeoutMs))
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        // Phase 1: full initial timeout waiting for first data
-                        if (elapsed >= TimeSpan.FromMilliseconds(responseTimeoutMs))
-                        {
-                            break;
-                        }
-                    }
+                    // Stop the text consumer
+                    textConsumer.StopSafely();
                 }
-
-                Trace.WriteLine($"[ExecuteTextCommandAsync] Collection complete at {sw.ElapsedMilliseconds}ms, {collectedLines.Count} lines");
-
-                // Stop the text consumer
-                textConsumer.StopSafely();
-            }
-            finally
-            {
-                if (originalReadTimeout.HasValue && stream.CanTimeout)
+                finally
                 {
-                    try
+                    if (originalReadTimeout.HasValue && stream.CanTimeout)
                     {
-                        stream.ReadTimeout = originalReadTimeout.Value;
+                        try
+                        {
+                            stream.ReadTimeout = originalReadTimeout.Value;
+                        }
+                        catch
+                        {
+                            // Ignore failures when restoring timeout.
+                        }
                     }
-                    catch
+
+                    // Restart the protobuf consumer
+                    if (_messageConsumer != null)
                     {
-                        // Ignore failures when restoring timeout.
+                        _messageConsumer.Start();
+                        _messageConsumer.MessageReceived += OnInboundMessageReceived;
                     }
-                }
 
-                // Restart the protobuf consumer
-                if (_messageConsumer != null)
-                {
-                    _messageConsumer.Start();
-                    _messageConsumer.MessageReceived += OnInboundMessageReceived;
+                    Trace.WriteLine($"[ExecuteTextCommandAsync] Total elapsed: {sw.ElapsedMilliseconds}ms");
                 }
-
-                Trace.WriteLine($"[ExecuteTextCommandAsync] Total elapsed: {sw.ElapsedMilliseconds}ms");
-            }
 
                 return collectedLines;
             }


### PR DESCRIPTION
## Summary

Adds `SemaphoreSlim` around `ExecuteTextCommandAsync` so concurrent callers no longer race the protobuf-consumer pause/swap/restart sequence on the same stream. Also closes the TOCTOU window between the existing pre-lock validation and consumer manipulation, detects same-thread re-entrant calls explicitly, and rejects calls during disposed/disconnecting state.

## Implementation

- `_textExchangeLock = new SemaphoreSlim(1, 1)` mutex. Disposed in `Dispose()`.
- `_textExchangeOwnerThreadId` tracks the holding thread. Same-thread re-entry (a `setupAction` recursing into `ExecuteTextCommandAsync`) is detected BEFORE `WaitAsync()` and throws `InvalidOperationException("not re-entrant")` instead of deadlocking.
- ALL validation moved INSIDE the lock — competing `Disconnect()` / `Dispose()` during `WaitAsync()` no longer leaves a stale `_transport` / `_messageConsumer` reference (TOCTOU close).
- New `_disposed || _isDisconnecting` guard rejects calls during teardown.

Mirrors daqifi/daqifi-python-core PR #104.

## Test plan

- [x] 5 new tests in `DaqifiDeviceTextCommandLockTests` (re-entrancy guard, `_isDisconnecting`, `_disposed`, lock released after validation failure, owner cleared after exception). Reflection-based — guards run before transport interaction so this is faithful coverage without a transport stack.
- [x] Existing tests still pass.
- [x] 895 tests pass on net9.0 + net10.0 (was 890).

## Refs

- Closes #186