### PR TITLE
docs(readme): use DAQiFi brand capitalization in prose contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Daqifi.Core
+# DAQiFi Core
 
 > **Revolutionizing the data collection experience with convenient, portable device connectivity.**
 >
@@ -15,11 +15,11 @@
 
 ---
 
-## What is Daqifi.Core?
+## What is DAQiFi Core?
 
 DAQiFi builds wireless data acquisition hardware designed to get out of the way so you can focus on the data, not the collection process.
 
-**Daqifi.Core is how you integrate that hardware into your own .NET applications** — custom dashboards, automated test rigs, research pipelines, production-monitoring tools. Discover devices, connect over WiFi or USB, stream samples in real time, configure networks, push firmware updates — all from one async, strongly-typed .NET API.
+**DAQiFi Core is how you integrate that hardware into your own .NET applications** — custom dashboards, automated test rigs, research pipelines, production-monitoring tools. Discover devices, connect over WiFi or USB, stream samples in real time, configure networks, push firmware updates — all from one async, strongly-typed .NET API.
 
 Prefer a ready-made GUI? Check out [DAQiFi Desktop](https://github.com/daqifi/daqifi-desktop), which is built on top of this library.
 
@@ -62,12 +62,12 @@ DAQiFi hardware is in the field for work like:
 
 More examples at [daqifi.com](https://daqifi.com).
 
-## Where Daqifi.Core fits
+## Where DAQiFi Core fits
 
 | Layer | What it is |
 |---|---|
 | Hardware | Nyquist 1 / Nyquist 3 — wireless DAQ devices (and their on-device firmware) |
-| **SDK** | **Daqifi.Core — this library** |
+| **SDK** | **DAQiFi Core — this library** |
 | App | [DAQiFi Desktop](https://github.com/daqifi/daqifi-desktop) — GUI built on this SDK |
 | Your code | Custom apps, dashboards, pipelines, test rigs |
 


### PR DESCRIPTION
## Summary

The recent README rewrite (#215) used the NuGet package identifier `Daqifi.Core` as a brand-style product name in prose contexts. Per DAQiFi marketing guidelines (verified against [daqifi.com](https://daqifi.com)), the brand is **DAQiFi** — so prose references to the product should be **DAQiFi Core**, matching the `DAQiFi {ProductName}` pattern already used by [daqifi-desktop](https://github.com/daqifi/daqifi-desktop) (`# DAQiFi Desktop`).

### Changed (prose contexts)
- Title: `# Daqifi.Core` → `# DAQiFi Core`
- Heading: `## What is Daqifi.Core?` → `## What is DAQiFi Core?`
- Body: `**Daqifi.Core is how you integrate...**` → `**DAQiFi Core is how you integrate...**`
- Heading: `## Where Daqifi.Core fits` → `## Where DAQiFi Core fits`
- Table cell: `**Daqifi.Core — this library**` → `**DAQiFi Core — this library**`

### Unchanged (code / package / badge contexts)
- NuGet badges (literal package name in URLs)
- `dotnet add package Daqifi.Core` (literal package name)
- `using Daqifi.Core.Device;` and other C# namespaces
- `DaqifiDeviceFactory`, `DaqifiOutMessage` class names

These follow .NET identifier conventions, not marketing style — the mixed-case `DAQiFi` brand form isn't legal/idiomatic in C# identifiers.

## Test plan
- [ ] GitHub renders the README with `# DAQiFi Core` heading.
- [ ] No prose-context `Daqifi.Core` references remain — only badges, shell commands, and C# code. (`grep -n "Daqifi" README.md` should show only those.)
- [ ] NuGet badges still resolve to the correct package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)