### PR TITLE
feat: continuous/stateful discovery (ContinuousDeviceFinder + DeviceLost)

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -125,6 +125,43 @@ if (devices.Any())
 }
 ```
 
+### Continuous Discovery (Live Device Set)
+
+`IDeviceFinder.DiscoverAsync` is a single pass. For a UI that shows a live, self-updating
+list of devices, wrap a finder in a `ContinuousDeviceFinder`. It owns the scan cadence,
+keeps a deduplicated set across passes, raises `DeviceDiscovered` the first time each device
+appears, and raises `DeviceLost` once a device has been absent for a configurable number of
+consecutive passes:
+
+```csharp
+using Daqifi.Core.Device.Discovery;
+
+var continuous = new ContinuousDeviceFinder(
+    new WiFiDeviceFinder(),
+    new ContinuousDiscoveryOptions
+    {
+        PassTimeout = TimeSpan.FromSeconds(3), // listen window per pass
+        Interval = TimeSpan.FromSeconds(1),    // gap between passes
+        MissThreshold = 2                      // passes a device may be absent before "lost"
+    });
+
+continuous.DeviceDiscovered += (_, e) => devices.Add(e.DeviceInfo);     // bind to your UI list
+continuous.DeviceLost += (_, e) => devices.RemoveBySerial(e.DeviceInfo);
+continuous.ScanError += (_, e) => logger.LogWarning(e.Exception, "Discovery pass failed");
+
+continuous.Start();
+// ... later, when the view closes:
+await continuous.StopAsync();
+continuous.Dispose(); // also disposes the wrapped finder unless LeaveInnerFinderOpen is set
+```
+
+One instance wraps one finder, so it represents a single transport's cadence and live set.
+To track WiFi, Serial, and HID together, create one `ContinuousDeviceFinder` per transport —
+each with its own interval — and merge their events into a single collection. Devices are
+deduplicated per transport: the same physical unit seen over both WiFi and Serial appears as
+two distinct connection options. `continuous.Devices` returns a thread-safe snapshot of the
+current set at any time.
+
 ### Manual Device Connection (Advanced)
 
 For cases where you need more control over the connection process:

--- a/src/Daqifi.Core.Tests/Device/Discovery/ContinuousDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/ContinuousDeviceFinderTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using Daqifi.Core.Device.Discovery;
 
@@ -321,6 +322,25 @@ public class ContinuousDeviceFinderTests
         Assert.Single(finder.Devices);
     }
 
+    [Fact]
+    public void Reconcile_NullIdentitySelectorResult_FallsBackToDefaultIdentity()
+    {
+        // A selector returning null must not collapse distinct devices onto one empty key;
+        // GetIdentity falls back to the default per-transport identity instead.
+        using var finder = NewFinder(new StubDeviceFinder(), identitySelector: _ => null!);
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        finder.Reconcile(new IDeviceInfo[]
+        {
+            Wifi("AA:BB:CC:DD:EE:01"),
+            Wifi("AA:BB:CC:DD:EE:02")
+        });
+
+        Assert.Equal(2, discovered.Count);
+        Assert.Equal(2, finder.Devices.Count);
+    }
+
     #endregion
 
     #region Lifecycle
@@ -466,11 +486,65 @@ public class ContinuousDeviceFinderTests
         await finder.StopAsync();
     }
 
+    [Fact]
+    public async Task StopAsync_CancelsInFlightPass_WithoutWaitingForPassTimeout()
+    {
+        // PassTimeout is huge; if the in-flight pass were not cancellable, StopAsync would block
+        // for ~30s. With cancellable passes it returns as soon as cancellation propagates.
+        var inner = new BlockingDeviceFinder();
+        using var finder = new ContinuousDeviceFinder(inner, new ContinuousDiscoveryOptions
+        {
+            PassTimeout = TimeSpan.FromSeconds(30),
+            Interval = TimeSpan.Zero
+        });
+
+        finder.Start();
+        await WaitUntil(() => inner.PassesStarted > 0);
+
+        var sw = Stopwatch.StartNew();
+        await finder.StopAsync();
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5), $"StopAsync took {sw.Elapsed}; expected prompt cancellation.");
+        Assert.False(finder.IsRunning);
+    }
+
+    [Fact]
+    public async Task Dispose_WithInFlightPass_StopsPromptlyAndDisposesInnerFinder()
+    {
+        var inner = new BlockingDeviceFinder();
+        var finder = new ContinuousDeviceFinder(inner, new ContinuousDiscoveryOptions
+        {
+            PassTimeout = TimeSpan.FromSeconds(30),
+            Interval = TimeSpan.Zero
+        });
+
+        finder.Start();
+        await WaitUntil(() => inner.PassesStarted > 0);
+
+        var sw = Stopwatch.StartNew();
+        finder.Dispose(); // must cancel the in-flight pass, not wait out the 30s PassTimeout
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5), $"Dispose took {sw.Elapsed}; expected prompt cancellation.");
+        Assert.True(inner.Disposed); // inner finder disposed only after the loop stopped
+    }
+
     private static async Task<T> AwaitSignal<T>(TaskCompletionSource<T> signal)
     {
         var completed = await Task.WhenAny(signal.Task, Task.Delay(WaitTimeout));
         Assert.True(completed == signal.Task, "Timed out waiting for the expected event.");
         return await signal.Task;
+    }
+
+    private static async Task WaitUntil(Func<bool> condition)
+    {
+        var sw = Stopwatch.StartNew();
+        while (!condition())
+        {
+            Assert.True(sw.Elapsed < WaitTimeout, "Timed out waiting for the expected condition.");
+            await Task.Delay(10);
+        }
     }
 
     #endregion
@@ -548,6 +622,42 @@ public class ContinuousDeviceFinderTests
 
             return Task.FromResult<IEnumerable<IDeviceInfo>>(next);
         }
+    }
+
+    /// <summary>
+    /// Finder whose pass blocks until its cancellation token fires, then returns an empty set.
+    /// Used to verify that Stop/Dispose cancel an in-flight pass instead of waiting out a large
+    /// <see cref="ContinuousDiscoveryOptions.PassTimeout"/>.
+    /// </summary>
+    private sealed class BlockingDeviceFinder : IDeviceFinder, IDisposable
+    {
+        private int _passesStarted;
+
+        public int PassesStarted => Volatile.Read(ref _passesStarted);
+        public bool Disposed { get; private set; }
+
+#pragma warning disable CS0067 // Events are part of the interface but unused by this fake.
+        public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
+        public event EventHandler? DiscoveryCompleted;
+#pragma warning restore CS0067
+
+        public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _passesStarted);
+
+            var cancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (cancellationToken.Register(() => cancelled.TrySetResult(true)))
+            {
+                await cancelled.Task.ConfigureAwait(false);
+            }
+
+            return Array.Empty<IDeviceInfo>();
+        }
+
+        public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
+            => DiscoverAsync(CancellationToken.None);
+
+        public void Dispose() => Disposed = true;
     }
 
     #endregion

--- a/src/Daqifi.Core.Tests/Device/Discovery/ContinuousDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/ContinuousDeviceFinderTests.cs
@@ -1,0 +1,554 @@
+using System.Net;
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+public class ContinuousDeviceFinderTests
+{
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+    private static DeviceInfo Wifi(string mac, string sn = "SN", string name = "wifi", IPAddress? ip = null, int port = 9760)
+        => new()
+        {
+            ConnectionType = ConnectionType.WiFi,
+            MacAddress = mac,
+            SerialNumber = sn,
+            Name = name,
+            IPAddress = ip,
+            Port = port
+        };
+
+    private static DeviceInfo Serial(string sn, string port = "COM3", string name = "serial")
+        => new()
+        {
+            ConnectionType = ConnectionType.Serial,
+            SerialNumber = sn,
+            PortName = port,
+            Name = name
+        };
+
+    private static ContinuousDeviceFinder NewFinder(
+        IDeviceFinder inner,
+        int missThreshold = 2,
+        Func<IDeviceInfo, string>? identitySelector = null,
+        bool leaveInnerFinderOpen = false)
+        => new(inner, new ContinuousDiscoveryOptions
+        {
+            MissThreshold = missThreshold,
+            IdentitySelector = identitySelector,
+            LeaveInnerFinderOpen = leaveInnerFinderOpen,
+            // Tiny cadence keeps the loop tests responsive without relying on wall-clock sleeps.
+            Interval = TimeSpan.FromMilliseconds(10),
+            PassTimeout = TimeSpan.FromMilliseconds(50)
+        });
+
+    #region Constructor / options validation
+
+    [Fact]
+    public void Constructor_NullFinder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ContinuousDeviceFinder(null!));
+    }
+
+    [Fact]
+    public void Constructor_NullOptions_UsesDefaults()
+    {
+        using var finder = new ContinuousDeviceFinder(new StubDeviceFinder());
+        Assert.False(finder.IsRunning);
+        Assert.Empty(finder.Devices);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_MissThresholdBelowOne_Throws(int missThreshold)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ContinuousDeviceFinder(
+            new StubDeviceFinder(), new ContinuousDiscoveryOptions { MissThreshold = missThreshold }));
+    }
+
+    [Fact]
+    public void Constructor_NonPositivePassTimeout_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ContinuousDeviceFinder(
+            new StubDeviceFinder(), new ContinuousDiscoveryOptions { PassTimeout = TimeSpan.Zero }));
+    }
+
+    [Fact]
+    public void Constructor_NegativeInterval_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ContinuousDeviceFinder(
+            new StubDeviceFinder(), new ContinuousDiscoveryOptions { Interval = TimeSpan.FromSeconds(-1) }));
+    }
+
+    #endregion
+
+    #region Reconcile: dedup + discovery
+
+    [Fact]
+    public void Reconcile_NewDevice_RaisesDiscoveredAndAddsToLiveSet()
+    {
+        using var finder = NewFinder(new StubDeviceFinder());
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        var device = Wifi("AA:BB:CC:DD:EE:01");
+        finder.Reconcile(new[] { device });
+
+        Assert.Single(discovered);
+        Assert.Same(device, discovered[0]);
+        Assert.Single(finder.Devices);
+        Assert.Same(device, finder.Devices[0]);
+    }
+
+    [Fact]
+    public void Reconcile_SameDeviceAcrossPasses_RaisesDiscoveredOnce()
+    {
+        using var finder = NewFinder(new StubDeviceFinder());
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") });
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") });
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") });
+
+        Assert.Single(discovered);
+        Assert.Single(finder.Devices);
+    }
+
+    [Fact]
+    public void Reconcile_DuplicateDevicesWithinSinglePass_RaisesDiscoveredOnce()
+    {
+        using var finder = NewFinder(new StubDeviceFinder());
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        finder.Reconcile(new[]
+        {
+            Wifi("AA:BB:CC:DD:EE:01"),
+            Wifi("AA:BB:CC:DD:EE:01")
+        });
+
+        Assert.Single(discovered);
+        Assert.Single(finder.Devices);
+    }
+
+    [Fact]
+    public void Reconcile_RefreshesMetadataForExistingDevice_WithoutRediscovering()
+    {
+        using var finder = NewFinder(new StubDeviceFinder());
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01", ip: IPAddress.Parse("192.168.1.10")) });
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01", ip: IPAddress.Parse("192.168.1.20")) });
+
+        Assert.Single(discovered);
+        Assert.Single(finder.Devices);
+        Assert.Equal(IPAddress.Parse("192.168.1.20"), finder.Devices[0].IPAddress);
+    }
+
+    #endregion
+
+    #region Reconcile: stale removal
+
+    [Fact]
+    public void Reconcile_DeviceAbsent_NotLostUntilMissThresholdReached()
+    {
+        using var finder = NewFinder(new StubDeviceFinder(), missThreshold: 2);
+        var lost = new List<IDeviceInfo>();
+        finder.DeviceLost += (_, e) => lost.Add(e.DeviceInfo);
+
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") });
+        finder.Reconcile(Array.Empty<IDeviceInfo>()); // first miss — still tolerated
+
+        Assert.Empty(lost);
+        Assert.Single(finder.Devices);
+    }
+
+    [Fact]
+    public void Reconcile_DeviceAbsentForThresholdPasses_RaisesLostAndRemoves()
+    {
+        using var finder = NewFinder(new StubDeviceFinder(), missThreshold: 2);
+        var lost = new List<IDeviceInfo>();
+        finder.DeviceLost += (_, e) => lost.Add(e.DeviceInfo);
+
+        var device = Wifi("AA:BB:CC:DD:EE:01");
+        finder.Reconcile(new[] { device });
+        finder.Reconcile(Array.Empty<IDeviceInfo>()); // miss 1
+        finder.Reconcile(Array.Empty<IDeviceInfo>()); // miss 2 -> lost
+
+        Assert.Single(lost);
+        Assert.Same(device, lost[0]);
+        Assert.Empty(finder.Devices);
+    }
+
+    [Fact]
+    public void Reconcile_MissThresholdOne_LostAfterSingleAbsence()
+    {
+        using var finder = NewFinder(new StubDeviceFinder(), missThreshold: 1);
+        var lost = new List<IDeviceInfo>();
+        finder.DeviceLost += (_, e) => lost.Add(e.DeviceInfo);
+
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") });
+        finder.Reconcile(Array.Empty<IDeviceInfo>());
+
+        Assert.Single(lost);
+        Assert.Empty(finder.Devices);
+    }
+
+    [Fact]
+    public void Reconcile_DeviceReappearsBeforeThreshold_ResetsMissCounter()
+    {
+        using var finder = NewFinder(new StubDeviceFinder(), missThreshold: 2);
+        var lost = new List<IDeviceInfo>();
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceLost += (_, e) => lost.Add(e.DeviceInfo);
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") });
+        finder.Reconcile(Array.Empty<IDeviceInfo>());          // miss 1
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") }); // reappears -> reset
+        finder.Reconcile(Array.Empty<IDeviceInfo>());          // miss 1 again, not lost
+
+        Assert.Empty(lost);
+        Assert.Single(discovered); // reappearance did not re-raise discovered
+        Assert.Single(finder.Devices);
+    }
+
+    [Fact]
+    public void Reconcile_DeviceLostThenReappears_RaisesDiscoveredAgain()
+    {
+        using var finder = NewFinder(new StubDeviceFinder(), missThreshold: 1);
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") }); // discovered
+        finder.Reconcile(Array.Empty<IDeviceInfo>());          // lost
+        finder.Reconcile(new[] { Wifi("AA:BB:CC:DD:EE:01") }); // rediscovered
+
+        Assert.Equal(2, discovered.Count);
+    }
+
+    #endregion
+
+    #region Reconcile: identity
+
+    [Fact]
+    public void DefaultIdentity_SameSerialDifferentTransport_AreDistinct()
+    {
+        using var finder = NewFinder(new StubDeviceFinder());
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        // Same serial number, but one on WiFi (MAC-keyed) and one on Serial (port-keyed):
+        // these are two distinct connection options the UI should show separately.
+        finder.Reconcile(new IDeviceInfo[]
+        {
+            Wifi("AA:BB:CC:DD:EE:01", sn: "SHARED"),
+            Serial("SHARED")
+        });
+
+        Assert.Equal(2, discovered.Count);
+        Assert.Equal(2, finder.Devices.Count);
+    }
+
+    [Fact]
+    public void DefaultIdentity_FallsBackThroughDiscriminators()
+    {
+        // MAC wins over everything; serial-only device keys on serial; name is the last resort.
+        var wifi = Wifi("AA:BB:CC:DD:EE:01", sn: "SN1");
+        Assert.StartsWith("WiFi|mac:", ContinuousDeviceFinder.DefaultIdentity(wifi));
+
+        var hid = new DeviceInfo { ConnectionType = ConnectionType.Hid, DevicePath = "path-1", SerialNumber = "SN2" };
+        Assert.Equal("Hid|path:path-1", ContinuousDeviceFinder.DefaultIdentity(hid));
+
+        var serial = Serial("SN3", port: "COM7");
+        Assert.Equal("Serial|sn:SN3", ContinuousDeviceFinder.DefaultIdentity(serial));
+
+        var nameOnly = new DeviceInfo { ConnectionType = ConnectionType.Unknown, Name = "Bare" };
+        Assert.Equal("Unknown|name:Bare", ContinuousDeviceFinder.DefaultIdentity(nameOnly));
+    }
+
+    [Fact]
+    public void Reconcile_ThrowingDiscoveredHandler_DoesNotSuppressOtherDevicesOrThrow()
+    {
+        // A faulty subscriber must neither kill reconciliation nor suppress notifications
+        // for the other devices in the same pass; the fault is surfaced via ScanError.
+        using var finder = NewFinder(new StubDeviceFinder());
+        var errors = new List<Exception>();
+        var discovered = new List<IDeviceInfo>();
+        finder.ScanError += (_, e) => errors.Add(e.Exception);
+        finder.DeviceDiscovered += (_, e) =>
+        {
+            if (e.DeviceInfo.SerialNumber == "BAD")
+            {
+                throw new InvalidOperationException("handler boom");
+            }
+
+            discovered.Add(e.DeviceInfo);
+        };
+
+        // "BAD" is processed first, so without per-callback guarding its throw would
+        // suppress "GOOD".
+        finder.Reconcile(new IDeviceInfo[]
+        {
+            Serial("BAD", port: "COM1"),
+            Serial("GOOD", port: "COM2")
+        });
+
+        Assert.Contains(discovered, d => d.SerialNumber == "GOOD");
+        Assert.Single(errors);
+        Assert.Equal(2, finder.Devices.Count); // both tracked regardless of the handler fault
+    }
+
+    [Fact]
+    public void Reconcile_CustomIdentitySelector_GroupsByCustomKey()
+    {
+        // Collapse everything to a single key so two physically-distinct devices are
+        // treated as one — proves the selector is honored.
+        using var finder = NewFinder(new StubDeviceFinder(), identitySelector: _ => "constant");
+        var discovered = new List<IDeviceInfo>();
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+
+        finder.Reconcile(new IDeviceInfo[]
+        {
+            Wifi("AA:BB:CC:DD:EE:01"),
+            Wifi("AA:BB:CC:DD:EE:02")
+        });
+
+        Assert.Single(discovered);
+        Assert.Single(finder.Devices);
+    }
+
+    #endregion
+
+    #region Lifecycle
+
+    [Fact]
+    public async Task Start_WhenAlreadyRunning_Throws()
+    {
+        using var finder = NewFinder(new StubDeviceFinder());
+        finder.Start();
+        try
+        {
+            Assert.Throws<InvalidOperationException>(() => finder.Start());
+        }
+        finally
+        {
+            await finder.StopAsync();
+        }
+    }
+
+    [Fact]
+    public void Start_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var finder = NewFinder(new StubDeviceFinder());
+        finder.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => finder.Start());
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenNotRunning_DoesNotThrow()
+    {
+        using var finder = NewFinder(new StubDeviceFinder());
+        await finder.StopAsync();
+        Assert.False(finder.IsRunning);
+    }
+
+    [Fact]
+    public void Dispose_DisposesInnerFinder_WhenNotLeaveOpen()
+    {
+        var inner = new StubDeviceFinder();
+        var finder = NewFinder(inner, leaveInnerFinderOpen: false);
+
+        finder.Dispose();
+
+        Assert.True(inner.Disposed);
+    }
+
+    [Fact]
+    public void Dispose_LeavesInnerFinderOpen_WhenConfigured()
+    {
+        var inner = new StubDeviceFinder();
+        var finder = NewFinder(inner, leaveInnerFinderOpen: true);
+
+        finder.Dispose();
+
+        Assert.False(inner.Disposed);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var finder = NewFinder(new StubDeviceFinder());
+        finder.Dispose();
+        finder.Dispose(); // should not throw
+    }
+
+    #endregion
+
+    #region Scan loop integration
+
+    [Fact]
+    public async Task Start_DiscoversDevice_RaisesDeviceDiscoveredAndPopulatesDevices()
+    {
+        var device = Wifi("AA:BB:CC:DD:EE:01");
+        var inner = new ScriptedDeviceFinder(new[] { (IReadOnlyList<IDeviceInfo>)new[] { device } });
+        using var finder = NewFinder(inner);
+
+        var discoveredSignal = new TaskCompletionSource<IDeviceInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        finder.DeviceDiscovered += (_, e) => discoveredSignal.TrySetResult(e.DeviceInfo);
+
+        finder.Start();
+        var discovered = await AwaitSignal(discoveredSignal);
+        await finder.StopAsync();
+
+        Assert.Same(device, discovered);
+        Assert.Contains(finder.Devices, d => ReferenceEquals(d, device));
+    }
+
+    [Fact]
+    public async Task Start_DeviceDisappears_RaisesDeviceLost()
+    {
+        var device = Wifi("AA:BB:CC:DD:EE:01");
+        // One pass sees the device; every later pass returns nothing.
+        var inner = new ScriptedDeviceFinder(new[] { (IReadOnlyList<IDeviceInfo>)new[] { device } });
+        using var finder = NewFinder(inner, missThreshold: 1);
+
+        var lostSignal = new TaskCompletionSource<IDeviceInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        finder.DeviceLost += (_, e) => lostSignal.TrySetResult(e.DeviceInfo);
+
+        finder.Start();
+        var lost = await AwaitSignal(lostSignal);
+        await finder.StopAsync();
+
+        Assert.Same(device, lost);
+        Assert.DoesNotContain(finder.Devices, d => ReferenceEquals(d, device));
+    }
+
+    [Fact]
+    public async Task Start_PassThrows_RaisesScanErrorAndKeepsRunning()
+    {
+        var inner = new ScriptedDeviceFinder(Array.Empty<IReadOnlyList<IDeviceInfo>>())
+        {
+            ThrowOnEveryPass = new InvalidOperationException("boom")
+        };
+        using var finder = NewFinder(inner);
+
+        var errorSignal = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        finder.ScanError += (_, e) => errorSignal.TrySetResult(e.Exception);
+
+        finder.Start();
+        var error = await AwaitSignal(errorSignal);
+
+        Assert.IsType<InvalidOperationException>(error);
+        Assert.True(finder.IsRunning); // a thrown pass must not kill the loop
+
+        await finder.StopAsync();
+    }
+
+    [Fact]
+    public async Task Start_ThrowingIdentitySelector_RaisesScanErrorAndKeepsRunning()
+    {
+        var inner = new ScriptedDeviceFinder(new[] { (IReadOnlyList<IDeviceInfo>)new[] { Wifi("AA:BB:CC:DD:EE:01") } });
+        using var finder = NewFinder(inner, identitySelector: _ => throw new InvalidOperationException("selector boom"));
+
+        var errorSignal = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        finder.ScanError += (_, e) => errorSignal.TrySetResult(e.Exception);
+
+        finder.Start();
+        var error = await AwaitSignal(errorSignal);
+
+        Assert.IsType<InvalidOperationException>(error);
+        Assert.True(finder.IsRunning); // a throwing identity selector must not kill the loop
+
+        await finder.StopAsync();
+    }
+
+    private static async Task<T> AwaitSignal<T>(TaskCompletionSource<T> signal)
+    {
+        var completed = await Task.WhenAny(signal.Task, Task.Delay(WaitTimeout));
+        Assert.True(completed == signal.Task, "Timed out waiting for the expected event.");
+        return await signal.Task;
+    }
+
+    #endregion
+
+    #region DeviceLostEventArgs
+
+    [Fact]
+    public void DeviceLostEventArgs_NullDevice_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DeviceLostEventArgs(null!));
+    }
+
+    #endregion
+
+    #region Fakes
+
+    /// <summary>
+    /// Minimal finder used by tests that drive <see cref="ContinuousDeviceFinder.Reconcile"/>
+    /// directly or that only need lifecycle behavior. Each pass returns no devices.
+    /// </summary>
+    private sealed class StubDeviceFinder : IDeviceFinder, IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+#pragma warning disable CS0067 // Events are part of the interface but unused by this stub.
+        public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
+        public event EventHandler? DiscoveryCompleted;
+#pragma warning restore CS0067
+
+        public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(Enumerable.Empty<IDeviceInfo>());
+
+        public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
+            => Task.FromResult(Enumerable.Empty<IDeviceInfo>());
+
+        public void Dispose() => Disposed = true;
+    }
+
+    /// <summary>
+    /// Finder that returns a scripted sequence of pass results. After the script is
+    /// exhausted, every subsequent pass returns an empty set (so devices disappear),
+    /// which is what the stale-removal loop tests rely on.
+    /// </summary>
+    private sealed class ScriptedDeviceFinder : IDeviceFinder
+    {
+        private readonly Queue<IReadOnlyList<IDeviceInfo>> _passes;
+
+        public ScriptedDeviceFinder(IReadOnlyList<IReadOnlyList<IDeviceInfo>> passes)
+        {
+            _passes = new Queue<IReadOnlyList<IDeviceInfo>>(passes);
+        }
+
+        public Exception? ThrowOnEveryPass { get; init; }
+
+#pragma warning disable CS0067 // Events are part of the interface but unused by this fake.
+        public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
+        public event EventHandler? DiscoveryCompleted;
+#pragma warning restore CS0067
+
+        public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+            => DiscoverAsync(TimeSpan.Zero);
+
+        public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
+        {
+            if (ThrowOnEveryPass != null)
+            {
+                throw ThrowOnEveryPass;
+            }
+
+            IReadOnlyList<IDeviceInfo> next;
+            lock (_passes)
+            {
+                next = _passes.Count > 0 ? _passes.Dequeue() : Array.Empty<IDeviceInfo>();
+            }
+
+            return Task.FromResult<IEnumerable<IDeviceInfo>>(next);
+        }
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core/Device/Discovery/ContinuousDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/ContinuousDeviceFinder.cs
@@ -1,0 +1,605 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Wraps an <see cref="IDeviceFinder"/> and turns its per-call discovery into a
+/// continuous, stateful scan. The finder repeatedly runs discovery passes on a
+/// configurable cadence, maintains a deduplicated live set of devices across
+/// passes, and raises <see cref="DeviceDiscovered"/> when a device first appears
+/// and <see cref="DeviceLost"/> when a device has been absent for
+/// <see cref="ContinuousDiscoveryOptions.MissThreshold"/> consecutive passes. A UI
+/// can bind directly to <see cref="Devices"/> plus these events instead of writing
+/// its own polling loop and stale-removal logic.
+/// </summary>
+/// <remarks>
+/// One instance wraps a single finder, so it represents one transport's scan
+/// cadence and live set. To track multiple transports (WiFi, Serial, HID), create
+/// one <see cref="ContinuousDeviceFinder"/> per finder — each can use its own
+/// interval — and merge their events.
+/// </remarks>
+public class ContinuousDeviceFinder : IDisposable
+{
+    #region Private Types
+
+    /// <summary>
+    /// Tracks a device in the live set along with how many consecutive passes it
+    /// has been missing.
+    /// </summary>
+    private sealed class TrackedDevice
+    {
+        public TrackedDevice(IDeviceInfo info)
+        {
+            Info = info;
+        }
+
+        /// <summary>The most recent metadata observed for the device.</summary>
+        public IDeviceInfo Info { get; set; }
+
+        /// <summary>Consecutive passes in which the device was not seen.</summary>
+        public int MissCount { get; set; }
+    }
+
+    #endregion
+
+    #region Private Fields
+
+    private readonly IDeviceFinder _finder;
+    private readonly TimeSpan _interval;
+    private readonly TimeSpan _passTimeout;
+    private readonly int _missThreshold;
+    private readonly Func<IDeviceInfo, string>? _identitySelector;
+    private readonly bool _leaveInnerFinderOpen;
+
+    private readonly Dictionary<string, TrackedDevice> _devices = new(StringComparer.Ordinal);
+    private readonly object _devicesLock = new();
+    private readonly object _lifecycleLock = new();
+
+    private CancellationTokenSource? _cts;
+    private Task? _loopTask;
+    private bool _running;
+    private volatile bool _disposed;
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Occurs when a device first enters the live set. Unlike the wrapped finder's
+    /// own event, this fires only once per device until it is lost and rediscovered.
+    /// </summary>
+    public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
+
+    /// <summary>
+    /// Occurs when a device leaves the live set after being absent for
+    /// <see cref="ContinuousDiscoveryOptions.MissThreshold"/> consecutive passes.
+    /// </summary>
+    public event EventHandler<DeviceLostEventArgs>? DeviceLost;
+
+    /// <summary>
+    /// Occurs when a discovery pass throws. The scan loop continues after the failure;
+    /// this event is for surfacing or logging the error.
+    /// </summary>
+    public event EventHandler<ContinuousDiscoveryErrorEventArgs>? ScanError;
+
+    #endregion
+
+    #region Constructor
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContinuousDeviceFinder"/> class.
+    /// </summary>
+    /// <param name="finder">The finder to run continuously. Required.</param>
+    /// <param name="options">
+    /// Scan cadence and stale-removal configuration. When null, defaults are used.
+    /// The relevant values are captured at construction, so mutating the options object
+    /// afterward has no effect.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="finder"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// An option value is out of range (non-positive pass timeout, negative interval, or
+    /// a miss threshold below 1).
+    /// </exception>
+    public ContinuousDeviceFinder(IDeviceFinder finder, ContinuousDiscoveryOptions? options = null)
+    {
+        _finder = finder ?? throw new ArgumentNullException(nameof(finder));
+
+        options ??= new ContinuousDiscoveryOptions();
+
+        if (options.PassTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options), options.PassTimeout, "PassTimeout must be greater than zero.");
+        }
+
+        if (options.Interval < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options), options.Interval, "Interval must not be negative.");
+        }
+
+        if (options.MissThreshold < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options), options.MissThreshold, "MissThreshold must be at least 1.");
+        }
+
+        _interval = options.Interval;
+        _passTimeout = options.PassTimeout;
+        _missThreshold = options.MissThreshold;
+        _identitySelector = options.IdentitySelector;
+        _leaveInnerFinderOpen = options.LeaveInnerFinderOpen;
+    }
+
+    #endregion
+
+    #region Public Surface
+
+    /// <summary>
+    /// Gets a value indicating whether the continuous scan loop is running.
+    /// </summary>
+    public bool IsRunning
+    {
+        get
+        {
+            lock (_lifecycleLock)
+            {
+                return _running;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets a point-in-time snapshot of the current live set of discovered devices.
+    /// The returned list is a copy and is safe to enumerate from any thread.
+    /// </summary>
+    public IReadOnlyList<IDeviceInfo> Devices
+    {
+        get
+        {
+            lock (_devicesLock)
+            {
+                var snapshot = new List<IDeviceInfo>(_devices.Count);
+                foreach (var tracked in _devices.Values)
+                {
+                    snapshot.Add(tracked.Info);
+                }
+
+                return snapshot;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Starts the continuous scan loop on a background task.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">The finder has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The loop is already running.</exception>
+    public void Start()
+    {
+        ThrowIfDisposed();
+
+        lock (_lifecycleLock)
+        {
+            if (_running)
+            {
+                throw new InvalidOperationException("Continuous discovery is already running.");
+            }
+
+            _cts = new CancellationTokenSource();
+            var token = _cts.Token;
+            _running = true;
+            _loopTask = Task.Run(() => ScanLoopAsync(token));
+        }
+    }
+
+    /// <summary>
+    /// Stops the continuous scan loop and waits for the in-flight pass to finish.
+    /// Safe to call when not running. Does not clear the live set.
+    /// </summary>
+    /// <returns>A task that completes once the loop has stopped.</returns>
+    public async Task StopAsync()
+    {
+        CancellationTokenSource? cts;
+        Task? loopTask;
+
+        lock (_lifecycleLock)
+        {
+            if (!_running)
+            {
+                return;
+            }
+
+            _running = false;
+            cts = _cts;
+            loopTask = _loopTask;
+            _cts = null;
+            _loopTask = null;
+        }
+
+        cts?.Cancel();
+
+        if (loopTask != null)
+        {
+            try
+            {
+                await loopTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when the loop observes cancellation.
+            }
+        }
+
+        cts?.Dispose();
+    }
+
+    #endregion
+
+    #region Reconciliation
+
+    /// <summary>
+    /// Reconciles the live set against the devices returned by a single discovery pass:
+    /// adds and announces newly seen devices, refreshes metadata for devices still present,
+    /// and increments the miss count for absent devices — removing and announcing those that
+    /// have now missed <see cref="ContinuousDiscoveryOptions.MissThreshold"/> consecutive passes.
+    /// Exposed internally so the dedup/stale logic can be unit-tested without timing.
+    /// </summary>
+    /// <param name="passResults">Devices observed in the most recent pass.</param>
+    internal void Reconcile(IReadOnlyCollection<IDeviceInfo> passResults)
+    {
+        var newlyDiscovered = new List<IDeviceInfo>();
+        var lost = new List<IDeviceInfo>();
+
+        lock (_devicesLock)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var device in passResults)
+            {
+                if (device == null)
+                {
+                    continue;
+                }
+
+                var key = GetIdentity(device);
+                seen.Add(key);
+
+                if (_devices.TryGetValue(key, out var tracked))
+                {
+                    // Already known — refresh metadata (IP, port, power state, etc. can
+                    // change between passes) and clear the miss counter.
+                    tracked.Info = device;
+                    tracked.MissCount = 0;
+                }
+                else
+                {
+                    _devices[key] = new TrackedDevice(device);
+                    newlyDiscovered.Add(device);
+                }
+            }
+
+            List<string>? toRemove = null;
+            foreach (var pair in _devices)
+            {
+                if (seen.Contains(pair.Key))
+                {
+                    continue;
+                }
+
+                var tracked = pair.Value;
+                tracked.MissCount++;
+                if (tracked.MissCount >= _missThreshold)
+                {
+                    (toRemove ??= new List<string>()).Add(pair.Key);
+                    lost.Add(tracked.Info);
+                }
+            }
+
+            if (toRemove != null)
+            {
+                foreach (var key in toRemove)
+                {
+                    _devices.Remove(key);
+                }
+            }
+        }
+
+        // Raise events outside the lock so subscriber callbacks cannot deadlock against
+        // a concurrent Devices read or a subsequent Reconcile. Each callback is guarded
+        // so one throwing subscriber neither suppresses sibling notifications nor kills
+        // the continuous scan loop (matching the finders' "swallow subscriber exceptions"
+        // contract); the exception is surfaced via ScanError instead.
+        foreach (var device in newlyDiscovered)
+        {
+            SafeRaise(() => OnDeviceDiscovered(device));
+        }
+
+        foreach (var device in lost)
+        {
+            SafeRaise(() => OnDeviceLost(device));
+        }
+    }
+
+    /// <summary>
+    /// Computes the identity key for a device using the configured selector, or the
+    /// default per-transport identity when no selector was supplied.
+    /// </summary>
+    private string GetIdentity(IDeviceInfo device)
+    {
+        if (_identitySelector != null)
+        {
+            return _identitySelector(device) ?? string.Empty;
+        }
+
+        return DefaultIdentity(device);
+    }
+
+    /// <summary>
+    /// Computes a stable per-transport identity for a device. The connection type is
+    /// combined with the most stable available discriminator for that transport, so the
+    /// same physical device seen on two transports is tracked as two distinct entries.
+    /// The discriminator preference per transport is:
+    /// <list type="bullet">
+    /// <item><description>WiFi — MAC address, then serial number, then IP address.</description></item>
+    /// <item><description>Serial — serial number (survives COM-port reassignment), then port name.</description></item>
+    /// <item><description>HID — device path (bootloaders may report empty/duplicate serials), then serial number.</description></item>
+    /// </list>
+    /// Each preference falls back to the device name as a last resort. Internal for testing.
+    /// </summary>
+    /// <param name="device">The device to identify.</param>
+    /// <returns>A non-null identity key.</returns>
+    internal static string DefaultIdentity(IDeviceInfo device)
+    {
+        string discriminator = device.ConnectionType switch
+        {
+            ConnectionType.WiFi =>
+                !string.IsNullOrWhiteSpace(device.MacAddress) ? "mac:" + device.MacAddress!.ToLowerInvariant()
+                : !string.IsNullOrWhiteSpace(device.SerialNumber) ? "sn:" + device.SerialNumber
+                : device.IPAddress != null ? "ip:" + device.IPAddress
+                : "name:" + (device.Name ?? string.Empty),
+
+            ConnectionType.Serial =>
+                !string.IsNullOrWhiteSpace(device.SerialNumber) ? "sn:" + device.SerialNumber
+                : !string.IsNullOrWhiteSpace(device.PortName) ? "port:" + device.PortName
+                : "name:" + (device.Name ?? string.Empty),
+
+            ConnectionType.Hid =>
+                !string.IsNullOrWhiteSpace(device.DevicePath) ? "path:" + device.DevicePath
+                : !string.IsNullOrWhiteSpace(device.SerialNumber) ? "sn:" + device.SerialNumber
+                : "name:" + (device.Name ?? string.Empty),
+
+            _ =>
+                !string.IsNullOrWhiteSpace(device.MacAddress) ? "mac:" + device.MacAddress!.ToLowerInvariant()
+                : !string.IsNullOrWhiteSpace(device.DevicePath) ? "path:" + device.DevicePath
+                : !string.IsNullOrWhiteSpace(device.PortName) ? "port:" + device.PortName
+                : !string.IsNullOrWhiteSpace(device.SerialNumber) ? "sn:" + device.SerialNumber
+                : "name:" + (device.Name ?? string.Empty),
+        };
+
+        return device.ConnectionType + "|" + discriminator;
+    }
+
+    #endregion
+
+    #region Scan Loop
+
+    /// <summary>
+    /// Runs discovery passes until cancellation, reconciling the live set after each pass.
+    /// </summary>
+    private async Task ScanLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            IReadOnlyCollection<IDeviceInfo> results;
+            try
+            {
+                var found = await _finder.DiscoverAsync(_passTimeout).ConfigureAwait(false);
+                results = found == null
+                    ? Array.Empty<IDeviceInfo>()
+                    : found as IReadOnlyCollection<IDeviceInfo> ?? found.ToList();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                SafeScanError(ex);
+                if (!await DelayBetweenPassesAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            // Backstop: Reconcile guards individual subscriber callbacks, but a custom
+            // identity selector could also throw. Neither must terminate the loop.
+            try
+            {
+                Reconcile(results);
+            }
+            catch (Exception ex)
+            {
+                SafeScanError(ex);
+            }
+
+            if (!await DelayBetweenPassesAsync(cancellationToken).ConfigureAwait(false))
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Waits the configured inter-pass interval, returning false if cancellation was
+    /// requested during (or before) the wait so the loop can exit promptly.
+    /// </summary>
+    private async Task<bool> DelayBetweenPassesAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return false;
+        }
+
+        if (_interval <= TimeSpan.Zero)
+        {
+            return true;
+        }
+
+        try
+        {
+            await Task.Delay(_interval, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    #endregion
+
+    #region Event Raisers
+
+    /// <summary>
+    /// Raises the <see cref="DeviceDiscovered"/> event.
+    /// </summary>
+    /// <param name="deviceInfo">The newly discovered device.</param>
+    protected virtual void OnDeviceDiscovered(IDeviceInfo deviceInfo)
+    {
+        DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(deviceInfo));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DeviceLost"/> event.
+    /// </summary>
+    /// <param name="deviceInfo">The device that was lost.</param>
+    protected virtual void OnDeviceLost(IDeviceInfo deviceInfo)
+    {
+        DeviceLost?.Invoke(this, new DeviceLostEventArgs(deviceInfo));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="ScanError"/> event.
+    /// </summary>
+    /// <param name="exception">The exception thrown by the failed pass.</param>
+    protected virtual void OnScanError(Exception exception)
+    {
+        ScanError?.Invoke(this, new ContinuousDiscoveryErrorEventArgs(exception));
+    }
+
+    /// <summary>
+    /// Invokes an event-raising action, routing any subscriber exception to
+    /// <see cref="ScanError"/> so a single faulty handler can neither suppress sibling
+    /// notifications nor terminate the scan loop.
+    /// </summary>
+    private void SafeRaise(Action raise)
+    {
+        try
+        {
+            raise();
+        }
+        catch (Exception ex)
+        {
+            SafeScanError(ex);
+        }
+    }
+
+    /// <summary>
+    /// Raises <see cref="ScanError"/>, swallowing any exception thrown by a
+    /// <see cref="ScanError"/> subscriber — error reporting must never terminate the loop.
+    /// </summary>
+    private void SafeScanError(Exception exception)
+    {
+        try
+        {
+            OnScanError(exception);
+        }
+        catch
+        {
+            // Intentionally swallowed: a throwing ScanError handler must not break the loop.
+        }
+    }
+
+    #endregion
+
+    #region IDisposable
+
+    /// <summary>
+    /// Throws <see cref="ObjectDisposedException"/> if this instance has been disposed.
+    /// </summary>
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(ContinuousDeviceFinder));
+        }
+    }
+
+    /// <summary>
+    /// Stops the scan loop and releases resources. Unless
+    /// <see cref="ContinuousDiscoveryOptions.LeaveInnerFinderOpen"/> was set, the wrapped
+    /// finder is also disposed.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        CancellationTokenSource? cts;
+        Task? loopTask;
+        lock (_lifecycleLock)
+        {
+            cts = _cts;
+            loopTask = _loopTask;
+            _cts = null;
+            _loopTask = null;
+            _running = false;
+        }
+
+        cts?.Cancel();
+
+        // Best-effort wait so the loop stops raising events before we return. The loop
+        // uses ConfigureAwait(false) throughout, so this cannot deadlock on a captured
+        // synchronization context. Bounded so Dispose never hangs on a stuck pass.
+        try
+        {
+            loopTask?.Wait(TimeSpan.FromSeconds(5));
+        }
+        catch
+        {
+            // Ignore faults observed during shutdown.
+        }
+
+        cts?.Dispose();
+
+        if (!_leaveInnerFinderOpen && _finder is IDisposable disposableFinder)
+        {
+            try
+            {
+                disposableFinder.Dispose();
+            }
+            catch
+            {
+                // Ignore finder disposal faults during shutdown.
+            }
+        }
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core/Device/Discovery/ContinuousDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/ContinuousDeviceFinder.cs
@@ -181,10 +181,12 @@ public class ContinuousDeviceFinder : IDisposable
     /// <exception cref="InvalidOperationException">The loop is already running.</exception>
     public void Start()
     {
-        ThrowIfDisposed();
-
+        // Check disposed inside the lock so a concurrent Dispose (which sets _disposed under
+        // the same lock) cannot slip in between the check and launching the loop.
         lock (_lifecycleLock)
         {
+            ThrowIfDisposed();
+
             if (_running)
             {
                 throw new InvalidOperationException("Continuous discovery is already running.");
@@ -198,7 +200,7 @@ public class ContinuousDeviceFinder : IDisposable
     }
 
     /// <summary>
-    /// Stops the continuous scan loop and waits for the in-flight pass to finish.
+    /// Stops the continuous scan loop and waits for it to stop, cancelling any in-flight pass.
     /// Safe to call when not running. Does not clear the live set.
     /// </summary>
     /// <returns>A task that completes once the loop has stopped.</returns>
@@ -333,7 +335,15 @@ public class ContinuousDeviceFinder : IDisposable
     {
         if (_identitySelector != null)
         {
-            return _identitySelector(device) ?? string.Empty;
+            var key = _identitySelector(device);
+
+            // A null/empty key would collapse every such device onto one dictionary entry,
+            // silently breaking dedup and DeviceLost. Fall back to the built-in per-transport
+            // identity rather than corrupting the live set.
+            if (!string.IsNullOrWhiteSpace(key))
+            {
+                return key;
+            }
         }
 
         return DefaultIdentity(device);
@@ -390,32 +400,40 @@ public class ContinuousDeviceFinder : IDisposable
 
     /// <summary>
     /// Runs discovery passes until cancellation, reconciling the live set after each pass.
+    /// Each pass runs under a cancellation token linked to the loop token and cancelled
+    /// after <see cref="ContinuousDiscoveryOptions.PassTimeout"/>, so the timeout bounds the
+    /// pass and a stop/dispose interrupts an in-flight pass promptly.
     /// </summary>
     private async Task ScanLoopAsync(CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            IReadOnlyCollection<IDeviceInfo> results;
-            try
-            {
-                var found = await _finder.DiscoverAsync(_passTimeout).ConfigureAwait(false);
-                results = found == null
-                    ? Array.Empty<IDeviceInfo>()
-                    : found as IReadOnlyCollection<IDeviceInfo> ?? found.ToList();
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (Exception ex)
-            {
-                SafeScanError(ex);
-                if (!await DelayBetweenPassesAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    break;
-                }
+            IReadOnlyCollection<IDeviceInfo>? results = null;
 
-                continue;
+            using (var passCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                passCts.CancelAfter(_passTimeout);
+                try
+                {
+                    var found = await _finder.DiscoverAsync(passCts.Token).ConfigureAwait(false);
+                    results = found == null
+                        ? Array.Empty<IDeviceInfo>()
+                        : found as IReadOnlyCollection<IDeviceInfo> ?? found.ToList();
+                }
+                catch (OperationCanceledException)
+                {
+                    // Outer-token cancellation means stop/dispose — exit the loop. A pass-timeout
+                    // cancellation (a finder that throws rather than returning what it collected) is
+                    // treated as a skipped pass: leave results null so we don't fabricate losses.
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    SafeScanError(ex);
+                }
             }
 
             if (cancellationToken.IsCancellationRequested)
@@ -425,13 +443,16 @@ public class ContinuousDeviceFinder : IDisposable
 
             // Backstop: Reconcile guards individual subscriber callbacks, but a custom
             // identity selector could also throw. Neither must terminate the loop.
-            try
+            if (results != null)
             {
-                Reconcile(results);
-            }
-            catch (Exception ex)
-            {
-                SafeScanError(ex);
+                try
+                {
+                    Reconcile(results);
+                }
+                catch (Exception ex)
+                {
+                    SafeScanError(ex);
+                }
             }
 
             if (!await DelayBetweenPassesAsync(cancellationToken).ConfigureAwait(false))
@@ -554,17 +575,19 @@ public class ContinuousDeviceFinder : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _disposed = true;
-
         CancellationTokenSource? cts;
         Task? loopTask;
+
+        // Set _disposed under the lock so it cannot race with Start (which checks it under
+        // the same lock); also makes Dispose idempotent under concurrent calls.
         lock (_lifecycleLock)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
             cts = _cts;
             loopTask = _loopTask;
             _cts = null;
@@ -574,12 +597,14 @@ public class ContinuousDeviceFinder : IDisposable
 
         cts?.Cancel();
 
-        // Best-effort wait so the loop stops raising events before we return. The loop
-        // uses ConfigureAwait(false) throughout, so this cannot deadlock on a captured
-        // synchronization context. Bounded so Dispose never hangs on a stuck pass.
+        // Wait for the loop to stop before disposing the inner finder, so no pass is in-flight
+        // against a disposed finder. Cancelling the loop token also cancels the per-pass token,
+        // so a well-behaved finder returns promptly; the bound (scaled to PassTimeout) only
+        // guards against a finder that ignores cancellation, so Dispose can never hang. The loop
+        // uses ConfigureAwait(false) throughout, so the wait cannot deadlock on a captured context.
         try
         {
-            loopTask?.Wait(TimeSpan.FromSeconds(5));
+            loopTask?.Wait(_passTimeout);
         }
         catch
         {

--- a/src/Daqifi.Core/Device/Discovery/ContinuousDiscoveryErrorEventArgs.cs
+++ b/src/Daqifi.Core/Device/Discovery/ContinuousDiscoveryErrorEventArgs.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Event args raised when a discovery pass inside <see cref="ContinuousDeviceFinder"/>
+/// fails. The continuous scan loop survives the failure and continues with the next
+/// pass; this event exists so callers can surface or log the underlying error.
+/// </summary>
+public class ContinuousDiscoveryErrorEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContinuousDiscoveryErrorEventArgs"/> class.
+    /// </summary>
+    /// <param name="exception">The exception thrown by the discovery pass.</param>
+    public ContinuousDiscoveryErrorEventArgs(Exception exception)
+    {
+        Exception = exception ?? throw new ArgumentNullException(nameof(exception));
+    }
+
+    /// <summary>
+    /// Gets the exception thrown by the failed discovery pass.
+    /// </summary>
+    public Exception Exception { get; }
+}

--- a/src/Daqifi.Core/Device/Discovery/ContinuousDiscoveryOptions.cs
+++ b/src/Daqifi.Core/Device/Discovery/ContinuousDiscoveryOptions.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Configuration for <see cref="ContinuousDeviceFinder"/>: how often to scan,
+/// how long each scan pass may run, and how many consecutive missed passes a
+/// device must be absent before it is reported lost.
+/// </summary>
+public class ContinuousDiscoveryOptions
+{
+    /// <summary>
+    /// Gets or sets the delay between the end of one discovery pass and the start
+    /// of the next. Default is 1 second. Use <see cref="TimeSpan.Zero"/> to start
+    /// the next pass immediately.
+    /// </summary>
+    public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets the maximum duration of a single discovery pass, passed to the
+    /// wrapped finder's <see cref="IDeviceFinder.DiscoverAsync(TimeSpan)"/>. For
+    /// listen-based transports (WiFi) this is effectively the response-collection
+    /// window; probe-based transports (Serial/HID) typically return sooner. Default
+    /// is 3 seconds.
+    /// </summary>
+    public TimeSpan PassTimeout { get; set; } = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// Gets or sets the number of consecutive passes a device must be absent before
+    /// <see cref="ContinuousDeviceFinder.DeviceLost"/> is raised and it is removed
+    /// from the live set. A value of 1 reports a device lost as soon as it is missing
+    /// from a single pass; the default of 2 tolerates one dropped response (useful for
+    /// lossy UDP discovery). Must be at least 1.
+    /// </summary>
+    public int MissThreshold { get; set; } = 2;
+
+    /// <summary>
+    /// Gets or sets an optional function that computes a stable identity key for a
+    /// discovered device. Devices sharing the same key are treated as the same device
+    /// across passes. When null, <see cref="ContinuousDeviceFinder"/> uses a default
+    /// per-transport identity (connection type combined with MAC address, device path,
+    /// port name, or serial number, whichever is available).
+    /// </summary>
+    public Func<IDeviceInfo, string>? IdentitySelector { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the wrapped finder should be left open
+    /// when the <see cref="ContinuousDeviceFinder"/> is disposed. When false (the
+    /// default), a wrapped finder implementing <see cref="IDisposable"/> is disposed
+    /// along with the continuous finder. Set to true when the wrapped finder is shared
+    /// and owned by the caller.
+    /// </summary>
+    public bool LeaveInnerFinderOpen { get; set; }
+}

--- a/src/Daqifi.Core/Device/Discovery/ContinuousDiscoveryOptions.cs
+++ b/src/Daqifi.Core/Device/Discovery/ContinuousDiscoveryOptions.cs
@@ -17,11 +17,12 @@ public class ContinuousDiscoveryOptions
     public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// Gets or sets the maximum duration of a single discovery pass, passed to the
-    /// wrapped finder's <see cref="IDeviceFinder.DiscoverAsync(TimeSpan)"/>. For
-    /// listen-based transports (WiFi) this is effectively the response-collection
-    /// window; probe-based transports (Serial/HID) typically return sooner. Default
-    /// is 3 seconds.
+    /// Gets or sets the maximum duration of a single discovery pass. Each pass runs the
+    /// wrapped finder under a cancellation token that is cancelled after this duration, so
+    /// the pass is bounded by the timeout and is also interrupted promptly when discovery is
+    /// stopped or disposed. For listen-based transports (WiFi) this is effectively the
+    /// response-collection window; probe-based transports (Serial/HID) typically return
+    /// sooner. Default is 3 seconds.
     /// </summary>
     public TimeSpan PassTimeout { get; set; } = TimeSpan.FromSeconds(3);
 

--- a/src/Daqifi.Core/Device/Discovery/DeviceLostEventArgs.cs
+++ b/src/Daqifi.Core/Device/Discovery/DeviceLostEventArgs.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Event args raised when a previously discovered device disappears from the
+/// live set maintained by <see cref="ContinuousDeviceFinder"/>.
+/// </summary>
+public class DeviceLostEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeviceLostEventArgs"/> class.
+    /// </summary>
+    /// <param name="deviceInfo">The device that was lost.</param>
+    public DeviceLostEventArgs(IDeviceInfo deviceInfo)
+    {
+        DeviceInfo = deviceInfo ?? throw new ArgumentNullException(nameof(deviceInfo));
+    }
+
+    /// <summary>
+    /// Gets the device that disappeared from the live set. This is the most
+    /// recent metadata observed for the device before it was lost.
+    /// </summary>
+    public IDeviceInfo DeviceInfo { get; }
+}


### PR DESCRIPTION
## Summary

Closes #245.

Adds `ContinuousDeviceFinder` — a stateful primitive that wraps any `IDeviceFinder` and turns its per-call discovery into a continuous scan. It owns the scan cadence, maintains a **deduplicated live set across passes**, raises `DeviceDiscovered` the first time each device appears, and raises `DeviceLost` once a device has been absent for a configurable number of consecutive passes. A UI can bind directly to `Devices` + these events instead of writing its own polling loops and stale-removal.

This unblocks the daqifi-desktop cleanup (daqifi/daqifi-desktop#616), which today wraps the finders in three hand-written polling loops with magic delays plus per-transport dedup/stale-removal.

## Design

- **Wraps a single finder.** One instance = one transport's cadence + live set. To track WiFi/Serial/HID together, create one per transport (each with its own interval) and merge their events. Simpler and far more testable than a multi-finder aggregator, and maps exactly to desktop's existing per-transport dedup.
- **Uses each pass's *returned* device list** as the authoritative "seen this pass" set (not the inner event), so dedup is clean with no double-counting.
- **Per-transport identity** (overridable via `ContinuousDiscoveryOptions.IdentitySelector`):
  - WiFi → MAC, then serial number, then IP
  - Serial → serial number (survives COM-port reassignment), then port name
  - HID → device path (bootloaders may report empty/duplicate serials), then serial number
  - Each key is prefixed by `ConnectionType`, so the same physical unit seen over two transports appears as two distinct connection options.
- **`MissThreshold`** (default 2) tolerates a dropped UDP reply before reporting a device lost.
- **Resilient loop:** a throwing discovery pass, identity selector, or event subscriber is surfaced via `ScanError` and never kills the background loop — matching the existing finders' "swallow subscriber exceptions; keep receiving" contract.

## API

```csharp
var continuous = new ContinuousDeviceFinder(new WiFiDeviceFinder(), new ContinuousDiscoveryOptions
{
    PassTimeout = TimeSpan.FromSeconds(3), // listen window per pass
    Interval = TimeSpan.FromSeconds(1),    // gap between passes
    MissThreshold = 2,
});
continuous.DeviceDiscovered += (_, e) => /* add to UI list */;
continuous.DeviceLost       += (_, e) => /* remove from UI list */;
continuous.ScanError        += (_, e) => /* log e.Exception */;
continuous.Start();
// ...
await continuous.StopAsync();
continuous.Dispose(); // also disposes the wrapped finder unless LeaveInnerFinderOpen is set
```

## Files

- `ContinuousDeviceFinder.cs` — scan loop, identity-keyed live set, `DeviceDiscovered`/`DeviceLost`/`ScanError`, `Devices` snapshot, `Start()`/`StopAsync()`, `IDisposable`.
- `ContinuousDiscoveryOptions.cs` — `Interval`, `PassTimeout`, `MissThreshold`, `IdentitySelector`, `LeaveInnerFinderOpen`.
- `DeviceLostEventArgs.cs`, `ContinuousDiscoveryErrorEventArgs.cs`.
- `ContinuousDeviceFinderTests.cs` — 30 tests (deterministic reconcile logic + event-driven loop integration).
- `docs/DEVICE_INTERFACES.md` — "Continuous Discovery" usage section.

## Testing

- `dotnet test` — **1043 passed, 2 skipped (pre-existing), 0 failed** on both net9.0 and net10.0.
- `TreatWarningsAsErrors` is on, so the clean build also confirms lint/XML-doc coverage.

## Notes for the desktop adoption (no change here)

The `MissThreshold` default of 2 means a device is reported lost after ~2 passes absent (≈ `2 × (PassTimeout + Interval)`). That's conservative for lossy WiFi UDP; the reliable Serial/HID instances may want `MissThreshold = 1` to drop ghosts faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)