### PR TITLE
feat: hardware-in-the-loop smoke test + /hil-smoke-test skill

### DIFF
--- a/.claude/skills/hil-smoke-test/SKILL.md
+++ b/.claude/skills/hil-smoke-test/SKILL.md
@@ -43,8 +43,8 @@ duration, or rate, pass them through:
 | `--duration=<seconds>` | `2` | Longer to surface slow leaks; shorter for tight iteration |
 | `--channels=<bitmask>` | `3` | Decimal bitmask, e.g. `255` for 8 channels |
 
-The binary picks net10.0 by default (preferred) but also runs on net9.0
-if needed (`-f net9.0`).
+The smoke-test project targets `net9.0` (the SDK's minimum). No `-f`
+flag needed.
 
 ## Interpreting exit codes
 

--- a/.claude/skills/hil-smoke-test/SKILL.md
+++ b/.claude/skills/hil-smoke-test/SKILL.md
@@ -17,7 +17,7 @@ state (no SD card writes, no network reconfig, no firmware updates).
 
 Your job here is **orchestration** — build, run the test, interpret the
 exit code, help diagnose failures. The actual test logic lives in
-[src/Daqifi.Core.SmokeTest/Program.cs](src/Daqifi.Core.SmokeTest/Program.cs)
+[src/Daqifi.Core.SmokeTest/Program.cs](../../../src/Daqifi.Core.SmokeTest/Program.cs)
 and is deterministic — do **not** reimplement it inline or instruct the
 user to copy-paste C# into a REPL. Always run the binary.
 

--- a/.claude/skills/hil-smoke-test/SKILL.md
+++ b/.claude/skills/hil-smoke-test/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: hil-smoke-test
+description: Run the hardware-in-the-loop smoke test against a USB-connected DAQiFi device — discover, connect, read metadata, stream briefly, verify samples flow, disconnect cleanly. Use after touching the SDK to confirm real-device integration still works. Triggers on "smoke test the device", "run hil test", "test with hardware", "verify device integration", "/hil", "/smoke-test".
+user-invocable: true
+allowed-tools:
+  - Bash(dotnet build *)
+  - Bash(dotnet run *)
+  - Bash(ls *)
+  - Read
+---
+
+# /hil-smoke-test — Hardware-in-the-Loop Smoke Test
+
+A quick sanity check that the SDK still talks to a real DAQiFi device over
+USB after you've made changes. Read-only with respect to persistent device
+state (no SD card writes, no network reconfig, no firmware updates).
+
+Your job here is **orchestration** — build, run the test, interpret the
+exit code, help diagnose failures. The actual test logic lives in
+[src/Daqifi.Core.SmokeTest/Program.cs](src/Daqifi.Core.SmokeTest/Program.cs)
+and is deterministic — do **not** reimplement it inline or instruct the
+user to copy-paste C# into a REPL. Always run the binary.
+
+## How to run it
+
+Build then run, in two separate commands so the user sees compile errors
+distinct from runtime failures:
+
+```bash
+dotnet build src/Daqifi.Core.SmokeTest/Daqifi.Core.SmokeTest.csproj -c Release
+dotnet run --project src/Daqifi.Core.SmokeTest -c Release --no-build -- [args]
+```
+
+Default invocation (auto-discover the USB device, stream 2s at 100 Hz on
+channels 0–1) takes no args. If the user mentions a specific port, baud,
+duration, or rate, pass them through:
+
+| Flag | Default | When to pass it |
+|---|---|---|
+| `--port=<name>` | `auto` | User names a port, or auto-discovery picks the wrong one |
+| `--baud=<int>` | `9600` | User has a non-default baud |
+| `--rate=<hz>` | `100` | User wants higher throughput pressure (try `1000`) |
+| `--duration=<seconds>` | `2` | Longer to surface slow leaks; shorter for tight iteration |
+| `--channels=<bitmask>` | `3` | Decimal bitmask, e.g. `255` for 8 channels |
+
+The binary picks net10.0 by default (preferred) but also runs on net9.0
+if needed (`-f net9.0`).
+
+## Interpreting exit codes
+
+The test exits with a stable code. **Use the code, not the message text** —
+the message wording may evolve.
+
+| Exit | Meaning | Most likely cause | What to suggest |
+|---|---|---|---|
+| `0` | PASS | — | Report pass cleanly. |
+| `2` | Bad arguments | Typo in flag | Show usage and re-run. |
+| `10` | No device found | USB not connected / device off / driver missing / charge-only cable | Check power LED, swap cable, confirm `ls /dev/cu.*` shows a DAQiFi entry on macOS, or `ls /dev/ttyACM*` on Linux. |
+| `11` | Connect / init failed | Device busy (another process holds the port), firmware mid-boot, bad serial state | Close DAQiFi Desktop / any other app holding the port. Power-cycle the device and retry. |
+| `12` | Metadata missing | Device responded but reported empty part number — possibly bootloader / partial init | Power-cycle; if it persists, this is a regression worth investigating in the init path. |
+| `13` | Degraded samples | Stream produced fewer samples than the threshold (~50% of `rate × duration`) | Re-run; if it repeats, the streaming or parsing path has regressed. Try a higher `--duration` to rule out cold-start latency. |
+| `20` | No samples received | Stream command sent but zero analog data came back | High-signal regression — likely in `EnableAdcChannels`, `StartStreaming`, the protobuf consumer, or `DaqifiOutMessage.AnalogInData` mapping. Check recent diffs in `src/Daqifi.Core/Communication/Consumers/` and `Device/DaqifiDevice.cs`. |
+| `99` | Unexpected exception | Bug in the SDK itself escaped to the smoke harness | Show the stack trace from stderr. |
+
+## When you should re-run before declaring a failure
+
+HIL tests are inherently a little flaky. **Re-run once** on exit codes `10`,
+`11`, or `13` before reporting failure — USB enumeration timing, DTR
+toggle races, and brief device-side latency can all produce one-shot
+hiccups. Do **not** retry exit code `0`, `2`, `12`, `20`, or `99` — those
+are deterministic states.
+
+## What to report back to the user
+
+After a successful run, summarize in one or two lines: device that was
+tested (part number + serial), and sample throughput. Don't paste the full
+stdout — the user can scroll if they want detail.
+
+After a failure, lead with the exit code's meaning, then the most likely
+cause from the table above, then ask what they want to do next. Don't
+auto-spawn investigation tasks unless the user asks — failures here can
+often be physical (cable, power) and a side-task wastes effort.
+
+## Out of scope for this skill
+
+If the user asks the smoke test to also exercise SD card operations,
+firmware updates, or network reconfiguration: **decline and explain why**.
+Each of those is destructive or hardware-modifying and belongs in its own
+opt-in skill, not a smoke test. Offer to design one separately.

--- a/Daqifi.Core.sln
+++ b/Daqifi.Core.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Core", "src\Daqifi.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Core.Tests", "src\Daqifi.Core.Tests\Daqifi.Core.Tests.csproj", "{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Core.SmokeTest", "src\Daqifi.Core.SmokeTest\Daqifi.Core.SmokeTest.csproj", "{FFB51BF3-CB42-4788-8D8D-36429FB2FC03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,9 +28,14 @@ Global
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFB51BF3-CB42-4788-8D8D-36429FB2FC03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFB51BF3-CB42-4788-8D8D-36429FB2FC03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFB51BF3-CB42-4788-8D8D-36429FB2FC03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFB51BF3-CB42-4788-8D8D-36429FB2FC03}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F30FE70B-E858-46F1-8BDA-16859680FE56} = {5412868F-5B63-486D-8EA6-ED8C83418517}
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128} = {5412868F-5B63-486D-8EA6-ED8C83418517}
+		{FFB51BF3-CB42-4788-8D8D-36429FB2FC03} = {5412868F-5B63-486D-8EA6-ED8C83418517}
 	EndGlobalSection
 EndGlobal

--- a/src/Daqifi.Core.SmokeTest/Daqifi.Core.SmokeTest.csproj
+++ b/src/Daqifi.Core.SmokeTest/Daqifi.Core.SmokeTest.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Daqifi.Core.SmokeTest</RootNamespace>
+    <AssemblyName>Daqifi.Core.SmokeTest</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Daqifi.Core\Daqifi.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Daqifi.Core.SmokeTest/Daqifi.Core.SmokeTest.csproj
+++ b/src/Daqifi.Core.SmokeTest/Daqifi.Core.SmokeTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Daqifi.Core.SmokeTest/Program.cs
+++ b/src/Daqifi.Core.SmokeTest/Program.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Globalization;
+using System.Numerics;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Device;
@@ -23,9 +25,8 @@ internal static class Program
     private const int DefaultBaudRate = 9600;
     private const int DefaultStreamRateHz = 100;
     private const int DefaultStreamDurationSeconds = 2;
-    private const string DefaultChannelBitmask = "3";
+    private const int DefaultChannelBitmask = 3;
     private const int DiscoveryTimeoutSeconds = 6;
-    private const int ConnectAttemptCount = 2;
 
     private static async Task<int> Main(string[] args)
     {
@@ -102,13 +103,16 @@ internal static class Program
         }
 
         // ─── Step 2: connect + initialize ───────────────────────────────────
+        // Always go through ConnectSerialAsync(port, baud) — ConnectFromDeviceInfoAsync's
+        // serial path drops baud back to the SDK default (9600), which would silently
+        // override the user's --baud when discovery succeeded at the requested rate.
         Console.WriteLine("Step 2/6  Connecting and initializing device…");
         DaqifiDevice device;
         try
         {
-            device = deviceInfo != null
-                ? await DaqifiDeviceFactory.ConnectFromDeviceInfoAsync(deviceInfo).ConfigureAwait(false)
-                : await DaqifiDeviceFactory.ConnectSerialAsync(options.PortName, options.BaudRate).ConfigureAwait(false);
+            var portName = deviceInfo?.PortName ?? options.PortName;
+            device = await DaqifiDeviceFactory.ConnectSerialAsync(portName, options.BaudRate)
+                .ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -158,8 +162,8 @@ internal static class Program
             device.MessageReceived += OnMessage;
             try
             {
-                Console.WriteLine($"Step 4/6  Enabling ADC channels (bitmask={options.ChannelBitmask}) and starting stream at {options.StreamRateHz} Hz…");
-                device.Send(ScpiMessageProducer.EnableAdcChannels(options.ChannelBitmask));
+                Console.WriteLine($"Step 4/6  Enabling ADC channels (bitmask={options.ChannelBitmask}, {options.EnabledChannelCount} channels) and starting stream at {options.StreamRateHz} Hz…");
+                device.Send(ScpiMessageProducer.EnableAdcChannels(options.ChannelBitmaskScpi));
                 device.Send(ScpiMessageProducer.StartStreaming(options.StreamRateHz));
 
                 // ─── Step 5: stream for N seconds ───────────────────────────
@@ -183,7 +187,11 @@ internal static class Program
             // Tolerate ~50% of the theoretical max — USB CDC framing,
             // initial channel-enable latency, and the stop window all eat
             // into the count. A real broken stream produces zero, not half.
-            var expected = options.StreamRateHz * options.StreamDurationSeconds;
+            // AnalogInData carries one element per enabled channel per tick,
+            // so the expected count scales with channel count too.
+            var expected = options.StreamRateHz
+                * options.StreamDurationSeconds
+                * options.EnabledChannelCount;
             var minAcceptable = Math.Max(1, expected / 2);
 
             if (analogSampleCount == 0)
@@ -262,8 +270,11 @@ internal static class Program
         public int BaudRate { get; init; } = DefaultBaudRate;
         public int StreamRateHz { get; init; } = DefaultStreamRateHz;
         public int StreamDurationSeconds { get; init; } = DefaultStreamDurationSeconds;
-        public string ChannelBitmask { get; init; } = DefaultChannelBitmask;
+        public int ChannelBitmask { get; init; } = DefaultChannelBitmask;
         public bool ShowHelp { get; init; }
+
+        public int EnabledChannelCount => BitOperations.PopCount((uint)ChannelBitmask);
+        public string ChannelBitmaskScpi => ChannelBitmask.ToString(CultureInfo.InvariantCulture);
 
         public static Options Parse(string[] args)
         {
@@ -299,7 +310,7 @@ internal static class Program
                         duration = ParseInt(key, value, min: 1);
                         break;
                     case "--channels":
-                        channels = RequireValue(key, value);
+                        channels = ParseInt(key, value, min: 1);
                         break;
                     default:
                         throw new ArgumentException($"unknown argument '{arg}'");

--- a/src/Daqifi.Core.SmokeTest/Program.cs
+++ b/src/Daqifi.Core.SmokeTest/Program.cs
@@ -160,9 +160,6 @@ internal static class Program
             {
                 Console.WriteLine($"Step 4/6  Enabling ADC channels (bitmask={options.ChannelBitmask}) and starting stream at {options.StreamRateHz} Hz…");
                 device.Send(ScpiMessageProducer.EnableAdcChannels(options.ChannelBitmask));
-                // Small gap so the channel-enable lands before the start-stream command
-                // — some firmware revisions return -200 if these arrive in the same frame.
-                await Task.Delay(100).ConfigureAwait(false);
                 device.Send(ScpiMessageProducer.StartStreaming(options.StreamRateHz));
 
                 // ─── Step 5: stream for N seconds ───────────────────────────
@@ -236,12 +233,14 @@ internal static class Program
               -h, --help            Show this help.
 
             Exit codes:
-              0   success                 13  degraded samples
-              2   bad arguments           99  unexpected error
+              0   success
+              2   bad arguments
               10  no device found
               11  connect or init failed
               12  metadata missing or unknown device type
+              13  degraded samples (below ~50% expected throughput)
               20  no samples received
+              99  unexpected error
             """);
     }
 

--- a/src/Daqifi.Core.SmokeTest/Program.cs
+++ b/src/Daqifi.Core.SmokeTest/Program.cs
@@ -1,0 +1,342 @@
+using System.Diagnostics;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Discovery;
+using DeviceType = Daqifi.Core.Device.DeviceType;
+
+namespace Daqifi.Core.SmokeTest;
+
+/// <summary>
+/// Hardware-in-the-loop smoke test for a USB-connected DAQiFi device.
+///
+/// Designed for a developer-local sanity check after touching the SDK:
+/// discover → connect → read metadata → enable channels → stream briefly
+/// → stop → disconnect. Read-only with respect to persistent device state
+/// (no SD card writes, no network config changes, no firmware updates).
+///
+/// Exits with a named, stable code so a wrapping skill or CI step can
+/// react to the failure mode rather than parsing the message text.
+/// </summary>
+internal static class Program
+{
+    private const int DefaultBaudRate = 9600;
+    private const int DefaultStreamRateHz = 100;
+    private const int DefaultStreamDurationSeconds = 2;
+    private const string DefaultChannelBitmask = "3";
+    private const int DiscoveryTimeoutSeconds = 6;
+    private const int ConnectAttemptCount = 2;
+
+    private static async Task<int> Main(string[] args)
+    {
+        Options options;
+        try
+        {
+            options = Options.Parse(args);
+        }
+        catch (ArgumentException ex)
+        {
+            Console.Error.WriteLine($"Argument error: {ex.Message}");
+            PrintUsage();
+            return (int)ExitCode.BadArgs;
+        }
+
+        if (options.ShowHelp)
+        {
+            PrintUsage();
+            return (int)ExitCode.Success;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            return (int)await RunAsync(options).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"FAIL  unexpected error: {ex.GetType().Name}: {ex.Message}");
+            Console.Error.WriteLine(ex.StackTrace);
+            return (int)ExitCode.Unexpected;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            Console.WriteLine($"Total elapsed: {stopwatch.Elapsed.TotalSeconds:0.00}s");
+        }
+    }
+
+    private static async Task<ExitCode> RunAsync(Options options)
+    {
+        // ─── Step 1: locate the device ──────────────────────────────────────
+        IDeviceInfo? deviceInfo;
+        if (options.PortName == "auto")
+        {
+            Console.WriteLine($"Step 1/6  Discovering DAQiFi USB devices (timeout {DiscoveryTimeoutSeconds}s)…");
+            using var finder = new SerialDeviceFinder(options.BaudRate);
+            var discovered = (await finder.DiscoverAsync(TimeSpan.FromSeconds(DiscoveryTimeoutSeconds))
+                .ConfigureAwait(false)).ToList();
+
+            if (discovered.Count == 0)
+            {
+                Console.Error.WriteLine("FAIL  no DAQiFi device found on any serial port.");
+                Console.Error.WriteLine("      Check that the device is powered, USB cable is data-capable, and drivers are installed.");
+                return ExitCode.NoDevice;
+            }
+
+            if (discovered.Count > 1)
+            {
+                Console.WriteLine($"      Found {discovered.Count} devices; using the first. Pass --port=<name> to pick one.");
+                foreach (var d in discovered)
+                {
+                    Console.WriteLine($"        - {d}");
+                }
+            }
+
+            deviceInfo = discovered[0];
+            Console.WriteLine($"      Discovered: {deviceInfo}");
+        }
+        else
+        {
+            Console.WriteLine($"Step 1/6  Using explicit port {options.PortName} (skipping discovery).");
+            deviceInfo = null;
+        }
+
+        // ─── Step 2: connect + initialize ───────────────────────────────────
+        Console.WriteLine("Step 2/6  Connecting and initializing device…");
+        DaqifiDevice device;
+        try
+        {
+            device = deviceInfo != null
+                ? await DaqifiDeviceFactory.ConnectFromDeviceInfoAsync(deviceInfo).ConfigureAwait(false)
+                : await DaqifiDeviceFactory.ConnectSerialAsync(options.PortName, options.BaudRate).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"FAIL  connect/init failed: {ex.GetType().Name}: {ex.Message}");
+            return ExitCode.ConnectFailed;
+        }
+
+        // From here on, ensure we always tear down the device and (best-effort)
+        // stop streaming, even on assertion failure or thrown exceptions —
+        // otherwise the device is left streaming and the next run starts with
+        // a torrent of stale samples that masks real regressions.
+        try
+        {
+            // ─── Step 3: read metadata ──────────────────────────────────────
+            Console.WriteLine("Step 3/6  Reading device metadata…");
+            var meta = device.Metadata;
+            Console.WriteLine($"      Part number:      {Display(meta.PartNumber)}");
+            Console.WriteLine($"      Serial number:    {Display(meta.SerialNumber)}");
+            Console.WriteLine($"      Firmware version: {Display(meta.FirmwareVersion)}");
+            Console.WriteLine($"      Hardware rev:     {Display(meta.HardwareRevision)}");
+            Console.WriteLine($"      Device type:      {meta.DeviceType}");
+            Console.WriteLine($"      Analog inputs:    {meta.Capabilities.AnalogInputChannels}");
+
+            if (string.IsNullOrWhiteSpace(meta.PartNumber) || meta.DeviceType == DeviceType.Unknown)
+            {
+                Console.Error.WriteLine("FAIL  device initialized but reported empty/unknown part number — initialization did not populate metadata.");
+                return ExitCode.MetadataMissing;
+            }
+
+            // ─── Step 4: subscribe + start streaming ────────────────────────
+            // Count both protobuf "stream" messages and the analog-in samples
+            // they carry. A device can emit messages without any analog data
+            // (e.g. status frames), and a healthy stream produces both — we
+            // want to be specific that we saw actual ADC data.
+            var streamMessageCount = 0;
+            var analogSampleCount = 0;
+            void OnMessage(object? sender, MessageReceivedEventArgs e)
+            {
+                if (e.Message.Data is not DaqifiOutMessage msg) return;
+                Interlocked.Increment(ref streamMessageCount);
+                if (msg.AnalogInData.Count > 0)
+                {
+                    Interlocked.Add(ref analogSampleCount, msg.AnalogInData.Count);
+                }
+            }
+
+            device.MessageReceived += OnMessage;
+            try
+            {
+                Console.WriteLine($"Step 4/6  Enabling ADC channels (bitmask={options.ChannelBitmask}) and starting stream at {options.StreamRateHz} Hz…");
+                device.Send(ScpiMessageProducer.EnableAdcChannels(options.ChannelBitmask));
+                // Small gap so the channel-enable lands before the start-stream command
+                // — some firmware revisions return -200 if these arrive in the same frame.
+                await Task.Delay(100).ConfigureAwait(false);
+                device.Send(ScpiMessageProducer.StartStreaming(options.StreamRateHz));
+
+                // ─── Step 5: stream for N seconds ───────────────────────────
+                Console.WriteLine($"Step 5/6  Streaming for {options.StreamDurationSeconds}s…");
+                await Task.Delay(TimeSpan.FromSeconds(options.StreamDurationSeconds)).ConfigureAwait(false);
+
+                device.Send(ScpiMessageProducer.StopStreaming);
+                // Let the producer drain any in-flight bytes before we tear down.
+                await Task.Delay(200).ConfigureAwait(false);
+            }
+            finally
+            {
+                device.MessageReceived -= OnMessage;
+            }
+
+            // ─── Step 6: verify ─────────────────────────────────────────────
+            Console.WriteLine("Step 6/6  Verifying sample throughput…");
+            Console.WriteLine($"      Protobuf messages received: {streamMessageCount}");
+            Console.WriteLine($"      Analog samples received:    {analogSampleCount}");
+
+            // Tolerate ~50% of the theoretical max — USB CDC framing,
+            // initial channel-enable latency, and the stop window all eat
+            // into the count. A real broken stream produces zero, not half.
+            var expected = options.StreamRateHz * options.StreamDurationSeconds;
+            var minAcceptable = Math.Max(1, expected / 2);
+
+            if (analogSampleCount == 0)
+            {
+                Console.Error.WriteLine("FAIL  no analog samples received — streaming pipeline is broken.");
+                return ExitCode.NoSamples;
+            }
+            if (analogSampleCount < minAcceptable)
+            {
+                Console.Error.WriteLine($"FAIL  sample count {analogSampleCount} below threshold {minAcceptable} (expected ~{expected}). Stream is degraded.");
+                return ExitCode.DegradedSamples;
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("PASS  device discovered, connected, initialized, streamed, and stopped cleanly.");
+            return ExitCode.Success;
+        }
+        finally
+        {
+            // Best-effort cleanup: stop streaming and dispose. We swallow
+            // exceptions here because the primary failure mode is already
+            // reflected in the exit code — we don't want cleanup noise to
+            // mask the real cause.
+            try { device.Send(ScpiMessageProducer.StopStreaming); } catch { }
+            try { device.Disconnect(); } catch { }
+            try { device.Dispose(); } catch { }
+        }
+    }
+
+    private static string Display(string value) =>
+        string.IsNullOrWhiteSpace(value) ? "<empty>" : value;
+
+    private static void PrintUsage()
+    {
+        Console.WriteLine("""
+            Daqifi.Core.SmokeTest — hardware-in-the-loop smoke test (USB/serial)
+
+            Usage:
+              dotnet run --project src/Daqifi.Core.SmokeTest -- [options]
+
+            Options:
+              --port=<name|auto>    Serial port. 'auto' (default) runs discovery.
+              --baud=<int>          Baud rate. Default: 9600.
+              --rate=<hz>           Stream sample rate in Hz. Default: 100.
+              --duration=<seconds>  Stream duration in seconds. Default: 2.
+              --channels=<bitmask>  Decimal ADC channel bitmask. Default: 3 (channels 0,1).
+              -h, --help            Show this help.
+
+            Exit codes:
+              0   success                 13  degraded samples
+              2   bad arguments           99  unexpected error
+              10  no device found
+              11  connect or init failed
+              12  metadata missing or unknown device type
+              20  no samples received
+            """);
+    }
+
+    private enum ExitCode
+    {
+        Success = 0,
+        BadArgs = 2,
+        NoDevice = 10,
+        ConnectFailed = 11,
+        MetadataMissing = 12,
+        NoSamples = 20,
+        DegradedSamples = 13,
+        Unexpected = 99,
+    }
+
+    private sealed class Options
+    {
+        public string PortName { get; init; } = "auto";
+        public int BaudRate { get; init; } = DefaultBaudRate;
+        public int StreamRateHz { get; init; } = DefaultStreamRateHz;
+        public int StreamDurationSeconds { get; init; } = DefaultStreamDurationSeconds;
+        public string ChannelBitmask { get; init; } = DefaultChannelBitmask;
+        public bool ShowHelp { get; init; }
+
+        public static Options Parse(string[] args)
+        {
+            var port = "auto";
+            var baud = DefaultBaudRate;
+            var rate = DefaultStreamRateHz;
+            var duration = DefaultStreamDurationSeconds;
+            var channels = DefaultChannelBitmask;
+            var help = false;
+
+            foreach (var raw in args)
+            {
+                var arg = raw.Trim();
+                if (arg is "-h" or "--help")
+                {
+                    help = true;
+                    continue;
+                }
+
+                var (key, value) = SplitKeyValue(arg);
+                switch (key)
+                {
+                    case "--port":
+                        port = RequireValue(key, value);
+                        break;
+                    case "--baud":
+                        baud = ParseInt(key, value, min: 1);
+                        break;
+                    case "--rate":
+                        rate = ParseInt(key, value, min: 1);
+                        break;
+                    case "--duration":
+                        duration = ParseInt(key, value, min: 1);
+                        break;
+                    case "--channels":
+                        channels = RequireValue(key, value);
+                        break;
+                    default:
+                        throw new ArgumentException($"unknown argument '{arg}'");
+                }
+            }
+
+            return new Options
+            {
+                PortName = port,
+                BaudRate = baud,
+                StreamRateHz = rate,
+                StreamDurationSeconds = duration,
+                ChannelBitmask = channels,
+                ShowHelp = help,
+            };
+        }
+
+        private static (string Key, string? Value) SplitKeyValue(string arg)
+        {
+            var eq = arg.IndexOf('=');
+            return eq < 0 ? (arg, null) : (arg[..eq], arg[(eq + 1)..]);
+        }
+
+        private static string RequireValue(string key, string? value) =>
+            string.IsNullOrWhiteSpace(value)
+                ? throw new ArgumentException($"{key} requires a value (e.g. {key}=value)")
+                : value!;
+
+        private static int ParseInt(string key, string? value, int min)
+        {
+            var raw = RequireValue(key, value);
+            if (!int.TryParse(raw, out var n) || n < min)
+            {
+                throw new ArgumentException($"{key} must be an integer >= {min} (got '{raw}')");
+            }
+            return n;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a developer-local hardware-in-the-loop (HIL) smoke test for confirming real-device USB/serial integration still works after touching the SDK. All existing tests are mock-based — this is the first piece of real-device coverage that lives in the repo.

Two pieces:

- **\`src/Daqifi.Core.SmokeTest/\`** — a standalone console project (\`net9.0;net10.0\`) that discovers, connects, reads metadata, enables ADC channels, streams briefly, asserts a reasonable sample throughput, and tears down cleanly. Exit codes are stable and named (\`10\`=no device, \`11\`=connect fail, \`12\`=metadata missing, \`13\`=degraded samples, \`20\`=no samples, \`99\`=unexpected). Runnable without Claude — \`dotnet run --project src/Daqifi.Core.SmokeTest\`.

- **\`.claude/skills/hil-smoke-test/SKILL.md\`** — a project-level Claude Code skill that orchestrates the binary, interprets exit codes with concrete remediation suggestions, retries transient failures once before reporting, and refuses out-of-scope destructive operations.

## Design notes

- **Test logic in C#, not in the AI prompt.** The skill is a thin orchestrator. The C# program is deterministic, diff-able, and could feed a future self-hosted CI runner without further changes.
- **Read-only w.r.t. persistent device state.** No SD card writes, no network reconfig, no firmware updates. Each of those is destructive enough to warrant its own opt-in skill.
- **Always tears down.** \`StopStreaming\` and \`Disconnect\` run in \`finally\` so a failed run doesn't leave the device streaming and poison the next attempt.
- **Tolerant sample-count threshold** (~50% of \`rate × duration\`). Real broken streams produce zero samples; a half-rate run is "weird but alive" and should be investigated, not silently passed.

## Test plan

- [ ] \`dotnet build src/Daqifi.Core.SmokeTest -c Release\` — passes on net9.0 and net10.0 ✓ (verified locally)
- [ ] \`dotnet run --project src/Daqifi.Core.SmokeTest -- --help\` — prints usage ✓ (verified locally)
- [ ] Plug in a DAQiFi device, run \`dotnet run --project src/Daqifi.Core.SmokeTest\` — confirm exit 0 and a sane sample count. **Not yet run against real hardware** — expect the first hardware run may need a tweak (sample-count threshold or post-\`StartStreaming\` delay).
- [ ] Disconnect the device, re-run — confirm exit code \`10\` (no device found).
- [ ] Invoke via Claude Code: \`smoke test the device\` or \`/hil-smoke-test\` — confirm the skill builds + runs + summarizes.

## Out of scope

Each of these is destructive or hardware-modifying and belongs in its own opt-in tool, not a smoke test:

- SD card formatting / log operations
- WiFi or LAN reconfiguration
- PIC32 or WiFi-module firmware updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)