### PR TITLE
feat(firmware): wait for application readiness after PIC32 reconnect (closes #145)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceWithTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceWithTransportTests.cs
@@ -217,14 +217,106 @@ public class DaqifiDeviceWithTransportTests
         // Arrange
         using var transport = new MockStreamTransport();
         using var device = new DaqifiDevice("Mock Device", transport);
-        
+
         device.Connect();
         Assert.Equal(ConnectionStatus.Connected, device.Status);
-        
-        // Act - Simulate transport connection loss 
+
+        // Act - Simulate transport connection loss
         transport.SimulateConnectionLoss();
-        
+
         // Assert
         Assert.Equal(ConnectionStatus.Lost, device.Status);
+    }
+
+    [Fact]
+    public void DaqifiDevice_DisconnectThenConnect_SendsToCurrentTransportStream()
+    {
+        // Regression for the latent stale-stream bug surfaced by PR #200's
+        // post-reconnect readiness probe: SerialStreamTransport.Stream returns
+        // _serialPort.BaseStream, which is a fresh instance after a transport
+        // Disconnect → Connect. Pre-fix, DaqifiDevice.Disconnect left
+        // _messageProducer / _messageConsumer alive with references to the
+        // PREVIOUS BaseStream, and Connect's "if (_messageProducer == null)"
+        // guard skipped recreation — so any subsequent Send() wrote to the
+        // disposed stream and silently no-op'd, leaving the text consumer
+        // with zero bytes on the new stream. Fix nulls them in Disconnect so
+        // Connect rebuilds them against the transport's current Stream.
+        using var transport = new SwappingMockStreamTransport();
+        using var device = new DaqifiDevice("Mock Device", transport);
+
+        device.Connect();
+        Thread.Sleep(50); // MessageProducer background thread spin-up
+        device.Send(ScpiMessageProducer.GetDeviceInfo);
+        Thread.Sleep(200); // Allow the producer to flush
+        var firstStreamBytes = transport.CurrentStreamSnapshot();
+        Assert.NotEmpty(firstStreamBytes);
+
+        device.Disconnect();
+        transport.RotateStream();
+        device.Connect();
+        Thread.Sleep(50);
+        device.Send(ScpiMessageProducer.GetDeviceInfo);
+        Thread.Sleep(200);
+
+        // The send AFTER reconnect must land on the new stream — not on the
+        // first (now-disposed) stream we captured above.
+        var secondStreamBytes = transport.CurrentStreamSnapshot();
+        Assert.NotEmpty(secondStreamBytes);
+        Assert.NotSame(firstStreamBytes, secondStreamBytes);
+    }
+
+    // Mock transport that swaps to a fresh MemoryStream on RotateStream(),
+    // mirroring the real SerialStreamTransport whose Stream property returns
+    // _serialPort.BaseStream — a new instance after each Disconnect → Connect.
+    private class SwappingMockStreamTransport : IStreamTransport
+    {
+        private MemoryStream _stream = new();
+        private bool _isConnected;
+        private bool _disposed;
+
+        public Stream Stream => _disposed ? throw new ObjectDisposedException(nameof(SwappingMockStreamTransport)) : _stream;
+        public bool IsConnected => _isConnected && !_disposed;
+        public string ConnectionInfo => _disposed ? "Disposed" : (_isConnected ? "Swap: Connected" : "Swap: Disconnected");
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        public void RotateStream()
+        {
+            var old = _stream;
+            _stream = new MemoryStream();
+            old.Dispose();
+        }
+
+        public byte[] CurrentStreamSnapshot() => _stream.ToArray();
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(SwappingMockStreamTransport));
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().Wait();
+        public void Disconnect() => DisconnectAsync().Wait();
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _isConnected = false;
+                _stream.Dispose();
+                _disposed = true;
+            }
+        }
     }
 }

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -607,6 +607,63 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateFirmwareAsync_PostReconnectProbeThrowsOwnOCE_RetriesAndCompletes()
+    {
+        // The probe may legitimately throw OperationCanceledException on its
+        // own (e.g. its internal CTS expired) without our timeoutCts firing.
+        // That must NOT crash the update loop — it should be treated as a
+        // probe failure and retried, just like any other thrown exception.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]);
+        hidTransport.EnqueueRead([0x01, 0x02]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x10]);
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var probeCallCount = 0;
+        var options = CreateFastOptions();
+        options.PostReconnectReadinessProbe = (_, _) =>
+        {
+            probeCallCount++;
+            // First two attempts: probe throws its own OCE (e.g. internal CTS).
+            // Third attempt: probe returns ready.
+            return probeCallCount < 3
+                ? Task.FromException<bool>(new OperationCanceledException("probe-internal-cancel"))
+                : Task.FromResult(true);
+        };
+        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(1);
+        options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]),
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(3, probeCallCount);
+    }
+
+    [Fact]
     public async Task UpdateFirmwareAsync_NoPostReconnectProbe_PreservesLegacyBehavior()
     {
         // No probe configured == legacy behavior: Complete fires as

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -769,6 +769,108 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateFirmwareAsync_PostReconnectStaleHandleDelay_TriggersExtraDisconnectReconnect()
+    {
+        // After PIC32 reset on macOS, the first SerialPort.Open() to succeed
+        // inside the USB CDC re-enum window is a "shadow" handle — open but
+        // bytes don't flow. The fix: close + brief settling delay + reopen
+        // to obtain a clean kernel binding. Validate the dance runs:
+        // expect TWO disconnect calls and TWO reconnect cycles inside
+        // JumpToApplicationAndReconnectAsync (the original after FORCEBOOT,
+        // plus the extra one introduced by the stale-handle workaround).
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]);
+        hidTransport.EnqueueRead([0x01, 0x02]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x10]);
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var options = CreateFastOptions();
+        options.PostReconnectStaleHandleDelay = TimeSpan.FromMilliseconds(20);
+
+        var disconnectsBeforeUpdate = device.DisconnectCalls;
+        var connectAttemptsBeforeUpdate = device.ConnectAttempts;
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]),
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        // Without the dance: 1 disconnect (FORCEBOOT) + 1 connect (reconnect after JumpToApp).
+        // With the dance:    2 disconnects (FORCEBOOT + stale-handle discard)
+        //                    + 2 connects (initial reconnect + clean re-open).
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(disconnectsBeforeUpdate + 2, device.DisconnectCalls);
+        Assert.Equal(connectAttemptsBeforeUpdate + 2, device.ConnectAttempts);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_PostReconnectStaleHandleDelayZero_SkipsExtraDisconnectReconnect()
+    {
+        // Opt-out path: setting PostReconnectStaleHandleDelay to Zero
+        // (e.g. on Windows where the first open is already clean) must
+        // skip the extra disconnect/reconnect cycle entirely.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]);
+        hidTransport.EnqueueRead([0x01, 0x02]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x10]);
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var options = CreateFastOptions(); // CreateFastOptions sets this to Zero
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]),
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        // 1 FORCEBOOT disconnect + 1 reconnect; no stale-handle dance.
+        Assert.Equal(1, device.DisconnectCalls);
+        Assert.Equal(1, device.ConnectAttempts);
+    }
+
+    [Fact]
     public void Constructor_ProbeWithReadinessTimeoutGteJumpToApp_Throws()
     {
         // The whole JumpToApp step is bounded by JumpingToApplicationTimeout
@@ -1267,7 +1369,11 @@ public class FirmwareUpdateServiceTests
             PostWifiReconnectDelay = TimeSpan.FromMilliseconds(5),
             HidConnectRetryDelay = TimeSpan.FromMilliseconds(5),
             FlashWriteRetryDelay = TimeSpan.FromMilliseconds(5),
-            WifiProcessTimeout = TimeSpan.FromSeconds(2)
+            WifiProcessTimeout = TimeSpan.FromSeconds(2),
+            // Disable the macOS USB CDC stale-handle settling delay for unit
+            // tests — FakeStreamingDevice doesn't reproduce the re-enum race,
+            // so the dance is pure latency that would blow the fast budgets.
+            PostReconnectStaleHandleDelay = TimeSpan.Zero
         };
     }
 

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -525,7 +525,9 @@ public class FirmwareUpdateServiceTests
             probeCallCount++;
             return Task.FromResult(probeCallCount >= 3);
         };
-        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(2);
+        // Readiness budget must be strictly less than JumpingToApplicationTimeout
+        // (CreateFastOptions uses 2s) — the probe succeeds within 50ms anyway.
+        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(1);
         options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
 
         var service = new FirmwareUpdateService(
@@ -646,6 +648,31 @@ public class FirmwareUpdateServiceTests
         }
 
         Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+    }
+
+    [Fact]
+    public void Constructor_ProbeWithReadinessTimeoutGteJumpToApp_Throws()
+    {
+        // The whole JumpToApp step is bounded by JumpingToApplicationTimeout
+        // via the outer state-timeout. If the readiness budget meets or
+        // exceeds it, the outer timeout fires first and surfaces a generic
+        // JumpingToApp error instead of the readiness-specific one. Validate()
+        // must reject the misconfiguration up front.
+        var options = CreateFastOptions();
+        options.PostReconnectReadinessProbe = (_, _) => Task.FromResult(true);
+        options.JumpingToApplicationTimeout = TimeSpan.FromSeconds(2);
+        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(2);
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01]]),
+            new FakeHidDeviceEnumerator([Array.Empty<HidDeviceInfo>()]),
+            options));
+
+        Assert.Equal(nameof(FirmwareUpdateServiceOptions.PostReconnectReadinessTimeout), ex.ParamName);
     }
 
     private static FirmwareUpdateServiceOptions CreateFastOptions()

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -491,6 +491,163 @@ public class FirmwareUpdateServiceTests
         Assert.Contains("SYSTem:COMMUnicate:LAN:FWUpdate", device.SentCommands);
     }
 
+    [Fact]
+    public async Task UpdateFirmwareAsync_PostReconnectReadinessProbe_AwaitedBeforeComplete()
+    {
+        // Closes #145: serial reconnect succeeds before the application
+        // firmware is ready to answer protobuf status queries. The
+        // optional readiness probe gives Core a way to wait for true
+        // application readiness — when set, no caller needs to
+        // reimplement that retry loop.
+        //
+        // The probe here returns false on the first 2 attempts and true
+        // on the 3rd, simulating a slow PIC32 application boot. Without
+        // the wait, the update would Complete immediately after serial
+        // reopens; with the wait, Complete is held back until the probe
+        // succeeds.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]);
+        hidTransport.EnqueueRead([0x01, 0x02]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x10]);
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var probeCallCount = 0;
+        var options = CreateFastOptions();
+        options.PostReconnectReadinessProbe = (_, _) =>
+        {
+            probeCallCount++;
+            return Task.FromResult(probeCallCount >= 3);
+        };
+        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(2);
+        options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]),
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(3, probeCallCount);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_PostReconnectReadinessProbe_TimeoutFailsTheUpdate()
+    {
+        // When the application never becomes ready within the configured
+        // budget, the update must transition to Failed with a clear
+        // timeout message — NOT silently complete and hand back a
+        // half-ready device. That's the entire reason for #145.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]);
+        hidTransport.EnqueueRead([0x01, 0x02]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x10]);
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var options = CreateFastOptions();
+        // Probe always returns false → never ready → must time out
+        options.PostReconnectReadinessProbe = (_, _) => Task.FromResult(false);
+        options.PostReconnectReadinessTimeout = TimeSpan.FromMilliseconds(150);
+        options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]),
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException ex;
+        try
+        {
+            ex = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+        Assert.Equal(FirmwareUpdateState.JumpingToApp, ex.FailedState);
+        var inner = Assert.IsType<TimeoutException>(ex.InnerException);
+        Assert.Contains("application-ready", inner.Message);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_NoPostReconnectProbe_PreservesLegacyBehavior()
+    {
+        // No probe configured == legacy behavior: Complete fires as
+        // soon as serial reopens. Belt-and-suspenders test that the
+        // new code path is fully opt-in.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]);
+        hidTransport.EnqueueRead([0x01, 0x02]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x10]);
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var options = CreateFastOptions();
+        // No PostReconnectReadinessProbe set - legacy path
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]),
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+    }
+
     private static FirmwareUpdateServiceOptions CreateFastOptions()
     {
         return new FirmwareUpdateServiceOptions

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -664,6 +664,67 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateFirmwareAsync_PostReconnectProbeThrowsThenFalseThenTimeout_DoesNotAttachStaleInner()
+    {
+        // The probe throws once, then returns false until the readiness budget
+        // expires. The TimeoutException must NOT carry the stale exception
+        // from attempt 1 as InnerException — a successful probe call (true OR
+        // false) should clear the captured exception.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]);
+        hidTransport.EnqueueRead([0x01, 0x02]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x03]);
+        hidTransport.EnqueueRead([0x01, 0x10]);
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var probeCallCount = 0;
+        var options = CreateFastOptions();
+        options.PostReconnectReadinessProbe = (_, _) =>
+        {
+            probeCallCount++;
+            // Attempt 1: throw. Subsequent attempts: return false until timeout.
+            return probeCallCount == 1
+                ? Task.FromException<bool>(new InvalidOperationException("transient-probe-error"))
+                : Task.FromResult(false);
+        };
+        options.PostReconnectReadinessTimeout = TimeSpan.FromMilliseconds(150);
+        options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]),
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException ex;
+        try
+        {
+            ex = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        var inner = Assert.IsType<TimeoutException>(ex.InnerException);
+        // Critical: the InvalidOperationException from attempt 1 must NOT
+        // be attached — the successful (false) probe in attempt 2+ cleared
+        // lastProbeException. InnerException.InnerException should be null.
+        Assert.Null(inner.InnerException);
+    }
+
+    [Fact]
     public async Task UpdateFirmwareAsync_NoPostReconnectProbe_PreservesLegacyBehavior()
     {
         // No probe configured == legacy behavior: Complete fires as

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -266,6 +266,18 @@ namespace Daqifi.Core.Device
                 _messageConsumer?.StopSafely();
                 _messageProducer?.StopSafely();
 
+                // Null the producer/consumer so a subsequent Connect()
+                // rebuilds them against the transport's current Stream.
+                // SerialStreamTransport.Stream returns _serialPort.BaseStream,
+                // which is a new instance after Disconnect() → Connect()
+                // reopens the port; reusing the old producer/consumer would
+                // leave them bound to the previous (disposed) BaseStream
+                // and any Send() would silently no-op. Surfaced by PR #200's
+                // post-reconnect readiness probe (LAN chip-info returning
+                // null on every attempt because Send went to a dead stream).
+                _messageConsumer = null;
+                _messageProducer = null;
+
                 // Disconnect transport if available
                 _transport?.Disconnect();
             }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -871,6 +871,12 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                     .WaitAsync(linkedToken)
                     .ConfigureAwait(false);
 
+                // Successful probe invocation (true OR false) means the most
+                // recent attempt completed normally. Clear lastProbeException
+                // so a later timeout doesn't carry forward a stale exception
+                // from an earlier failed attempt as its InnerException.
+                lastProbeException = null;
+
                 if (isReady)
                 {
                     if (probesExecuted > 1)

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -880,12 +880,28 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 }
                 _logger.LogDebug("Application-ready probe returned false on attempt {Attempt}; will retry.", attempt);
             }
-            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
             {
-                throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout} (attempt {attempt}). " +
-                    "The wait for the readiness probe was canceled by the timeout — note the probe may ignore cancellation and continue running in the background.",
-                    lastProbeException);
+                // Two cases reach here:
+                // 1. The wait deadline fired (timeoutCts canceled) — surface
+                //    as TimeoutException so callers see the readiness budget.
+                // 2. The probe itself threw OperationCanceledException for
+                //    some unrelated reason (its own internal CTS, etc). That
+                //    must NOT crash the update loop — treat it as a probe
+                //    failure and retry, same as any other thrown exception.
+                if (timeoutCts.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"Device did not become application-ready within {totalTimeout} (attempt {attempt}). " +
+                        "The wait for the readiness probe was canceled by the timeout — note the probe may ignore cancellation and continue running in the background.",
+                        lastProbeException ?? ex);
+                }
+
+                lastProbeException = ex;
+                _logger.LogDebug(
+                    ex,
+                    "Application-ready probe was canceled on attempt {Attempt}; treating as not-ready and retrying.",
+                    attempt);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -852,8 +852,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}). " +
-                    "The serial transport reopened but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.",
+                    $"Device did not become application-ready within {totalTimeout} (attempt {attempt}). " +
+                    "The transport reconnected but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.",
                     lastProbeException);
             }
 
@@ -883,8 +883,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}). " +
-                    "The readiness probe was canceled by the timeout while running.",
+                    $"Device did not become application-ready within {totalTimeout} (attempt {attempt}). " +
+                    "The wait for the readiness probe was canceled by the timeout — note the probe may ignore cancellation and continue running in the background.",
                     lastProbeException);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -903,7 +903,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}).",
+                    $"Device did not become application-ready within {totalTimeout} (attempt {attempt}).",
                     lastProbeException);
             }
         }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -841,10 +841,12 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         // are on.
         Exception? lastProbeException = null;
 
-        var attempt = 0;
+        // Tracks how many probe invocations have actually run. Distinct from
+        // the loop iteration counter so the timeout messages don't claim
+        // "attempt N" when the timeout fired before a probe ever executed.
+        var probesExecuted = 0;
         while (true)
         {
-            attempt++;
             try
             {
                 linkedToken.ThrowIfCancellationRequested();
@@ -852,13 +854,14 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout} (attempt {attempt}). " +
+                    $"Device did not become application-ready within {totalTimeout} (probes executed: {probesExecuted}). " +
                     "The transport reconnected but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.",
                     lastProbeException);
             }
 
             try
             {
+                probesExecuted++;
                 // WaitAsync(linkedToken) enforces the timeout deadline even
                 // when the probe ignores its own CancellationToken and would
                 // otherwise hang or return after the budget elapses. When
@@ -870,15 +873,15 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
                 if (isReady)
                 {
-                    if (attempt > 1)
+                    if (probesExecuted > 1)
                     {
                         _logger.LogDebug(
                             "Device became application-ready on probe attempt {Attempt}.",
-                            attempt);
+                            probesExecuted);
                     }
                     return;
                 }
-                _logger.LogDebug("Application-ready probe returned false on attempt {Attempt}; will retry.", attempt);
+                _logger.LogDebug("Application-ready probe returned false on attempt {Attempt}; will retry.", probesExecuted);
             }
             catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
             {
@@ -892,7 +895,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 if (timeoutCts.IsCancellationRequested)
                 {
                     throw new TimeoutException(
-                        $"Device did not become application-ready within {totalTimeout} (attempt {attempt}). " +
+                        $"Device did not become application-ready within {totalTimeout} (probes executed: {probesExecuted}). " +
                         "The wait for the readiness probe was canceled by the timeout — note the probe may ignore cancellation and continue running in the background.",
                         lastProbeException ?? ex);
                 }
@@ -901,7 +904,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 _logger.LogDebug(
                     ex,
                     "Application-ready probe was canceled on attempt {Attempt}; treating as not-ready and retrying.",
-                    attempt);
+                    probesExecuted);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -909,7 +912,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 _logger.LogDebug(
                     ex,
                     "Application-ready probe threw on attempt {Attempt}; treating as not-ready and retrying.",
-                    attempt);
+                    probesExecuted);
             }
 
             try
@@ -919,7 +922,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout} (attempt {attempt}). " +
+                    $"Device did not become application-ready within {totalTimeout} (probes executed: {probesExecuted}). " +
                     "The transport reconnected but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.",
                     lastProbeException);
             }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -806,6 +806,86 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
         await SafeDisconnectHidAsync().ConfigureAwait(false);
         await WaitForSerialReconnectAsync(device, cancellationToken).ConfigureAwait(false);
+
+        // Application-readiness probe (closes #145). Serial transport
+        // re-enumeration succeeds well before the PIC32 application
+        // firmware is actually ready to answer protobuf status queries;
+        // if a downstream flow (LAN chip info, WiFi prep) starts before
+        // the app is up, those queries fail and callers reimplement
+        // their own retry. The probe is opt-in via options — when null,
+        // the legacy "serial reopened == done" semantics apply.
+        if (_options.PostReconnectReadinessProbe is { } probe)
+        {
+            await WaitForApplicationReadyAsync(device, probe, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task WaitForApplicationReadyAsync(
+        IStreamingDevice device,
+        Func<IStreamingDevice, CancellationToken, Task<bool>> probe,
+        CancellationToken cancellationToken)
+    {
+        var totalTimeout = _options.PostReconnectReadinessTimeout;
+        var retryDelay = _options.PostReconnectReadinessRetryDelay;
+
+        using var timeoutCts = new CancellationTokenSource(totalTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+        var linkedToken = linkedCts.Token;
+
+        var attempt = 0;
+        while (true)
+        {
+            attempt++;
+            try
+            {
+                linkedToken.ThrowIfCancellationRequested();
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Device did not become application-ready within {totalTimeout.TotalSeconds:F0}s after PIC32 reconnect (attempt {attempt}). " +
+                    "The serial transport reopened but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.");
+            }
+
+            try
+            {
+                if (await probe(device, linkedToken).ConfigureAwait(false))
+                {
+                    if (attempt > 1)
+                    {
+                        _logger.LogDebug(
+                            "Device became application-ready on probe attempt {Attempt}.",
+                            attempt);
+                    }
+                    return;
+                }
+                _logger.LogDebug("Application-ready probe returned false on attempt {Attempt}; will retry.", attempt);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Device did not become application-ready within {totalTimeout.TotalSeconds:F0}s after PIC32 reconnect (attempt {attempt}). " +
+                    "The readiness probe was canceled by the timeout while running.");
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogDebug(
+                    ex,
+                    "Application-ready probe threw on attempt {Attempt}; treating as not-ready and retrying.",
+                    attempt);
+            }
+
+            try
+            {
+                await Task.Delay(retryDelay, linkedToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Device did not become application-ready within {totalTimeout.TotalSeconds:F0}s after PIC32 reconnect (attempt {attempt}).");
+            }
+        }
     }
 
     private async Task WaitForSerialReconnectAsync(

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -850,24 +850,16 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
             try
             {
-                var isReady = await probe(device, linkedToken).ConfigureAwait(false);
-
-                // Re-check the budget after the await: a probe that ignores
-                // its CancellationToken could otherwise return true after
-                // the timeout has elapsed and bypass the budget. Caller's
-                // CT propagates as OperationCanceledException out of this
-                // method (caught at the same handler below); only the
-                // timeout-CT case is reinterpreted as TimeoutException.
-                try
-                {
-                    linkedToken.ThrowIfCancellationRequested();
-                }
-                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                {
-                    throw new TimeoutException(
-                        $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}). " +
-                        "The readiness probe ignored cancellation and returned after the deadline.");
-                }
+                // WaitAsync(linkedToken) enforces the timeout deadline even
+                // when the probe ignores its own CancellationToken and would
+                // otherwise hang or return after the budget elapses. When
+                // the deadline fires, WaitAsync throws OperationCanceledException
+                // immediately — we don't keep waiting for the rogue probe.
+                // (Stronger than a post-await re-check: that would still
+                // wait for the probe to return; this short-circuits.)
+                var isReady = await probe(device, linkedToken)
+                    .WaitAsync(linkedToken)
+                    .ConfigureAwait(false);
 
                 if (isReady)
                 {

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -1011,6 +1011,26 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         await SafeDisconnectHidAsync().ConfigureAwait(false);
         await WaitForSerialReconnectAsync(device, cancellationToken).ConfigureAwait(false);
 
+        // Discard the race-winning serial handle from the USB CDC re-enumeration
+        // window. On macOS the first SerialPort.Open() that succeeds after a PIC32
+        // reset is typically a "shadow" handle: IsOpen==true, but the kernel
+        // device-node isn't fully wired yet — writes silently drop and reads see
+        // zero bytes. A fresh open after a brief settling delay yields a clean
+        // binding. Symptom without this step: SCPI Sends after reconnect appear
+        // to succeed but the device never responds (LEDs stay off, readiness
+        // probe returns null indefinitely until budget expires).
+        // Opt out by setting PostReconnectStaleHandleDelay = TimeSpan.Zero
+        // (callers on platforms where the first open is already clean).
+        if (_options.PostReconnectStaleHandleDelay > TimeSpan.Zero)
+        {
+            _logger.LogDebug(
+                "Discarding race-winning serial handle; closing and re-opening after {Delay} to obtain a clean USB CDC binding.",
+                _options.PostReconnectStaleHandleDelay);
+            device.Disconnect();
+            await Task.Delay(_options.PostReconnectStaleHandleDelay, cancellationToken).ConfigureAwait(false);
+            await WaitForSerialReconnectAsync(device, cancellationToken).ConfigureAwait(false);
+        }
+
         // Application-readiness probe (closes #145). Serial transport
         // re-enumeration succeeds well before the PIC32 application
         // firmware is actually ready to answer protobuf status queries;

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -903,7 +903,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout} (attempt {attempt}).",
+                    $"Device did not become application-ready within {totalTimeout} (attempt {attempt}). " +
+                    "The transport reconnected but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.",
                     lastProbeException);
             }
         }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -833,6 +833,14 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             cancellationToken, timeoutCts.Token);
         var linkedToken = linkedCts.Token;
 
+        // Capture the most recent probe-thrown exception so a TimeoutException
+        // can carry the underlying cause as InnerException. Without this,
+        // deterministic probe failures (e.g. transport says it's open but
+        // the device never responds to status queries) report only as
+        // "timed out" — losing the actual error context unless Debug logs
+        // are on.
+        Exception? lastProbeException = null;
+
         var attempt = 0;
         while (true)
         {
@@ -845,7 +853,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             {
                 throw new TimeoutException(
                     $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}). " +
-                    "The serial transport reopened but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.");
+                    "The serial transport reopened but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.",
+                    lastProbeException);
             }
 
             try
@@ -855,8 +864,6 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 // otherwise hang or return after the budget elapses. When
                 // the deadline fires, WaitAsync throws OperationCanceledException
                 // immediately — we don't keep waiting for the rogue probe.
-                // (Stronger than a post-await re-check: that would still
-                // wait for the probe to return; this short-circuits.)
                 var isReady = await probe(device, linkedToken)
                     .WaitAsync(linkedToken)
                     .ConfigureAwait(false);
@@ -877,10 +884,12 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             {
                 throw new TimeoutException(
                     $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}). " +
-                    "The readiness probe was canceled by the timeout while running.");
+                    "The readiness probe was canceled by the timeout while running.",
+                    lastProbeException);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                lastProbeException = ex;
                 _logger.LogDebug(
                     ex,
                     "Application-ready probe threw on attempt {Attempt}; treating as not-ready and retrying.",
@@ -894,7 +903,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}).");
+                    $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}).",
+                    lastProbeException);
             }
         }
     }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -828,6 +828,16 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         var totalTimeout = _options.PostReconnectReadinessTimeout;
         var retryDelay = _options.PostReconnectReadinessRetryDelay;
 
+        // Surface the wait at Information level so observers tailing the
+        // log can distinguish "stuck" from "deliberately polling". The
+        // wait can take up to PostReconnectReadinessTimeout (default 30s);
+        // without this, the JumpingToApp state appears hung beyond the
+        // initial transport reopen.
+        _logger.LogInformation(
+            "Waiting up to {Timeout} for device to become application-ready (post-reconnect readiness probe).",
+            totalTimeout);
+        var waitStart = DateTime.UtcNow;
+
         using var timeoutCts = new CancellationTokenSource(totalTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken, timeoutCts.Token);
@@ -879,12 +889,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
                 if (isReady)
                 {
-                    if (probesExecuted > 1)
-                    {
-                        _logger.LogDebug(
-                            "Device became application-ready on probe attempt {Attempt}.",
-                            probesExecuted);
-                    }
+                    var elapsed = DateTime.UtcNow - waitStart;
+                    _logger.LogInformation(
+                        "Device became application-ready after {Elapsed} on probe attempt {Attempt}.",
+                        elapsed,
+                        probesExecuted);
                     return;
                 }
                 _logger.LogDebug("Application-ready probe returned false on attempt {Attempt}; will retry.", probesExecuted);

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -1023,12 +1023,38 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         // (callers on platforms where the first open is already clean).
         if (_options.PostReconnectStaleHandleDelay > TimeSpan.Zero)
         {
-            _logger.LogDebug(
+            _logger.LogInformation(
                 "Discarding race-winning serial handle; closing and re-opening after {Delay} to obtain a clean USB CDC binding.",
                 _options.PostReconnectStaleHandleDelay);
             device.Disconnect();
             await Task.Delay(_options.PostReconnectStaleHandleDelay, cancellationToken).ConfigureAwait(false);
             await WaitForSerialReconnectAsync(device, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Wake the post-reset device. PIC32 application firmware boots
+        // dormant (LEDs off, WiFi subsystem unpowered, won't answer LAN
+        // queries) until SYSTem:POWer:STATe 1 is sent. InitializeAsync
+        // handles that plus the rest of the standard init sequence
+        // (echo off, stream format, etc.). Without this, callers writing
+        // a "natural" probe like GetLanChipInfoAsync would silently fail
+        // for tens of seconds because the device is still dormant.
+        // Skipped for non-DaqifiDevice transports (e.g. test fakes); they
+        // are responsible for their own readiness if needed.
+        if (device is DaqifiDevice initializableDevice)
+        {
+            _logger.LogInformation("Waking post-reset device via InitializeAsync.");
+            try
+            {
+                await initializableDevice.InitializeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Don't fail the firmware update outright — the readiness
+                // probe (if configured) is the source of truth for "ready".
+                // Surface the init failure as a warning so a probe timeout
+                // later isn't mysterious.
+                _logger.LogWarning(ex, "InitializeAsync after reconnect threw; continuing to readiness probe.");
+            }
         }
 
         // Application-readiness probe (closes #145). Serial transport

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -850,7 +850,26 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
             try
             {
-                if (await probe(device, linkedToken).ConfigureAwait(false))
+                var isReady = await probe(device, linkedToken).ConfigureAwait(false);
+
+                // Re-check the budget after the await: a probe that ignores
+                // its CancellationToken could otherwise return true after
+                // the timeout has elapsed and bypass the budget. Caller's
+                // CT propagates as OperationCanceledException out of this
+                // method (caught at the same handler below); only the
+                // timeout-CT case is reinterpreted as TimeoutException.
+                try
+                {
+                    linkedToken.ThrowIfCancellationRequested();
+                }
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"Device did not become application-ready within {totalTimeout.TotalSeconds:F0}s after PIC32 reconnect (attempt {attempt}). " +
+                        "The readiness probe ignored cancellation and returned after the deadline.");
+                }
+
+                if (isReady)
                 {
                     if (attempt > 1)
                     {

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -844,7 +844,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout.TotalSeconds:F0}s after PIC32 reconnect (attempt {attempt}). " +
+                    $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}). " +
                     "The serial transport reopened but the readiness probe never returned true; the device may still be initializing or the firmware may have failed to start.");
             }
 
@@ -865,7 +865,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
                     throw new TimeoutException(
-                        $"Device did not become application-ready within {totalTimeout.TotalSeconds:F0}s after PIC32 reconnect (attempt {attempt}). " +
+                        $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}). " +
                         "The readiness probe ignored cancellation and returned after the deadline.");
                 }
 
@@ -884,7 +884,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout.TotalSeconds:F0}s after PIC32 reconnect (attempt {attempt}). " +
+                    $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}). " +
                     "The readiness probe was canceled by the timeout while running.");
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -902,7 +902,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new TimeoutException(
-                    $"Device did not become application-ready within {totalTimeout.TotalSeconds:F0}s after PIC32 reconnect (attempt {attempt}).");
+                    $"Device did not become application-ready within {totalTimeout} after PIC32 reconnect (attempt {attempt}).");
             }
         }
     }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -1,3 +1,5 @@
+using Daqifi.Core.Device;
+
 namespace Daqifi.Core.Firmware;
 
 /// <summary>
@@ -120,6 +122,34 @@ public sealed class FirmwareUpdateServiceOptions
     public string? WifiPortOverride { get; set; }
 
     /// <summary>
+    /// Optional callback that returns true once the device is ready to
+    /// answer normal application commands after PIC32 firmware update +
+    /// reconnect (closes #145). The serial transport can re-enumerate
+    /// well before the application firmware is actually ready to respond
+    /// to protobuf status queries — without this probe, the next steps
+    /// in a downstream flow (LAN chip-info, WiFi prep) hit a half-started
+    /// device and have to retry. When set, the firmware service polls
+    /// the probe with bounded retry after each PIC32 reconnect; if it
+    /// never returns true within <see cref="PostReconnectReadinessTimeout"/>,
+    /// the update transitions to Failed with a clear timeout exception
+    /// rather than silently handing back a half-ready device. When null,
+    /// reconnect succeeds as soon as the serial port reopens (legacy
+    /// behavior).
+    /// </summary>
+    public Func<IStreamingDevice, CancellationToken, Task<bool>>? PostReconnectReadinessProbe { get; set; }
+
+    /// <summary>
+    /// Wall-clock budget for the post-reconnect readiness probe. Default
+    /// 30s covers a slow PIC32 boot and downstream-firmware initialization.
+    /// </summary>
+    public TimeSpan PostReconnectReadinessTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Delay between readiness-probe attempts (cancellation-aware).
+    /// </summary>
+    public TimeSpan PostReconnectReadinessRetryDelay { get; set; } = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
     /// Gets the configured timeout for a given firmware update state.
     /// </summary>
     /// <param name="state">The target state.</param>
@@ -159,6 +189,8 @@ public sealed class FirmwareUpdateServiceOptions
         ValidatePositive(HidConnectRetryDelay, nameof(HidConnectRetryDelay));
         ValidatePositive(FlashWriteRetryDelay, nameof(FlashWriteRetryDelay));
         ValidatePositive(WifiProcessTimeout, nameof(WifiProcessTimeout));
+        ValidatePositive(PostReconnectReadinessTimeout, nameof(PostReconnectReadinessTimeout));
+        ValidatePositive(PostReconnectReadinessRetryDelay, nameof(PostReconnectReadinessRetryDelay));
 
         if (HidConnectRetryCount < 1)
         {

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -142,6 +142,15 @@ public sealed class FirmwareUpdateServiceOptions
     /// Wall-clock budget for the post-reconnect readiness probe. Default
     /// 30s covers a slow PIC32 boot and downstream-firmware initialization.
     /// </summary>
+    /// <remarks>
+    /// This budget runs INSIDE the JumpingToApp state, so the effective
+    /// upper bound is <c>JumpingToApplicationTimeout - (serial reconnect
+    /// elapsed)</c>. With the defaults (45s state timeout, ~1-5s typical
+    /// reconnect, 30s readiness budget) the readiness probe gets its full
+    /// budget; if you raise this near or above the state timeout, the
+    /// outer state-timeout will fire first and callers will see a generic
+    /// JumpingToApp timeout instead of the readiness-specific message.
+    /// </remarks>
     public TimeSpan PostReconnectReadinessTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -198,22 +198,29 @@ public sealed class FirmwareUpdateServiceOptions
         ValidatePositive(HidConnectRetryDelay, nameof(HidConnectRetryDelay));
         ValidatePositive(FlashWriteRetryDelay, nameof(FlashWriteRetryDelay));
         ValidatePositive(WifiProcessTimeout, nameof(WifiProcessTimeout));
-        ValidatePositive(PostReconnectReadinessTimeout, nameof(PostReconnectReadinessTimeout));
-        ValidatePositive(PostReconnectReadinessRetryDelay, nameof(PostReconnectReadinessRetryDelay));
 
-        // The whole JumpToApp step is wrapped by JumpingToApplicationTimeout,
-        // so a probe budget that meets or exceeds it would always be cut off
-        // by the outer state-timeout — surfacing a generic JumpingToApp error
-        // instead of the readiness-specific message. Reject the configuration
-        // up front so misconfigurations fail fast.
-        if (PostReconnectReadinessProbe is not null &&
-            PostReconnectReadinessTimeout >= JumpingToApplicationTimeout)
+        // The readiness options only matter when a probe is configured —
+        // gate every readiness validation behind that, both the positive
+        // checks and the cross-property constraint, so callers that don't
+        // use the probe never have to think about these timeouts.
+        if (PostReconnectReadinessProbe is not null)
         {
-            throw new ArgumentOutOfRangeException(
-                nameof(PostReconnectReadinessTimeout),
-                PostReconnectReadinessTimeout,
-                $"{nameof(PostReconnectReadinessTimeout)} must be strictly less than {nameof(JumpingToApplicationTimeout)} when {nameof(PostReconnectReadinessProbe)} is set, " +
-                "otherwise the outer state-timeout fires first and masks the readiness-specific timeout.");
+            ValidatePositive(PostReconnectReadinessTimeout, nameof(PostReconnectReadinessTimeout));
+            ValidatePositive(PostReconnectReadinessRetryDelay, nameof(PostReconnectReadinessRetryDelay));
+
+            // The whole JumpToApp step is wrapped by JumpingToApplicationTimeout,
+            // so a probe budget that meets or exceeds it would always be cut off
+            // by the outer state-timeout — surfacing a generic JumpingToApp error
+            // instead of the readiness-specific message. Reject the configuration
+            // up front so misconfigurations fail fast.
+            if (PostReconnectReadinessTimeout >= JumpingToApplicationTimeout)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(PostReconnectReadinessTimeout),
+                    PostReconnectReadinessTimeout,
+                    $"{nameof(PostReconnectReadinessTimeout)} must be strictly less than {nameof(JumpingToApplicationTimeout)} when {nameof(PostReconnectReadinessProbe)} is set, " +
+                    "otherwise the outer state-timeout fires first and masks the readiness-specific timeout.");
+            }
         }
 
         if (HidConnectRetryCount < 1)

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -201,6 +201,21 @@ public sealed class FirmwareUpdateServiceOptions
         ValidatePositive(PostReconnectReadinessTimeout, nameof(PostReconnectReadinessTimeout));
         ValidatePositive(PostReconnectReadinessRetryDelay, nameof(PostReconnectReadinessRetryDelay));
 
+        // The whole JumpToApp step is wrapped by JumpingToApplicationTimeout,
+        // so a probe budget that meets or exceeds it would always be cut off
+        // by the outer state-timeout — surfacing a generic JumpingToApp error
+        // instead of the readiness-specific message. Reject the configuration
+        // up front so misconfigurations fail fast.
+        if (PostReconnectReadinessProbe is not null &&
+            PostReconnectReadinessTimeout >= JumpingToApplicationTimeout)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(PostReconnectReadinessTimeout),
+                PostReconnectReadinessTimeout,
+                $"{nameof(PostReconnectReadinessTimeout)} must be strictly less than {nameof(JumpingToApplicationTimeout)} when {nameof(PostReconnectReadinessProbe)} is set, " +
+                "otherwise the outer state-timeout fires first and masks the readiness-specific timeout.");
+        }
+
         if (HidConnectRetryCount < 1)
         {
             throw new ArgumentOutOfRangeException(

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -159,6 +159,20 @@ public sealed class FirmwareUpdateServiceOptions
     public TimeSpan PostReconnectReadinessRetryDelay { get; set; } = TimeSpan.FromMilliseconds(500);
 
     /// <summary>
+    /// Settling delay between discarding the race-winning serial handle
+    /// and re-opening the port after a PIC32 reset (closes the macOS-USB-CDC
+    /// shadow-handle problem). After PIC32 firmware update completes the
+    /// device's USB CDC interface re-enumerates; on macOS the first
+    /// SerialPort.Open() that succeeds during that window is typically a
+    /// "shadow" handle — IsOpen==true but writes silently drop and reads
+    /// see zero bytes. Closing and re-opening after a brief delay yields
+    /// a clean kernel binding. Default 2s covers macOS-observed timing;
+    /// set to TimeSpan.Zero on platforms (notably Windows) where the
+    /// first open is already clean and the extra cycle is pure latency.
+    /// </summary>
+    public TimeSpan PostReconnectStaleHandleDelay { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
     /// Total attempts (initial + retries) for LAN chip-info queries before
     /// the WiFi version decision falls through to "couldn't check, proceed
     /// with flash". Right after a PIC32 firmware update the application is


### PR DESCRIPTION
## Summary

Adds an opt-in readiness probe so a PIC32 firmware update doesn't transition to `Complete` until the device is actually ready to answer normal application commands. Serial transport re-enumeration succeeds well before the application firmware is up; without this wait, downstream flows (LAN chip-info queries, WiFi prep) hit a half-started device — exactly the pattern desktop had to work around with its own retry loop.

## API additions

`FirmwareUpdateServiceOptions` gains 3 new properties:
- `PostReconnectReadinessProbe` — `Func<IStreamingDevice, CancellationToken, Task<bool>>?`. Returns `true` when the application is responsive. **Null disables the wait** (legacy behavior preserved).
- `PostReconnectReadinessTimeout` (default **30s**) — wall-clock budget for the wait.
- `PostReconnectReadinessRetryDelay` (default **500ms**) — delay between probe attempts.

When the timeout elapses without the probe returning true, the update transitions to `Failed` with a `TimeoutException` wrapped in `FirmwareUpdateException` — **NOT** a silent `Complete` on a half-ready device, which is the entire point of #145.

## Test plan

- [x] Probe succeeds on attempt N>1 holds back `Complete` until ready (assert `Complete` state + probe call count = 3)
- [x] Timeout raises a properly wrapped `FirmwareUpdateException` with `FailedState=JumpingToApp` and the readiness keyword in the inner message
- [x] Null probe preserves legacy fast-complete path (belt-and-suspenders)
- [x] Build clean on net9.0 + net10.0
- [x] Full suite: 893/895 (2 skipped require live hardware)

Closes #145