### PR TITLE
fix(firmware): raise bootloader HID timeouts 10s to 30s (resolves daqifi-desktop#575)

### DIFF
--- a/src/Daqifi.Core/Communication/Transport/HidLibraryTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidLibraryTransport.cs
@@ -7,8 +7,13 @@ namespace Daqifi.Core.Communication.Transport;
 /// </summary>
 public sealed class HidLibraryTransport : IHidTransport
 {
-    private static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan DefaultWriteTimeout = TimeSpan.FromSeconds(10);
+    // 30 s (was 10 s): a late bootloader flash op can leave the device's HID
+    // endpoint busy/NAKing well past 10 s, which surfaced here as
+    // "IOException: HID write failed" mid-programming (daqifi-desktop #575).
+    // The old synchronous desktop flasher used unbounded blocking HID I/O and
+    // tolerated this; restore headroom so a single attempt waits the op out.
+    private static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultWriteTimeout = TimeSpan.FromSeconds(30);
 
     private readonly IHidPlatform _hidPlatform;
     private readonly SemaphoreSlim _connectionLock = new(1, 1);

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -59,8 +59,10 @@ public sealed class FirmwareUpdateServiceOptions
 
     /// <summary>
     /// Timeout used for individual bootloader read operations.
+    /// 30 s (was 10 s): a late bootloader flash op can keep the device busy
+    /// past 10 s, which timed out mid-programming (daqifi-desktop #575).
     /// </summary>
-    public TimeSpan BootloaderResponseTimeout { get; set; } = TimeSpan.FromSeconds(10);
+    public TimeSpan BootloaderResponseTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Delay after sending SCPI FORCEBOOT before disconnecting serial.


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Raise PIC32 bootloader HID timeouts to 30s to prevent mid-flash failures
<code>🐞 Bug fix</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Problem
In-app PIC32 firmware update intermittently fails mid-`Programming` with `System.IO.IOException: HID write failed` (daqifi/daqifi-desktop#575).

## Root cause (evidence)
- **USBPcap capture:** ~9,213 HID records program fine (~5 ms each), then one late HID **write** goes ~10 s without the device accepting it — twice (the two `ExecuteWithRetryAsync` attempts) — then gives up. No USB STALL; device stays enumerated.
- **Bootloader exonerated:** unchanged since 2024-11, and **desktop v3.0.0 flashes the same firmware fine**. v3.0.0's old flasher (`Daqifi.Desktop.Bootloader.Pic32Bootloader`, pre-#379) used unbounded blocking HID I/O (`WriteReport`/`FastReadReport`), so a late bootloader flash op keeping the endpoint busy >10 s was simply waited out. The new async transport caps each op at 10 s and fails.
- Protocol, CRC-16 framing, and protected-range record filtering are identical old-vs-new — the only material difference is the per-op timeout.

## Fix
Raise bootloader HID timeouts 10 s to 30 s so a single attempt waits the op out:
- `FirmwareUpdateServiceOptions.BootloaderResponseTimeout` 10 to 30 s (ack read)
- `HidLibraryTransport.Default{Read,Write}Timeout` 10 to 30 s (the write is what fired)

Overall `ProgrammingTimeout` stays 10 min. Builds clean; no test asserts the literal 10 s default.

## Verification
Hardware-tested: with the 30 s timeouts the in-app PIC32 update completes (no mid-`Programming` HID-write timeout).

## Follow-up
If a future op exceeds 30 s, the more robust fix is matching the old synchronous lock-step (wait per record; avoid cancel+retry mid-op) rather than only widening the window.

Resolves daqifi/daqifi-desktop#575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Increase bootloader HID read/write defaults from 10s to 30s to avoid intermittent timeouts.
• Raise per-bootloader response timeout to 30s while keeping overall programming timeout unchanged.
• Document rationale and link to daqifi-desktop#575 for future troubleshooting.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["FirmwareUpdateService"] --> B["Update options"]
  A --> C["IHidTransport"] --> D["HidLibraryTransport"] --> E["HidSharp HID I/O"] --> F{{"PIC32 bootloader"}}
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Adaptive per-op timeout/backoff</b></summary>

- ➕ Wait longer only when the device shows slow responses
- ➕ Reduces worst-case latency impact in normal cases
- ➖ More complex state/telemetry to decide when to extend
- ➖ Harder to validate across platforms/devices

</details>

<details>
<summary><b>2. Restore synchronous lock-step flash loop</b></summary>

- ➕ Closest to behavior of the known-good v3.0.0 flasher
- ➕ Avoids cancel/retry races mid-HID operation
- ➖ Larger refactor; higher risk and longer review
- ➖ Potentially blocks threads unless carefully implemented

</details>

<details>
<summary><b>3. Expose timeouts as app-level configuration</b></summary>

- ➕ Allows field tuning without shipping new binaries
- ➕ Lets power users/workflows set device-specific values
- ➖ Adds configuration surface area and support burden
- ➖ Still needs sane defaults; doesn’t fix root behavior alone

</details>

**Recommendation:** Raising the defaults to 30s is the lowest-risk fix aligned with the reported USBPcap evidence and preserves the existing 10-minute overall ProgrammingTimeout. Consider follow-up work if failures persist: either reintroduce a synchronous/lock-step flashing strategy (to avoid cancel+retry mid-op) or add an adaptive/backoff timeout policy.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>HidLibraryTransport.cs</strong> <code>Increase default HID read/write timeouts to 30 seconds</code> <code>+7/-2</code></summary>

<br/>

>Increase default HID read/write timeouts to 30 seconds
>
><pre>
>• Raises the transport’s DefaultReadTimeout and DefaultWriteTimeout from 10s to 30s. Adds context comments tying the longer window to intermittent mid-programming HID write failures during PIC32 bootloader flashing (daqifi-desktop#575).
></pre>
>
><a href='https://github.com/daqifi/daqifi-core/pull/235/files#diff-3f46e51b1cf69a5a2d5d472f2b2c77e4ebe963bbecede722227f4df868f29709'>src/Daqifi.Core/Communication/Transport/HidLibraryTransport.cs</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>FirmwareUpdateServiceOptions.cs</strong> <code>Raise default bootloader response timeout to 30 seconds</code> <code>+3/-1</code></summary>

<br/>

>Raise default bootloader response timeout to 30 seconds
>
><pre>
>• Updates FirmwareUpdateServiceOptions.BootloaderResponseTimeout default from 10s to 30s and documents the bootloader busy/NAK rationale. Leaves the higher-level per-state timeouts (e.g., ProgrammingTimeout) unchanged.
></pre>
>
><a href='https://github.com/daqifi/daqifi-core/pull/235/files#diff-065563771c9b2c3d422efb108b97f0e702d0b643d628b58054be85f94335ccf6'>src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>