### PR TITLE
feat(firmware): retry LAN chip-info probe during startup transients (closes #144)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -812,6 +812,79 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_TotalTimeoutHit_ShortCircuitsToChipInfoUnavailable()
+    {
+        // Closes a Qodo follow-up on PR #199: per-attempt query timeouts
+        // compound with retry delays, so a high MaxAttempts × non-trivial
+        // per-attempt latency could block far beyond the configured retry
+        // budget while holding _operationLock. The total-timeout cap caps
+        // wall-clock time independent of attempt counts.
+        //
+        // The fake's per-attempt latency is the Task.Delay below; with
+        // 200ms latency × 10 max attempts × 100ms retry delay, a naive
+        // implementation would block ~2.9s. The 100ms total timeout
+        // forces an early ChipInfoUnavailable return after the first
+        // attempt's latency exceeds the budget.
+        var device = new SlowFakeLanChipInfoStreamingDevice(
+            "COM17",
+            attemptLatency: TimeSpan.FromMilliseconds(200));
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 10;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(100);
+        options.LanChipInfoTotalTimeout = TimeSpan.FromMilliseconds(100);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+        stopwatch.Stop();
+
+        Assert.False(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.ChipInfoUnavailable, status.Reason);
+        // Should bail well before attempting all 10 × (200ms + 100ms) = 3s.
+        // Allowing 1500ms for CI variance / xunit overhead.
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(1500),
+            $"Probe took {stopwatch.ElapsedMilliseconds}ms, expected <1500ms with TotalTimeout=100ms.");
+    }
+
+    private sealed class SlowFakeLanChipInfoStreamingDevice : IStreamingDevice, ILanChipInfoProvider
+    {
+        private readonly TimeSpan _attemptLatency;
+        public SlowFakeLanChipInfoStreamingDevice(string name, TimeSpan attemptLatency)
+        {
+            Name = name;
+            _attemptLatency = attemptLatency;
+            IsConnected = true;
+        }
+        public string Name { get; }
+        public IPAddress? IpAddress => null;
+        public bool IsConnected { get; private set; }
+        public ConnectionStatus Status => ConnectionStatus.Connected;
+        public int StreamingFrequency { get; set; }
+        public bool IsStreaming { get; private set; }
+        public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
+        public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
+        public void Connect() => IsConnected = true;
+        public void Disconnect() => IsConnected = false;
+        public void Send<T>(IOutboundMessage<T> message) { }
+        public void StartStreaming() => IsStreaming = true;
+        public void StopStreaming() => IsStreaming = false;
+        public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(_attemptLatency, cancellationToken).ConfigureAwait(false);
+            return null;
+        }
+    }
+
+    [Fact]
     public async Task CheckWifiFirmwareStatusAsync_FirstAttemptSucceeds_DoesNotRetry()
     {
         // Steady-state path: no retry overhead when the first call works.

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -730,6 +730,124 @@ public class FirmwareUpdateServiceTests
         Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
     }
 
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenLanChipInfoFailsTransiently_RetriesUntilSuccess()
+    {
+        // Closes #144: post-PIC32-reboot the WiFi subsystem can lag the
+        // application by a few seconds, so the first chip-info query
+        // transiently fails. Without retry, the WiFi version decision
+        // would short-circuit and trigger an unnecessary multi-minute
+        // reflash. The retry budget covers the startup window.
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 5, 4, null, 0),
+            TagName = "19.5.4",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM14",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            },
+            transientFailuresBeforeSuccess: 2);
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5); // Keep test fast
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+        Assert.True(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.UpToDate, status.Reason);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenLanChipInfoFailsAllAttempts_ReturnsChipInfoUnavailable()
+    {
+        // After exhausting LanChipInfoMaxAttempts the planning method must
+        // fall through to ChipInfoUnavailable, NOT hang or surface the
+        // raw exception. This preserves the "couldn't check, default to
+        // running update" semantics for genuinely-broken devices.
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM15",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            },
+            transientFailuresBeforeSuccess: 99);
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+        Assert.False(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.ChipInfoUnavailable, status.Reason);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_FirstAttemptSucceeds_DoesNotRetry()
+    {
+        // Steady-state path: no retry overhead when the first call works.
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 5, 4, null, 0),
+            TagName = "19.5.4",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM16",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            });
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(1, device.GetLanChipInfoCallCount);
+    }
+
     private sealed class SyncProgress<T> : IProgress<T>
     {
         private readonly Action<T> _handler;
@@ -848,13 +966,17 @@ public class FirmwareUpdateServiceTests
     {
         private readonly LanChipInfo? _chipInfo;
         private ConnectionStatus _status = ConnectionStatus.Connected;
+        private int _remainingTransientFailures;
 
-        public FakeLanChipInfoStreamingDevice(string name, LanChipInfo? chipInfo)
+        public FakeLanChipInfoStreamingDevice(string name, LanChipInfo? chipInfo, int transientFailuresBeforeSuccess = 0)
         {
             Name = name;
             _chipInfo = chipInfo;
+            _remainingTransientFailures = transientFailuresBeforeSuccess;
             IsConnected = true;
         }
+
+        public int GetLanChipInfoCallCount { get; private set; }
 
         public string Name { get; }
         public IPAddress? IpAddress => null;
@@ -899,6 +1021,12 @@ public class FirmwareUpdateServiceTests
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
+            GetLanChipInfoCallCount++;
+            if (_remainingTransientFailures > 0)
+            {
+                _remainingTransientFailures--;
+                throw new InvalidOperationException("Simulated transient post-reboot failure.");
+            }
             return Task.FromResult(_chipInfo);
         }
     }

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1098,7 +1098,11 @@ public class FirmwareUpdateServiceTests
             if (_remainingTransientFailures > 0)
             {
                 _remainingTransientFailures--;
-                throw new InvalidOperationException("Simulated transient post-reboot failure.");
+                // Faulted task (not sync throw) more accurately simulates how
+                // a real async method surfaces failure — caller's await sees a
+                // genuinely-async exception path.
+                return Task.FromException<LanChipInfo?>(
+                    new InvalidOperationException("Simulated transient post-reboot failure."));
             }
             return Task.FromResult(_chipInfo);
         }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -613,14 +613,38 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     {
         var maxAttempts = Math.Max(1, _options.LanChipInfoMaxAttempts);
         var retryDelay = _options.LanChipInfoRetryDelay;
+        var totalTimeout = _options.LanChipInfoTotalTimeout;
+
+        // Wall-clock budget guards against the pathological case where
+        // attempt-count × per-attempt-timeout + retry-delay sum vastly
+        // exceeds the configured retry budget (e.g., 3 × 2s device timeout
+        // + 2 × 2s delay = ~10s while _operationLock is held). Linking
+        // the caller's CT preserves cancellation semantics; the timeout
+        // CTS just adds a deadline.
+        using var timeoutCts = new CancellationTokenSource(totalTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+        var linkedToken = linkedCts.Token;
 
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                linkedToken.ThrowIfCancellationRequested();
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug(
+                    "LAN chip-info probe hit total timeout ({Timeout}) before attempt {Attempt}/{Max}.",
+                    totalTimeout,
+                    attempt,
+                    maxAttempts);
+                return null;
+            }
 
             try
             {
-                var chipInfo = await lanChipInfoProvider.GetLanChipInfoAsync(cancellationToken).ConfigureAwait(false);
+                var chipInfo = await lanChipInfoProvider.GetLanChipInfoAsync(linkedToken).ConfigureAwait(false);
                 if (chipInfo != null)
                 {
                     if (attempt > 1)
@@ -637,6 +661,15 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                     attempt,
                     maxAttempts);
             }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug(
+                    "LAN chip-info probe hit total timeout ({Timeout}) during attempt {Attempt}/{Max}.",
+                    totalTimeout,
+                    attempt,
+                    maxAttempts);
+                return null;
+            }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogDebug(
@@ -648,7 +681,19 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
             if (attempt < maxAttempts)
             {
-                await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await Task.Delay(retryDelay, linkedToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogDebug(
+                        "LAN chip-info probe hit total timeout ({Timeout}) during retry delay after attempt {Attempt}/{Max}.",
+                        totalTimeout,
+                        attempt,
+                        maxAttempts);
+                    return null;
+                }
             }
         }
 

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -536,21 +536,15 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             };
         }
 
-        LanChipInfo? chipInfo;
-        try
-        {
-            chipInfo = await lanChipInfoProvider.GetLanChipInfoAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogDebug(ex, "Failed to query LAN chip info; reporting status as ChipInfoUnavailable.");
-            return new WifiFirmwareStatus
-            {
-                IsUpToDate = false,
-                Reason = WifiFirmwareStatusReason.ChipInfoUnavailable,
-            };
-        }
-
+        // Bounded retry for the LAN chip-info probe (closes #144). Right
+        // after a PIC32 firmware update the application is up while WiFi
+        // is still finishing startup, so the first chip-info query can
+        // transiently fail; without retry, the WiFi version decision
+        // would short-circuit to ChipInfoUnavailable and flow on to a
+        // multi-minute reflash of already-current WiFi firmware. The
+        // retry budget is bounded (LanChipInfoMaxAttempts × RetryDelay)
+        // and observes cancellation between attempts.
+        var chipInfo = await TryGetLanChipInfoWithRetryAsync(lanChipInfoProvider, cancellationToken).ConfigureAwait(false);
         if (chipInfo == null)
         {
             return new WifiFirmwareStatus
@@ -611,6 +605,57 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             IsUpToDate = isCurrent,
             Reason = isCurrent ? WifiFirmwareStatusReason.UpToDate : WifiFirmwareStatusReason.UpdateAvailable,
         };
+    }
+
+    private async Task<LanChipInfo?> TryGetLanChipInfoWithRetryAsync(
+        ILanChipInfoProvider lanChipInfoProvider,
+        CancellationToken cancellationToken)
+    {
+        var maxAttempts = Math.Max(1, _options.LanChipInfoMaxAttempts);
+        var retryDelay = _options.LanChipInfoRetryDelay;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var chipInfo = await lanChipInfoProvider.GetLanChipInfoAsync(cancellationToken).ConfigureAwait(false);
+                if (chipInfo != null)
+                {
+                    if (attempt > 1)
+                    {
+                        _logger.LogDebug(
+                            "LAN chip-info query succeeded on attempt {Attempt}/{Max}.",
+                            attempt,
+                            maxAttempts);
+                    }
+                    return chipInfo;
+                }
+                _logger.LogDebug(
+                    "LAN chip-info query returned null on attempt {Attempt}/{Max}.",
+                    attempt,
+                    maxAttempts);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogDebug(
+                    ex,
+                    "LAN chip-info query failed on attempt {Attempt}/{Max}.",
+                    attempt,
+                    maxAttempts);
+            }
+
+            if (attempt < maxAttempts)
+            {
+                await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        _logger.LogDebug(
+            "LAN chip-info query exhausted {Max} attempts; reporting status as ChipInfoUnavailable.",
+            maxAttempts);
+        return null;
     }
 
     private ExternalProcessRequest BuildWifiProcessRequest(

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -126,16 +126,35 @@ public sealed class FirmwareUpdateServiceOptions
     /// typically up while the WiFi subsystem is still finishing startup, so
     /// the first chip-info query can transiently fail; bounded retry covers
     /// that window so callers don't unnecessarily reflash up-to-date WiFi
-    /// firmware (closes #144). Default 3 attempts × 2s delay = up to 4s
-    /// wait in the worst case, which fits the observed startup window.
+    /// firmware (closes #144).
     /// </summary>
+    /// <remarks>
+    /// Each attempt also incurs the per-attempt timeout from the device
+    /// implementation (e.g., <c>DaqifiStreamingDevice.GetLanChipInfoAsync</c>
+    /// uses 2s). Total wall-clock budget is therefore
+    /// <c>sum(attempt durations) + (MaxAttempts-1) * RetryDelay</c>; with the
+    /// 2s device default, 3 attempts and 2s delay sum to ~10s in the worst
+    /// case. The retry loop holds <c>_operationLock</c>, so use
+    /// <see cref="LanChipInfoTotalTimeout"/> to cap the actual wall-clock
+    /// time independent of attempt counts.
+    /// </remarks>
     public int LanChipInfoMaxAttempts { get; set; } = 3;
 
     /// <summary>
     /// Delay between LAN chip-info retry attempts (cancellation-aware).
-    /// Total worst-case wait = (LanChipInfoMaxAttempts - 1) * LanChipInfoRetryDelay.
     /// </summary>
     public TimeSpan LanChipInfoRetryDelay { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Hard upper bound on wall-clock time spent in the LAN chip-info
+    /// probe (including per-attempt query timeouts and retry delays).
+    /// When exceeded, the loop short-circuits to ChipInfoUnavailable
+    /// regardless of remaining attempts. Prevents pathological multi-
+    /// attempt cases (e.g., 3 attempts × 2s device timeout + 2 × 2s delays
+    /// = ~10s) from stalling firmware flows or UI status probes that hold
+    /// the operation lock.
+    /// </summary>
+    public TimeSpan LanChipInfoTotalTimeout { get; set; } = TimeSpan.FromSeconds(8);
 
     /// <summary>
     /// Gets the configured timeout for a given firmware update state.
@@ -203,6 +222,7 @@ public sealed class FirmwareUpdateServiceOptions
         }
 
         ValidatePositive(LanChipInfoRetryDelay, nameof(LanChipInfoRetryDelay));
+        ValidatePositive(LanChipInfoTotalTimeout, nameof(LanChipInfoTotalTimeout));
 
         if (BootloaderVendorId < 0 || BootloaderVendorId > 0xFFFF)
         {

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -120,6 +120,24 @@ public sealed class FirmwareUpdateServiceOptions
     public string? WifiPortOverride { get; set; }
 
     /// <summary>
+    /// Total attempts (initial + retries) for LAN chip-info queries before
+    /// the WiFi version decision falls through to "couldn't check, proceed
+    /// with flash". Right after a PIC32 firmware update the application is
+    /// typically up while the WiFi subsystem is still finishing startup, so
+    /// the first chip-info query can transiently fail; bounded retry covers
+    /// that window so callers don't unnecessarily reflash up-to-date WiFi
+    /// firmware (closes #144). Default 3 attempts × 2s delay = up to 4s
+    /// wait in the worst case, which fits the observed startup window.
+    /// </summary>
+    public int LanChipInfoMaxAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Delay between LAN chip-info retry attempts (cancellation-aware).
+    /// Total worst-case wait = (LanChipInfoMaxAttempts - 1) * LanChipInfoRetryDelay.
+    /// </summary>
+    public TimeSpan LanChipInfoRetryDelay { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
     /// Gets the configured timeout for a given firmware update state.
     /// </summary>
     /// <param name="state">The target state.</param>
@@ -175,6 +193,16 @@ public sealed class FirmwareUpdateServiceOptions
                 FlashWriteRetryCount,
                 "Flash write retry count must be at least 1.");
         }
+
+        if (LanChipInfoMaxAttempts < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(LanChipInfoMaxAttempts),
+                LanChipInfoMaxAttempts,
+                "LAN chip-info max attempts must be at least 1.");
+        }
+
+        ValidatePositive(LanChipInfoRetryDelay, nameof(LanChipInfoRetryDelay));
 
         if (BootloaderVendorId < 0 || BootloaderVendorId > 0xFFFF)
         {


### PR DESCRIPTION
## Summary

Adds bounded retry policy for the LAN chip-info probe so post-PIC32-reboot WiFi-subsystem startup transients don't force an unnecessary multi-minute reflash of already-current WiFi firmware.

Right after a PIC32 update the application is up while the WiFi subsystem is still finishing startup — the first `GetLanChipInfo` query can transiently fail. Without retry, the WiFi version decision short-circuits to `ChipInfoUnavailable` and Core flows on to flash. Desktop's existing workaround was a bounded retry loop in the app; this PR moves that policy into Core where the WiFi-update decision lives.

## API additions

Two new `FirmwareUpdateServiceOptions` properties:
- `LanChipInfoMaxAttempts` (default **3**) — total tries before giving up
- `LanChipInfoRetryDelay` (default **2s**) — wait between attempts

Worst-case wait = (MaxAttempts - 1) × RetryDelay = **4s** by default, which fits the observed startup window without slowing steady state. The retry loop observes cancellation between attempts.

Wired into `CheckWifiFirmwareStatusCoreAsync` so both the legacy `IsWifiFirmwareUpToDateAsync` hit-path AND the new (PR #198) `CheckWifiFirmwareStatusAsync` planning method get the retry behavior automatically.

## Stacked on PR #198

This branch is built on top of `feat/wifi-update-check-status` — it depends on the `WifiFirmwareStatus` shape introduced there. Needs PR #198 to merge first; this PR's diff against main shows only the incremental changes once #198 lands.

## Test plan

- [x] 3 new tests cover transient-failure recovery within budget, exhausted-budget falls through to ChipInfoUnavailable, steady-state success doesn't trigger retry overhead
- [x] Extended `FakeLanChipInfoStreamingDevice` with `transientFailuresBeforeSuccess` + `GetLanChipInfoCallCount` instrumentation
- [x] All 15 LanChipInfo-related tests pass
- [x] Full suite: 898/900 (2 skipped require live hardware)
- [x] Build clean on net9.0 + net10.0

Closes #144