### PR TITLE
docs: AI-native MCP planning (RFC + v0.1 issue drafts)

### DIFF
--- a/docs/planning/mcp/GITHUB_ISSUES.md
+++ b/docs/planning/mcp/GITHUB_ISSUES.md
@@ -1,0 +1,752 @@
+# GitHub Issues — DAQiFi MCP v0.1
+
+Ready-to-paste issue drafts for the v0.1 launch of the AI-native DAQiFi MCP. See [`RFC.md`](RFC.md) for the full proposal.
+
+**Suggested milestone:** `DAQiFi MCP v0.1`
+**Suggested labels:** `enhancement`, `mcp`, `ai-integration` (plus per-issue labels noted below)
+
+Create issues in the order listed. Dependencies are noted on each issue.
+
+---
+
+## Epic: DAQiFi MCP v0.1 — AI-Native Control Surface
+
+### Title
+Epic: Ship DAQiFi MCP v0.1 — agent-driven control surface for Nyquist devices
+
+### Labels
+`epic`, `enhancement`, `mcp`, `ai-integration`
+
+### Description
+
+#### Problem statement
+
+Today, every workflow involving a DAQiFi Nyquist device requires writing C# code against `Daqifi.Core` or driving the Desktop application by hand. There is no way for an AI agent (Claude, Cursor, Cline, etc.) to control a device end-to-end, and no MCP server exists for the test & measurement category at all. The window to plant a flag in this position is open *right now*; every major T&M vendor will bolt LLM chat onto an existing GUI within 12 months.
+
+#### Proposed solution
+
+Ship a first-class Model Context Protocol (MCP) server (`Daqifi.Mcp`) in this repository, built on top of `Daqifi.Core`, exposing discovery, channel configuration, streaming (with LLM-safe summaries), and SD card operations. Reposition the product around "AI-native data acquisition."
+
+See [`docs/planning/mcp/RFC.md`](docs/planning/mcp/RFC.md) for the full design rationale, stack decision, tool specification, safety model, and launch plan.
+
+#### Architecture overview
+
+```
+src/
+├── Daqifi.Core/         # existing SDK — referenced, not modified
+└── Daqifi.Mcp/          # new project
+    ├── Tools/           # MCP tool implementations
+    ├── Resources/       # MCP resources (daqifi://...)
+    ├── Prompts/         # MCP prompts ("recipes")
+    ├── Streaming/       # ring buffer, summarizer, window reader
+    ├── Safety/          # mode gating, clamps, confirmation
+    └── Server/          # MCP host wiring
+```
+
+#### Stack decision
+
+.NET, using the official `ModelContextProtocol` NuGet package. In-process reference to `Daqifi.Core` — no IPC, no protocol translation. Distribution via AOT binary, `dotnet tool`, and an `npx` shim. Python audience served by a separate v0.3 client package.
+
+#### Implementation phases
+
+This epic is broken down into 12 implementation issues, designed to be worked roughly sequentially with some parallelism possible (see dependency graph at the bottom of this doc).
+
+| Issue | Title | Effort | Depends on |
+|---|---|---|---|
+| #mcp-1 | Project scaffold + CI | 4h | — |
+| #mcp-2 | Discovery & connection tools | 6h | #mcp-1 |
+| #mcp-3 | Device introspection tools | 3h | #mcp-2 |
+| #mcp-4 | Channel configuration tools | 5h | #mcp-2 |
+| #mcp-5 | Streaming infrastructure (ring buffer, summarizer) | 8h | #mcp-1 |
+| #mcp-6 | Streaming tools | 6h | #mcp-4, #mcp-5 |
+| #mcp-7 | SD card tools (non-destructive) | 5h | #mcp-2 |
+| #mcp-8 | Resources (daqifi://) | 4h | #mcp-3, #mcp-6 |
+| #mcp-9 | Safety model | 5h | #mcp-1 |
+| #mcp-10 | Starter recipe prompts | 6h | #mcp-6, #mcp-7 |
+| #mcp-11 | Distribution (AOT, dotnet tool, npx) | 8h | all tool issues |
+| #mcp-12 | Documentation rewrite | 6h | #mcp-10, #mcp-11 |
+
+**Total estimated effort:** ~66 hours (~4–6 calendar weeks part-time).
+
+#### Success criteria
+
+- [ ] `Daqifi.Mcp` project builds and produces an AOT binary per supported OS
+- [ ] Claude Desktop (or any STDIO-MCP client) can launch the server, discover a Nyquist device, configure 4 analog channels, start streaming, and retrieve a stream summary
+- [ ] All v0.1 tools have integration tests covering happy-path behavior
+- [ ] Safety modes (`read-only`, `control`, `admin`) gate destructive operations correctly
+- [ ] At least 5 recipe prompts ship and are demonstrable on real hardware
+- [ ] `npx @daqifi/mcp` works on macOS, Linux, and Windows
+- [ ] README is rewritten to lead with the agent workflow
+- [ ] Launch post drafted and ready for v0.1.0 tag
+
+#### Non-goals (v0.1)
+
+- Destructive SD ops (`delete_sd_file`, `format_sd_card`) — v0.2
+- Network reconfiguration, firmware updates — v0.2
+- `send_scpi` escape hatch — v0.2
+- `wait_for_condition` event waiting — v0.2
+- Python client package — v0.3
+- REST/HTTP transport — v0.2
+- Cloud-managed device fleet — v0.3+
+
+#### Open questions
+
+See [RFC §Open questions](RFC.md#open-questions). Most pressing decisions for the epic:
+
+- Default safety mode for the `npx` distribution: `read-only` or `control`?
+- Telemetry opt-in: yes or no?
+- MCP stability contract: what do we promise users?
+
+---
+
+## #mcp-1: Project scaffold and CI
+
+### Title
+MCP: Scaffold `Daqifi.Mcp` project and wire CI
+
+### Labels
+`mcp`, `infrastructure`, `phase-1`
+
+### Objective
+
+Create the `Daqifi.Mcp` .NET project, wire it up to `Daqifi.Core` and the `ModelContextProtocol` SDK, and add CI coverage so subsequent issues can land green.
+
+### Tasks
+
+- [ ] Create `src/Daqifi.Mcp/Daqifi.Mcp.csproj` (.NET 10, executable)
+- [ ] Add project reference to `Daqifi.Core`
+- [ ] Add NuGet reference to `ModelContextProtocol` (latest)
+- [ ] Implement `Program.cs` with minimal CLI: `--mode`, `--max-sample-rate-hz`, `--max-voltage-range`, `--allow-raw-scpi`, `--transport=stdio|http`, `--port`
+- [ ] Implement `Server/McpServerHost.cs` — wires up STDIO transport, registers (empty) tool/resource/prompt collections
+- [ ] Implement `Server/DeviceRegistry.cs` — in-memory `device_id` → `IDaqifiDevice` map with thread-safe add/remove/get
+- [ ] Add `src/Daqifi.Mcp.Tests/Daqifi.Mcp.Tests.csproj` (xUnit)
+- [ ] Add `MinimalStartupTest`: server starts, accepts an MCP `initialize`, returns capabilities, shuts down cleanly
+- [ ] Update `.github/workflows/*.yml` to build and test the new project
+- [ ] Update solution file to include both new projects
+
+### Acceptance criteria
+
+- [ ] `dotnet build` succeeds across all target frameworks
+- [ ] `dotnet test src/Daqifi.Mcp.Tests` passes
+- [ ] `dotnet run --project src/Daqifi.Mcp -- --help` prints the CLI flags
+- [ ] CI passes on the PR
+
+### Estimated effort
+
+4 hours
+
+### Dependencies
+
+None
+
+### Related
+
+Part of the [DAQiFi MCP v0.1 epic](#epic-daqifi-mcp-v01--ai-native-control-surface)
+
+---
+
+## #mcp-2: Discovery and connection tools
+
+### Title
+MCP: Implement discovery and connection tools
+
+### Labels
+`mcp`, `tools`, `phase-2`
+
+### Objective
+
+Implement the four foundational tools that let an agent find devices and open connections.
+
+### Tools
+
+- `discover_devices(timeout_ms?, transports?)`
+- `connect_device(device_id)`
+- `disconnect_device(device_id)`
+- `list_connected_devices()`
+
+### Tasks
+
+- [ ] Implement `Tools/DiscoveryTools.cs` with the four tools above
+- [ ] `discover_devices` wraps `WiFiDeviceFinder` + `SerialDeviceFinder`, merges results, mints stable `device_id` (suggest `{transport}:{serial_or_address}`)
+- [ ] `connect_device` calls `ConnectFromDeviceInfoAsync()`, registers in `DeviceRegistry`
+- [ ] `disconnect_device` removes from registry and disposes the device
+- [ ] `list_connected_devices` enumerates `DeviceRegistry`
+- [ ] All inputs validated; errors return MCP error responses with actionable messages
+- [ ] Integration tests using a real device (or simulator if available; otherwise skip-on-no-hardware pattern)
+
+### Acceptance criteria
+
+- [ ] Agent can call `discover_devices` and receive a list of devices
+- [ ] Agent can call `connect_device` with a `device_id` from discovery and the device becomes connected
+- [ ] `list_connected_devices` reflects the connected state
+- [ ] `disconnect_device` cleans up cleanly; subsequent `list_connected_devices` reflects disconnection
+- [ ] Tool descriptions are written for agent ergonomics (clear, one-sentence purpose; parameter docs include units and examples)
+- [ ] Integration test passes against real hardware
+
+### Files to create
+
+- `src/Daqifi.Mcp/Tools/DiscoveryTools.cs`
+- `src/Daqifi.Mcp.Tests/Tools/DiscoveryToolsTests.cs`
+
+### Estimated effort
+
+6 hours
+
+### Dependencies
+
+- #mcp-1 (Project scaffold)
+
+---
+
+## #mcp-3: Device introspection tools
+
+### Title
+MCP: Implement device introspection tools
+
+### Labels
+`mcp`, `tools`, `phase-2`
+
+### Objective
+
+Implement read-only tools that let an agent learn about a device's identity, capabilities, and current state.
+
+### Tools
+
+- `get_device_info(device_id)`
+- `get_device_status(device_id)`
+
+### Tasks
+
+- [ ] Implement `Tools/DeviceTools.cs`
+- [ ] `get_device_info` returns `{part_number, firmware_version, channel_counts: {analog, digital}, resolution_bits, voltage_range, capabilities[]}`
+- [ ] `get_device_status` returns `{connection_state, streaming, sample_rate_hz, sd_logging, sd_free_bytes, channels_enabled[]}`
+- [ ] Both tools surface meaningful errors when device is not connected
+- [ ] Unit tests with a fake `IDaqifiDevice`
+
+### Acceptance criteria
+
+- [ ] Both tools return the documented shapes
+- [ ] Calling either on a disconnected device returns a clean error
+- [ ] Tool descriptions tell the agent when to prefer one over the other
+
+### Files to create
+
+- `src/Daqifi.Mcp/Tools/DeviceTools.cs`
+- `src/Daqifi.Mcp.Tests/Tools/DeviceToolsTests.cs`
+
+### Estimated effort
+
+3 hours
+
+### Dependencies
+
+- #mcp-2 (Discovery & connection)
+
+---
+
+## #mcp-4: Channel configuration tools
+
+### Title
+MCP: Implement channel configuration tools
+
+### Labels
+`mcp`, `tools`, `phase-2`
+
+### Objective
+
+Implement tools that let an agent enumerate and configure analog/digital channels and set the sample rate.
+
+### Tools
+
+- `list_channels(device_id, kind?)`
+- `configure_analog_channel(device_id, channel, enabled, range?, label?)`
+- `configure_digital_channel(device_id, channel, direction, label?)`
+- `set_sample_rate(device_id, rate_hz)`
+
+### Tasks
+
+- [ ] Implement `Tools/ChannelTools.cs`
+- [ ] `list_channels` returns the full channel inventory with current state
+- [ ] `configure_analog_channel` wraps `IAnalogChannel` configuration
+- [ ] `configure_digital_channel` wraps `IDigitalChannel` configuration
+- [ ] `set_sample_rate` respects `--max-sample-rate-hz` clamp (set in #mcp-9; for now, parameter is wired but enforcement lands with safety issue)
+- [ ] Validate channel indices against device capabilities; clear error for out-of-range
+- [ ] Unit tests + an integration test that configures 4 channels and verifies via `get_device_status`
+
+### Acceptance criteria
+
+- [ ] Agent can list channels, configure several, and see the changes via `get_device_status`
+- [ ] Out-of-range channel index returns clean error
+- [ ] Out-of-range sample rate returns clean error (after #mcp-9)
+- [ ] Configuration persists across `list_channels` calls within a session
+
+### Files to create
+
+- `src/Daqifi.Mcp/Tools/ChannelTools.cs`
+- `src/Daqifi.Mcp.Tests/Tools/ChannelToolsTests.cs`
+
+### Estimated effort
+
+5 hours
+
+### Dependencies
+
+- #mcp-2 (Discovery & connection)
+
+---
+
+## #mcp-5: Streaming infrastructure (ring buffer + summarizer)
+
+### Title
+MCP: Streaming infrastructure — ring buffer, summarizer, window reader
+
+### Labels
+`mcp`, `infrastructure`, `streaming`, `phase-3`
+
+### Objective
+
+Build the server-side infrastructure that lets agents reason about live waveform data without pulling raw samples into context. **This is the differentiating technical capability** of the v0.1 release.
+
+### Components
+
+- `Streaming/RingBuffer.cs` — bounded per-stream, per-channel ring buffer. Configurable size in seconds. Thread-safe single-producer multi-consumer.
+- `Streaming/StreamSummarizer.cs` — computes per-channel `{n, min, max, mean, rms, std, dominant_freq_hz, sparkline}` over a configurable window. Sparkline is a 40-char Unicode block-character string.
+- `Streaming/WindowReader.cs` — given `(start_s, end_s, max_points)`, returns decimated samples (decimation factor chosen to stay under `max_points`).
+- `Server/StreamRegistry.cs` — tracks active streams by `stream_id`.
+
+### Tasks
+
+- [ ] Implement `RingBuffer<T>` with bounded capacity, overwrite-oldest semantics, timestamped samples
+- [ ] Implement `StreamSummarizer` with min/max/mean/rms/std (single-pass Welford) and a simple Goertzel-based dominant frequency estimate
+- [ ] Implement sparkline rendering using `▁▂▃▄▅▆▇█`
+- [ ] Implement `WindowReader` with server-side decimation (averaging buckets)
+- [ ] Implement `StreamRegistry` with stream lifecycle (start, stop, dispose)
+- [ ] Wire streaming subscription to `IDaqifiDevice` message events
+- [ ] Unit tests for ring buffer correctness, summarizer math (against a known sine wave), and window decimation
+- [ ] Benchmark: 1000 Hz × 16 channels × 60 s ring buffer must stay under 50 MB RAM
+
+### Acceptance criteria
+
+- [ ] Ring buffer correctly retains the last N seconds of samples per channel
+- [ ] Summarizer returns mathematically correct stats for a known input (sine wave: mean ≈ 0, rms ≈ amplitude/√2, dominant_freq matches input)
+- [ ] Window reader respects `max_points` cap and returns decimated data when input exceeds cap
+- [ ] All unit tests pass
+- [ ] Benchmark target met
+
+### Files to create
+
+- `src/Daqifi.Mcp/Streaming/RingBuffer.cs`
+- `src/Daqifi.Mcp/Streaming/StreamSummarizer.cs`
+- `src/Daqifi.Mcp/Streaming/WindowReader.cs`
+- `src/Daqifi.Mcp/Server/StreamRegistry.cs`
+- `src/Daqifi.Mcp.Tests/Streaming/*Tests.cs`
+
+### Estimated effort
+
+8 hours
+
+### Dependencies
+
+- #mcp-1 (Project scaffold)
+
+---
+
+## #mcp-6: Streaming tools
+
+### Title
+MCP: Implement streaming tools (start, stop, summary, window)
+
+### Labels
+`mcp`, `tools`, `streaming`, `phase-3`
+
+### Objective
+
+Expose the streaming infrastructure built in #mcp-5 as MCP tools.
+
+### Tools
+
+- `start_streaming(device_id, duration_s?, ring_buffer_s?)`
+- `stop_streaming(stream_id)`
+- `get_stream_summary(stream_id, channels?, window_s?)`
+- `read_stream_window(stream_id, channels, start_s, end_s, max_points?)`
+
+### Tasks
+
+- [ ] Implement `Tools/StreamingTools.cs`
+- [ ] `start_streaming` creates a `StreamRegistry` entry, subscribes to device data events, returns `stream_id`
+- [ ] `stop_streaming` tears down the subscription, returns total samples + duration
+- [ ] `get_stream_summary` delegates to `StreamSummarizer`
+- [ ] `read_stream_window` delegates to `WindowReader`
+- [ ] Auto-stop streams when their `duration_s` elapses
+- [ ] Auto-cleanup streams when their device disconnects
+- [ ] Integration test: start streaming for 5s on a real device (or simulated waveform if no hardware), call `get_stream_summary` mid-stream, verify stats look reasonable
+
+### Acceptance criteria
+
+- [ ] Agent can start a 10-second stream, sleep, call `get_stream_summary`, and get a non-empty result
+- [ ] `read_stream_window` returns decimated samples for a specified time range
+- [ ] Disconnecting a device cleans up its active streams
+- [ ] Tool descriptions explicitly tell the agent: "prefer `get_stream_summary` over `read_stream_window` for reasoning about waveforms; only use `read_stream_window` for zoom-in"
+
+### Files to create
+
+- `src/Daqifi.Mcp/Tools/StreamingTools.cs`
+- `src/Daqifi.Mcp.Tests/Tools/StreamingToolsTests.cs`
+
+### Estimated effort
+
+6 hours
+
+### Dependencies
+
+- #mcp-4 (Channel configuration)
+- #mcp-5 (Streaming infrastructure)
+
+---
+
+## #mcp-7: SD card tools (non-destructive)
+
+### Title
+MCP: Implement non-destructive SD card tools
+
+### Labels
+`mcp`, `tools`, `sd-card`, `phase-3`
+
+### Objective
+
+Expose SD card listing, downloading, and logging start/stop operations as MCP tools. Destructive operations (delete, format) are deferred to v0.2.
+
+### Tools
+
+- `list_sd_files(device_id)`
+- `download_sd_file(device_id, remote_name, local_path?)`
+- `start_sd_logging(device_id, filename?)`
+- `stop_sd_logging(device_id)`
+
+### Tasks
+
+- [ ] Implement `Tools/SdCardTools.cs`
+- [ ] Wrap `ISdCardOperations` (already in `Daqifi.Core`)
+- [ ] `download_sd_file` defaults `local_path` to a sensible temp directory; returns post-download summary (channels, duration, basic stats)
+- [ ] `start_sd_logging` auto-generates a filename if not provided (`yyyy-MM-dd-HHmmss.csv`)
+- [ ] All operations respect connection state; clean errors when not connected or SD card not present
+- [ ] Integration test against a real device with an SD card
+
+### Acceptance criteria
+
+- [ ] Agent can list, download, and start/stop logging
+- [ ] Downloads include a useful post-download summary (so the agent has something to talk about without re-reading the file)
+- [ ] Errors for "SD card not present" / "not connected" are clear
+
+### Files to create
+
+- `src/Daqifi.Mcp/Tools/SdCardTools.cs`
+- `src/Daqifi.Mcp.Tests/Tools/SdCardToolsTests.cs`
+
+### Estimated effort
+
+5 hours
+
+### Dependencies
+
+- #mcp-2 (Discovery & connection)
+
+---
+
+## #mcp-8: MCP resources (daqifi://)
+
+### Title
+MCP: Implement read-only resources (`daqifi://...`)
+
+### Labels
+`mcp`, `resources`, `phase-3`
+
+### Objective
+
+Expose live device state as MCP resources, which agents can subscribe to without explicit tool calls.
+
+### Resources
+
+- `daqifi://devices`
+- `daqifi://devices/{id}/info`
+- `daqifi://devices/{id}/channels`
+- `daqifi://streams/{id}/summary` (auto-refresh ~1 Hz)
+
+### Tasks
+
+- [ ] Implement `Resources/DaqifiResources.cs`
+- [ ] Wire resource list to `DeviceRegistry` and `StreamRegistry`
+- [ ] Implement resource change notifications for `daqifi://streams/{id}/summary` (~1 Hz throttled)
+- [ ] Resource URIs are stable and documented in README
+
+### Acceptance criteria
+
+- [ ] Listing resources via MCP returns the documented URIs
+- [ ] Reading `daqifi://devices` returns the same data as `list_connected_devices()`
+- [ ] Reading `daqifi://streams/{id}/summary` returns a stream summary
+- [ ] Stream summary resource emits change notifications during active streaming
+
+### Files to create
+
+- `src/Daqifi.Mcp/Resources/DaqifiResources.cs`
+- `src/Daqifi.Mcp.Tests/Resources/DaqifiResourcesTests.cs`
+
+### Estimated effort
+
+4 hours
+
+### Dependencies
+
+- #mcp-3 (Device introspection)
+- #mcp-6 (Streaming tools)
+
+---
+
+## #mcp-9: Safety model
+
+### Title
+MCP: Implement safety model (modes, clamps, confirmation)
+
+### Labels
+`mcp`, `safety`, `phase-3`
+
+### Objective
+
+Implement the three server-launch modes (`read-only`, `control`, `admin`) and the parameter clamps that prevent an agent from over-driving hardware. Also lay groundwork for the confirmation pattern used by destructive tools (full destructive tools land in v0.2).
+
+### Tasks
+
+- [ ] Implement `Safety/ServerMode.cs` enum and CLI parsing in `Program.cs`
+- [ ] Implement tool-level gating: each tool declares the minimum mode it requires; the MCP server filters the published tool list accordingly
+- [ ] Wire `--max-sample-rate-hz` clamp into `set_sample_rate`
+- [ ] Wire `--max-voltage-range` clamp into `configure_analog_channel`
+- [ ] Implement `Safety/Confirmation.cs` — pattern for tools that take `confirmed: bool` and return a preview if `confirmed == false` (used by v0.2 destructive tools, but defined here)
+- [ ] Default mode for the `npx @daqifi/mcp` distribution: **resolve via [open question #3 on the RFC](RFC.md#open-questions) before merging**
+- [ ] Document modes prominently in the README
+- [ ] Tests covering: mode filtering hides correct tools; clamps enforce limits; confirmation preview shape
+
+### Acceptance criteria
+
+- [ ] Launching with `--mode=read-only` exposes only read-only tools
+- [ ] `set_sample_rate` above `--max-sample-rate-hz` returns a clean error
+- [ ] `configure_analog_channel` above `--max-voltage-range` returns a clean error
+- [ ] Documentation includes a clear table of which tools are available in which mode
+
+### Files to create
+
+- `src/Daqifi.Mcp/Safety/ServerMode.cs`
+- `src/Daqifi.Mcp/Safety/Confirmation.cs`
+- `src/Daqifi.Mcp.Tests/Safety/*Tests.cs`
+
+### Estimated effort
+
+5 hours
+
+### Dependencies
+
+- #mcp-1 (Project scaffold)
+
+---
+
+## #mcp-10: Starter recipe prompts
+
+### Title
+MCP: Implement 5 starter recipe prompts
+
+### Labels
+`mcp`, `prompts`, `marketing`, `phase-4`
+
+### Objective
+
+Ship 5 MCP prompts that double as in-product onboarding and marketing artifacts. Each prompt is parameterized and runnable end-to-end against a real Nyquist device.
+
+### Prompts
+
+- `setup_thermocouple_sweep(channels, sample_rate_hz, threshold_c, log_to_sd?)`
+- `battery_soak_test(channels, duration_h, summary_interval_min, log_to_sd?)`
+- `vibration_capture_fft(channel, duration_s, sample_rate_hz)`
+- `multi_channel_pressure_test(channels, sample_rate_hz, threshold_v, log_to_sd?)`
+- `wifi_provision_new_device(ssid, password)`
+
+### Tasks
+
+- [ ] Implement `Prompts/RecipePrompts.cs`
+- [ ] Each prompt returns a structured message to the agent describing the goal, the suggested tool sequence, and any safety considerations
+- [ ] Document each recipe in the README with a screenshot and a 60-second demo video link (videos can land in #mcp-12)
+- [ ] Each prompt has at least one integration test that runs it end-to-end against a connected device (or a deterministic mock if hardware unavailable in CI)
+- [ ] Coordinate with #mcp-12 author for the README rewrite
+
+### Acceptance criteria
+
+- [ ] All 5 prompts are discoverable via the MCP `list_prompts` call
+- [ ] Each prompt can be parameterized and invoked from Claude Desktop end-to-end
+- [ ] Each prompt produces a useful working test rig in under 60 seconds of agent activity (excluding the actual test duration)
+
+### Files to create
+
+- `src/Daqifi.Mcp/Prompts/RecipePrompts.cs`
+- `src/Daqifi.Mcp.Tests/Prompts/RecipePromptsTests.cs`
+
+### Estimated effort
+
+6 hours
+
+### Dependencies
+
+- #mcp-6 (Streaming tools)
+- #mcp-7 (SD card tools)
+
+---
+
+## #mcp-11: Distribution (AOT, dotnet tool, npx shim)
+
+### Title
+MCP: Distribution — AOT binary, `dotnet tool`, and `npx` shim
+
+### Labels
+`mcp`, `release`, `infrastructure`, `phase-4`
+
+### Objective
+
+Ship three distribution artifacts off the single `Daqifi.Mcp` codebase so users on every platform can install with one command.
+
+### Artifacts
+
+- AOT-published native binaries for `osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`, `win-x64`
+- `dotnet tool` package on NuGet (`Daqifi.Mcp`)
+- npm package `@daqifi/mcp` — a tiny Node shim that downloads the right native binary on first run
+
+### Tasks
+
+- [ ] Configure AOT publish in `Daqifi.Mcp.csproj`
+- [ ] GitHub Actions workflow that on tag (`v*.*.*`) publishes binaries to the release as platform-specific zips
+- [ ] Configure `dotnet tool` packaging (PackAsTool, ToolCommandName, etc.)
+- [ ] CI publishes the .NET tool to NuGet on tagged releases
+- [ ] Build the `@daqifi/mcp` npm package in a sibling repo or under `packages/npm/`:
+  - `bin/daqifi-mcp` Node script
+  - On first run, downloads the matching native binary from GitHub releases into `~/.daqifi-mcp/<version>/<arch>/`
+  - Verifies SHA-256
+  - Subsequent runs exec the cached binary
+- [ ] CI publishes the npm package on tagged releases
+- [ ] Document install: `npx @daqifi/mcp` should "just work" in Claude Desktop config
+- [ ] Smoke-test the install on macOS, Linux, Windows
+
+### Acceptance criteria
+
+- [ ] On a fresh machine, `npx @daqifi/mcp --help` works without any other install
+- [ ] On a fresh machine, `dotnet tool install -g Daqifi.Mcp && daqifi-mcp --help` works
+- [ ] Claude Desktop config snippet `{"command": "npx", "args": ["@daqifi/mcp"]}` launches the server cleanly
+- [ ] Released binaries are checksummed and the npm shim verifies before exec
+
+### Files to create
+
+- `.github/workflows/release.yml`
+- `packages/npm/` (or sibling repo) — Node shim
+- Release notes template
+
+### Estimated effort
+
+8 hours
+
+### Dependencies
+
+- All tool issues (#mcp-2 through #mcp-10) — needs a working server to package
+
+---
+
+## #mcp-12: Documentation rewrite
+
+### Title
+MCP: Rewrite README and ship agent recipe guide
+
+### Labels
+`mcp`, `documentation`, `marketing`, `phase-4`
+
+### Objective
+
+Reposition the repository's README around the agent workflow, and ship a dedicated agent recipe guide that doubles as launch-week content.
+
+### Tasks
+
+- [ ] Rewrite `README.md`:
+  - Hero is "AI-native data acquisition for the test bench"
+  - Show a 5-line Claude Desktop config snippet up top
+  - Embed a 60-second demo GIF (recorded against real hardware) showing one recipe end-to-end
+  - Specs move below the fold
+  - Old README content (API examples, etc.) moves to `docs/SDK_USAGE.md`
+- [ ] Write `docs/AGENT_RECIPES.md`:
+  - One section per recipe prompt
+  - Each section includes the prompt, an example user instruction, a screenshot of the agent run, and the tool sequence the agent typically uses
+- [ ] Update `docs/DEVICE_INTERFACES.md` to link out to the MCP tool reference
+- [ ] Draft the Hacker News / launch post in `docs/planning/mcp/LAUNCH_POST.md` (not published; just drafted for review)
+- [ ] Update repo description and topics on GitHub
+
+### Acceptance criteria
+
+- [ ] Someone landing on the repo README within 30 seconds understands: (a) this is a DAQ device, (b) you control it with an AI agent, (c) here's how to install
+- [ ] All 5 recipes have working documented examples
+- [ ] Old SDK-first usage content is preserved (under `docs/SDK_USAGE.md`), not lost
+- [ ] Launch post draft exists and is ready for marketing review
+
+### Files to create / modify
+
+- `README.md` (rewrite)
+- `docs/AGENT_RECIPES.md` (new)
+- `docs/SDK_USAGE.md` (extracted from old README)
+- `docs/planning/mcp/LAUNCH_POST.md` (draft)
+
+### Estimated effort
+
+6 hours
+
+### Dependencies
+
+- #mcp-10 (Recipe prompts — need them implemented to document them)
+- #mcp-11 (Distribution — need install commands that work)
+
+---
+
+## Dependency graph
+
+```
+                           #mcp-1 (scaffold)
+                          /        |        \
+                #mcp-2 (discovery) #mcp-5 (stream infra)  #mcp-9 (safety)
+                  /    |    \              \
+        #mcp-3   #mcp-4  #mcp-7             \
+        (info) (channels) (SD)               \
+                 \              \             \
+                  +--- #mcp-6 (streaming tools)
+                              \
+                               +--- #mcp-8 (resources)
+                              \
+                               +--- #mcp-10 (prompts)
+                                            \
+                                             #mcp-11 (distribution)
+                                                       \
+                                                        #mcp-12 (docs)
+```
+
+Issues #mcp-1, #mcp-5, and #mcp-9 can start in parallel.
+Issues #mcp-2/3/4/7 can be parallelized after #mcp-1.
+Issues #mcp-6/8/10 unblock once their dependencies land.
+Issues #mcp-11/12 finalize the release.
+
+---
+
+## Labels to create (if missing)
+
+- `mcp`
+- `ai-integration`
+- `epic`
+- `tools`
+- `streaming`
+- `sd-card`
+- `safety`
+- `prompts`
+- `release`
+- `phase-1`, `phase-2`, `phase-3`, `phase-4`
+
+## Milestone
+
+`DAQiFi MCP v0.1`

--- a/docs/planning/mcp/README.md
+++ b/docs/planning/mcp/README.md
@@ -1,0 +1,28 @@
+# DAQiFi MCP Planning
+
+**Status:** Draft RFC — open for feedback.
+
+This folder contains the active planning effort for the **AI-native DAQiFi** initiative: a first-class Model Context Protocol (MCP) server for Nyquist devices, plus the launch positioning that surrounds it.
+
+## Contents
+
+- [`RFC.md`](RFC.md) — the proposal. Motivation, stack decision, architecture, MCP tool specification, safety model, distribution, phasing, marketing plan, and open questions.
+- [`GITHUB_ISSUES.md`](GITHUB_ISSUES.md) — ready-to-paste issue drafts for the v0.1 milestone. One epic plus twelve implementation issues, with dependencies, effort estimates, and acceptance criteria.
+
+## How to use this folder
+
+1. **Review the RFC.** Comment on the PR with feedback on the strategic direction, the stack choice, the tool surface, the safety model, and the open questions.
+2. **Once aligned, create the GitHub issues** from `GITHUB_ISSUES.md`. The drafts are written so each section maps to one issue; the dependency graph at the bottom of that doc shows the order.
+3. **Build.** Start with `#mcp-1` (scaffold). `#mcp-5` (streaming infrastructure) and `#mcp-9` (safety) can run in parallel.
+4. **Archive when superseded.** When the v0.1 launch ships and the plan is no longer the active reference, move this folder to `docs/archive/mcp-v0.1/` (matching the `docs/archive/simulator/` pattern).
+
+## Quick links
+
+- [Strategic summary](RFC.md#summary)
+- [Stack decision rationale](RFC.md#tech-stack-decision)
+- [Tool spec (appendix)](RFC.md#appendix-complete-tool-reference)
+- [Safety model](RFC.md#safety-model)
+- [Launch plan](RFC.md#marketing--launch-plan)
+- [Open questions](RFC.md#open-questions)
+- [v0.1 epic](GITHUB_ISSUES.md#epic-daqifi-mcp-v01--ai-native-control-surface)
+- [v0.1 dependency graph](GITHUB_ISSUES.md#dependency-graph)

--- a/docs/planning/mcp/RFC.md
+++ b/docs/planning/mcp/RFC.md
@@ -1,0 +1,348 @@
+# RFC: AI-Native DAQiFi via MCP
+
+**Status:** Draft — open for feedback
+**Author:** Tyler Kron (drafted with Claude)
+**Date:** 2026-05-26
+**Target:** v0.1 launch within ~6 weeks of approval
+
+---
+
+## Summary
+
+Ship a first-class Model Context Protocol (MCP) server for DAQiFi hardware, written in .NET on top of the existing `Daqifi.Core` SDK, and reposition the product around the tagline **"the AI-native DAQ."** Lab researchers, test engineers, and educators can drive Nyquist devices end-to-end through Claude, Cursor, Cline, or any other MCP-aware agent — discovery, channel configuration, streaming, SD logging, alerts — without writing application code.
+
+The MCP is not the product. The product is the workflow it unlocks: *go from idea to running test rig in one conversation.* The MCP is the wedge that makes that workflow real, and that everyone else in test & measurement will spend 12+ months catching up on.
+
+---
+
+## Motivation
+
+### Why now
+
+1. **The T&M industry is sleepy.** LabVIEW dates to 1986. The dominant vendors (NI, MCC/Measurement Computing, Dataq) ship Windows-first GUIs and stack-locked SDKs. Every one of them will bolt an LLM chat panel onto an existing GUI within 12 months. None will rewrite their core control surface to be agent-first, because they cannot — too much legacy, too much certification, too much internal politics.
+2. **DAQiFi has the asymmetric advantage.** Two SKUs (Nyquist 1, Nyquist 3), a clean cross-platform .NET SDK, no installed-base baggage, and a small team that can ship in weeks rather than quarters. The window to plant a flag in this position is open *now*, and is unlikely to be open in 12 months.
+3. **MCP is becoming the default agent integration surface.** Claude Desktop, Cursor, Cline, Zed, and a growing list of agent frameworks consume MCP servers natively. Anthropic and Microsoft now co-maintain an official .NET MCP SDK, so the "ecosystem is Node-only" objection is no longer load-bearing.
+
+### What lab users actually want to do
+
+The user goal is not "call our API." It is, paraphrased from real conversations:
+
+> "Set up a 4-channel pressure test at 1 kHz, log to the SD card, alert me if any channel exceeds 4 V, and tell me when it's done."
+
+Today that's a half-day of LabVIEW or a few hundred lines of custom C#. With a domain-aware MCP, it's one sentence to an agent that already knows the device.
+
+### Competitive framing
+
+| Failure mode | Vendor | DAQiFi answer |
+|---|---|---|
+| Heavy, expensive, locked to Windows; AI bolted on the side | LabVIEW / NI | Cross-platform, agent-first, $-per-channel competitive |
+| DIY, no calibration, no wireless, no SCPI | Arduino + ADC stacks | Real metrology hardware with a 5-minute agent setup |
+| Closed ecosystems, slow updates | MCC, Dataq | Open SDK + MCP + recipes shipped with the product |
+
+The position to own: **real benchtop metrology with the workflow ergonomics of a chat interface.**
+
+---
+
+## Goals and non-goals
+
+### Goals (v0.1)
+
+- Ship a working MCP server (`Daqifi.Mcp`) that exposes discovery, connection, channel configuration, streaming, and SD card operations.
+- Make streaming **LLM-safe** by default — agents reason on summaries; raw samples are never dumped into context.
+- Ship distribution artifacts that work for the three audiences who matter: .NET devs, agent-tool users (`npx`), and Python/lab users (separate client package).
+- Ship 3–5 prebuilt "recipe" prompts that are usable demos and marketable artifacts on day one.
+- Establish a safety model that prevents an agent from overdriving a sensor, wiping an SD card, or reflashing firmware without explicit confirmation.
+
+### Non-goals (v0.1)
+
+- A REST API. (MCP is the surface. REST can come later if cloud-deployed agents need it.)
+- A standalone GUI client. (Agent UIs are the front end.)
+- High-fidelity simulator integration. (Use real hardware for v0.1 development; revisit simulator when the smoke test surface is stable.)
+- Cloud-managed device fleet. (Local-first; remote can come in v0.3+.)
+- Replacing `Daqifi.Desktop`. (Different product, different audience.)
+
+---
+
+## Proposed solution
+
+### Tech stack decision
+
+**Server: .NET, using the official `ModelContextProtocol` NuGet package.**
+
+The case:
+
+- **The SDK is the asset.** All the hard, hardware-specific code — protobuf wire format, SCPI command generation, UDP discovery, SD card parser, firmware OTA, async message loop, calibration math — already lives in `Daqifi.Core`. Forking that to Node or Python doubles the maintenance burden forever and creates drift risk on every firmware change.
+- **First-class .NET MCP support.** `ModelContextProtocol` is co-maintained by Anthropic and Microsoft. It is not a community port. STDIO and HTTP transports are supported; tool/resource/prompt registration uses attributes and reflection.
+- **Distribution is solved.** Three artifacts off one codebase:
+  1. `dotnet publish -p:PublishAot=true` produces a ~30 MB self-contained native binary per OS. No .NET runtime required.
+  2. `dotnet tool install -g Daqifi.Mcp` for the .NET-friendly audience.
+  3. `npx @daqifi/mcp` — a tiny Node shim that downloads the right native binary on first run. Most agent UIs launch MCP servers via `npx` or `uvx`, so this is the entry point most users will use. They never know it is .NET underneath.
+- **Python audience is served by a separate client package**, not a rewrite. `pip install daqifi` ships a Python client that either (a) speaks MCP out-of-process to the same server, or (b) wraps it via `pythonnet`. Either way, lab/ML users get idiomatic Python without forking the protocol logic.
+
+The wrong move would be to rewrite the wire protocol in Node or Python "to fit the ecosystem." That trades DAQiFi's strongest asset for an ecosystem alignment that no longer matters.
+
+**Long-term flag (out of scope for v0.1):** if a future device family runs an ESP32-class module with enough resources to host an MCP server natively, Rust becomes interesting. Not a today decision; noted for the firmware roadmap.
+
+### Architecture
+
+```
+src/
+├── Daqifi.Core/                    # existing SDK — no changes
+└── Daqifi.Mcp/                     # new project
+    ├── Daqifi.Mcp.csproj           # references Daqifi.Core, ModelContextProtocol
+    ├── Program.cs                  # CLI entry; parses --mode, --max-sample-rate, etc.
+    ├── Server/
+    │   ├── McpServerHost.cs        # MCP server setup, transport selection
+    │   ├── DeviceRegistry.cs       # tracks connected devices by device_id
+    │   └── StreamRegistry.cs       # tracks active streams + ring buffers
+    ├── Tools/
+    │   ├── DiscoveryTools.cs       # discover_devices, connect_device, ...
+    │   ├── DeviceTools.cs          # get_device_info, get_device_status, ...
+    │   ├── ChannelTools.cs         # configure_*_channel, set_sample_rate
+    │   ├── StreamingTools.cs       # start_streaming, get_stream_summary, ...
+    │   ├── SdCardTools.cs          # list_sd_files, download_sd_file, ...
+    │   ├── NetworkTools.cs         # configure_wifi, configure_static_ip
+    │   ├── FirmwareTools.cs        # check_firmware_update, update_firmware
+    │   └── ScpiTools.cs            # send_scpi (gated)
+    ├── Resources/
+    │   └── DaqifiResources.cs      # daqifi://devices, daqifi://streams/{id}/summary
+    ├── Prompts/
+    │   └── RecipePrompts.cs        # thermocouple_sweep, soak_test, vibration_fft, ...
+    ├── Streaming/
+    │   ├── RingBuffer.cs           # bounded per-stream ring buffer
+    │   ├── StreamSummarizer.cs     # min/max/mean/rms/std/dom_freq + sparkline
+    │   └── WindowReader.cs         # decimated zoom queries
+    └── Safety/
+        ├── ServerMode.cs           # ReadOnly | Control | Admin
+        └── Confirmation.cs         # destructive-action confirmation pattern
+```
+
+Key choices:
+
+- **In-process, not IPC.** `Daqifi.Mcp` references `Daqifi.Core` directly. No serialization boundary, no protocol translation, no drift.
+- **STDIO transport is default.** Matches how Claude Desktop, Cursor, Cline launch MCP servers. HTTP transport is a future flag (`--transport=http`) for hosted use cases.
+- **Per-stream ring buffers live in the server, not in agent context.** Agents request summaries or decimated windows; raw samples never traverse the LLM context window.
+
+### MCP tool spec (v0.1)
+
+Full reference is in the [appendix](#appendix-complete-tool-reference). Summary:
+
+| Category | Tools | v0.1? |
+|---|---|---|
+| Discovery & connection | `discover_devices`, `connect_device`, `disconnect_device`, `list_connected_devices` | yes |
+| Device introspection | `get_device_info`, `get_device_status` | yes |
+| Channel configuration | `list_channels`, `configure_analog_channel`, `configure_digital_channel`, `set_sample_rate` | yes |
+| Streaming (LLM-safe) | `start_streaming`, `stop_streaming`, `get_stream_summary`, `read_stream_window` | yes |
+| Streaming (advanced) | `wait_for_condition` | v0.2 |
+| SD card | `list_sd_files`, `download_sd_file`, `start_sd_logging`, `stop_sd_logging` | yes |
+| SD card (destructive) | `delete_sd_file`, `format_sd_card` | v0.2 |
+| Network | `configure_wifi`, `configure_static_ip` | v0.2 |
+| Firmware | `check_firmware_update`, `update_firmware` | v0.2 |
+| Escape hatch | `send_scpi` | v0.2 (behind `--allow-raw-scpi`) |
+
+#### The streaming layer is the differentiator
+
+Most product MCPs shipping today are REST endpoints in a trenchcoat. The DAQiFi MCP wins by being domain-aware about *waveform data*, which agents otherwise cannot reason about cheaply.
+
+- **`get_stream_summary`** returns per-channel min/max/mean/RMS/std/dominant_freq plus a 40-character ASCII sparkline. ~200 bytes per channel. Agents call this freely.
+- **`read_stream_window`** returns decimated samples for a time slice, hard-capped at `max_points` (default 500). Server decimates; agent gets a useful zoom view.
+- **`wait_for_condition`** (v0.2) lets an agent write "watch for over-voltage" loops without polling.
+
+Build this surface and *copy it from yourself* when competitors catch up.
+
+### Resources (read-only, auto-updating)
+
+- `daqifi://devices` — current device list
+- `daqifi://devices/{id}/info` — device metadata
+- `daqifi://devices/{id}/channels` — channel configuration
+- `daqifi://streams/{id}/summary` — live stream summary, ~1 Hz refresh
+
+### Prompts (the "recipes")
+
+These ship with v0.1 and **are the marketing**. Each one becomes a YouTube demo and a README snippet.
+
+- `setup_thermocouple_sweep` — multi-channel temperature, sample rate, SD logging, threshold alerting
+- `battery_soak_test` — long-duration logging with hourly stat summaries
+- `vibration_capture_fft` — burst capture with frequency-domain analysis
+- `multi_channel_pressure_test` — the medical-R&D pattern called out in the README
+- `wifi_provision_new_device` — out-of-box onboarding via agent
+
+### Safety model
+
+Three server-launch modes plus a confirmation pattern:
+
+- `--mode=read-only` (default in CI/automated contexts)
+  - Allows: `discover_*`, `get_*`, `list_*`, `read_stream_*`
+  - Blocks: configuration changes, streaming start, destructive operations
+- `--mode=control` (default for interactive use)
+  - Adds: channel configuration, streaming, SD download, SD logging start/stop
+  - Blocks: firmware updates, WiFi reconfiguration, SD format, SD delete
+- `--mode=admin`
+  - Allows everything; destructive tools still require `confirmed: true` and return a human-readable preview before acting.
+
+Plus:
+
+- `--max-sample-rate-hz=…` clamps `set_sample_rate` requests
+- `--max-voltage-range=…` clamps `configure_analog_channel` requests
+- `--allow-raw-scpi` is off by default
+
+Bake this in for v0.1. It becomes a marketing point ("agent-safe by design") and it is much harder to retrofit after the first incident.
+
+### Distribution
+
+Three artifacts, one codebase, one CI job:
+
+1. **AOT binary** — `dotnet publish -p:PublishAot=true` per OS/arch, attached to GitHub releases. ~30 MB, no runtime required.
+2. **`dotnet tool`** — `dotnet tool install -g Daqifi.Mcp` for the .NET audience.
+3. **`npx` shim** — `npm i -g @daqifi/mcp` publishes a tiny Node wrapper that downloads the right binary on first run. This is what most agent UIs will use to launch the server.
+
+Python client (`pip install daqifi`) is a v0.3 deliverable, not v0.1.
+
+---
+
+## Phasing
+
+### v0.1 — "It works, end to end" (~4–6 weeks)
+
+Goal: a lab user can install the MCP, point Claude Desktop at it, and run a 4-channel sample-rate-1kHz test that logs to SD and gives them a sparkline. Ship as `0.1.0` and make some noise.
+
+Issues are enumerated in [`GITHUB_ISSUES.md`](GITHUB_ISSUES.md). Summary:
+
+1. Project scaffold + CI ([#mcp-1](GITHUB_ISSUES.md#mcp-1))
+2. Discovery & connection tools ([#mcp-2](GITHUB_ISSUES.md#mcp-2))
+3. Device introspection tools ([#mcp-3](GITHUB_ISSUES.md#mcp-3))
+4. Channel configuration tools ([#mcp-4](GITHUB_ISSUES.md#mcp-4))
+5. Streaming infrastructure: ring buffer, summarizer, window reader ([#mcp-5](GITHUB_ISSUES.md#mcp-5))
+6. Streaming tools: `start_streaming`, `stop_streaming`, `get_stream_summary`, `read_stream_window` ([#mcp-6](GITHUB_ISSUES.md#mcp-6))
+7. SD card tools (non-destructive) ([#mcp-7](GITHUB_ISSUES.md#mcp-7))
+8. Resources (`daqifi://`) ([#mcp-8](GITHUB_ISSUES.md#mcp-8))
+9. Safety model: modes, clamps, confirmation pattern ([#mcp-9](GITHUB_ISSUES.md#mcp-9))
+10. Prompts: 5 starter recipes ([#mcp-10](GITHUB_ISSUES.md#mcp-10))
+11. Distribution: AOT binary + `dotnet tool` + `npx` shim ([#mcp-11](GITHUB_ISSUES.md#mcp-11))
+12. Documentation: README rewrite + agent recipe guide ([#mcp-12](GITHUB_ISSUES.md#mcp-12))
+
+### v0.2 — Power features and gated ops (~3–4 weeks)
+
+- `wait_for_condition` (event-style waiting for agents)
+- Destructive SD ops (`delete_sd_file`, `format_sd_card`) behind admin mode
+- Network reconfiguration (`configure_wifi`, `configure_static_ip`)
+- Firmware update tools (`check_firmware_update`, `update_firmware`)
+- `send_scpi` escape hatch behind `--allow-raw-scpi`
+- HTTP transport for hosted use cases
+
+### v0.3+ — Ecosystem and platforms
+
+- Python client package (`pip install daqifi`) with both async API and MCP-over-IPC option
+- LangChain / LlamaIndex tool wrappers (auto-generated from the MCP surface)
+- Cloud deployment story for fleet monitoring
+- Agent-managed recipe library (saved configurations, parameterized)
+
+---
+
+## Marketing & launch plan
+
+The MCP is the wedge; the marketing is what turns the wedge into a position.
+
+### Pre-launch (during v0.1 build)
+
+- **Reposition `README.md`.** Hero is an agent demo, not a spec table. Specs go below the fold. ([#mcp-12](GITHUB_ISSUES.md#mcp-12))
+- **Record the 5 recipe demos** as the prompts land. Each demo is a ~60-second screen recording: prompt in, working test rig out.
+- **Reserve the position.** Land a placeholder page at the marketing site: "AI-native data acquisition. Coming soon." Capture emails.
+
+### Launch week
+
+- **Headline post**: *"I had Claude run a 3-day soak test on a benchtop DAQ from a single sentence."* Posted to Hacker News, r/labrats, r/embedded, r/electronics, Hackaday tip line. Include the prompt, the install command, the data plot, and a link to the recipe.
+- **Submit MCP to Anthropic's directory.**
+- **Publish LangChain and LlamaIndex tool wrappers** the same week — free distribution into adjacent ecosystems before competitors notice.
+
+### Post-launch (first 90 days)
+
+- **YouTube creator outreach.** Send units + a 10-minute scripted demo brief to 2–3 niche T&M creators. First-call list: Marco Reps, EEVblog, Applied Science, The Signal Path. Pitch: "10-minute test rig with an AI agent."
+- **Educator angle.** Reach out to 2–3 EE/ME department chairs with the LabVIEW-compatibility + SCPI + agent story. "Students can drive the lab bench from Claude." Quotable.
+- **Recipe library.** Publish 1 new recipe per week for the first 8 weeks. Each is a blog post, a YouTube short, and a saved prompt the MCP exposes.
+
+### What we do *not* do
+
+- We do not pre-announce. Ship first, talk second.
+- We do not chase enterprise. The wedge is greenfield labs, hobbyist-adjacent pros, and educators. Enterprise can come for v1.0.
+- We do not market on the SDK. The SDK is plumbing. The story is the workflow.
+
+---
+
+## Open questions
+
+These need a decision before or during v0.1. Each is a candidate for a thread on the RFC PR.
+
+1. **Buyer segmentation.** AI-native marketing pulls greenfield buyers. Migrators (existing LabVIEW shops) won't switch on the AI story alone. Do we accept that, or invest in migration tooling?
+2. **Pricing strategy.** Does the AI story support a higher ASP, a SaaS tier (managed recipes, hosted dashboard), or neither? This needs to be decided *before* the launch copy is written.
+3. **Agent action boundaries.** Is the default "control" mode the right safety posture, or do we ship "read-only" as default and require an opt-in flag for control? The conservative choice protects us from launch-week horror stories.
+4. **Telemetry.** Do we want anonymous usage telemetry from the MCP server to learn what agents actually call? If yes, opt-in only, and stated clearly in the README.
+5. **MCP stability contract.** What is our promise to users about tool name/schema stability? Suggest: tool *names* are stable from v0.1; tool *parameters* may add optional fields without notice; breaking changes bump major version.
+6. **LabVIEW interop.** Is there a story where the MCP can drive a LabVIEW VI as a tool call? Probably v0.3+, but flagging now because it could be a marketing weapon against NI.
+7. **Hosted recipe library vs. in-repo.** Recipes as MCP prompts ship in the binary. Do we also stand up a hosted directory where users contribute and rate recipes? Network effect potential, but support burden.
+8. **DAQiFi Desktop alignment.** Does Desktop adopt the MCP internally as its control layer, or stay separate? Adopting it would force a clean API and double as dogfooding, but adds scope.
+
+---
+
+## Appendix: complete tool reference
+
+### Discovery & connection
+
+| Tool | Inputs | Returns | Notes |
+|---|---|---|---|
+| `discover_devices` | `timeout_ms?: int=2000`, `transports?: ["wifi","serial"]` | `[{device_id, name, transport, address, serial_number, part_number, firmware_version}]` | Wraps `WiFiDeviceFinder` / `SerialDeviceFinder`. |
+| `connect_device` | `device_id: string` | `{device_id, status, capabilities}` | Wraps `ConnectFromDeviceInfoAsync()`. |
+| `disconnect_device` | `device_id: string` | `{ok: bool}` | |
+| `list_connected_devices` | — | `[{device_id, name, state, streaming: bool}]` | Cheap; agents call often. |
+
+### Device introspection
+
+| Tool | Inputs | Returns |
+|---|---|---|
+| `get_device_info` | `device_id` | `{part_number, firmware_version, channel_counts: {analog, digital}, resolution_bits, voltage_range, capabilities[]}` |
+| `get_device_status` | `device_id` | `{connection_state, streaming, sample_rate_hz, sd_logging, sd_free_bytes, channels_enabled[]}` |
+
+### Channel configuration
+
+| Tool | Inputs | Returns | Notes |
+|---|---|---|---|
+| `list_channels` | `device_id`, `kind?: "analog"\|"digital"` | `[{index, kind, label, enabled, range, direction}]` | |
+| `configure_analog_channel` | `device_id`, `channel: int`, `enabled: bool`, `range?: float`, `label?: string` | `{channel, applied}` | Wraps `IAnalogChannel`. |
+| `configure_digital_channel` | `device_id`, `channel: int`, `direction: "input"\|"output"`, `label?` | `{channel, applied}` | |
+| `set_sample_rate` | `device_id`, `rate_hz: int` | `{rate_hz, applied}` | Clamped to `--max-sample-rate-hz`. |
+
+### Streaming
+
+| Tool | Inputs | Returns | Notes |
+|---|---|---|---|
+| `start_streaming` | `device_id`, `duration_s?: int`, `ring_buffer_s?: int=60` | `{stream_id, started_at}` | Server owns ring buffer. |
+| `stop_streaming` | `stream_id` | `{stream_id, total_samples, duration_s}` | |
+| `get_stream_summary` | `stream_id`, `channels?: int[]`, `window_s?: float=5` | `{per_channel: [{channel, n, min, max, mean, rms, std, dominant_freq_hz, sparkline}]}` | The headline tool. |
+| `read_stream_window` | `stream_id`, `channels: int[]`, `start_s`, `end_s`, `max_points?: int=500` | `{channel, t[], v[], decimation_factor}` | Hard-capped; decimates server-side. |
+| `wait_for_condition` | `stream_id`, `channel`, `predicate: ">4.5"\|"<0"\|"abs>2"\|"rising_edge"`, `timeout_s` | `{matched: bool, t, v}` | **v0.2** |
+
+### SD card operations
+
+| Tool | Inputs | Returns | Destructive | v0.1? |
+|---|---|---|---|---|
+| `list_sd_files` | `device_id` | `[{name, size_bytes, modified}]` | no | yes |
+| `download_sd_file` | `device_id`, `remote_name`, `local_path?` | `{local_path, size_bytes, channels, duration_s, summary}` | no | yes |
+| `start_sd_logging` | `device_id`, `filename?` | `{filename}` | no | yes |
+| `stop_sd_logging` | `device_id` | `{filename, size_bytes}` | no | yes |
+| `delete_sd_file` | `device_id`, `remote_name`, `confirmed: bool` | `{ok}` | **yes** | v0.2 |
+| `format_sd_card` | `device_id`, `confirmed: bool` | `{ok}` | **yes** | v0.2 |
+
+### Network & firmware (gated, v0.2)
+
+| Tool | Inputs | Destructive |
+|---|---|---|
+| `configure_wifi` | `device_id`, `ssid`, `password`, `confirmed` | **yes** |
+| `configure_static_ip` | `device_id`, `ip`, `mask`, `gateway`, `confirmed` | **yes** |
+| `check_firmware_update` | `device_id` | no |
+| `update_firmware` | `device_id`, `target: "pic32"\|"wifi"`, `confirmed` | **yes** |
+
+### Escape hatch (v0.2, off by default)
+
+| Tool | Inputs | Notes |
+|---|---|---|
+| `send_scpi` | `device_id`, `command`, `expect_response?: bool` | Requires `--allow-raw-scpi`. |


### PR DESCRIPTION
## Summary

Proposes positioning DAQiFi as the **AI-native DAQ** by shipping a first-class MCP (Model Context Protocol) server for Nyquist devices. Lab researchers, test engineers, and educators would drive a device end-to-end through Claude, Cursor, Cline, or any MCP-aware agent — discovery, channel configuration, streaming, SD logging, alerts — without writing application code.

**The strategic bet:** every T&M competitor (NI, MCC, Dataq) will bolt LLM chat onto an aging GUI within 12 months. None can rewrite their core control surface to be agent-first without years of internal lift. DAQiFi has two SKUs, a clean cross-platform .NET SDK, and no installed-base baggage — we can ship in weeks and plant a flag in this position before it's contested.

## What's in this PR

Three documents under [`docs/planning/mcp/`](docs/planning/mcp/), mirroring the [`docs/archive/simulator/`](docs/archive/simulator/) planning convention:

- **[RFC.md](docs/planning/mcp/RFC.md)** — full proposal: motivation, stack decision rationale, architecture, MCP tool spec, safety model, distribution plan, phasing, launch plan, 8 open questions
- **[GITHUB_ISSUES.md](docs/planning/mcp/GITHUB_ISSUES.md)** — ready-to-paste issue drafts: 1 epic + 12 implementation issues for v0.1, each with task list, acceptance criteria, effort estimate, file paths, and dependencies. Total: ~66h / 4-6 weeks part-time. Includes a dependency graph.
- **[README.md](docs/planning/mcp/README.md)** — folder index with quick links into both docs

## Key decisions captured in the RFC

- **Stack:** stay in .NET, using the official `ModelContextProtocol` NuGet (co-maintained by Microsoft + Anthropic). `Daqifi.Core` is the asset — rewriting the wire protocol in Node or Python doubles maintenance forever. Distribution via AOT binary + `dotnet tool` + `npx` shim covers every audience without forking the protocol logic.
- **Differentiator:** LLM-safe streaming. Agents reason on per-channel summaries (min/max/RMS/dominant frequency + ASCII sparkline) instead of raw sample dumps. This is the part most product MCPs shipping today miss — and the part competitors will be slowest to copy.
- **Safety model:** three server modes (`read-only` / `control` / `admin`), parameter clamps for sample rate and voltage range, confirmation flags for destructive ops. ""Agent-safe by design"" doubles as marketing.
- **What ships in v0.1:** discovery + connection + channel config + LLM-safe streaming + non-destructive SD ops + 5 recipe prompts + safety model + distribution + README rewrite. Firmware updates, WiFi reconfig, raw SCPI, destructive SD ops all deferred to v0.2.

## Decisions that need an answer

Two of the [open questions](docs/planning/mcp/RFC.md#open-questions) in the RFC are blocking or near-blocking:

1. **Default safety mode** for the `npx @daqifi/mcp` distribution: ``read-only`` (safer; the launch demo doesn't work until users pass a flag) or ``control`` (works on first try; an agent could mis-configure on first contact). Blocks [#mcp-9](docs/planning/mcp/GITHUB_ISSUES.md#mcp-9-safety-model).
2. **Pricing strategy.** Does the AI story support a higher ASP or a SaaS tier (managed recipes, hosted dashboard)? Doesn't block code, but needs an answer before launch copy is written.

The other six open questions (buyer segmentation, telemetry, MCP stability contract, LabVIEW interop, hosted recipe library, Desktop alignment) are flagged for discussion but don't block v0.1.

## Test plan

This PR is documentation-only; nothing to run.

- [ ] Read [RFC.md](docs/planning/mcp/RFC.md) top-to-bottom
- [ ] Skim the 12 issue drafts; sanity-check they map to coherent units of work
- [ ] Answer the two blocking decisions above (inline comments work)
- [ ] Approve to create issues, or request changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)