### PR TITLE
fix: use device-reported timestamp_freq in TimestampProcessor

### DIFF
--- a/src/Daqifi.Core.Tests/Device/TimestampProcessorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/TimestampProcessorTests.cs
@@ -445,6 +445,175 @@ public class TimestampProcessorTests
 
     #endregion
 
+    #region Device Timestamp Frequency Tests
+
+    [Fact]
+    public void DefaultTimestampFrequency_MatchesDefaultTickPeriod()
+    {
+        Assert.Equal(TimestampProcessor.DefaultTickPeriod, 1.0 / TimestampProcessor.DefaultTimestampFrequency);
+    }
+
+    [Fact]
+    public void SetTimestampFrequency_NonDefaultFrequency_ScalesElapsedTimeCorrectly()
+    {
+        // Arrange - a device whose timestamp timer runs at 10MHz instead of 50MHz
+        var processor = new TimestampProcessor();
+        const uint deviceFrequency = 10_000_000;
+        processor.SetTimestampFrequency(TestDeviceId, deviceFrequency);
+
+        // Act - 10 million cycles at 10MHz = exactly 1 second
+        processor.ProcessTimestamp(TestDeviceId, 0);
+        var result = processor.ProcessTimestamp(TestDeviceId, deviceFrequency);
+
+        // Assert - at the hardcoded 50MHz default this would (incorrectly) be 0.2 seconds
+        Assert.Equal(1.0, result.SecondsBetweenMessages, precision: 6);
+    }
+
+    [Fact]
+    public void SetTimestampFrequency_ZeroFrequency_RevertsToFallbackTickPeriod()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+        processor.SetTimestampFrequency(TestDeviceId, 10_000_000);
+
+        // Act - zero means unknown/unreported (e.g., older firmware)
+        processor.SetTimestampFrequency(TestDeviceId, 0);
+
+        // Assert
+        Assert.Equal(TimestampProcessor.DefaultTickPeriod, processor.GetTickPeriod(TestDeviceId));
+    }
+
+    [Fact]
+    public void GetTickPeriod_NoFrequencySet_ReturnsFallbackTickPeriod()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+
+        // Act & Assert
+        Assert.Equal(processor.TickPeriod, processor.GetTickPeriod(TestDeviceId));
+    }
+
+    [Fact]
+    public void GetTickPeriod_FrequencySet_ReturnsReciprocalOfFrequency()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+        const uint deviceFrequency = 10_000_000;
+
+        // Act
+        processor.SetTimestampFrequency(TestDeviceId, deviceFrequency);
+
+        // Assert
+        Assert.Equal(1.0 / deviceFrequency, processor.GetTickPeriod(TestDeviceId));
+    }
+
+    [Fact]
+    public void SetTimestampFrequency_OnlyAffectsSpecifiedDevice()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+        const string device1 = "device-001";
+        const string device2 = "device-002";
+
+        // Act - device1 runs at 1MHz, device2 stays at the 50MHz default
+        processor.SetTimestampFrequency(device1, 1_000_000);
+
+        processor.ProcessTimestamp(device1, 0);
+        processor.ProcessTimestamp(device2, 0);
+        var result1 = processor.ProcessTimestamp(device1, 1_000_000);
+        var result2 = processor.ProcessTimestamp(device2, 1_000_000);
+
+        // Assert
+        Assert.Equal(1.0, result1.SecondsBetweenMessages, precision: 6);
+        Assert.Equal(1_000_000 * TimestampProcessor.DefaultTickPeriod, result2.SecondsBetweenMessages, precision: 6);
+    }
+
+    [Fact]
+    public void SetTimestampFrequency_MidStream_AppliesToSubsequentMessages()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+        processor.ProcessTimestamp(TestDeviceId, 0);
+        var beforeResult = processor.ProcessTimestamp(TestDeviceId, 1_000_000);
+
+        // Act - frequency arrives (e.g., system info response parsed after first messages)
+        processor.SetTimestampFrequency(TestDeviceId, 1_000_000);
+        var afterResult = processor.ProcessTimestamp(TestDeviceId, 2_000_000);
+
+        // Assert
+        Assert.Equal(1_000_000 * TimestampProcessor.DefaultTickPeriod, beforeResult.SecondsBetweenMessages, precision: 6);
+        Assert.Equal(1.0, afterResult.SecondsBetweenMessages, precision: 6);
+    }
+
+    [Fact]
+    public void SetTimestampFrequency_Rollover_UsesDeviceTickPeriod()
+    {
+        // Arrange - 10MHz device
+        var processor = new TimestampProcessor();
+        processor.SetTimestampFrequency(TestDeviceId, 10_000_000);
+        const uint nearMax = uint.MaxValue - 5_000_000; // 0.5 seconds before max at 10MHz
+        const uint afterRollover = 5_000_000; // 0.5 seconds after rollover at 10MHz
+
+        // Act
+        processor.ProcessTimestamp(TestDeviceId, nearMax);
+        var result = processor.ProcessTimestamp(TestDeviceId, afterRollover);
+
+        // Assert - ~1 second total at 10MHz (would be ~0.2 seconds at the 50MHz default)
+        Assert.True(result.WasRollover);
+        Assert.InRange(result.SecondsBetweenMessages, 0.9, 1.1);
+    }
+
+    [Fact]
+    public void Reset_PreservesDeviceTimestampFrequency()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+        processor.SetTimestampFrequency(TestDeviceId, 10_000_000);
+        processor.ProcessTimestamp(TestDeviceId, 1000);
+
+        // Act - new streaming session; the device's clock frequency hasn't changed
+        processor.Reset(TestDeviceId);
+
+        // Assert
+        Assert.Equal(1.0 / 10_000_000, processor.GetTickPeriod(TestDeviceId));
+    }
+
+    [Fact]
+    public void ResetAll_ClearsDeviceTimestampFrequencies()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+        processor.SetTimestampFrequency(TestDeviceId, 10_000_000);
+
+        // Act
+        processor.ResetAll();
+
+        // Assert
+        Assert.Equal(TimestampProcessor.DefaultTickPeriod, processor.GetTickPeriod(TestDeviceId));
+    }
+
+    [Fact]
+    public void SetTimestampFrequency_NullDeviceId_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => processor.SetTimestampFrequency(null!, 50_000_000));
+    }
+
+    [Fact]
+    public void GetTickPeriod_NullDeviceId_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var processor = new TimestampProcessor();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => processor.GetTickPeriod(null!));
+    }
+
+    #endregion
+
     #region Edge Case Tests
 
     [Fact]

--- a/src/Daqifi.Core/Device/ITimestampProcessor.cs
+++ b/src/Daqifi.Core/Device/ITimestampProcessor.cs
@@ -9,9 +9,33 @@ namespace Daqifi.Core.Device;
 public interface ITimestampProcessor
 {
     /// <summary>
-    /// Gets the tick period in seconds. The default is 20 nanoseconds (20E-9).
+    /// Gets the fallback tick period in seconds, used for devices that have no
+    /// device-specific frequency set via <see cref="SetTimestampFrequency"/>.
+    /// The default is 20 nanoseconds (20E-9), corresponding to a 50MHz clock.
     /// </summary>
     double TickPeriod { get; }
+
+    /// <summary>
+    /// Sets the timestamp clock frequency for a specific device, as reported by the
+    /// device (e.g., the <c>timestamp_freq</c> field of the protobuf system info message).
+    /// Subsequent <see cref="ProcessTimestamp"/> calls for that device use a tick period
+    /// of <c>1 / frequencyHz</c> seconds.
+    /// </summary>
+    /// <param name="deviceId">Unique identifier for the device (e.g., serial number).</param>
+    /// <param name="frequencyHz">
+    /// The timestamp clock frequency in Hz. A value of zero clears any device-specific
+    /// frequency and reverts the device to the fallback <see cref="TickPeriod"/>.
+    /// </param>
+    void SetTimestampFrequency(string deviceId, uint frequencyHz);
+
+    /// <summary>
+    /// Gets the effective tick period in seconds for a specific device.
+    /// Returns the device-specific tick period if a frequency has been set via
+    /// <see cref="SetTimestampFrequency"/>; otherwise returns the fallback <see cref="TickPeriod"/>.
+    /// </summary>
+    /// <param name="deviceId">Unique identifier for the device (e.g., serial number).</param>
+    /// <returns>The tick period in seconds used for the device's timestamp calculations.</returns>
+    double GetTickPeriod(string deviceId);
 
     /// <summary>
     /// Processes a device timestamp and returns the calculated system timestamp.
@@ -26,12 +50,16 @@ public interface ITimestampProcessor
     /// <summary>
     /// Resets the timestamp state for a specific device.
     /// Call this when starting a new streaming session.
+    /// Any device-specific frequency set via <see cref="SetTimestampFrequency"/> is preserved,
+    /// since the timestamp clock frequency is static device configuration that does not
+    /// change between streaming sessions.
     /// </summary>
     /// <param name="deviceId">Unique identifier for the device to reset.</param>
     void Reset(string deviceId);
 
     /// <summary>
-    /// Resets all timestamp state for all devices.
+    /// Resets all timestamp state for all devices, including any device-specific
+    /// frequencies set via <see cref="SetTimestampFrequency"/>.
     /// Call this when the processor should be completely cleared.
     /// </summary>
     void ResetAll();

--- a/src/Daqifi.Core/Device/TimestampProcessor.cs
+++ b/src/Daqifi.Core/Device/TimestampProcessor.cs
@@ -14,6 +14,13 @@ namespace Daqifi.Core.Device;
 /// This processor detects rollover and calculates accurate elapsed time.
 /// </para>
 /// <para>
+/// The tick period defaults to 20ns (50MHz) but should be set per device from the
+/// device-reported timestamp frequency (the <c>timestamp_freq</c> field of the protobuf
+/// system info message, surfaced as <see cref="DaqifiDevice.TimestampFrequency"/>) via
+/// <see cref="SetTimestampFrequency"/>. Devices without a configured frequency fall back
+/// to the processor-wide <see cref="TickPeriod"/>.
+/// </para>
+/// <para>
 /// A 10-second sanity check is applied to detected rollovers. If the calculated
 /// time between messages exceeds 10 seconds after rollover correction, the rollover
 /// is considered a false positive (likely caused by out-of-order messages).
@@ -31,6 +38,12 @@ public sealed class TimestampProcessor : ITimestampProcessor
     public const double DefaultTickPeriod = 20E-9;
 
     /// <summary>
+    /// Default timestamp clock frequency in Hz (50MHz), corresponding to
+    /// <see cref="DefaultTickPeriod"/>.
+    /// </summary>
+    public const uint DefaultTimestampFrequency = 50_000_000;
+
+    /// <summary>
     /// Maximum time in seconds between messages before a rollover is considered invalid.
     /// If a detected rollover would result in more than this time between messages,
     /// the rollover is treated as a false positive.
@@ -38,6 +51,7 @@ public sealed class TimestampProcessor : ITimestampProcessor
     private const double MaxRolloverTimeBetweenMessages = 10.0;
 
     private readonly ConcurrentDictionary<string, DeviceTimestampState> _deviceStates = new();
+    private readonly ConcurrentDictionary<string, double> _deviceTickPeriods = new();
 
     /// <inheritdoc />
     public double TickPeriod { get; }
@@ -69,10 +83,34 @@ public sealed class TimestampProcessor : ITimestampProcessor
     }
 
     /// <inheritdoc />
+    public void SetTimestampFrequency(string deviceId, uint frequencyHz)
+    {
+        ArgumentNullException.ThrowIfNull(deviceId);
+
+        if (frequencyHz == 0)
+        {
+            // Unknown/unreported frequency (e.g., older firmware): revert to the fallback tick period
+            _deviceTickPeriods.TryRemove(deviceId, out _);
+            return;
+        }
+
+        _deviceTickPeriods[deviceId] = 1.0 / frequencyHz;
+    }
+
+    /// <inheritdoc />
+    public double GetTickPeriod(string deviceId)
+    {
+        ArgumentNullException.ThrowIfNull(deviceId);
+
+        return _deviceTickPeriods.TryGetValue(deviceId, out var tickPeriod) ? tickPeriod : TickPeriod;
+    }
+
+    /// <inheritdoc />
     public TimestampResult ProcessTimestamp(string deviceId, uint deviceTimestamp)
     {
         ArgumentNullException.ThrowIfNull(deviceId);
 
+        var tickPeriod = GetTickPeriod(deviceId);
         var state = _deviceStates.GetOrAdd(deviceId, _ => new DeviceTimestampState());
 
         lock (state.SyncLock)
@@ -104,7 +142,7 @@ public sealed class TimestampProcessor : ITimestampProcessor
                 clockCyclesBetweenMessages = deviceTimestamp - previousDeviceTimestamp;
             }
 
-            var secondsBetweenMessages = clockCyclesBetweenMessages * TickPeriod;
+            var secondsBetweenMessages = clockCyclesBetweenMessages * tickPeriod;
 
             // Apply sanity check for false positive rollover detection
             // If we detected rollover but the time between messages is > 10 seconds,
@@ -113,7 +151,7 @@ public sealed class TimestampProcessor : ITimestampProcessor
             {
                 // Recalculate as if no rollover occurred (going backwards in time)
                 clockCyclesBetweenMessages = previousDeviceTimestamp - deviceTimestamp;
-                secondsBetweenMessages = clockCyclesBetweenMessages * TickPeriod * -1;
+                secondsBetweenMessages = clockCyclesBetweenMessages * tickPeriod * -1;
             }
 
             var messageTimestamp = state.PreviousSystemTimestamp.AddSeconds(secondsBetweenMessages);
@@ -142,6 +180,7 @@ public sealed class TimestampProcessor : ITimestampProcessor
     public void ResetAll()
     {
         _deviceStates.Clear();
+        _deviceTickPeriods.Clear();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #234.

`TimestampProcessor` converted clock-cycle deltas with a hardcoded 20 ns tick period (50 MHz), ignoring the `timestamp_freq` the device advertises in its protobuf system info message (`SYST:SYSInfoPB?`). Any device whose timestamp timer does not run at exactly 50 MHz got a time axis scaled by `actualFreq / 50 MHz`.

This implements option 2 from the issue: since the processor is already multi-device (keyed by `deviceId`), the tick period is now configurable per device.

## Changes

- **`ITimestampProcessor.SetTimestampFrequency(deviceId, frequencyHz)`** — sets the per-device tick period to `1 / frequencyHz`. Callers route `DaqifiDevice.TimestampFrequency` (parsed from the system info message) here. Passing `0` (unknown/older firmware) clears the override and reverts to the fallback tick period, per the issue's guard requirement.
- **`ITimestampProcessor.GetTickPeriod(deviceId)`** — returns the effective tick period for a device (override if set, else the processor-wide fallback `TickPeriod`).
- **`ProcessTimestamp`** now uses the per-device tick period for elapsed-time math and the rollover sanity check.
- **`Reset(deviceId)` preserves** the configured frequency — it is static device configuration that does not change between streaming sessions, and silently reverting to 50 MHz on session reset would reintroduce the bug mid-app. **`ResetAll()` clears** frequencies, matching its "completely cleared" contract.
- **`TimestampProcessor.DefaultTimestampFrequency`** (50 MHz) constant added alongside `DefaultTickPeriod`.
- The existing constructors (default 20 ns, or custom tick period) are unchanged, so current consumers (e.g. daqifi-desktop constructing `new TimestampProcessor()`) keep working and can adopt the new API with one call after device info arrives.

## Acceptance criteria from #234

- [x] When the device advertises `timestamp_freq = F`, elapsed-time math uses `1/F` as the tick period — `SetTimestampFrequency_NonDefaultFrequency_ScalesElapsedTimeCorrectly` and others
- [x] Unknown/zero `timestamp_freq` falls back to the documented 50 MHz default — `SetTimestampFrequency_ZeroFrequency_RevertsToFallbackTickPeriod`
- [x] Unit test covers a non-50 MHz frequency producing correctly-scaled deltas (10 MHz and 1 MHz cases, including rollover and mid-stream frequency arrival)

## Testing

- Full test suite: **1007 passed** on net9.0 and net10.0 (12 new tests).
- **Real hardware (Nyquist on USB/COM3, Windows):** connected via `DaqifiDeviceFactory.ConnectSerialAsync`, device reported `timestamp_freq = 50000000`; routed it through `SetTimestampFrequency` and streamed 100 messages at 10 Hz for 10 s:
  - Steady-state processor elapsed time tracked wall clock within **0.01%** (9.800 s vs 9.801 s).
  - A second processor configured at half the device frequency scaled the same raw deltas by exactly **2.00x**, confirming the per-device tick period drives the conversion.
  - Note: the first stream message after `StartStreaming` carried a stale buffered timestamp; the existing 10 s sanity check neutralized it. That is the separate buffer/anchor issue tracked in daqifi/daqifi-desktop#573, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
