### PR TITLE
feat(network): add LAN static IP/subnet/gateway configuration (closes #205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The DAQiFi Core Library is a .NET library designed to simplify interaction with 
 - **Firmware Update Orchestration**: Programmatic PIC32 bootloader updates with state/progress reporting, timeout/retry handling, and cancellation support
 - **Transport Layer**: TCP, UDP, and Serial communication with async/await patterns
 - **Protocol Buffers**: Efficient binary message serialization for device communication
-- **Network Configuration**: Programmatic WiFi SSID/password/mode updates via `INetworkConfigurable`
+- **Network Configuration**: Programmatic WiFi SSID/password/mode and LAN static IP/subnet/gateway updates via `INetworkConfigurable`
 - **Cross-Platform**: Compatible with .NET 9.0 and .NET 10.0
 
 ## Getting Started
@@ -171,6 +171,24 @@ if (device is INetworkConfigurable networkDevice)
     };
     await networkDevice.UpdateNetworkConfigurationAsync(config);
 }
+```
+
+To assign a static LAN address, set `StaticIP` / `SubnetMask` / `Gateway` (IPv4 only). Leaving any of them `null` means "leave unchanged" so DHCP-only callers see no behavior change:
+
+```csharp
+using System.Net;
+using Daqifi.Core.Device.Network;
+
+var config = new NetworkConfiguration
+{
+    Ssid = "MyNetwork",
+    Password = "secret",
+    Mode = WifiMode.ExistingNetwork,
+    StaticIP = IPAddress.Parse("192.168.1.42"),
+    SubnetMask = IPAddress.Parse("255.255.255.0"),
+    Gateway = IPAddress.Parse("192.168.1.1"),
+};
+await networkDevice.UpdateNetworkConfigurationAsync(config);
 ```
 
 ### Firmware Update Orchestration

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Text;
 using Daqifi.Core.Communication;
 using Daqifi.Core.Communication.Messages;
@@ -233,6 +234,96 @@ public class ScpiMessageProducerTests
     {
         var message = ScpiMessageProducer.SetNetworkWifiPassword("password123");
         Assert.Equal("SYSTem:COMMunicate:LAN:PASs \"password123\"", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetLanAddress_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetLanAddress(IPAddress.Parse("192.168.1.42"));
+        Assert.Equal("SYSTem:COMMunicate:LAN:ADDRess \"192.168.1.42\"", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetLanAddress_NullAddress_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ScpiMessageProducer.SetLanAddress(null!));
+    }
+
+    [Fact]
+    public void SetLanMask_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetLanMask(IPAddress.Parse("255.255.255.0"));
+        Assert.Equal("SYSTem:COMMunicate:LAN:MASK \"255.255.255.0\"", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetLanMask_NullMask_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ScpiMessageProducer.SetLanMask(null!));
+    }
+
+    [Fact]
+    public void SetLanGateway_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetLanGateway(IPAddress.Parse("192.168.1.1"));
+        Assert.Equal("SYSTem:COMMunicate:LAN:GATEway \"192.168.1.1\"", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetLanGateway_NullGateway_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ScpiMessageProducer.SetLanGateway(null!));
+    }
+
+    [Fact]
+    public void GetLanAddress_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetLanAddress;
+        Assert.Equal("SYSTem:COMMunicate:LAN:ADDRess?", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void GetLanMask_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetLanMask;
+        Assert.Equal("SYSTem:COMMunicate:LAN:MASK?", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void GetLanGateway_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetLanGateway;
+        Assert.Equal("SYSTem:COMMunicate:LAN:GATEway?", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void GetLanConfiguredAddress_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetLanConfiguredAddress;
+        Assert.Equal("SYSTem:COMMunicate:LAN:CONFigure:ADDRess?", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void GetLanConfiguredMask_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetLanConfiguredMask;
+        Assert.Equal("SYSTem:COMMunicate:LAN:CONFigure:MASK?", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void GetLanConfiguredGateway_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetLanConfiguredGateway;
+        Assert.Equal("SYSTem:COMMunicate:LAN:CONFigure:GATEway?", message.Data);
         AssertMessageFormat(message);
     }
 

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -252,6 +252,12 @@ public class ScpiMessageProducerTests
     }
 
     [Fact]
+    public void SetLanAddress_IPv6_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ScpiMessageProducer.SetLanAddress(IPAddress.IPv6Loopback));
+    }
+
+    [Fact]
     public void SetLanMask_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.SetLanMask(IPAddress.Parse("255.255.255.0"));
@@ -266,6 +272,12 @@ public class ScpiMessageProducerTests
     }
 
     [Fact]
+    public void SetLanMask_IPv6_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ScpiMessageProducer.SetLanMask(IPAddress.IPv6Loopback));
+    }
+
+    [Fact]
     public void SetLanGateway_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.SetLanGateway(IPAddress.Parse("192.168.1.1"));
@@ -277,6 +289,12 @@ public class ScpiMessageProducerTests
     public void SetLanGateway_NullGateway_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => ScpiMessageProducer.SetLanGateway(null!));
+    }
+
+    [Fact]
+    public void SetLanGateway_IPv6_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ScpiMessageProducer.SetLanGateway(IPAddress.IPv6Loopback));
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
@@ -182,6 +182,12 @@ namespace Daqifi.Core.Tests.Device.Network
             Assert.True(applyIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:ADDRess \"10.0.0.5\""));
             Assert.True(applyIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:MASK \"255.255.255.0\""));
             Assert.True(applyIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:GATEway \"10.0.0.1\""));
+
+            // SAVE persists what APPLY pushed, so it must come after every static-IP setter too.
+            var saveIndex = sentCommands.IndexOf("SYSTem:COMMunicate:LAN:SAVE");
+            Assert.True(saveIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:ADDRess \"10.0.0.5\""));
+            Assert.True(saveIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:MASK \"255.255.255.0\""));
+            Assert.True(saveIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:GATEway \"10.0.0.1\""));
         }
 
         [Fact]
@@ -231,6 +237,38 @@ namespace Daqifi.Core.Tests.Device.Network
             Assert.Contains("SYSTem:COMMunicate:LAN:ADDRess \"10.0.0.5\"", sentCommands);
             Assert.DoesNotContain(sentCommands, c => c.StartsWith("SYSTem:COMMunicate:LAN:MASK "));
             Assert.DoesNotContain(sentCommands, c => c.StartsWith("SYSTem:COMMunicate:LAN:GATEway "));
+        }
+
+        [Fact]
+        public async Task UpdateNetworkConfigurationAsync_WithNullStaticFields_PreservesPreviouslyCachedValues()
+        {
+            // Arrange — first call seeds the cache with a known static IP.
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var originalStaticIP = IPAddress.Parse("10.0.0.5");
+            var originalSubnet = IPAddress.Parse("255.255.255.0");
+            var originalGateway = IPAddress.Parse("10.0.0.1");
+            await device.UpdateNetworkConfigurationAsync(new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "Net",
+                "Pass",
+                originalStaticIP,
+                originalSubnet,
+                originalGateway));
+
+            // Act — second call only changes WiFi settings; static IP fields are
+            // null which means "leave unchanged". The cache must not be cleared.
+            await device.UpdateNetworkConfigurationAsync(new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "OtherNet",
+                "OtherPass"));
+
+            // Assert
+            Assert.Equal(originalStaticIP, device.NetworkConfiguration.StaticIP);
+            Assert.Equal(originalSubnet, device.NetworkConfiguration.SubnetMask);
+            Assert.Equal(originalGateway, device.NetworkConfiguration.Gateway);
         }
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
@@ -153,6 +153,114 @@ namespace Daqifi.Core.Tests.Device.Network
         }
 
         [Fact]
+        public async Task UpdateNetworkConfigurationAsync_WithStaticIP_SendsAddressMaskGatewayBeforeApply()
+        {
+            // Arrange
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "Net",
+                "Pass",
+                IPAddress.Parse("10.0.0.5"),
+                IPAddress.Parse("255.255.255.0"),
+                IPAddress.Parse("10.0.0.1"));
+
+            // Act
+            await device.UpdateNetworkConfigurationAsync(config);
+
+            // Assert
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+
+            Assert.Contains("SYSTem:COMMunicate:LAN:ADDRess \"10.0.0.5\"", sentCommands);
+            Assert.Contains("SYSTem:COMMunicate:LAN:MASK \"255.255.255.0\"", sentCommands);
+            Assert.Contains("SYSTem:COMMunicate:LAN:GATEway \"10.0.0.1\"", sentCommands);
+
+            // Apply must follow all three (firmware reads runtime config at APPLY time).
+            var applyIndex = sentCommands.IndexOf("SYSTem:COMMunicate:LAN:APPLY");
+            Assert.True(applyIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:ADDRess \"10.0.0.5\""));
+            Assert.True(applyIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:MASK \"255.255.255.0\""));
+            Assert.True(applyIndex > sentCommands.IndexOf("SYSTem:COMMunicate:LAN:GATEway \"10.0.0.1\""));
+        }
+
+        [Fact]
+        public async Task UpdateNetworkConfigurationAsync_WithoutStaticIP_DoesNotSendAddressMaskGateway()
+        {
+            // Arrange
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "Net",
+                "Pass");
+
+            // Act
+            await device.UpdateNetworkConfigurationAsync(config);
+
+            // Assert
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+
+            Assert.DoesNotContain(sentCommands, c => c.StartsWith("SYSTem:COMMunicate:LAN:ADDRess "));
+            Assert.DoesNotContain(sentCommands, c => c.StartsWith("SYSTem:COMMunicate:LAN:MASK "));
+            Assert.DoesNotContain(sentCommands, c => c.StartsWith("SYSTem:COMMunicate:LAN:GATEway "));
+        }
+
+        [Fact]
+        public async Task UpdateNetworkConfigurationAsync_WithPartialStaticIP_OnlySendsNonNullFields()
+        {
+            // Arrange
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "Net",
+                "Pass",
+                IPAddress.Parse("10.0.0.5"),
+                subnetMask: null,
+                gateway: null);
+
+            // Act
+            await device.UpdateNetworkConfigurationAsync(config);
+
+            // Assert
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+
+            Assert.Contains("SYSTem:COMMunicate:LAN:ADDRess \"10.0.0.5\"", sentCommands);
+            Assert.DoesNotContain(sentCommands, c => c.StartsWith("SYSTem:COMMunicate:LAN:MASK "));
+            Assert.DoesNotContain(sentCommands, c => c.StartsWith("SYSTem:COMMunicate:LAN:GATEway "));
+        }
+
+        [Fact]
+        public async Task UpdateNetworkConfigurationAsync_WithStaticIP_UpdatesLocalConfiguration()
+        {
+            // Arrange
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var staticIP = IPAddress.Parse("10.0.0.5");
+            var subnet = IPAddress.Parse("255.255.255.0");
+            var gateway = IPAddress.Parse("10.0.0.1");
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "Net",
+                "Pass",
+                staticIP,
+                subnet,
+                gateway);
+
+            // Act
+            await device.UpdateNetworkConfigurationAsync(config);
+
+            // Assert
+            Assert.Equal(staticIP, device.NetworkConfiguration.StaticIP);
+            Assert.Equal(subnet, device.NetworkConfiguration.SubnetMask);
+            Assert.Equal(gateway, device.NetworkConfiguration.Gateway);
+        }
+
+        [Fact]
         public async Task UpdateNetworkConfigurationAsync_PreparesLanInterface()
         {
             // Arrange

--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurationTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Daqifi.Core.Device.Network;
 using Xunit;
 
@@ -16,6 +17,9 @@ namespace Daqifi.Core.Tests.Device.Network
             Assert.Equal(WifiSecurityType.WpaPskPhrase, config.SecurityType);
             Assert.Equal(string.Empty, config.Ssid);
             Assert.Equal(string.Empty, config.Password);
+            Assert.Null(config.StaticIP);
+            Assert.Null(config.SubnetMask);
+            Assert.Null(config.Gateway);
         }
 
         [Fact]
@@ -79,6 +83,102 @@ namespace Daqifi.Core.Tests.Device.Network
             Assert.Equal(WifiSecurityType.None, config.SecurityType);
             Assert.Equal("NewSSID", config.Ssid);
             Assert.Equal("NewPassword", config.Password);
+        }
+
+        [Fact]
+        public void StaticIPConstructor_SetsAllProperties()
+        {
+            // Arrange
+            var staticIP = IPAddress.Parse("10.0.0.5");
+            var subnet = IPAddress.Parse("255.255.255.0");
+            var gateway = IPAddress.Parse("10.0.0.1");
+
+            // Act
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "Net",
+                "Pass",
+                staticIP,
+                subnet,
+                gateway);
+
+            // Assert
+            Assert.Equal(WifiMode.ExistingNetwork, config.Mode);
+            Assert.Equal(WifiSecurityType.WpaPskPhrase, config.SecurityType);
+            Assert.Equal("Net", config.Ssid);
+            Assert.Equal("Pass", config.Password);
+            Assert.Equal(staticIP, config.StaticIP);
+            Assert.Equal(subnet, config.SubnetMask);
+            Assert.Equal(gateway, config.Gateway);
+        }
+
+        [Fact]
+        public void StaticIPProperties_CanBeAssignedAndCleared()
+        {
+            // Arrange
+            var config = new NetworkConfiguration
+            {
+                StaticIP = IPAddress.Parse("192.168.1.10"),
+                SubnetMask = IPAddress.Parse("255.255.255.0"),
+                Gateway = IPAddress.Parse("192.168.1.1")
+            };
+
+            // Act
+            config.StaticIP = null;
+            config.SubnetMask = null;
+            config.Gateway = null;
+
+            // Assert
+            Assert.Null(config.StaticIP);
+            Assert.Null(config.SubnetMask);
+            Assert.Null(config.Gateway);
+        }
+
+        [Fact]
+        public void Clone_PreservesStaticIPFields()
+        {
+            // Arrange
+            var original = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "Net",
+                "Pass",
+                IPAddress.Parse("10.0.0.5"),
+                IPAddress.Parse("255.255.255.0"),
+                IPAddress.Parse("10.0.0.1"));
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            Assert.Equal(original.StaticIP, clone.StaticIP);
+            Assert.Equal(original.SubnetMask, clone.SubnetMask);
+            Assert.Equal(original.Gateway, clone.Gateway);
+
+            // Verify independence — replacing the clone's references should not
+            // affect the original.
+            clone.StaticIP = IPAddress.Parse("172.16.0.5");
+            Assert.NotEqual(original.StaticIP, clone.StaticIP);
+        }
+
+        [Fact]
+        public void Clone_PreservesNullStaticIPFields()
+        {
+            // Arrange
+            var original = new NetworkConfiguration(
+                WifiMode.SelfHosted,
+                WifiSecurityType.None,
+                "Net",
+                string.Empty);
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            Assert.Null(clone.StaticIP);
+            Assert.Null(clone.SubnetMask);
+            Assert.Null(clone.Gateway);
         }
     }
 

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Net.Sockets;
 using Daqifi.Core.Communication.Messages;
 
 namespace Daqifi.Core.Communication.Producers;
@@ -472,11 +473,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetLanAddress(IPAddress address)
     {
-        if (address == null)
-        {
-            throw new ArgumentNullException(nameof(address));
-        }
-
+        RequireIPv4(address, nameof(address));
         return new ScpiMessage($"SYSTem:COMMunicate:LAN:ADDRess \"{address}\"");
     }
 
@@ -489,11 +486,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetLanMask(IPAddress mask)
     {
-        if (mask == null)
-        {
-            throw new ArgumentNullException(nameof(mask));
-        }
-
+        RequireIPv4(mask, nameof(mask));
         return new ScpiMessage($"SYSTem:COMMunicate:LAN:MASK \"{mask}\"");
     }
 
@@ -506,12 +499,26 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetLanGateway(IPAddress gateway)
     {
-        if (gateway == null)
+        RequireIPv4(gateway, nameof(gateway));
+        return new ScpiMessage($"SYSTem:COMMunicate:LAN:GATEway \"{gateway}\"");
+    }
+
+    // Firmware's LAN setters parse the payload via inet_addr (IPv4 dotted quad
+    // only — see SCPILAN.c's SCPI_LANAddrSetImpl). IPv6 inputs would stringify
+    // with colons and silently mis-set on the device, so reject them here.
+    private static void RequireIPv4(IPAddress address, string paramName)
+    {
+        if (address == null)
         {
-            throw new ArgumentNullException(nameof(gateway));
+            throw new ArgumentNullException(paramName);
         }
 
-        return new ScpiMessage($"SYSTem:COMMunicate:LAN:GATEway \"{gateway}\"");
+        if (address.AddressFamily != AddressFamily.InterNetwork)
+        {
+            throw new ArgumentException(
+                "Address must be IPv4 (AddressFamily.InterNetwork).",
+                paramName);
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using Daqifi.Core.Communication.Messages;
 
 namespace Daqifi.Core.Communication.Producers;
@@ -459,6 +460,111 @@ public class ScpiMessageProducer
         return new ScpiMessage($"SYSTem:COMMunicate:LAN:PASs \"{password}\"");
     }
         
+    /// <summary>
+    /// Creates a command message to set the static IP address for the LAN.
+    /// </summary>
+    /// <param name="address">The static IP address to assign to the device.</param>
+    /// <remarks>
+    /// The new value is staged into the device's runtime WiFi settings and takes
+    /// effect on the next <see cref="ApplyNetworkLan"/>. Persist across reboots
+    /// with <see cref="SaveNetworkLan"/>.
+    /// Command: SYSTem:COMMunicate:LAN:ADDRess "x.x.x.x"
+    /// </remarks>
+    public static IOutboundMessage<string> SetLanAddress(IPAddress address)
+    {
+        if (address == null)
+        {
+            throw new ArgumentNullException(nameof(address));
+        }
+
+        return new ScpiMessage($"SYSTem:COMMunicate:LAN:ADDRess \"{address}\"");
+    }
+
+    /// <summary>
+    /// Creates a command message to set the subnet mask for the LAN.
+    /// </summary>
+    /// <param name="mask">The subnet mask to assign to the device.</param>
+    /// <remarks>
+    /// Command: SYSTem:COMMunicate:LAN:MASK "x.x.x.x"
+    /// </remarks>
+    public static IOutboundMessage<string> SetLanMask(IPAddress mask)
+    {
+        if (mask == null)
+        {
+            throw new ArgumentNullException(nameof(mask));
+        }
+
+        return new ScpiMessage($"SYSTem:COMMunicate:LAN:MASK \"{mask}\"");
+    }
+
+    /// <summary>
+    /// Creates a command message to set the default gateway for the LAN.
+    /// </summary>
+    /// <param name="gateway">The default gateway to assign to the device.</param>
+    /// <remarks>
+    /// Command: SYSTem:COMMunicate:LAN:GATEway "x.x.x.x"
+    /// </remarks>
+    public static IOutboundMessage<string> SetLanGateway(IPAddress gateway)
+    {
+        if (gateway == null)
+        {
+            throw new ArgumentNullException(nameof(gateway));
+        }
+
+        return new ScpiMessage($"SYSTem:COMMunicate:LAN:GATEway \"{gateway}\"");
+    }
+
+    /// <summary>
+    /// Creates a query message to read the staged (pre-apply) LAN IP address.
+    /// </summary>
+    /// <remarks>
+    /// Returns the address currently in the device's runtime WiFi settings — the value
+    /// that <see cref="ApplyNetworkLan"/> would push next, which may differ from the
+    /// active address reported by <see cref="GetLanAddress"/>.
+    /// Command: SYSTem:COMMunicate:LAN:CONFigure:ADDRess?
+    /// </remarks>
+    public static IOutboundMessage<string> GetLanConfiguredAddress => new ScpiMessage("SYSTem:COMMunicate:LAN:CONFigure:ADDRess?");
+
+    /// <summary>
+    /// Creates a query message to read the staged (pre-apply) LAN subnet mask.
+    /// </summary>
+    /// <remarks>
+    /// Command: SYSTem:COMMunicate:LAN:CONFigure:MASK?
+    /// </remarks>
+    public static IOutboundMessage<string> GetLanConfiguredMask => new ScpiMessage("SYSTem:COMMunicate:LAN:CONFigure:MASK?");
+
+    /// <summary>
+    /// Creates a query message to read the staged (pre-apply) LAN default gateway.
+    /// </summary>
+    /// <remarks>
+    /// Command: SYSTem:COMMunicate:LAN:CONFigure:GATEway?
+    /// </remarks>
+    public static IOutboundMessage<string> GetLanConfiguredGateway => new ScpiMessage("SYSTem:COMMunicate:LAN:CONFigure:GATEway?");
+
+    /// <summary>
+    /// Creates a query message to read the active LAN IP address.
+    /// </summary>
+    /// <remarks>
+    /// Command: SYSTem:COMMunicate:LAN:ADDRess?
+    /// </remarks>
+    public static IOutboundMessage<string> GetLanAddress => new ScpiMessage("SYSTem:COMMunicate:LAN:ADDRess?");
+
+    /// <summary>
+    /// Creates a query message to read the active LAN subnet mask.
+    /// </summary>
+    /// <remarks>
+    /// Command: SYSTem:COMMunicate:LAN:MASK?
+    /// </remarks>
+    public static IOutboundMessage<string> GetLanMask => new ScpiMessage("SYSTem:COMMunicate:LAN:MASK?");
+
+    /// <summary>
+    /// Creates a query message to read the active LAN default gateway.
+    /// </summary>
+    /// <remarks>
+    /// Command: SYSTem:COMMunicate:LAN:GATEway?
+    /// </remarks>
+    public static IOutboundMessage<string> GetLanGateway => new ScpiMessage("SYSTem:COMMunicate:LAN:GATEway?");
+
     /// <summary>
     /// Creates a command message to disable LAN communication.
     /// </summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -263,14 +263,25 @@ namespace Daqifi.Core.Device
             // Save configuration to persist across restarts
             Send(ScpiMessageProducer.SaveNetworkLan);
 
-            // Update local configuration
+            // Update local configuration. Static IP fields use null = "leave
+            // unchanged" semantics, so only overwrite when the caller provided
+            // a value — otherwise we'd clobber the previously known static IP.
             _networkConfiguration.Mode = configuration.Mode;
             _networkConfiguration.SecurityType = configuration.SecurityType;
             _networkConfiguration.Ssid = configuration.Ssid;
             _networkConfiguration.Password = configuration.Password;
-            _networkConfiguration.StaticIP = configuration.StaticIP;
-            _networkConfiguration.SubnetMask = configuration.SubnetMask;
-            _networkConfiguration.Gateway = configuration.Gateway;
+            if (configuration.StaticIP != null)
+            {
+                _networkConfiguration.StaticIP = configuration.StaticIP;
+            }
+            if (configuration.SubnetMask != null)
+            {
+                _networkConfiguration.SubnetMask = configuration.SubnetMask;
+            }
+            if (configuration.Gateway != null)
+            {
+                _networkConfiguration.Gateway = configuration.Gateway;
+            }
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -235,6 +235,22 @@ namespace Daqifi.Core.Device
                     throw new ArgumentOutOfRangeException(nameof(configuration), configuration.SecurityType, "Unsupported WiFi security type.");
             }
 
+            // Stage static IP fields (firmware writes these into the runtime
+            // WiFi settings that ApplyNetworkLan consumes). Skip any field the
+            // caller left null so DHCP-only callers see no behavior change.
+            if (configuration.StaticIP != null)
+            {
+                Send(ScpiMessageProducer.SetLanAddress(configuration.StaticIP));
+            }
+            if (configuration.SubnetMask != null)
+            {
+                Send(ScpiMessageProducer.SetLanMask(configuration.SubnetMask));
+            }
+            if (configuration.Gateway != null)
+            {
+                Send(ScpiMessageProducer.SetLanGateway(configuration.Gateway));
+            }
+
             // Apply configuration
             Send(ScpiMessageProducer.ApplyNetworkLan);
 
@@ -252,6 +268,9 @@ namespace Daqifi.Core.Device
             _networkConfiguration.SecurityType = configuration.SecurityType;
             _networkConfiguration.Ssid = configuration.Ssid;
             _networkConfiguration.Password = configuration.Password;
+            _networkConfiguration.StaticIP = configuration.StaticIP;
+            _networkConfiguration.SubnetMask = configuration.SubnetMask;
+            _networkConfiguration.Gateway = configuration.Gateway;
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
+++ b/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
@@ -29,6 +29,7 @@ namespace Daqifi.Core.Device.Network
         /// <item><description>Sets the SSID</description></item>
         /// <item><description>Sets the security type</description></item>
         /// <item><description>Sets the password (if security is enabled)</description></item>
+        /// <item><description>Sets the static IP, subnet mask, and gateway (only those provided as non-null)</description></item>
         /// <item><description>Applies the LAN configuration</description></item>
         /// <item><description>Waits for the WiFi module to restart</description></item>
         /// <item><description>Re-enables the LAN interface</description></item>

--- a/src/Daqifi.Core/Device/Network/NetworkConfiguration.cs
+++ b/src/Daqifi.Core/Device/Network/NetworkConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Daqifi.Core.Device.Network
 {
     /// <summary>
@@ -30,6 +32,33 @@ namespace Daqifi.Core.Device.Network
         public string Password { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the static IP address to assign to the device.
+        /// </summary>
+        /// <remarks>
+        /// A null value means "leave unchanged" — the device retains its current
+        /// IP configuration (typically DHCP). Provide all three of
+        /// <see cref="StaticIP"/>, <see cref="SubnetMask"/>, and <see cref="Gateway"/>
+        /// to fully define a static IP configuration.
+        /// </remarks>
+        public IPAddress? StaticIP { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subnet mask to use with <see cref="StaticIP"/>.
+        /// </summary>
+        /// <remarks>
+        /// A null value means "leave unchanged" on the device.
+        /// </remarks>
+        public IPAddress? SubnetMask { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default gateway to use with <see cref="StaticIP"/>.
+        /// </summary>
+        /// <remarks>
+        /// A null value means "leave unchanged" on the device.
+        /// </remarks>
+        public IPAddress? Gateway { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="NetworkConfiguration"/> class
         /// with default values.
         /// </summary>
@@ -39,7 +68,7 @@ namespace Daqifi.Core.Device.Network
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NetworkConfiguration"/> class
-        /// with the specified settings.
+        /// with the specified WiFi settings.
         /// </summary>
         /// <param name="mode">The WiFi operating mode.</param>
         /// <param name="securityType">The WiFi security type.</param>
@@ -54,12 +83,48 @@ namespace Daqifi.Core.Device.Network
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="NetworkConfiguration"/> class
+        /// with the specified WiFi and static IP settings.
+        /// </summary>
+        /// <param name="mode">The WiFi operating mode.</param>
+        /// <param name="securityType">The WiFi security type.</param>
+        /// <param name="ssid">The network SSID.</param>
+        /// <param name="password">The network password.</param>
+        /// <param name="staticIP">The static IP address, or null to leave unchanged.</param>
+        /// <param name="subnetMask">The subnet mask, or null to leave unchanged.</param>
+        /// <param name="gateway">The default gateway, or null to leave unchanged.</param>
+        public NetworkConfiguration(
+            WifiMode mode,
+            WifiSecurityType securityType,
+            string ssid,
+            string password,
+            IPAddress? staticIP,
+            IPAddress? subnetMask,
+            IPAddress? gateway)
+        {
+            Mode = mode;
+            SecurityType = securityType;
+            Ssid = ssid;
+            Password = password;
+            StaticIP = staticIP;
+            SubnetMask = subnetMask;
+            Gateway = gateway;
+        }
+
+        /// <summary>
         /// Creates a copy of this network configuration.
         /// </summary>
         /// <returns>A new <see cref="NetworkConfiguration"/> instance with the same values.</returns>
         public NetworkConfiguration Clone()
         {
-            return new NetworkConfiguration(Mode, SecurityType, Ssid, Password);
+            return new NetworkConfiguration(
+                Mode,
+                SecurityType,
+                Ssid,
+                Password,
+                StaticIP,
+                SubnetMask,
+                Gateway);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add nullable `StaticIP` / `SubnetMask` / `Gateway` (`IPAddress?`) to `NetworkConfiguration`, with a 7-arg constructor and `Clone()` carrying them; null = "leave unchanged" so DHCP-only callers see no behavior change.
- Add `ScpiMessageProducer.SetLanAddress / SetLanMask / SetLanGateway` (quoted form) plus `Get*` and `GetLanConfigured*` query variants matching the firmware's `SYSTem:COMMunicate:LAN:{ADDRess,MASK,GATEway}` and `:CONFigure:` endpoints.
- Wire the three setters into `DaqifiStreamingDevice.UpdateNetworkConfigurationAsync` between password and `APPLY` (firmware reads runtime WiFi settings at APPLY time — see [SCPILAN.c#L531](https://github.com/daqifi/daqifi-nyquist-firmware/blob/master/firmware/src/services/SCPI/SCPILAN.c#L531)). Only non-null fields are emitted.
- Update `INetworkConfigurable` step-list docstring.

Closes #205. Parent: #52 (Phase 7.1).

## Firmware verification
Cross-checked against `daqifi-nyquist-firmware`:
- `SCPI_LANAddrSet` / `MaskSet` / `GatewaySet` accept the address as a `SCPI_SafeParamString` payload (quoted form is what existing SSID code uses and what the firmware accepts).
- `SCPI_LANSettingsApply` calls `wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)`, so the setters MUST run before `APPLY` — not just before `SAVE` as the issue text loosely states.

## Test plan
- [x] `dotnet build Daqifi.Core.sln` — clean (no new warnings).
- [x] `dotnet test Daqifi.Core.sln` — 986 passed / 0 failed on net9.0 and net10.0.
- [x] New SCPI producer tests (round-trip + null-arg guards + query variants).
- [x] New `NetworkConfiguration` tests (defaults, full ctor, assign/clear, Clone with and without static IPs).
- [x] New `INetworkConfigurable` tests (full static IP, none → no static commands, partial → only non-null commands, local-cache update, ordering: ADDRess/MASK/GATEway all precede APPLY).
- [ ] Manual: send full static-IP `UpdateNetworkConfigurationAsync` against a real Nyquist device and confirm the device comes back up on the requested address after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)