### PR TITLE
feat(firmware): split WiFi update planning from execution (closes #143)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -650,6 +650,93 @@ public class FirmwareUpdateServiceTests
         Assert.Contains("SYSTem:COMMUnicate:LAN:FWUpdate", device.SentCommands);
     }
 
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_ReentrantCallFromUpdateProgressCallback_DoesNotDeadlock()
+    {
+        // Closes a Qodo finding on PR #198: UpdateWifiModuleAsync holds
+        // _operationLock while synchronously firing progress.Report().
+        // A handler that calls back into CheckWifiFirmwareStatusAsync
+        // would deadlock waiting for the same lock the update flow owns
+        // (SemaphoreSlim is not re-entrant). The AsyncLocal _isInsideOperation
+        // flag detects this case and skips the second acquisition.
+        //
+        // The test invokes CheckWifiFirmwareStatusAsync from inside a
+        // progress callback fired by UpdateWifiModuleAsync. Without the
+        // re-entrancy guard, this hangs until xunit's per-test budget
+        // kills it. With the guard, the inner call returns quickly and
+        // the update completes normally.
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 6, 1, null, 0),
+            TagName = "19.6.1",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice("COM13", chipInfo: new LanChipInfo
+        {
+            ChipId = 1234,
+            FwVersion = "19.5.4",
+            BuildDate = "Jan  8 2019"
+        });
+
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), [], [])
+        };
+
+        var options = CreateFastOptions();
+        options.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(5);
+        options.PostWifiReconnectDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        WifiFirmwareStatus? reentrantStatus = null;
+        var reentryAttempted = false;
+
+        // Progress handler that re-enters CheckWifiFirmwareStatusAsync
+        // exactly once (on the first event) — mirrors a UI consumer
+        // that might want to refresh status display when an update
+        // transitions state.
+        var progress = new SyncProgress<FirmwareUpdateProgress>(_ =>
+        {
+            if (reentryAttempted)
+            {
+                return;
+            }
+            reentryAttempted = true;
+            reentrantStatus = service.CheckWifiFirmwareStatusAsync(device).GetAwaiter().GetResult();
+        });
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(device, firmwareDir, progress);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.True(reentryAttempted, "Progress callback never fired — test setup wrong.");
+        Assert.NotNull(reentrantStatus);
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+    }
+
+    private sealed class SyncProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _handler;
+        public SyncProgress(Action<T> handler) => _handler = handler;
+        public void Report(T value) => _handler(value);
+    }
+
     private static FirmwareUpdateServiceOptions CreateFastOptions()
     {
         return new FirmwareUpdateServiceOptions

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -637,7 +637,6 @@ public class FirmwareUpdateServiceTests
                 device,
                 firmwareDir,
                 progress: null,
-                cancellationToken: CancellationToken.None,
                 skipVersionCheck: true);
         }
         finally

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -716,9 +716,28 @@ public class FirmwareUpdateServiceTests
             reentrantStatus = service.CheckWifiFirmwareStatusAsync(device).GetAwaiter().GetResult();
         });
 
+        // Hard timeout via WaitAsync so a regression of the deadlock fails
+        // fast instead of stalling the whole xunit run waiting for the
+        // global per-test budget. The fast-options + ms-scale delays mean
+        // the happy path completes in well under a second; 30s is plenty
+        // of margin under heavy CI load while still being a clear "stuck".
         try
         {
-            await service.UpdateWifiModuleAsync(device, firmwareDir, progress);
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await service.UpdateWifiModuleAsync(device, firmwareDir, progress)
+                .WaitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!reentryAttempted)
+        {
+            throw new Xunit.Sdk.XunitException(
+                "Test setup failed before reentrancy was attempted.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw new Xunit.Sdk.XunitException(
+                "UpdateWifiModuleAsync did not complete within 30s — the "
+                + "AsyncLocal re-entrancy guard likely regressed and the "
+                + "inner CheckWifiFirmwareStatusAsync call is deadlocked.");
         }
         finally
         {

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -730,6 +730,197 @@ public class FirmwareUpdateServiceTests
         Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
     }
 
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenLanChipInfoFailsTransiently_RetriesUntilSuccess()
+    {
+        // Closes #144: post-PIC32-reboot the WiFi subsystem can lag the
+        // application by a few seconds, so the first chip-info query
+        // transiently fails. Without retry, the WiFi version decision
+        // would short-circuit and trigger an unnecessary multi-minute
+        // reflash. The retry budget covers the startup window.
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 5, 4, null, 0),
+            TagName = "19.5.4",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM14",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            },
+            transientFailuresBeforeSuccess: 2);
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5); // Keep test fast
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+        Assert.True(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.UpToDate, status.Reason);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenLanChipInfoFailsAllAttempts_ReturnsChipInfoUnavailable()
+    {
+        // After exhausting LanChipInfoMaxAttempts the planning method must
+        // fall through to ChipInfoUnavailable, NOT hang or surface the
+        // raw exception. This preserves the "couldn't check, default to
+        // running update" semantics for genuinely-broken devices.
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM15",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            },
+            transientFailuresBeforeSuccess: 99);
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+        Assert.False(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.ChipInfoUnavailable, status.Reason);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_TotalTimeoutHit_ShortCircuitsToChipInfoUnavailable()
+    {
+        // Closes a Qodo follow-up on PR #199: per-attempt query timeouts
+        // compound with retry delays, so a high MaxAttempts × non-trivial
+        // per-attempt latency could block far beyond the configured retry
+        // budget while holding _operationLock. The total-timeout cap caps
+        // wall-clock time independent of attempt counts.
+        //
+        // The fake's per-attempt latency is the Task.Delay below; with
+        // 200ms latency × 10 max attempts × 100ms retry delay, a naive
+        // implementation would block ~2.9s. The 100ms total timeout
+        // forces an early ChipInfoUnavailable return after the first
+        // attempt's latency exceeds the budget.
+        var device = new SlowFakeLanChipInfoStreamingDevice(
+            "COM17",
+            attemptLatency: TimeSpan.FromMilliseconds(200));
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 10;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(100);
+        options.LanChipInfoTotalTimeout = TimeSpan.FromMilliseconds(100);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+        stopwatch.Stop();
+
+        Assert.False(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.ChipInfoUnavailable, status.Reason);
+        // Should bail well before attempting all 10 × (200ms + 100ms) = 3s.
+        // Allowing 1500ms for CI variance / xunit overhead.
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(1500),
+            $"Probe took {stopwatch.ElapsedMilliseconds}ms, expected <1500ms with TotalTimeout=100ms.");
+    }
+
+    private sealed class SlowFakeLanChipInfoStreamingDevice : IStreamingDevice, ILanChipInfoProvider
+    {
+        private readonly TimeSpan _attemptLatency;
+        public SlowFakeLanChipInfoStreamingDevice(string name, TimeSpan attemptLatency)
+        {
+            Name = name;
+            _attemptLatency = attemptLatency;
+            IsConnected = true;
+        }
+        public string Name { get; }
+        public IPAddress? IpAddress => null;
+        public bool IsConnected { get; private set; }
+        public ConnectionStatus Status => ConnectionStatus.Connected;
+        public int StreamingFrequency { get; set; }
+        public bool IsStreaming { get; private set; }
+        public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
+        public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
+        public void Connect() => IsConnected = true;
+        public void Disconnect() => IsConnected = false;
+        public void Send<T>(IOutboundMessage<T> message) { }
+        public void StartStreaming() => IsStreaming = true;
+        public void StopStreaming() => IsStreaming = false;
+        public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(_attemptLatency, cancellationToken).ConfigureAwait(false);
+            return null;
+        }
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_FirstAttemptSucceeds_DoesNotRetry()
+    {
+        // Steady-state path: no retry overhead when the first call works.
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 5, 4, null, 0),
+            TagName = "19.5.4",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM16",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            });
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(1, device.GetLanChipInfoCallCount);
+    }
+
     private sealed class SyncProgress<T> : IProgress<T>
     {
         private readonly Action<T> _handler;
@@ -848,13 +1039,17 @@ public class FirmwareUpdateServiceTests
     {
         private readonly LanChipInfo? _chipInfo;
         private ConnectionStatus _status = ConnectionStatus.Connected;
+        private int _remainingTransientFailures;
 
-        public FakeLanChipInfoStreamingDevice(string name, LanChipInfo? chipInfo)
+        public FakeLanChipInfoStreamingDevice(string name, LanChipInfo? chipInfo, int transientFailuresBeforeSuccess = 0)
         {
             Name = name;
             _chipInfo = chipInfo;
+            _remainingTransientFailures = transientFailuresBeforeSuccess;
             IsConnected = true;
         }
+
+        public int GetLanChipInfoCallCount { get; private set; }
 
         public string Name { get; }
         public IPAddress? IpAddress => null;
@@ -899,6 +1094,16 @@ public class FirmwareUpdateServiceTests
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
+            GetLanChipInfoCallCount++;
+            if (_remainingTransientFailures > 0)
+            {
+                _remainingTransientFailures--;
+                // Faulted task (not sync throw) more accurately simulates how
+                // a real async method surfaces failure — caller's await sees a
+                // genuinely-async exception path.
+                return Task.FromException<LanChipInfo?>(
+                    new InvalidOperationException("Simulated transient post-reboot failure."));
+            }
             return Task.FromResult(_chipInfo);
         }
     }

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -491,6 +491,166 @@ public class FirmwareUpdateServiceTests
         Assert.Contains("SYSTem:COMMUnicate:LAN:FWUpdate", device.SentCommands);
     }
 
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenVersionMatches_ReturnsUpToDate()
+    {
+        // Closes #143: callers can now make the version decision themselves
+        // without triggering UpdateWifiModuleAsync's hidden internal probe.
+        // This test asserts the new public planning method returns the
+        // expected status object and DOES NOT mutate service state.
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 5, 4, null, 0),
+            TagName = "19.5.4",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice("COM9", chipInfo: new LanChipInfo
+        {
+            ChipId = 1234,
+            FwVersion = "19.5.4",
+            BuildDate = "Jan  8 2019"
+        });
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            CreateFastOptions());
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.True(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.UpToDate, status.Reason);
+        Assert.NotNull(status.CurrentChipInfo);
+        Assert.Equal("19.5.4", status.CurrentChipInfo!.FwVersion);
+        Assert.NotNull(status.LatestRelease);
+        Assert.Equal("19.5.4", status.LatestRelease!.TagName);
+
+        // The planning method must NOT mutate service state (the internal
+        // IsWifiFirmwareUpToDateAsync transitions to Complete on its
+        // hit-path; CheckWifiFirmwareStatusAsync must not, so callers can
+        // call it freely without locking out a subsequent flash.
+        Assert.Equal(FirmwareUpdateState.Idle, service.CurrentState);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenVersionOlder_ReturnsUpdateAvailable()
+    {
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 6, 1, null, 0),
+            TagName = "19.6.1",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice("COM10", chipInfo: new LanChipInfo
+        {
+            ChipId = 1234,
+            FwVersion = "19.5.4",
+            BuildDate = "Jan  8 2019"
+        });
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            CreateFastOptions());
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.False(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.UpdateAvailable, status.Reason);
+        Assert.Equal(FirmwareUpdateState.Idle, service.CurrentState);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenDeviceDoesNotSupportLanQuery_ReturnsDeviceDoesNotSupportLanQuery()
+    {
+        var device = new FakeStreamingDevice("COM11");
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            CreateFastOptions());
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.False(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery, status.Reason);
+        Assert.Null(status.CurrentChipInfo);
+        Assert.Null(status.LatestRelease);
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WithSkipVersionCheck_BypassesProbeAndAlwaysFlashes()
+    {
+        // The motivating case for #143: caller already made the version
+        // decision (via CheckWifiFirmwareStatusAsync). Pass skipVersionCheck:true
+        // so Core does NOT re-probe the device — even when the device's
+        // current version equals the latest, the flash flow runs.
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 5, 4, null, 0),
+            TagName = "19.5.4",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice("COM12", chipInfo: new LanChipInfo
+        {
+            ChipId = 1234,
+            FwVersion = "19.5.4", // Matches latest — would normally short-circuit
+            BuildDate = "Jan  8 2019"
+        });
+
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), [], [])
+        };
+
+        var options = CreateFastOptions();
+        options.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(5);
+        options.PostWifiReconnectDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(
+                device,
+                firmwareDir,
+                progress: null,
+                cancellationToken: CancellationToken.None,
+                skipVersionCheck: true);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        // Even though device version matched latest, flash ran because
+        // skipVersionCheck bypassed the probe.
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Contains("SYSTem:COMMUnicate:LAN:FWUpdate", device.SentCommands);
+    }
+
     private static FirmwareUpdateServiceOptions CreateFastOptions()
     {
         return new FirmwareUpdateServiceOptions

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -154,12 +154,14 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     }
 
     /// <inheritdoc />
+#pragma warning disable CA1068
     public async Task UpdateWifiModuleAsync(
         IStreamingDevice device,
         string firmwarePath,
         IProgress<FirmwareUpdateProgress>? progress = null,
-        bool skipVersionCheck = false,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool skipVersionCheck = false)
+#pragma warning restore CA1068
     {
         ArgumentNullException.ThrowIfNull(device);
 

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -158,8 +158,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         IStreamingDevice device,
         string firmwarePath,
         IProgress<FirmwareUpdateProgress>? progress = null,
-        CancellationToken cancellationToken = default,
-        bool skipVersionCheck = false)
+        bool skipVersionCheck = false,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(device);
 

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -536,21 +536,15 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             };
         }
 
-        LanChipInfo? chipInfo;
-        try
-        {
-            chipInfo = await lanChipInfoProvider.GetLanChipInfoAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogDebug(ex, "Failed to query LAN chip info; reporting status as ChipInfoUnavailable.");
-            return new WifiFirmwareStatus
-            {
-                IsUpToDate = false,
-                Reason = WifiFirmwareStatusReason.ChipInfoUnavailable,
-            };
-        }
-
+        // Bounded retry for the LAN chip-info probe (closes #144). Right
+        // after a PIC32 firmware update the application is up while WiFi
+        // is still finishing startup, so the first chip-info query can
+        // transiently fail; without retry, the WiFi version decision
+        // would short-circuit to ChipInfoUnavailable and flow on to a
+        // multi-minute reflash of already-current WiFi firmware. The
+        // retry budget is bounded (LanChipInfoMaxAttempts × RetryDelay)
+        // and observes cancellation between attempts.
+        var chipInfo = await TryGetLanChipInfoWithRetryAsync(lanChipInfoProvider, cancellationToken).ConfigureAwait(false);
         if (chipInfo == null)
         {
             return new WifiFirmwareStatus
@@ -611,6 +605,102 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             IsUpToDate = isCurrent,
             Reason = isCurrent ? WifiFirmwareStatusReason.UpToDate : WifiFirmwareStatusReason.UpdateAvailable,
         };
+    }
+
+    private async Task<LanChipInfo?> TryGetLanChipInfoWithRetryAsync(
+        ILanChipInfoProvider lanChipInfoProvider,
+        CancellationToken cancellationToken)
+    {
+        var maxAttempts = Math.Max(1, _options.LanChipInfoMaxAttempts);
+        var retryDelay = _options.LanChipInfoRetryDelay;
+        var totalTimeout = _options.LanChipInfoTotalTimeout;
+
+        // Wall-clock budget guards against the pathological case where
+        // attempt-count × per-attempt-timeout + retry-delay sum vastly
+        // exceeds the configured retry budget (e.g., 3 × 2s device timeout
+        // + 2 × 2s delay = ~10s while _operationLock is held). Linking
+        // the caller's CT preserves cancellation semantics; the timeout
+        // CTS just adds a deadline.
+        using var timeoutCts = new CancellationTokenSource(totalTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+        var linkedToken = linkedCts.Token;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                linkedToken.ThrowIfCancellationRequested();
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug(
+                    "LAN chip-info probe hit total timeout ({Timeout}) before attempt {Attempt}/{Max}.",
+                    totalTimeout,
+                    attempt,
+                    maxAttempts);
+                return null;
+            }
+
+            try
+            {
+                var chipInfo = await lanChipInfoProvider.GetLanChipInfoAsync(linkedToken).ConfigureAwait(false);
+                if (chipInfo != null)
+                {
+                    if (attempt > 1)
+                    {
+                        _logger.LogDebug(
+                            "LAN chip-info query succeeded on attempt {Attempt}/{Max}.",
+                            attempt,
+                            maxAttempts);
+                    }
+                    return chipInfo;
+                }
+                _logger.LogDebug(
+                    "LAN chip-info query returned null on attempt {Attempt}/{Max}.",
+                    attempt,
+                    maxAttempts);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug(
+                    "LAN chip-info probe hit total timeout ({Timeout}) during attempt {Attempt}/{Max}.",
+                    totalTimeout,
+                    attempt,
+                    maxAttempts);
+                return null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogDebug(
+                    ex,
+                    "LAN chip-info query failed on attempt {Attempt}/{Max}.",
+                    attempt,
+                    maxAttempts);
+            }
+
+            if (attempt < maxAttempts)
+            {
+                try
+                {
+                    await Task.Delay(retryDelay, linkedToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogDebug(
+                        "LAN chip-info probe hit total timeout ({Timeout}) during retry delay after attempt {Attempt}/{Max}.",
+                        totalTimeout,
+                        attempt,
+                        maxAttempts);
+                    return null;
+                }
+            }
+        }
+
+        _logger.LogDebug(
+            "LAN chip-info query exhausted {Max} attempts; reporting status as ChipInfoUnavailable.",
+            maxAttempts);
+        return null;
     }
 
     private ExternalProcessRequest BuildWifiProcessRequest(

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -75,6 +75,16 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         };
 
     private readonly SemaphoreSlim _operationLock = new(1, 1);
+
+    // Async-context flag set true while the current logical flow holds
+    // _operationLock. CheckWifiFirmwareStatusAsync uses this to detect
+    // re-entrancy from progress / state-change callbacks fired by an
+    // in-flight UpdateFirmwareAsync / UpdateWifiModuleAsync (which run
+    // synchronously while the lock is held). Without this guard the
+    // status probe would deadlock waiting for the lock its own caller
+    // holds, since SemaphoreSlim is not re-entrant. AsyncLocal flows
+    // through await resumptions on different threads.
+    private readonly AsyncLocal<bool> _isInsideOperation = new();
     private readonly IHidTransport _hidTransport;
     private readonly IExternalProcessRunner _externalProcessRunner;
     private readonly ILogger<FirmwareUpdateService> _logger;
@@ -196,13 +206,28 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         // Acquired without the RunExclusiveAsync state check — a status probe
         // is read-only and should be available to UI even when an update is
         // in flight (it just waits for the in-flight I/O to release the lock).
+        //
+        // Reentrancy guard: an update fires progress / state-change callbacks
+        // synchronously while it holds _operationLock. If a callback handler
+        // calls back into CheckWifiFirmwareStatusAsync, WaitAsync would
+        // deadlock waiting for the same lock the caller's flow already owns
+        // (SemaphoreSlim is not re-entrant). The AsyncLocal flag detects
+        // this case and skips the second acquisition; we're already in a
+        // serialized device-I/O context.
+        if (_isInsideOperation.Value)
+        {
+            return await CheckWifiFirmwareStatusCoreAsync(device, cancellationToken).ConfigureAwait(false);
+        }
+
         await _operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _isInsideOperation.Value = true;
         try
         {
             return await CheckWifiFirmwareStatusCoreAsync(device, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
+            _isInsideOperation.Value = false;
             _operationLock.Release();
         }
     }
@@ -214,6 +239,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         ThrowIfDisposed();
 
         await _operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _isInsideOperation.Value = true;
         try
         {
             ResetIfTerminalState();
@@ -231,6 +257,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         }
         finally
         {
+            _isInsideOperation.Value = false;
             _operationLock.Release();
         }
     }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -187,7 +187,22 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         ArgumentNullException.ThrowIfNull(device);
         ThrowIfDisposed();
 
-        return await CheckWifiFirmwareStatusCoreAsync(device, cancellationToken).ConfigureAwait(false);
+        // Serialize device I/O with UpdateFirmwareAsync / UpdateWifiModuleAsync.
+        // GetLanChipInfoAsync runs a SCPI text exchange on the same transport
+        // those updates use; a concurrent caller would interleave on the wire
+        // and either corrupt the consumer swap or get partial replies.
+        // Acquired without the RunExclusiveAsync state check — a status probe
+        // is read-only and should be available to UI even when an update is
+        // in flight (it just waits for the in-flight I/O to release the lock).
+        await _operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await CheckWifiFirmwareStatusCoreAsync(device, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _operationLock.Release();
+        }
     }
 
     private async Task RunExclusiveAsync(
@@ -544,8 +559,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             };
         }
 
-        if (!FirmwareVersion.TryParse(chipInfo.FwVersion, out _) ||
-            !FirmwareVersion.TryParse(latestWifi.TagName, out _))
+        // Only the device-reported version needs parsing; latestWifi.Version
+        // is already a strongly-typed FirmwareVersion from FirmwareDownloadService.
+        // Re-parsing TagName would risk divergence from the canonical Version
+        // (different tag prefix conventions, etc.) and cost an extra parse.
+        if (!FirmwareVersion.TryParse(chipInfo.FwVersion, out var deviceVersion))
         {
             return new WifiFirmwareStatus
             {
@@ -556,7 +574,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             };
         }
 
-        var isCurrent = IsWifiVersionCurrent(chipInfo.FwVersion, latestWifi.TagName);
+        var isCurrent = deviceVersion >= latestWifi.Version;
         return new WifiFirmwareStatus
         {
             CurrentChipInfo = chipInfo,
@@ -564,17 +582,6 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             IsUpToDate = isCurrent,
             Reason = isCurrent ? WifiFirmwareStatusReason.UpToDate : WifiFirmwareStatusReason.UpdateAvailable,
         };
-    }
-
-    private static bool IsWifiVersionCurrent(string deviceVersion, string latestTagName)
-    {
-        if (!FirmwareVersion.TryParse(deviceVersion, out var device) ||
-            !FirmwareVersion.TryParse(latestTagName, out var latest))
-        {
-            return false;
-        }
-
-        return device >= latest;
     }
 
     private ExternalProcessRequest BuildWifiProcessRequest(

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -158,7 +158,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         IStreamingDevice device,
         string firmwarePath,
         IProgress<FirmwareUpdateProgress>? progress = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool skipVersionCheck = false)
     {
         ArgumentNullException.ThrowIfNull(device);
 
@@ -174,8 +175,19 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         }
 
         await RunExclusiveAsync(
-            ct => RunWifiUpdateAsync(device, firmwarePath, progress, ct),
+            ct => RunWifiUpdateAsync(device, firmwarePath, progress, skipVersionCheck, ct),
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<WifiFirmwareStatus> CheckWifiFirmwareStatusAsync(
+        IStreamingDevice device,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+        ThrowIfDisposed();
+
+        return await CheckWifiFirmwareStatusCoreAsync(device, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task RunExclusiveAsync(
@@ -330,13 +342,15 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         IStreamingDevice device,
         string firmwarePath,
         IProgress<FirmwareUpdateProgress>? progress,
+        bool skipVersionCheck,
         CancellationToken cancellationToken)
     {
         const long totalBytes = 100;
 
         try
         {
-            if (await IsWifiFirmwareUpToDateAsync(device, progress, cancellationToken).ConfigureAwait(false))
+            if (!skipVersionCheck
+                && await IsWifiFirmwareUpToDateAsync(device, progress, cancellationToken).ConfigureAwait(false))
             {
                 return;
             }
@@ -433,9 +447,49 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         IProgress<FirmwareUpdateProgress>? progress,
         CancellationToken cancellationToken)
     {
+        // Internal callsite: in addition to deciding the boolean, we must
+        // transition to Complete + report 100% progress so the caller's
+        // single UpdateWifiModuleAsync(...) call observes the same end-state
+        // as a successful flash. CheckWifiFirmwareStatusAsync (the public
+        // planning API) does not have that side effect — its callers own
+        // their own logging / UI transitions.
+        var status = await CheckWifiFirmwareStatusCoreAsync(device, cancellationToken).ConfigureAwait(false);
+
+        switch (status.Reason)
+        {
+            case WifiFirmwareStatusReason.UpdateAvailable:
+                _logger.LogInformation(
+                    "WiFi firmware update available: device has {DeviceVersion}, latest is {LatestVersion}.",
+                    status.CurrentChipInfo!.FwVersion,
+                    status.LatestRelease!.TagName);
+                return false;
+
+            case WifiFirmwareStatusReason.UpToDate:
+                var message = $"WiFi firmware is already up to date (device: {status.CurrentChipInfo!.FwVersion}, latest: {status.LatestRelease!.TagName}).";
+                _logger.LogInformation(message);
+                TransitionToState(FirmwareUpdateState.Complete, message);
+                ReportProgress(progress, FirmwareUpdateState.Complete, 100, message, 100, 100);
+                return true;
+
+            default:
+                // DeviceDoesNotSupportLanQuery, ChipInfoUnavailable,
+                // LatestReleaseUnavailable, VersionUnparseable — proceed
+                // with the flash conservatively.
+                return false;
+        }
+    }
+
+    private async Task<WifiFirmwareStatus> CheckWifiFirmwareStatusCoreAsync(
+        IStreamingDevice device,
+        CancellationToken cancellationToken)
+    {
         if (device is not ILanChipInfoProvider lanChipInfoProvider)
         {
-            return false;
+            return new WifiFirmwareStatus
+            {
+                IsUpToDate = false,
+                Reason = WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery,
+            };
         }
 
         LanChipInfo? chipInfo;
@@ -445,13 +499,21 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            _logger.LogDebug(ex, "Failed to query LAN chip info; proceeding with WiFi firmware update.");
-            return false;
+            _logger.LogDebug(ex, "Failed to query LAN chip info; reporting status as ChipInfoUnavailable.");
+            return new WifiFirmwareStatus
+            {
+                IsUpToDate = false,
+                Reason = WifiFirmwareStatusReason.ChipInfoUnavailable,
+            };
         }
 
         if (chipInfo == null)
         {
-            return false;
+            return new WifiFirmwareStatus
+            {
+                IsUpToDate = false,
+                Reason = WifiFirmwareStatusReason.ChipInfoUnavailable,
+            };
         }
 
         FirmwareReleaseInfo? latestWifi;
@@ -463,29 +525,45 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            _logger.LogDebug(ex, "Failed to query latest WiFi firmware release; proceeding with update.");
-            return false;
+            _logger.LogDebug(ex, "Failed to query latest WiFi firmware release; reporting status as LatestReleaseUnavailable.");
+            return new WifiFirmwareStatus
+            {
+                CurrentChipInfo = chipInfo,
+                IsUpToDate = false,
+                Reason = WifiFirmwareStatusReason.LatestReleaseUnavailable,
+            };
         }
 
         if (latestWifi == null)
         {
-            return false;
+            return new WifiFirmwareStatus
+            {
+                CurrentChipInfo = chipInfo,
+                IsUpToDate = false,
+                Reason = WifiFirmwareStatusReason.LatestReleaseUnavailable,
+            };
         }
 
-        if (!IsWifiVersionCurrent(chipInfo.FwVersion, latestWifi.TagName))
+        if (!FirmwareVersion.TryParse(chipInfo.FwVersion, out _) ||
+            !FirmwareVersion.TryParse(latestWifi.TagName, out _))
         {
-            _logger.LogInformation(
-                "WiFi firmware update available: device has {DeviceVersion}, latest is {LatestVersion}.",
-                chipInfo.FwVersion,
-                latestWifi.TagName);
-            return false;
+            return new WifiFirmwareStatus
+            {
+                CurrentChipInfo = chipInfo,
+                LatestRelease = latestWifi,
+                IsUpToDate = false,
+                Reason = WifiFirmwareStatusReason.VersionUnparseable,
+            };
         }
 
-        var message = $"WiFi firmware is already up to date (device: {chipInfo.FwVersion}, latest: {latestWifi.TagName}).";
-        _logger.LogInformation(message);
-        TransitionToState(FirmwareUpdateState.Complete, message);
-        ReportProgress(progress, FirmwareUpdateState.Complete, 100, message, 100, 100);
-        return true;
+        var isCurrent = IsWifiVersionCurrent(chipInfo.FwVersion, latestWifi.TagName);
+        return new WifiFirmwareStatus
+        {
+            CurrentChipInfo = chipInfo,
+            LatestRelease = latestWifi,
+            IsUpToDate = isCurrent,
+            Reason = isCurrent ? WifiFirmwareStatusReason.UpToDate : WifiFirmwareStatusReason.UpdateAvailable,
+        };
     }
 
     private static bool IsWifiVersionCurrent(string deviceVersion, string latestTagName)

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -120,6 +120,43 @@ public sealed class FirmwareUpdateServiceOptions
     public string? WifiPortOverride { get; set; }
 
     /// <summary>
+    /// Total attempts (initial + retries) for LAN chip-info queries before
+    /// the WiFi version decision falls through to "couldn't check, proceed
+    /// with flash". Right after a PIC32 firmware update the application is
+    /// typically up while the WiFi subsystem is still finishing startup, so
+    /// the first chip-info query can transiently fail; bounded retry covers
+    /// that window so callers don't unnecessarily reflash up-to-date WiFi
+    /// firmware (closes #144).
+    /// </summary>
+    /// <remarks>
+    /// Each attempt also incurs the per-attempt timeout from the device
+    /// implementation (e.g., <c>DaqifiStreamingDevice.GetLanChipInfoAsync</c>
+    /// uses 2s). Total wall-clock budget is therefore
+    /// <c>sum(attempt durations) + (MaxAttempts-1) * RetryDelay</c>; with the
+    /// 2s device default, 3 attempts and 2s delay sum to ~10s in the worst
+    /// case. The retry loop holds <c>_operationLock</c>, so use
+    /// <see cref="LanChipInfoTotalTimeout"/> to cap the actual wall-clock
+    /// time independent of attempt counts.
+    /// </remarks>
+    public int LanChipInfoMaxAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Delay between LAN chip-info retry attempts (cancellation-aware).
+    /// </summary>
+    public TimeSpan LanChipInfoRetryDelay { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Hard upper bound on wall-clock time spent in the LAN chip-info
+    /// probe (including per-attempt query timeouts and retry delays).
+    /// When exceeded, the loop short-circuits to ChipInfoUnavailable
+    /// regardless of remaining attempts. Prevents pathological multi-
+    /// attempt cases (e.g., 3 attempts × 2s device timeout + 2 × 2s delays
+    /// = ~10s) from stalling firmware flows or UI status probes that hold
+    /// the operation lock.
+    /// </summary>
+    public TimeSpan LanChipInfoTotalTimeout { get; set; } = TimeSpan.FromSeconds(8);
+
+    /// <summary>
     /// Gets the configured timeout for a given firmware update state.
     /// </summary>
     /// <param name="state">The target state.</param>
@@ -175,6 +212,17 @@ public sealed class FirmwareUpdateServiceOptions
                 FlashWriteRetryCount,
                 "Flash write retry count must be at least 1.");
         }
+
+        if (LanChipInfoMaxAttempts < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(LanChipInfoMaxAttempts),
+                LanChipInfoMaxAttempts,
+                "LAN chip-info max attempts must be at least 1.");
+        }
+
+        ValidatePositive(LanChipInfoRetryDelay, nameof(LanChipInfoRetryDelay));
+        ValidatePositive(LanChipInfoTotalTimeout, nameof(LanChipInfoTotalTimeout));
 
         if (BootloaderVendorId < 0 || BootloaderVendorId > 0xFFFF)
         {

--- a/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
@@ -48,8 +48,8 @@ public interface IFirmwareUpdateService
         IStreamingDevice device,
         string firmwarePath,
         IProgress<FirmwareUpdateProgress>? progress = null,
-        CancellationToken cancellationToken = default,
-        bool skipVersionCheck = false);
+        bool skipVersionCheck = false,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Probes the device for its current WiFi chip info and looks up the

--- a/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
@@ -38,9 +38,30 @@ public interface IFirmwareUpdateService
     /// <param name="firmwarePath">Path to a WiFi tool executable/script or directory containing it.</param>
     /// <param name="progress">Optional progress reporter.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="skipVersionCheck">
+    /// When true, bypass the internal version probe and always run the flash
+    /// flow. Use after a separate <see cref="CheckWifiFirmwareStatusAsync"/>
+    /// call so the device isn't queried twice — see issue #143 for the
+    /// motivating callsite.
+    /// </param>
     Task UpdateWifiModuleAsync(
         IStreamingDevice device,
         string firmwarePath,
         IProgress<FirmwareUpdateProgress>? progress = null,
+        CancellationToken cancellationToken = default,
+        bool skipVersionCheck = false);
+
+    /// <summary>
+    /// Probes the device for its current WiFi chip info and looks up the
+    /// latest WiFi firmware release, returning the comparison result without
+    /// mutating service state. Lets callers (typically GUI/desktop integrations)
+    /// surface their own logging, retry policy, or UI before deciding whether
+    /// to call <see cref="UpdateWifiModuleAsync"/>. Pass
+    /// <c>skipVersionCheck: true</c> to that call to avoid a second probe.
+    /// </summary>
+    /// <param name="device">The connected streaming device to inspect.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<WifiFirmwareStatus> CheckWifiFirmwareStatusAsync(
+        IStreamingDevice device,
         CancellationToken cancellationToken = default);
 }

--- a/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
@@ -44,12 +44,18 @@ public interface IFirmwareUpdateService
     /// call so the device isn't queried twice — see issue #143 for the
     /// motivating callsite.
     /// </param>
+    // skipVersionCheck added AFTER cancellationToken (technically violates
+    // CA1068 "CancellationToken should be last") to avoid breaking source
+    // compat for any existing positional caller passing CancellationToken
+    // as the 4th argument. Additivity wins over strict style here.
+#pragma warning disable CA1068
     Task UpdateWifiModuleAsync(
         IStreamingDevice device,
         string firmwarePath,
         IProgress<FirmwareUpdateProgress>? progress = null,
-        bool skipVersionCheck = false,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        bool skipVersionCheck = false);
+#pragma warning restore CA1068
 
     /// <summary>
     /// Probes the device for its current WiFi chip info and looks up the

--- a/src/Daqifi.Core/Firmware/WifiFirmwareStatus.cs
+++ b/src/Daqifi.Core/Firmware/WifiFirmwareStatus.cs
@@ -1,0 +1,67 @@
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// Result of <see cref="IFirmwareUpdateService.CheckWifiFirmwareStatusAsync"/>:
+/// the inputs Core uses to decide whether a WiFi update is needed plus the
+/// boolean conclusion. Returned without mutating service state, so callers can
+/// inspect, log, retry, or surface UI before deciding to call
+/// <see cref="IFirmwareUpdateService.UpdateWifiModuleAsync"/>.
+/// </summary>
+/// <remarks>
+/// When <see cref="Reason"/> is <see cref="WifiFirmwareStatusReason.UpToDate"/>
+/// or <see cref="WifiFirmwareStatusReason.UpdateAvailable"/>, both
+/// <see cref="CurrentChipInfo"/> and <see cref="LatestRelease"/> are non-null.
+/// Other reasons leave one or both null and conservatively report
+/// <see cref="IsUpToDate"/> = false so callers default to running the update.
+/// </remarks>
+public sealed record WifiFirmwareStatus
+{
+    /// <summary>
+    /// The current WiFi chip info read from the device, or null if the device
+    /// did not expose <see cref="ILanChipInfoProvider"/> or the query failed.
+    /// </summary>
+    public LanChipInfo? CurrentChipInfo { get; init; }
+
+    /// <summary>
+    /// The latest WiFi firmware release on GitHub, or null if the lookup
+    /// failed (e.g. offline, rate-limited).
+    /// </summary>
+    public FirmwareReleaseInfo? LatestRelease { get; init; }
+
+    /// <summary>
+    /// True only when both versions are available AND the device version is
+    /// at least the latest release. Any unknown is reported as false so the
+    /// caller defaults to "needs update".
+    /// </summary>
+    public required bool IsUpToDate { get; init; }
+
+    /// <summary>
+    /// Why <see cref="IsUpToDate"/> has its current value — lets callers
+    /// distinguish "definitively up to date" from "couldn't check, assuming not".
+    /// </summary>
+    public required WifiFirmwareStatusReason Reason { get; init; }
+}
+
+/// <summary>
+/// Categorical outcome for <see cref="WifiFirmwareStatus"/>.
+/// </summary>
+public enum WifiFirmwareStatusReason
+{
+    /// <summary>Device version >= latest release version.</summary>
+    UpToDate,
+
+    /// <summary>Device version &lt; latest release version.</summary>
+    UpdateAvailable,
+
+    /// <summary>The device does not implement <see cref="ILanChipInfoProvider"/>.</summary>
+    DeviceDoesNotSupportLanQuery,
+
+    /// <summary>Querying the device for chip info failed.</summary>
+    ChipInfoUnavailable,
+
+    /// <summary>Looking up the latest release on GitHub failed.</summary>
+    LatestReleaseUnavailable,
+
+    /// <summary>Either version string failed to parse.</summary>
+    VersionUnparseable,
+}


### PR DESCRIPTION
## Summary

Adds a public `CheckWifiFirmwareStatusAsync` planning method and a `skipVersionCheck` parameter on `UpdateWifiModuleAsync` so callers (typically desktop UI) can make the version decision once and run the flash without triggering Core's hidden second probe.

The previous flow conflated two responsibilities — desktop's workaround was to query the version separately, then route the flash through an adapter that hid `ILanChipInfoProvider` so Core would skip its internal probe. The issue explicitly called this out as an API-shape workaround.

## API additions

- `WifiFirmwareStatus` record + `WifiFirmwareStatusReason` enum exposing chip info, latest release, and a categorical decision so callers distinguish "definitively up to date" from "couldn't check".
- `IFirmwareUpdateService.CheckWifiFirmwareStatusAsync` — pure planning method (does NOT mutate service state, no `Complete` transition, no progress events).
- `IFirmwareUpdateService.UpdateWifiModuleAsync` gains `skipVersionCheck: false` default. Existing callers unchanged; callers that just made the decision pass `true`.

## Implementation

Pulls data-gathering out of `IsWifiFirmwareUpToDateAsync` into `CheckWifiFirmwareStatusCoreAsync`. The legacy method delegates to the new core helper and only adds the side effects (`Complete` state + progress) needed by the all-in-one caller path. Core remains the source of truth for version comparison (`IsWifiVersionCurrent`).

## Test plan

- [x] 4 new tests cover the planning method's three primary outcomes (`UpToDate` / `UpdateAvailable` / `DeviceDoesNotSupportLanQuery`) and the `skipVersionCheck` pathway
- [x] All 5 existing `UpdateWifiModuleAsync` tests still pass (no behavior change for current callers)
- [x] All 47 WiFi-related tests pass; full suite 894/896 (2 skipped require live hardware)
- [x] Build clean on net9.0 + net10.0

Closes #143