### PR TITLE
feat(discovery): add macOS ioreg USB VID/PID filtering for serial ports

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/UsbPortDescriptorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/UsbPortDescriptorTests.cs
@@ -44,4 +44,111 @@ public class UsbPortDescriptorTests
         Assert.Null(provider.GetDescriptor("/dev/ttyACM1"));
         Assert.Null(provider.GetDescriptor(""));
     }
+
+    [Fact]
+    public void MacOsUsbPortDescriptorProvider_Parse_EmptyInput_ReturnsEmpty()
+    {
+        var result = MacOsUsbPortDescriptorProvider.Parse(string.Empty);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MacOsUsbPortDescriptorProvider_Parse_SingleDaqifiDevice_MapsCorrectly()
+    {
+        const string ioregOutput = """
+              | {
+              |   "idVendor" = 1240
+              |   "idProduct" = 63380
+              |   {
+              |     "IOCalloutDevice" = "/dev/cu.usbmodem101"
+              |   }
+              | }
+            """;
+
+        var result = MacOsUsbPortDescriptorProvider.Parse(ioregOutput);
+
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("/dev/cu.usbmodem101"));
+        Assert.Equal(1240, result["/dev/cu.usbmodem101"].VendorId);   // 0x04D8
+        Assert.Equal(63380, result["/dev/cu.usbmodem101"].ProductId); // 0xF794
+    }
+
+    [Fact]
+    public void MacOsUsbPortDescriptorProvider_Parse_MultipleDevices_MapsAll()
+    {
+        const string ioregOutput = """
+              | {
+              |   "idVendor" = 1240
+              |   "idProduct" = 63380
+              |   {
+              |     "IOCalloutDevice" = "/dev/cu.usbmodem101"
+              |   }
+              | }
+              | {
+              |   "idVendor" = 1027
+              |   "idProduct" = 24577
+              |   {
+              |     "IOCalloutDevice" = "/dev/cu.usbserial-1420"
+              |   }
+              | }
+            """;
+
+        var result = MacOsUsbPortDescriptorProvider.Parse(ioregOutput);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1240, result["/dev/cu.usbmodem101"].VendorId);
+        Assert.Equal(1027, result["/dev/cu.usbserial-1420"].VendorId);
+    }
+
+    [Fact]
+    public void MacOsUsbPortDescriptorProvider_Parse_DeviceWithoutCallout_NotMapped()
+    {
+        const string ioregOutput = """
+              | {
+              |   "idVendor" = 1240
+              |   "idProduct" = 63380
+              | }
+            """;
+
+        var result = MacOsUsbPortDescriptorProvider.Parse(ioregOutput);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MacOsUsbPortDescriptorProvider_Parse_CalloutWithoutVidPid_NotMapped()
+    {
+        const string ioregOutput = """
+              | {
+              |   "IOCalloutDevice" = "/dev/cu.usbmodem101"
+              | }
+            """;
+
+        var result = MacOsUsbPortDescriptorProvider.Parse(ioregOutput);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MacOsUsbPortDescriptorProvider_Parse_VidPidCarryOverToNextCallout()
+    {
+        // A single USB device may expose multiple serial interfaces. Both
+        // callout devices should get the same VID/PID from the parent node.
+        const string ioregOutput = """
+              | {
+              |   "idVendor" = 1240
+              |   "idProduct" = 63380
+              |   {
+              |     "IOCalloutDevice" = "/dev/cu.usbmodem1011"
+              |   }
+              |   {
+              |     "IOCalloutDevice" = "/dev/cu.usbmodem1013"
+              |   }
+              | }
+            """;
+
+        var result = MacOsUsbPortDescriptorProvider.Parse(ioregOutput);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1240, result["/dev/cu.usbmodem1011"].VendorId);
+        Assert.Equal(1240, result["/dev/cu.usbmodem1013"].VendorId);
+    }
 }

--- a/src/Daqifi.Core/Device/Discovery/IUsbPortDescriptorProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/IUsbPortDescriptorProvider.cs
@@ -10,9 +10,10 @@ namespace Daqifi.Core.Device.Discovery;
 /// </summary>
 /// <remarks>
 /// Implementations are platform-specific: Windows uses WMI, Linux reads
-/// <c>/sys/class/tty</c>. Platforms without an implementation fall back to
-/// <see cref="NullUsbPortDescriptorProvider"/> which returns null for every
-/// port, preserving the legacy "probe every port" behavior.
+/// <c>/sys/class/tty</c>, macOS runs <c>ioreg</c>. Platforms without an
+/// implementation fall back to <see cref="NullUsbPortDescriptorProvider"/>
+/// which returns null for every port, preserving the legacy "probe every
+/// port" behavior.
 /// </remarks>
 public interface IUsbPortDescriptorProvider
 {

--- a/src/Daqifi.Core/Device/Discovery/MacOsUsbPortDescriptorProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/MacOsUsbPortDescriptorProvider.cs
@@ -6,24 +6,47 @@ namespace Daqifi.Core.Device.Discovery;
 
 /// <summary>
 /// Resolves USB VID/PID for serial ports via <c>ioreg</c> on macOS.
-/// Runs ioreg once and caches the full port map for the lifetime of the
-/// instance so repeated <see cref="GetDescriptor"/> calls don't re-invoke
-/// the process.
+/// Runs ioreg at most once per <see cref="CacheTtlMs"/> window so a single
+/// discovery pass (many <see cref="GetDescriptor"/> calls within ~1s) pays
+/// one ioreg invocation, while back-to-back passes always see fresh device
+/// state (a device plugged in between passes is detected on the next pass).
 /// </summary>
 internal sealed class MacOsUsbPortDescriptorProvider : IUsbPortDescriptorProvider
 {
     private const int IoregTimeoutMs = 5000;
 
-    private readonly Lazy<Dictionary<string, UsbPortDescriptor>> _cache =
-        new(BuildDescriptorMap);
+    // One ioreg invocation covers a full discovery pass (all ports probed
+    // within ~1.2s), but a subsequent pass always fetches fresh state.
+    // This matches the per-call freshness of the Windows/Linux providers
+    // while avoiding N redundant ioreg invocations per pass.
+    private const int CacheTtlMs = 2000;
+
+    private static readonly object CacheLock = new();
+    private static Dictionary<string, UsbPortDescriptor> _cachedMap = new();
+    private static long _cacheExpiresAtMs;
 
     public UsbPortDescriptor? GetDescriptor(string portName)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             return null;
 
-        _cache.Value.TryGetValue(portName, out var descriptor);
+        var map = GetOrRefreshMap();
+        map.TryGetValue(portName, out var descriptor);
         return descriptor;
+    }
+
+    private static Dictionary<string, UsbPortDescriptor> GetOrRefreshMap()
+    {
+        var nowMs = Environment.TickCount64;
+        lock (CacheLock)
+        {
+            if (nowMs < _cacheExpiresAtMs)
+                return _cachedMap;
+
+            _cachedMap = BuildDescriptorMap();
+            _cacheExpiresAtMs = nowMs + CacheTtlMs;
+            return _cachedMap;
+        }
     }
 
     private static Dictionary<string, UsbPortDescriptor> BuildDescriptorMap()

--- a/src/Daqifi.Core/Device/Discovery/MacOsUsbPortDescriptorProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/MacOsUsbPortDescriptorProvider.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Resolves USB VID/PID for serial ports via <c>ioreg</c> on macOS.
+/// Runs ioreg once and caches the full port map for the lifetime of the
+/// instance so repeated <see cref="GetDescriptor"/> calls don't re-invoke
+/// the process.
+/// </summary>
+internal sealed class MacOsUsbPortDescriptorProvider : IUsbPortDescriptorProvider
+{
+    private const int IoregTimeoutMs = 5000;
+
+    private readonly Lazy<Dictionary<string, UsbPortDescriptor>> _cache =
+        new(BuildDescriptorMap);
+
+    public UsbPortDescriptor? GetDescriptor(string portName)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return null;
+
+        _cache.Value.TryGetValue(portName, out var descriptor);
+        return descriptor;
+    }
+
+    private static Dictionary<string, UsbPortDescriptor> BuildDescriptorMap()
+    {
+        // AppleUSBDevice covers most macOS versions; IOUSBHostDevice is used
+        // on newer kernel releases. Try both and take the first non-empty result.
+        var result = Parse(RunIoreg("AppleUSBDevice"));
+        if (result.Count == 0)
+            result = Parse(RunIoreg("IOUSBHostDevice"));
+        return result;
+    }
+
+    /// <summary>
+    /// Parses the stdout of <c>ioreg -r -c {usbClassName} -l -w0</c> into a
+    /// port-name → VID/PID map. Exposed internally for unit testing without
+    /// spawning a real process.
+    /// </summary>
+    internal static Dictionary<string, UsbPortDescriptor> Parse(string ioregOutput)
+    {
+        var result = new Dictionary<string, UsbPortDescriptor>();
+        if (string.IsNullOrEmpty(ioregOutput))
+            return result;
+
+        // ioreg -r prints each top-level USB device followed by its descendants.
+        // idVendor / idProduct appear as properties on the USB device node;
+        // IOCalloutDevice appears inside a child IOSerialBSDClient. Tracking the
+        // most-recently-seen VID/PID and associating it with each callout device
+        // works because ioreg always prints a node's own properties before those
+        // of its children.
+        int? currentVid = null;
+        int? currentPid = null;
+
+        foreach (var line in ioregOutput.Split('\n'))
+        {
+            var vidMatch = Regex.Match(line, @"""idVendor""\s*=\s*(\d+)");
+            if (vidMatch.Success)
+            {
+                currentVid = int.Parse(vidMatch.Groups[1].Value,
+                    System.Globalization.CultureInfo.InvariantCulture);
+                continue;
+            }
+
+            var pidMatch = Regex.Match(line, @"""idProduct""\s*=\s*(\d+)");
+            if (pidMatch.Success)
+            {
+                currentPid = int.Parse(pidMatch.Groups[1].Value,
+                    System.Globalization.CultureInfo.InvariantCulture);
+                continue;
+            }
+
+            var portMatch = Regex.Match(line, @"""IOCalloutDevice""\s*=\s*""([^""]+)""");
+            if (portMatch.Success && currentVid.HasValue && currentPid.HasValue)
+            {
+                result[portMatch.Groups[1].Value] = new UsbPortDescriptor(currentVid.Value, currentPid.Value);
+            }
+        }
+
+        return result;
+    }
+
+    private static string RunIoreg(string usbClassName)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/usr/sbin/ioreg",
+                    Arguments = $"-r -c {usbClassName} -l -w0",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+
+            // Read stdout asynchronously so WaitForExit can enforce the timeout.
+            // Calling ReadToEnd() before WaitForExit() deadlocks if the output
+            // buffer fills before the process exits.
+            var readTask = process.StandardOutput.ReadToEndAsync();
+            if (process.WaitForExit(IoregTimeoutMs) && readTask.Wait(IoregTimeoutMs))
+                return readTask.Result;
+
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            return string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -139,9 +139,8 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             // to <1s by skipping every non-DAQiFi port without opening it.
             // It also stops the previous behavior of sending SCPI commands
             // to other vendors' COM ports (Bluetooth radios, GPS, etc.).
-            // Ports the descriptor provider can't classify (e.g. on macOS
-            // where we have no impl yet) fall through to legacy probing,
-            // matched only by name-pattern in FilterProbableDaqifiPorts.
+            // Ports the descriptor provider can't classify fall through to
+            // legacy probing, matched only by name-pattern in FilterProbableDaqifiPorts.
             var allPorts = _portNameProvider?.Invoke()
                 ?? SerialStreamTransport.GetAvailablePortNames();
             var nameFilteredPorts = FilterProbableDaqifiPorts(allPorts);

--- a/src/Daqifi.Core/Device/Discovery/UsbPortDescriptorProviderFactory.cs
+++ b/src/Daqifi.Core/Device/Discovery/UsbPortDescriptorProviderFactory.cs
@@ -4,7 +4,7 @@ namespace Daqifi.Core.Device.Discovery;
 
 /// <summary>
 /// Picks the platform-appropriate <see cref="IUsbPortDescriptorProvider"/>:
-/// Windows → WMI, Linux → sysfs, others → null fallback (legacy probe-all).
+/// Windows → WMI, Linux → sysfs, macOS → ioreg, others → null fallback (legacy probe-all).
 /// </summary>
 internal static class UsbPortDescriptorProviderFactory
 {
@@ -23,6 +23,11 @@ internal static class UsbPortDescriptorProviderFactory
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             return new LinuxUsbPortDescriptorProvider();
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return new MacOsUsbPortDescriptorProvider();
         }
 
         return NullUsbPortDescriptorProvider.Instance;


### PR DESCRIPTION
## Summary

PR #201 shipped `NullUsbPortDescriptorProvider` as the macOS fallback, meaning serial discovery on macOS still probes every port — the same slow behavior the Windows/Linux filtering was meant to eliminate. Since this is a cross-platform library, macOS deserves a real implementation.

This PR adds `MacOsUsbPortDescriptorProvider`, which:

- Runs `ioreg -r -c AppleUSBDevice -l -w0` (with `IOUSBHostDevice` as a fallback for newer kernels) to enumerate USB serial ports and their VID/PID
- Caches results in a `Lazy<Dictionary>` so `ioreg` runs once per discovery cycle, not once per port
- Returns `null` for ports not found in ioreg output (unknown → probe, consistent with Windows/Linux behavior)
- Is wired into `UsbPortDescriptorProviderFactory` alongside the existing Windows and Linux providers

## Test plan

- [x] 948 existing tests pass on net9.0 (6 new tests added for `MacOsUsbPortDescriptorProvider.Parse`)
- [x] Parse tests cover: empty input, single DAQiFi device, multiple devices, device with no callout, callout with no VID/PID, multi-interface device (VID/PID carry-over)
- [ ] Hardware test on macOS with `--discover-serial` on a real DAQiFi device at `/dev/cu.usbmodem*`

Closes the macOS gap left by #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)