### PR TITLE
feat(firmware): add WifiBridgeActivator helper (closes #210)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
@@ -1,0 +1,30 @@
+using Daqifi.Core.Firmware;
+
+namespace Daqifi.Core.Tests.Firmware;
+
+public class WifiBridgeActivatorTests
+{
+    [Fact]
+    public void Activate_NullPortName_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => WifiBridgeActivator.Activate(null!));
+    }
+
+    [Fact]
+    public void Activate_AlreadyCancelled_ThrowsBeforeOpeningPort()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Use a bogus port name; if cancellation isn't honored up-front the test would
+        // surface a port-open failure instead of OperationCanceledException.
+        Assert.Throws<OperationCanceledException>(
+            () => WifiBridgeActivator.Activate("COM999", cts.Token));
+    }
+
+    [Fact]
+    public void Activate_InvalidPort_Throws()
+    {
+        Assert.ThrowsAny<Exception>(() => WifiBridgeActivator.Activate("COM999"));
+    }
+}

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -1,0 +1,82 @@
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Communication.Transport;
+
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// Transient SCPI-over-serial helper that kicks the device's WiFi module into
+/// bridge mode during a firmware update.
+/// </summary>
+/// <remarks>
+/// Used between the initial LAN-FW-update-mode handshake (sent over the regular
+/// device transport) and the WINC flash tool's programming phase.
+/// The flash tool needs exclusive access to the serial port, so this
+/// helper opens a short-lived transport, sends the
+/// <c>SYSTem:COMMUnicate:LAN:FWUpdate</c> / <c>SYSTem:COMMunicate:LAN:APPLY</c>
+/// pair with the timing the firmware's WiFi-deinit/reinit state machine
+/// expects, then closes the port so it can be handed back.
+/// </remarks>
+public static class WifiBridgeActivator
+{
+    // USB CDC virtual ports ignore the baud rate, but firmware checks DTR
+    // (isCdcHostConnected) before accepting commands. Match SerialStreamTransport
+    // defaults so port settings stay in one place.
+    private static readonly TimeSpan DtrSettleDelay = TimeSpan.FromMilliseconds(200);
+    private static readonly TimeSpan InterCommandDelay = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan ApplySettleDelay = TimeSpan.FromMilliseconds(300);
+
+    /// <summary>
+    /// Briefly opens <paramref name="portName"/>, sends the SCPI sequence that
+    /// puts the device's WiFi module into bridge mode for firmware update, then
+    /// closes the port.
+    /// </summary>
+    /// <param name="portName">The serial port name (e.g. <c>COM5</c>, <c>/dev/cu.usbmodem1</c>).</param>
+    /// <param name="cancellationToken">Cancellation token observed between port-open, each command write, and each inter-command delay.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="portName"/> is null.</exception>
+    /// <exception cref="OperationCanceledException">Cancellation was requested.</exception>
+    public static void Activate(string portName, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(portName);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var transport = new SerialStreamTransport(portName);
+        transport.Connect();
+
+        // Allow firmware to recognise DTR before sending commands.
+        WaitOrCancel(DtrSettleDelay, cancellationToken);
+
+        // Re-assert the FW-update-requested flag (idempotent with the earlier handshake).
+        WriteCommand(transport, ScpiMessageProducer.SetLanFirmwareUpdateMode);
+        WaitOrCancel(InterCommandDelay, cancellationToken);
+
+        // Trigger the WiFi manager REINIT to bridge-mode state machine.
+        WriteCommand(transport, ScpiMessageProducer.ApplyNetworkLan);
+
+        // Give firmware time to enqueue APPLY before the port closes.
+        WaitOrCancel(ApplySettleDelay, cancellationToken);
+    }
+
+    private static void WriteCommand(SerialStreamTransport transport, IOutboundMessage<string> message)
+    {
+        var bytes = message.GetBytes();
+        var stream = transport.Stream;
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Flush();
+    }
+
+    private static void WaitOrCancel(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.CanBeCanceled)
+        {
+            if (cancellationToken.WaitHandle.WaitOne(delay))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+        else
+        {
+            Thread.Sleep(delay);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `WifiBridgeActivator.Activate(portName, cancellationToken)` in `Daqifi.Core.Firmware` — a static helper that opens a transient `SerialStreamTransport`, sends `SYSTem:COMMUnicate:LAN:FWUpdate` + `SYSTem:COMMunicate:LAN:APPLY` with the 200/100/300 ms firmware-state-machine timing, then closes the port.
- Lets daqifi-desktop drop the last raw `new SerialPort(...)` in its transport path (see [DaqifiViewModel.cs:910](https://github.com/daqifi/daqifi-desktop/blob/main/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs#L910)) in a follow-up PR — wire-level concerns (SCPI strings, port settings, timing) now live in Core.
- Reuses `ScpiMessageProducer.SetLanFirmwareUpdateMode` and `ScpiMessageProducer.ApplyNetworkLan` so command strings stay in one place.

Closes #210. Companion to #204 — both come from a sweep to remove direct `Google.Protobuf` and `System.IO.Ports` dependencies from `daqifi-desktop` now that Core owns the device protocol layer.

## Test plan
- [x] `dotnet build` clean on net9.0 + net10.0 (no new warnings)
- [x] New unit tests pass (3 tests: null-arg, pre-cancelled token, invalid port)
- [x] Full test suite green: 993 passed, 0 failed, 2 skipped (unchanged) on both target frameworks
- [ ] Hardware validation — covered when desktop bumps its `Daqifi.Core` package and the full WiFi-firmware-update flow runs end-to-end (or via a temporary `--wifi-bridge-activate` flag in the CLI example app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)