### PR TITLE
chore: eliminate CA2024 warnings and enforce TreatWarningsAsErrors

### DIFF
--- a/src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj
+++ b/src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutputFormat>cobertura</CoverletOutputFormat>
     <CoverletOutput>$(MSBuildThisFileDirectory)../coverage/</CoverletOutput>

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
@@ -477,7 +477,8 @@ public sealed class SdCardCsvFileParserTests
 
         var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        // ReadLineAsync surfaces cancellation as TaskCanceledException (a subclass of OperationCanceledException).
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
             await parser.ParseAsync(stream, "test.csv", ct: cts.Token);
         });

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
@@ -316,8 +316,9 @@ public sealed class SdCardJsonFileParserTests
             FallbackTimestampFrequency = 100
         };
 
-        // Act & Assert — ParseAsync reads all lines upfront and throws when the token is already cancelled
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        // Act & Assert — ParseAsync reads all lines upfront and throws when the token is already cancelled.
+        // ReadLineAsync surfaces cancellation as TaskCanceledException (a subclass of OperationCanceledException).
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
             await parser.ParseAsync(stream, "test.json", options, cts.Token);
         });

--- a/src/Daqifi.Core/Daqifi.Core.csproj
+++ b/src/Daqifi.Core/Daqifi.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- Package Metadata -->
     <PackageId>Daqifi.Core</PackageId>

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -50,10 +50,9 @@ public sealed class SdCardCsvFileParser
         var lines = new List<string>();
         using (var reader = new StreamReader(fileStream, leaveOpen: true))
         {
-            while (!reader.EndOfStream)
+            string? line;
+            while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
             {
-                ct.ThrowIfCancellationRequested();
-                var line = await reader.ReadLineAsync(ct);
                 if (!string.IsNullOrWhiteSpace(line))
                 {
                     lines.Add(line);

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -42,10 +42,9 @@ public sealed class SdCardJsonFileParser
         var lines = new List<string>();
         using (var reader = new StreamReader(fileStream, leaveOpen: true))
         {
-            while (!reader.EndOfStream)
+            string? line;
+            while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
             {
-                ct.ThrowIfCancellationRequested();
-                var line = await reader.ReadLineAsync(ct);
                 if (!string.IsNullOrWhiteSpace(line))
                 {
                     lines.Add(line);


### PR DESCRIPTION
Closes #220.

## Summary

- Fix the two `CA2024` warnings (`SdCardJsonFileParser.cs:45`, `SdCardCsvFileParser.cs:53`) by driving the read loop off `ReadLineAsync`'s null return instead of the synchronous `EndOfStream` property.
- Enable `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` in both `Daqifi.Core.csproj` and `Daqifi.Core.Tests.csproj` so new warnings fail the build instead of accumulating.

## Behavior note

Cancellation surfaces from `ReadLineAsync(ct)` as `TaskCanceledException` (a subclass of `OperationCanceledException`), where the old loop threw `OperationCanceledException` directly via `ct.ThrowIfCancellationRequested()`. Callers using `catch (OperationCanceledException)` are unaffected. The two cancellation tests were updated to use `Assert.ThrowsAnyAsync<OperationCanceledException>` so they accept either type.

## Test plan

- [x] `dotnet build -c Release --no-incremental` → `0 Warning(s), 0 Error(s)` on both `net9.0` and `net10.0`.
- [x] `dotnet test -c Release` → 993 passed / 0 failed / 2 skipped on both target frameworks.
- [x] Sanity-checked locally by dropping a file with `CS0414` (private field assigned but never used) — build correctly failed with `error CS0414` instead of a warning. Probe file then removed.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)