### PR TITLE
fix: surface typed exception when serial port closes mid-operation (#238)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
@@ -54,6 +54,31 @@ public class SerialStreamTransportTests
     }
 
     [Fact]
+    public void SerialStreamTransport_SetSerialPortForTesting_TakesOwnershipAndDisposesPreviousPort()
+    {
+        // The seam documents that the transport takes ownership: a previously held port is
+        // disposed when replaced or cleared (qodo #240 review). Exercise every branch.
+        using var transport = new SerialStreamTransport("COM1");
+        var first = new DisposalTrackingSerialPort();
+        var second = new DisposalTrackingSerialPort();
+
+        transport.SetSerialPortForTesting(first);
+
+        // Re-assigning the same instance is a no-op and must NOT dispose it.
+        transport.SetSerialPortForTesting(first);
+        Assert.False(first.IsDisposed);
+
+        // Swapping in a different instance disposes the previous one.
+        transport.SetSerialPortForTesting(second);
+        Assert.True(first.IsDisposed);
+        Assert.False(second.IsDisposed);
+
+        // Clearing disposes the current one.
+        transport.SetSerialPortForTesting(null);
+        Assert.True(second.IsDisposed);
+    }
+
+    [Fact]
     public void SerialStreamTransport_Stream_WhenPortClosedMidOperation_ThrowsTypedException_NotRawBaseStreamMessage()
     {
         // Arrange - simulate the issue #238 scenario: the port is non-null but closed
@@ -212,9 +237,24 @@ public class SerialStreamTransportTests
         Assert.True(connectedArgs.IsConnected);
         
         await transport.DisconnectAsync();
-        
+
         Assert.False(transport.IsConnected);
         Assert.NotNull(disconnectedArgs);
         Assert.False(disconnectedArgs.IsConnected);
+    }
+
+    /// <summary>
+    /// A <see cref="SerialPort"/> that records whether it has been disposed, so tests can assert
+    /// the transport's ownership/disposal contract. Never opened.
+    /// </summary>
+    private sealed class DisposalTrackingSerialPort : SerialPort
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
@@ -34,9 +34,44 @@ public class SerialStreamTransportTests
     {
         // Arrange
         using var transport = new SerialStreamTransport("COM1");
-        
-        // Act & Assert
-        Assert.Throws<InvalidOperationException>(() => transport.Stream);
+
+        // Act & Assert - ThrowsAny (assignability), mirroring how a consumer's
+        // catch (InvalidOperationException) still catches the now-derived typed exception.
+        Assert.ThrowsAny<InvalidOperationException>(() => transport.Stream);
+    }
+
+    [Fact]
+    public void SerialStreamTransport_Stream_WhenNotConnected_ThrowsTransportNotConnectedException()
+    {
+        // Arrange - never connected: _serialPort is null
+        using var transport = new SerialStreamTransport("COM1");
+
+        // Act & Assert - the typed exception, which is still an InvalidOperationException
+        // so existing broad catches keep working.
+        var ex = Assert.Throws<TransportNotConnectedException>(() => transport.Stream);
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
+        Assert.Contains("COM1", ex.Message);
+    }
+
+    [Fact]
+    public void SerialStreamTransport_Stream_WhenPortClosedMidOperation_ThrowsTypedException_NotRawBaseStreamMessage()
+    {
+        // Arrange - simulate the issue #238 scenario: the port is non-null but closed
+        // (device unplugged, or a DTR-triggered MCU reset re-enumerated the COM port
+        // mid-connect). A constructed-but-unopened SerialPort reports IsOpen == false and
+        // its BaseStream getter throws the raw framework message we must NOT leak.
+        using var transport = new SerialStreamTransport("COM1");
+        transport.SetSerialPortForTesting(new SerialPort("COM1"));
+
+        // IsConnected must reflect the closed-port state so callers can pre-check.
+        Assert.False(transport.IsConnected);
+
+        // Act & Assert - the guard surfaces the typed exception before BaseStream is touched.
+        var ex = Assert.Throws<TransportNotConnectedException>(() => transport.Stream);
+
+        // The message must name the transport state, not the raw framework message.
+        Assert.DoesNotContain("BaseStream is only available", ex.Message);
+        Assert.Contains("not connected", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Communication/Transport/TcpStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/TcpStreamTransportTests.cs
@@ -35,9 +35,22 @@ public class TcpStreamTransportTests
     {
         // Arrange
         using var transport = new TcpStreamTransport(IPAddress.Loopback, 5000);
-        
-        // Act & Assert
-        Assert.Throws<InvalidOperationException>(() => transport.Stream);
+
+        // Act & Assert - ThrowsAny (assignability), mirroring how a consumer's
+        // catch (InvalidOperationException) still catches the now-derived typed exception.
+        Assert.ThrowsAny<InvalidOperationException>(() => transport.Stream);
+    }
+
+    [Fact]
+    public void TcpStreamTransport_Stream_WhenNotConnected_ThrowsTransportNotConnectedException()
+    {
+        // Arrange
+        using var transport = new TcpStreamTransport(IPAddress.Loopback, 5000);
+
+        // Act & Assert - the typed exception (uniform with the serial transport), which is
+        // still an InvalidOperationException so existing broad catches keep working.
+        var ex = Assert.Throws<TransportNotConnectedException>(() => transport.Stream);
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceWithTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceWithTransportTests.cs
@@ -144,6 +144,15 @@ public class DaqifiDeviceWithTransportTests
             StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, "Connection lost"));
         }
 
+        // Test helper: simulate a *silent* drop — the underlying transport closes without
+        // raising a status event, mirroring a serial port closed by an unplug or a
+        // DTR-triggered MCU reset mid-connect. The owning device keeps reporting Connected
+        // because it never received a StatusChanged(false) (issue #238).
+        public void SimulateSilentConnectionLoss()
+        {
+            _isConnected = false;
+        }
+
         public void Dispose()
         {
             if (!_disposed)
@@ -209,6 +218,33 @@ public class DaqifiDeviceWithTransportTests
         Assert.DoesNotContain(ConnectionStatus.Lost, statusChanges);
         Assert.Contains(ConnectionStatus.Disconnected, statusChanges);
         Assert.Equal(ConnectionStatus.Disconnected, device.Status);
+    }
+
+    [Fact]
+    public async Task DaqifiDevice_ExecuteTextCommand_WhenTransportDroppedSilently_ThrowsTransportNotConnectedException()
+    {
+        // Arrange — the device believes it is still Connected (no StatusChanged was fired),
+        // but the underlying transport has silently dropped: the serial analog is a port closed
+        // by an unplug or a DTR-triggered MCU reset mid-connect, which raises no status event.
+        using var transport = new MockStreamTransport();
+        using var device = new DaqifiDevice("Mock Device", transport);
+        device.Connect();
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+
+        transport.SimulateSilentConnectionLoss();
+
+        // Device still reports Connected (status-based), but the transport does not.
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+        Assert.False(transport.IsConnected);
+
+        // Act & Assert — InitializeAsync drives ExecuteTextCommandCoreAsync, which must surface
+        // the typed transport-disconnected exception (still an InvalidOperationException for
+        // backward compatibility) rather than dereferencing Stream and leaking a raw framework
+        // message (issue #238).
+        var ex = await Assert.ThrowsAsync<TransportNotConnectedException>(
+            () => device.InitializeAsync());
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
+        Assert.Equal(DeviceState.Error, device.State);
     }
 
     [Fact]

--- a/src/Daqifi.Core/Communication/Transport/IStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/IStreamTransport.cs
@@ -10,6 +10,10 @@ public interface IStreamTransport : IDisposable
     /// <summary>
     /// Gets the underlying stream for read/write operations.
     /// </summary>
+    /// <exception cref="TransportNotConnectedException">
+    /// Thrown when the transport is not connected (e.g. never connected, or the underlying
+    /// connection was closed or dropped).
+    /// </exception>
     Stream Stream { get; }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -45,11 +45,19 @@ public class SerialStreamTransport : IStreamTransport
     /// Test seam: injects the underlying <see cref="SerialPort"/> so the closed-port
     /// stream-access path (issue #238) can be exercised without real hardware — e.g. by
     /// passing a constructed-but-unopened port whose <see cref="SerialPort.IsOpen"/> is
-    /// <c>false</c>. The transport takes ownership and disposes it. Never used in production.
+    /// <c>false</c>. The transport takes ownership: any previously held port is disposed when
+    /// replaced or cleared, and the current port is disposed on <see cref="Dispose"/>. Never
+    /// used in production.
     /// </summary>
     /// <param name="serialPort">The serial port to use, or <c>null</c> to clear it.</param>
     internal void SetSerialPortForTesting(SerialPort? serialPort)
     {
+        if (ReferenceEquals(_serialPort, serialPort))
+        {
+            return;
+        }
+
+        _serialPort?.Dispose();
         _serialPort = serialPort;
     }
 
@@ -67,6 +75,12 @@ public class SerialStreamTransport : IStreamTransport
         {
             ThrowIfDisposed();
 
+            // Capture the field into a local so the check-then-access below is stable: a
+            // concurrent Disconnect()/Dispose() nulls _serialPort in a finally with no
+            // synchronization, which would otherwise turn the BaseStream dereference into a
+            // NullReferenceException instead of the intended typed signal.
+            var port = _serialPort;
+
             // Guard on IsOpen (not just non-null) before touching BaseStream. When the port is
             // non-null but closed — the device was unplugged, or a DTR-triggered MCU reset
             // re-enumerated the COM port mid-connect — SerialPort.BaseStream's getter itself
@@ -74,13 +88,26 @@ public class SerialStreamTransport : IStreamTransport
             // port is open.") that reads like an app bug. Surface a typed, transport-state
             // exception instead so consumers can classify a dropped transport as a transient,
             // environmental condition (issue #238; serial analog of #237).
-            if (_serialPort?.IsOpen != true)
+            if (port?.IsOpen != true)
             {
                 throw new TransportNotConnectedException(
                     $"Serial transport is not connected ({_portName}).");
             }
 
-            return _serialPort.BaseStream;
+            try
+            {
+                return port.BaseStream;
+            }
+            catch (InvalidOperationException ex)
+            {
+                // The port can close between the IsOpen check above and this getter — the exact
+                // unplug / DTR-reset race #238 is about. SerialPort.BaseStream's only
+                // InvalidOperationException is the "only available when the port is open" case,
+                // so translate it to the typed signal (preserving the original as InnerException)
+                // rather than leaking the raw framework message.
+                throw new TransportNotConnectedException(
+                    $"Serial transport is not connected ({_portName}).", ex);
+            }
         }
     }
 

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -42,15 +42,45 @@ public class SerialStreamTransport : IStreamTransport
     }
 
     /// <summary>
+    /// Test seam: injects the underlying <see cref="SerialPort"/> so the closed-port
+    /// stream-access path (issue #238) can be exercised without real hardware — e.g. by
+    /// passing a constructed-but-unopened port whose <see cref="SerialPort.IsOpen"/> is
+    /// <c>false</c>. The transport takes ownership and disposes it. Never used in production.
+    /// </summary>
+    /// <param name="serialPort">The serial port to use, or <c>null</c> to clear it.</param>
+    internal void SetSerialPortForTesting(SerialPort? serialPort)
+    {
+        _serialPort = serialPort;
+    }
+
+    /// <summary>
     /// Gets the underlying stream for read/write operations.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when not connected.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the transport has been disposed.</exception>
+    /// <exception cref="TransportNotConnectedException">
+    /// Thrown when the serial port is not open — either never connected, or closed mid-operation
+    /// by a device unplug or a DTR-triggered MCU reset that re-enumerated the COM port.
+    /// </exception>
     public Stream Stream
     {
         get
         {
             ThrowIfDisposed();
-            return _serialPort?.BaseStream ?? throw new InvalidOperationException("Transport is not connected.");
+
+            // Guard on IsOpen (not just non-null) before touching BaseStream. When the port is
+            // non-null but closed — the device was unplugged, or a DTR-triggered MCU reset
+            // re-enumerated the COM port mid-connect — SerialPort.BaseStream's getter itself
+            // throws a raw InvalidOperationException ("The BaseStream is only available when the
+            // port is open.") that reads like an app bug. Surface a typed, transport-state
+            // exception instead so consumers can classify a dropped transport as a transient,
+            // environmental condition (issue #238; serial analog of #237).
+            if (_serialPort?.IsOpen != true)
+            {
+                throw new TransportNotConnectedException(
+                    $"Serial transport is not connected ({_portName}).");
+            }
+
+            return _serialPort.BaseStream;
         }
     }
 

--- a/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
@@ -77,13 +77,18 @@ public class TcpStreamTransport : IStreamTransport
     /// <summary>
     /// Gets the underlying stream for read/write operations.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when not connected.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the transport has been disposed.</exception>
+    /// <exception cref="TransportNotConnectedException">
+    /// Thrown when the TCP connection has not been established or has dropped.
+    /// </exception>
     public Stream Stream
     {
         get
         {
             ThrowIfDisposed();
-            return _networkStream ?? throw new InvalidOperationException("Transport is not connected.");
+            // Surface the same typed exception as the serial transport so consumers can
+            // classify a not-connected transport uniformly across transport types (issue #238).
+            return _networkStream ?? throw new TransportNotConnectedException("TCP transport is not connected.");
         }
     }
 

--- a/src/Daqifi.Core/Communication/Transport/TransportNotConnectedException.cs
+++ b/src/Daqifi.Core/Communication/Transport/TransportNotConnectedException.cs
@@ -1,0 +1,58 @@
+namespace Daqifi.Core.Communication.Transport;
+
+/// <summary>
+/// Thrown when a transport operation requires an active connection but the underlying
+/// transport is not connected — for example, accessing <see cref="IStreamTransport.Stream"/>
+/// after the serial port was closed by a device unplug or a DTR-triggered MCU reset that
+/// re-enumerated the COM port mid-connect, or when a TCP connection was never established or
+/// has since dropped.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Derives from <see cref="InvalidOperationException"/> so existing callers that catch
+/// <see cref="InvalidOperationException"/> around stream access continue to work unchanged.
+/// New consumers can catch this specific type to classify a dropped/closed transport as a
+/// transient, environmental condition (an unplug or reset re-enumeration) rather than an
+/// application bug.
+/// </para>
+/// <para>
+/// This is the stream-access analog of surfacing a typed <see cref="TimeoutException"/> for a
+/// TCP connect timeout: the goal is to replace a raw framework message — such as
+/// <c>"The BaseStream is only available when the port is open."</c> from
+/// <see cref="System.IO.Ports.SerialPort.BaseStream"/> — with a clear, classifiable signal
+/// that names the transport state.
+/// </para>
+/// </remarks>
+public class TransportNotConnectedException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TransportNotConnectedException"/> class
+    /// with a default message.
+    /// </summary>
+    public TransportNotConnectedException()
+        : base("Transport is not connected.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TransportNotConnectedException"/> class
+    /// with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the transport state.</param>
+    public TransportNotConnectedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TransportNotConnectedException"/> class
+    /// with a specified error message and a reference to the inner exception that is the cause
+    /// of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the transport state.</param>
+    /// <param name="innerException">The exception that caused the current exception, or <c>null</c>.</param>
+    public TransportNotConnectedException(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -497,6 +497,18 @@ namespace Daqifi.Core.Device
                     throw new InvalidOperationException("ExecuteTextCommandAsync requires a transport-based connection.");
                 }
 
+                // The device-level IsConnected check above is status-based and can still report
+                // Connected when the underlying transport has dropped (e.g. a serial port closed
+                // by an unplug or a DTR-triggered MCU reset mid-connect). Detect that here and
+                // fail with the typed transport-disconnected exception, rather than dereferencing
+                // Stream below and surfacing the framework's raw "BaseStream is only available
+                // when the port is open." message (issue #238).
+                if (!_transport.IsConnected)
+                {
+                    throw new TransportNotConnectedException(
+                        "Device transport is no longer connected.");
+                }
+
                 var sw = Stopwatch.StartNew();
                 var collectedLines = new List<string>();
                 var stream = _transport.Stream;


### PR DESCRIPTION
## Summary

Fixes #238 — the serial analog of #237.

`SerialStreamTransport.Stream` was:

```csharp
return _serialPort?.BaseStream ?? throw new InvalidOperationException("Transport is not connected.");
```

When the underlying `SerialPort` is **non-null but closed** (device unplugged, or a DTR-triggered MCU reset re-enumerated the COM port mid-connect), the `SerialPort.BaseStream` *getter itself* throws **before** the `?? throw` guard can run:

> System.InvalidOperationException: The BaseStream is only available when the port is open.

So the intended typed signal never surfaced; consumers got a raw framework exception that reads like an app bug and is auto-filed as an error by crash reporting (daqifi/daqifi-desktop#588).

## Changes

- **New `TransportNotConnectedException : InvalidOperationException`** (`Communication/Transport/`). Deriving from `InvalidOperationException` keeps backward compatibility — existing `catch (InvalidOperationException)` blocks and the `IStreamTransport.Stream` contract still hold — while giving consumers a precise type to classify a dropped/closed transport as a transient, environmental condition (the same tier as `FileNotFoundException` / `UnauthorizedAccessException` and the TCP `TimeoutException` from #237).
- **`SerialStreamTransport.Stream`** now guards on `_serialPort?.IsOpen != true` *before* touching `BaseStream`, throwing the typed exception with a message that names the transport state instead of leaking the raw framework message. (`IsConnected` already returns `false` once the port closes, since it is `=> _serialPort?.IsOpen == true` — issue point 2 was already satisfied.)
- **`TcpStreamTransport.Stream`** throws the same typed exception for cross-transport consistency (the WiFi twin, daqifi-desktop#595).
- **`DaqifiDevice.ExecuteTextCommandCoreAsync`** detects a dropped transport (`_transport.IsConnected == false`) and fails with the typed exception rather than dereferencing `Stream` and leaking the framework message (issue point 3). The device-level `IsConnected` is status-based and can still report `Connected` when the transport has silently dropped (a serial unplug/DTR-reset raises no status event).

## Tests

- `SerialStreamTransport_Stream_WhenPortClosedMidOperation_ThrowsTypedException_NotRawBaseStreamMessage` — injects a constructed-but-unopened `SerialPort` (via an internal test seam), asserts the typed exception **and** that the message is *not* the raw `"BaseStream is only available..."` text, and that `IsConnected` is `false`. No hardware needed.
- Typed-exception assertions for the never-connected case (serial + TCP), plus the existing not-connected tests updated to `Assert.ThrowsAny<InvalidOperationException>` to lock in the preserved assignability contract.
- `DaqifiDevice_ExecuteTextCommand_WhenTransportDroppedSilently_ThrowsTransportNotConnectedException` — drives `InitializeAsync` → `ExecuteTextCommandCoreAsync` against a transport that silently drops, asserting the typed exception and `DeviceState.Error`.

All 1011 tests pass on both `net9.0` and `net10.0`; Release solution build is clean with `TreatWarningsAsErrors`. Also verified end-to-end against a real device on COM3: the happy path returns the live `SerialStream` unchanged, and the closed-port path surfaces the typed exception without leaking the raw message.

## Consumer impact / release notes

Behavioral API change worth a release-notes mention (as with #237): consumers catching the raw `InvalidOperationException` around stream access / connect to detect a dropped serial transport should catch `TransportNotConnectedException`. Because it derives from `InvalidOperationException`, existing broad catches keep working unchanged; consumers opt in to the warning-tier classification by adding the specific type.

## References

- Serial analog of #237 (TCP connect timeout → `TimeoutException`)
- Consumer-side issue: daqifi/daqifi-desktop#588
- WiFi twin precedent: daqifi/daqifi-desktop#595

🤖 Generated with [Claude Code](https://claude.com/claude-code)