### PR TITLE
fix: block InitializeAsync until channels populate or timeout (#247)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -123,6 +123,76 @@ namespace Daqifi.Core.Tests.Device
             Assert.Equal(DeviceState.Error, device.State);
         }
 
+        [Fact]
+        public async Task InitializeAsync_WhenChannelsPopulate_ExposesPopulatedChannels()
+        {
+            // Arrange — device responds to GetDeviceInfo by populating channels
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            await device.InitializeAsync();
+
+            // Assert — initialization blocked until ChannelsPopulated fired, so the
+            // returned device is fully populated rather than empty
+            Assert.Equal(DeviceState.Ready, device.State);
+            Assert.Equal(4, device.Channels.Count); // 2 analog + 2 digital
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenChannelsNeverPopulate_ThrowsTimeoutExceptionAndResends()
+        {
+            // Arrange — device never reports channel configuration
+            var device = new TestableDaqifiDevice("TestDevice", populateChannelsOnDeviceInfo: false);
+            device.Connect();
+
+            // Act & Assert — a clear timeout, not a silently-unpopulated device
+            await Assert.ThrowsAsync<TimeoutException>(
+                () => device.InitializeAsync(TimeSpan.FromMilliseconds(150)));
+
+            Assert.Equal(DeviceState.Error, device.State);
+            Assert.Empty(device.Channels);
+            // GetDeviceInfo is re-sent while waiting (initial request + at least one retry).
+            Assert.True(device.DeviceInfoRequestCount >= 2);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_OnReconnect_WaitsForFreshStatusInsteadOfStaleChannels()
+        {
+            // Arrange — first init populates channels; the instance is then reused across a
+            // reconnect (e.g. FirmwareUpdateService post-reset wake). Disconnect leaves the
+            // prior session's channels in place, so initialization must wait for a fresh
+            // status rather than short-circuiting on the stale channels.
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+            await device.InitializeAsync();
+            Assert.NotEmpty(device.Channels); // stale channels now linger
+
+            device.Disconnect();
+            device.Connect();
+
+            // The reconnected device does not report a fresh status.
+            device.PopulateChannelsOnDeviceInfo = false;
+
+            // Act & Assert — times out instead of returning stale channels.
+            await Assert.ThrowsAsync<TimeoutException>(
+                () => device.InitializeAsync(TimeSpan.FromMilliseconds(150)));
+            Assert.Equal(DeviceState.Error, device.State);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenCancelledDuringWait_ThrowsOperationCanceledException()
+        {
+            // Arrange — device never populates, so the wait loop is observing cancellation
+            var device = new TestableDaqifiDevice("TestDevice", populateChannelsOnDeviceInfo: false);
+            device.Connect();
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => device.InitializeAsync(TimeSpan.FromSeconds(5), cts.Token));
+        }
+
         /// <summary>
         /// A testable DaqifiDevice that captures sent messages without needing a real transport.
         /// Overrides ExecuteTextCommandAsync to bypass transport requirements in unit tests.
@@ -136,13 +206,27 @@ namespace Daqifi.Core.Tests.Device
             /// </summary>
             public List<IOutboundMessage<string>> DirectSentMessages { get; } = new();
 
+            /// <summary>
+            /// Number of GetDeviceInfo (SYSInfoPB?) requests observed.
+            /// </summary>
+            public int DeviceInfoRequestCount { get; private set; }
+
+            /// <summary>
+            /// When true, a GetDeviceInfo request synchronously populates channels (simulating
+            /// the device's status response). Settable so tests can toggle the behavior between
+            /// initialization attempts.
+            /// </summary>
+            public bool PopulateChannelsOnDeviceInfo { get; set; }
+
             public TestableDaqifiDevice(
                 string name,
                 IPAddress? ipAddress = null,
-                IReadOnlyList<string>? textCommandResponse = null)
+                IReadOnlyList<string>? textCommandResponse = null,
+                bool populateChannelsOnDeviceInfo = true)
                 : base(name, ipAddress)
             {
                 _textCommandResponse = textCommandResponse ?? Array.Empty<string>();
+                PopulateChannelsOnDeviceInfo = populateChannelsOnDeviceInfo;
             }
 
             public override void Send<T>(IOutboundMessage<T> message)
@@ -150,6 +234,22 @@ namespace Daqifi.Core.Tests.Device
                 if (message is IOutboundMessage<string> stringMessage)
                 {
                     DirectSentMessages.Add(stringMessage);
+
+                    // Simulate the device responding to GetDeviceInfo (SYSInfoPB?) with a
+                    // protobuf status message that populates channels. The real flow does this
+                    // via the protobuf consumer, which has no backing transport in unit tests.
+                    if (stringMessage.Data.Contains("SYSInfoPB"))
+                    {
+                        DeviceInfoRequestCount++;
+                        if (PopulateChannelsOnDeviceInfo)
+                        {
+                            PopulateChannelsFromStatus(new DaqifiOutMessage
+                            {
+                                AnalogInPortNum = 2,
+                                DigitalPortNum = 2
+                            });
+                        }
+                    }
                 }
             }
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -191,6 +191,89 @@ namespace Daqifi.Core.Tests.Device
             // Act & Assert
             await Assert.ThrowsAsync<OperationCanceledException>(
                 () => device.InitializeAsync(TimeSpan.FromSeconds(5), cts.Token));
+
+            // Caller-initiated cancellation is not a device fault — state must not flip to Error.
+            Assert.NotEqual(DeviceState.Error, device.State);
+            Assert.Equal(DeviceState.Connected, device.State);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenChannelsPopulateAsynchronously_CompletesViaWaitLoop()
+        {
+            // Arrange — channels arrive on a background thread after a delay (as on real hardware
+            // via the consumer thread), forcing the Task.WhenAny wait loop rather than the
+            // synchronous short-circuit.
+            var device = new TestableDaqifiDevice("TestDevice")
+            {
+                AsyncPopulationDelay = TimeSpan.FromMilliseconds(150)
+            };
+            device.Connect();
+
+            // Act
+            await device.InitializeAsync(TimeSpan.FromSeconds(5));
+
+            // Assert
+            Assert.Equal(DeviceState.Ready, device.State);
+            Assert.Equal(4, device.Channels.Count);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_StreamingUsb_Succeeds_SetsReadyAndRoutesToUsb()
+        {
+            // Arrange
+            var device = new TestableStreamingDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            await device.InitializeAsync();
+
+            // Assert — device is ready and the USB stream-interface command was sent
+            Assert.Equal(DeviceState.Ready, device.State);
+            Assert.Equal(4, device.Channels.Count);
+            Assert.Contains(device.SentData, d => d.Contains("SYSTem:STReam:INTerface 0"));
+        }
+
+        [Fact]
+        public async Task InitializeAsync_StreamingUsb_WhenUsbStepReturnsScpiError_SetsErrorNotReady()
+        {
+            // Arrange — the USB SetStreamInterface step fails after base init populated channels
+            var device = new TestableStreamingDevice("TestDevice", UsbStepBehavior.ScpiError);
+            device.Connect();
+
+            // Act & Assert — failure in the override must not leave the device falsely Ready
+            await Assert.ThrowsAsync<InvalidOperationException>(() => device.InitializeAsync());
+            Assert.Equal(DeviceState.Error, device.State);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_StreamingUsb_WhenCancelledDuringUsbStep_RevertsToConnected()
+        {
+            // Arrange — cancellation hits the USB step after base init reached the channel wait
+            var device = new TestableStreamingDevice("TestDevice", UsbStepBehavior.Cancel);
+            device.Connect();
+
+            // Act & Assert — cancellation in the override is not a fault; state reverts, not Error,
+            // and not the falsely-Ready state the old override could leave behind.
+            await Assert.ThrowsAsync<OperationCanceledException>(() => device.InitializeAsync());
+            Assert.Equal(DeviceState.Connected, device.State);
+            Assert.NotEqual(DeviceState.Ready, device.State);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1000)]
+        public async Task InitializeAsync_WithNonPositiveTimeout_ThrowsArgumentOutOfRangeException(int timeoutMs)
+        {
+            // Arrange
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            // Act & Assert — a misconfigured timeout is an argument error, not a device timeout
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                () => device.InitializeAsync(TimeSpan.FromMilliseconds(timeoutMs)));
+
+            // Misconfiguration must not flip the device into an error state.
+            Assert.Equal(DeviceState.Connected, device.State);
         }
 
         /// <summary>
@@ -218,6 +301,14 @@ namespace Daqifi.Core.Tests.Device
             /// </summary>
             public bool PopulateChannelsOnDeviceInfo { get; set; }
 
+            /// <summary>
+            /// When set, channels populate asynchronously after this delay on a background thread
+            /// (simulating a status that arrives via the consumer thread) instead of synchronously
+            /// inside Send. This exercises the production Task.WhenAny wait loop rather than the
+            /// synchronous short-circuit.
+            /// </summary>
+            public TimeSpan? AsyncPopulationDelay { get; set; }
+
             public TestableDaqifiDevice(
                 string name,
                 IPAddress? ipAddress = null,
@@ -243,11 +334,26 @@ namespace Daqifi.Core.Tests.Device
                         DeviceInfoRequestCount++;
                         if (PopulateChannelsOnDeviceInfo)
                         {
-                            PopulateChannelsFromStatus(new DaqifiOutMessage
+                            if (AsyncPopulationDelay is { } delay)
                             {
-                                AnalogInPortNum = 2,
-                                DigitalPortNum = 2
-                            });
+                                _ = Task.Run(async () =>
+                                {
+                                    await Task.Delay(delay);
+                                    PopulateChannelsFromStatus(new DaqifiOutMessage
+                                    {
+                                        AnalogInPortNum = 2,
+                                        DigitalPortNum = 2
+                                    });
+                                });
+                            }
+                            else
+                            {
+                                PopulateChannelsFromStatus(new DaqifiOutMessage
+                                {
+                                    AnalogInPortNum = 2,
+                                    DigitalPortNum = 2
+                                });
+                            }
                         }
                     }
                 }
@@ -262,6 +368,80 @@ namespace Daqifi.Core.Tests.Device
                 // Run the setup action so that Send() calls inside it are captured
                 setupAction();
                 return Task.FromResult(_textCommandResponse);
+            }
+        }
+
+        /// <summary>
+        /// Outcome of the streaming device's USB SetStreamInterface step, used to exercise the
+        /// failure paths of the OnDeviceInitializingAsync hook.
+        /// </summary>
+        private enum UsbStepBehavior
+        {
+            Succeed,
+            ScpiError,
+            Cancel
+        }
+
+        /// <summary>
+        /// A testable DaqifiStreamingDevice (always USB) whose base init populates channels on
+        /// GetDeviceInfo and whose USB stream-interface step can be made to succeed, return a SCPI
+        /// error, or be canceled.
+        /// </summary>
+        private class TestableStreamingDevice : DaqifiStreamingDevice
+        {
+            private readonly UsbStepBehavior _usbStepBehavior;
+            private readonly List<string> _sent = new();
+
+            public IReadOnlyList<string> SentData => _sent;
+
+            public override bool IsUsbConnection => true;
+
+            public TestableStreamingDevice(string name, UsbStepBehavior usbStepBehavior = UsbStepBehavior.Succeed)
+                : base(name, (IPAddress?)null)
+            {
+                _usbStepBehavior = usbStepBehavior;
+            }
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    _sent.Add(stringMessage.Data);
+                    if (stringMessage.Data.Contains("SYSInfoPB"))
+                    {
+                        PopulateChannelsFromStatus(new DaqifiOutMessage
+                        {
+                            AnalogInPortNum = 2,
+                            DigitalPortNum = 2
+                        });
+                    }
+                }
+            }
+
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+                Action setupAction,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default)
+            {
+                var before = _sent.Count;
+                setupAction();
+                var sentThisCall = _sent.Skip(before).ToList();
+                var isUsbStep = sentThisCall.Any(d => d.Contains("STReam:INTerface"));
+
+                if (isUsbStep)
+                {
+                    switch (_usbStepBehavior)
+                    {
+                        case UsbStepBehavior.ScpiError:
+                            return Task.FromResult<IReadOnlyList<string>>(
+                                new[] { "**ERROR: -200, \"Execution error\"\r\n" });
+                        case UsbStepBehavior.Cancel:
+                            throw new OperationCanceledException();
+                    }
+                }
+
+                return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
             }
         }
     }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -829,6 +829,7 @@ namespace Daqifi.Core.Device
         /// channels populate or <paramref name="channelPopulationTimeout"/> elapses (which
         /// surfaces a <see cref="TimeoutException"/>).
         /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="channelPopulationTimeout"/> is not positive.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the device is not connected, or the device returns a SCPI error during initialization.</exception>
         /// <exception cref="TimeoutException">Thrown when the device does not report its channel configuration within <paramref name="channelPopulationTimeout"/>.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
@@ -848,6 +849,18 @@ namespace Daqifi.Core.Device
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Validate the effective timeout up front (outside the try) so an invalid
+            // configuration surfaces as ArgumentOutOfRangeException rather than a misleading
+            // TimeoutException that blames the device, and without flipping device state.
+            var effectiveChannelPopulationTimeout = channelPopulationTimeout ?? DefaultChannelPopulationTimeout;
+            if (effectiveChannelPopulationTimeout <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(channelPopulationTimeout),
+                    effectiveChannelPopulationTimeout,
+                    "Channel population timeout must be positive.");
+            }
+
             State = DeviceState.Initializing;
 
             try
@@ -858,9 +871,13 @@ namespace Daqifi.Core.Device
                     streamMessageHandler: OnStreamMessageReceived
                 );
 
-                // Wire up message consumer to route messages through protocol handler
+                // Wire up message consumer to route messages through protocol handler.
+                // Remove first so a retried initialization (e.g. after a prior timeout or
+                // cancellation that left the device connected) does not double-subscribe and
+                // process every inbound message twice; '-=' is a no-op when not subscribed.
                 if (_messageConsumer != null)
                 {
+                    _messageConsumer.MessageReceived -= OnInboundMessageReceived;
                     _messageConsumer.MessageReceived += OnInboundMessageReceived;
                 }
 
@@ -898,11 +915,25 @@ namespace Daqifi.Core.Device
                 // unpopulated device on serial/CDC connections whose first status message
                 // had not yet arrived.
                 await WaitForChannelsPopulatedAsync(
-                    channelPopulationTimeout ?? DefaultChannelPopulationTimeout,
+                    effectiveChannelPopulationTimeout,
                     cancellationToken).ConfigureAwait(false);
+
+                // Run any derived-class initialization (e.g. routing the stream to USB) as part of
+                // this try/catch so a failure there leaves the device in a consistent terminal state
+                // rather than a falsely-ready device. _isInitialized is only set after it succeeds,
+                // so a failed init can be safely retried.
+                await OnDeviceInitializingAsync(cancellationToken).ConfigureAwait(false);
 
                 _isInitialized = true;
                 State = DeviceState.Ready;
+            }
+            catch (OperationCanceledException)
+            {
+                // Caller-initiated cancellation is not a device fault. Revert to a
+                // non-error state so upstream logic that treats Error as a hardware or
+                // connection failure isn't misled into reporting a phantom failure.
+                State = IsConnected ? DeviceState.Connected : DeviceState.Disconnected;
+                throw;
             }
             catch (Exception)
             {
@@ -910,6 +941,21 @@ namespace Daqifi.Core.Device
                 throw;
             }
         }
+
+        /// <summary>
+        /// When overridden in a derived class, performs additional device-specific initialization
+        /// after the device reports its channel configuration but before it is marked initialized
+        /// and ready.
+        /// </summary>
+        /// <remarks>
+        /// This runs inside <see cref="InitializeAsync"/>'s exception handling, so a failure here
+        /// leaves the device in a consistent terminal state — cancellation reverts to the connection
+        /// state and other faults set <see cref="DeviceState.Error"/> — rather than a falsely-ready
+        /// device, and the failed initialization can be retried. The base implementation does nothing.
+        /// </remarks>
+        /// <param name="cancellationToken">A cancellation token to observe.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        protected virtual Task OnDeviceInitializingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         /// <summary>
         /// Sends <c>GetDeviceInfo</c> and waits for the device to report its channel
@@ -925,7 +971,16 @@ namespace Daqifi.Core.Device
         {
             var populatedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            void OnChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e) => populatedTcs.TrySetResult(true);
+            void OnChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e)
+            {
+                // Only complete on a status that actually reported channels. A status with zero
+                // channels would otherwise satisfy the wait with an empty device — the exact
+                // outcome this method exists to prevent.
+                if (e.AnalogChannelCount + e.DigitalChannelCount > 0)
+                {
+                    populatedTcs.TrySetResult(true);
+                }
+            }
 
             // Subscribe before sending so a fast response cannot fire the event in the
             // window between Send() and subscription.
@@ -970,8 +1025,14 @@ namespace Daqifi.Core.Device
                         return;
                     }
 
-                    // The delay elapsed (or was canceled). Surface cancellation before
-                    // re-requesting.
+                    // The delay elapsed (or was canceled). Honor a result that arrived in the same
+                    // window as cancellation rather than discarding it, then surface cancellation
+                    // before re-requesting.
+                    if (populatedTcs.Task.IsCompleted)
+                    {
+                        return;
+                    }
+
                     cancellationToken.ThrowIfCancellationRequested();
 
                     // Re-request device info: serial/CDC devices can miss the first request

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -81,6 +81,21 @@ namespace Daqifi.Core.Device
         private bool _isInitialized;
         private readonly List<IChannel> _channels = new();
 
+        /// <summary>
+        /// Default time <see cref="InitializeAsync"/> waits for the device to report its
+        /// channel configuration (via the <see cref="ChannelsPopulated"/> event) before
+        /// failing with a <see cref="TimeoutException"/>.
+        /// </summary>
+        private static readonly TimeSpan DefaultChannelPopulationTimeout = TimeSpan.FromSeconds(8);
+
+        /// <summary>
+        /// Interval at which <see cref="InitializeAsync"/> re-sends <c>GetDeviceInfo</c> while
+        /// waiting for the first status message. Serial/CDC devices can miss the initial
+        /// request while the port is still settling, so the request is repeated until
+        /// channels populate or the timeout elapses.
+        /// </summary>
+        private static readonly TimeSpan ChannelPopulationPollInterval = TimeSpan.FromSeconds(1);
+
         // Serializes ExecuteTextCommandAsync calls device-wide (closes #186).
         // Multiple callers — e.g. concurrent GetSdCardFilesAsync /
         // DrainErrorQueueAsync / GetSystemInfoAsync — would otherwise race the
@@ -792,6 +807,12 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Initializes the device by running the standard initialization sequence.
         /// </summary>
+        /// <param name="channelPopulationTimeout">
+        /// Maximum time to wait for the device to report its channel configuration (via the
+        /// <see cref="ChannelsPopulated"/> event) before failing. If <c>null</c>, a default of
+        /// 8 seconds is used.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token to observe while initializing.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         /// <remarks>
         /// The initialization sequence includes:
@@ -799,11 +820,21 @@ namespace Daqifi.Core.Device
         /// 2. Stop any running streaming
         /// 3. Turn device on (if needed)
         /// 4. Set protobuf message format
-        /// 5. Query device info and capabilities
+        /// 5. Query device info and block until the device reports its channel configuration
         ///
-        /// Delays are added between commands to give the device time to process each request.
+        /// Rather than returning after a fixed delay, the method awaits the first
+        /// <see cref="ChannelsPopulated"/> event so callers receive a fully populated device.
+        /// Serial/CDC devices can take noticeably longer than the previous fixed wait to send
+        /// their first status message, so <c>GetDeviceInfo</c> is re-sent periodically until
+        /// channels populate or <paramref name="channelPopulationTimeout"/> elapses (which
+        /// surfaces a <see cref="TimeoutException"/>).
         /// </remarks>
-        public virtual async Task InitializeAsync()
+        /// <exception cref="InvalidOperationException">Thrown when the device is not connected, or the device returns a SCPI error during initialization.</exception>
+        /// <exception cref="TimeoutException">Thrown when the device does not report its channel configuration within <paramref name="channelPopulationTimeout"/>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        public virtual async Task InitializeAsync(
+            TimeSpan? channelPopulationTimeout = null,
+            CancellationToken cancellationToken = default)
         {
             if (!IsConnected)
             {
@@ -814,6 +845,8 @@ namespace Daqifi.Core.Device
             {
                 return; // Already initialized
             }
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             State = DeviceState.Initializing;
 
@@ -848,7 +881,7 @@ namespace Daqifi.Core.Device
                     Thread.Sleep(100);
 
                     Send(ScpiMessageProducer.SetProtobufStreamFormat);
-                }, responseTimeoutMs: 1000, cancellationToken: CancellationToken.None);
+                }, responseTimeoutMs: 1000, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 // Surface any SCPI error that occurred during initialization so callers
                 // know the device is not in the expected state.
@@ -860,10 +893,13 @@ namespace Daqifi.Core.Device
                         $"Device returned a SCPI error during initialization: {errorLine.Trim()}");
                 }
 
-                // Query device info – expects a protobuf response, so use plain Send()
-                // now that the protobuf consumer is running again.
-                Send(ScpiMessageProducer.GetDeviceInfo);
-                await Task.Delay(500); // Longer delay to allow device info response
+                // Query device info and block until the device reports its channel
+                // configuration. This replaces the previous fixed delay, which returned an
+                // unpopulated device on serial/CDC connections whose first status message
+                // had not yet arrived.
+                await WaitForChannelsPopulatedAsync(
+                    channelPopulationTimeout ?? DefaultChannelPopulationTimeout,
+                    cancellationToken).ConfigureAwait(false);
 
                 _isInitialized = true;
                 State = DeviceState.Ready;
@@ -872,6 +908,90 @@ namespace Daqifi.Core.Device
             {
                 State = DeviceState.Error;
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Sends <c>GetDeviceInfo</c> and waits for the device to report its channel
+        /// configuration via the <see cref="ChannelsPopulated"/> event, re-sending the request
+        /// periodically until channels populate or the timeout elapses.
+        /// </summary>
+        /// <param name="timeout">Maximum time to wait before failing.</param>
+        /// <param name="cancellationToken">A cancellation token to observe.</param>
+        /// <returns>A task that completes once channels are populated.</returns>
+        /// <exception cref="TimeoutException">Thrown when no channels are populated within <paramref name="timeout"/>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        private async Task WaitForChannelsPopulatedAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            var populatedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            void OnChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e) => populatedTcs.TrySetResult(true);
+
+            // Subscribe before sending so a fast response cannot fire the event in the
+            // window between Send() and subscription.
+            ChannelsPopulated += OnChannelsPopulated;
+            try
+            {
+                var stopwatch = Stopwatch.StartNew();
+
+                // Query device info – expects a protobuf response, so use plain Send()
+                // now that the protobuf consumer is running again.
+                Send(ScpiMessageProducer.GetDeviceInfo);
+
+                // If the response arrived synchronously (e.g. the consumer thread fired the
+                // event before we reached the wait loop), short-circuit. We gate on the
+                // completion source rather than _channels.Count so we only react to a status
+                // received after this init began — a prior session may have left stale
+                // channels behind (Disconnect does not clear them), and a fresh SYSInfoPB?
+                // response always repopulates them regardless.
+                if (populatedTcs.Task.IsCompleted)
+                {
+                    return;
+                }
+
+                while (true)
+                {
+                    var remaining = timeout - stopwatch.Elapsed;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        break;
+                    }
+
+                    var pollDelay = remaining < ChannelPopulationPollInterval
+                        ? remaining
+                        : ChannelPopulationPollInterval;
+
+                    var completed = await Task.WhenAny(
+                        populatedTcs.Task,
+                        Task.Delay(pollDelay, cancellationToken)).ConfigureAwait(false);
+
+                    if (completed == populatedTcs.Task)
+                    {
+                        return;
+                    }
+
+                    // The delay elapsed (or was canceled). Surface cancellation before
+                    // re-requesting.
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    // Re-request device info: serial/CDC devices can miss the first request
+                    // while the port is still settling.
+                    Send(ScpiMessageProducer.GetDeviceInfo);
+                }
+
+                // The event may have fired right at the timeout boundary.
+                if (populatedTcs.Task.IsCompleted)
+                {
+                    return;
+                }
+
+                throw new TimeoutException(
+                    $"Device '{Name}' did not report its channel configuration within {timeout.TotalSeconds:0.#}s. "
+                    + "The device may be unresponsive or still initializing.");
+            }
+            finally
+            {
+                ChannelsPopulated -= OnChannelsPopulated;
             }
         }
 

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -305,7 +305,8 @@ public static class DaqifiDeviceFactory
         {
             DeviceName = deviceName,
             ConnectionRetry = effectiveOptions.ConnectionRetry,
-            InitializeDevice = effectiveOptions.InitializeDevice
+            InitializeDevice = effectiveOptions.InitializeDevice,
+            ChannelPopulationTimeout = effectiveOptions.ChannelPopulationTimeout
         };
 
         // Honor LocalInterfaceAddress so multi-homed hosts egress on the NIC that
@@ -346,7 +347,8 @@ public static class DaqifiDeviceFactory
         {
             DeviceName = deviceName,
             ConnectionRetry = effectiveOptions.ConnectionRetry,
-            InitializeDevice = effectiveOptions.InitializeDevice
+            InitializeDevice = effectiveOptions.InitializeDevice,
+            ChannelPopulationTimeout = effectiveOptions.ChannelPopulationTimeout
         };
 
         return await ConnectSerialAsync(
@@ -399,7 +401,8 @@ public static class DaqifiDeviceFactory
             // Step 4: Initialize the device if requested
             if (options.InitializeDevice)
             {
-                await device.InitializeAsync().ConfigureAwait(false);
+                await device.InitializeAsync(options.ChannelPopulationTimeout, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             return device;

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -114,14 +114,21 @@ namespace Daqifi.Core.Device
         /// consumer to receive nothing. Sending <c>SYSTem:STReam:INTerface 0</c> during USB
         /// initialization ensures data flows to the serial port.
         /// </remarks>
+        /// <param name="channelPopulationTimeout">
+        /// Maximum time to wait for the device to report its channel configuration before
+        /// failing. If <c>null</c>, the base implementation's default is used.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token to observe while initializing.</param>
         /// <returns>A task representing the asynchronous initialization operation.</returns>
-        public override async Task InitializeAsync()
+        public override async Task InitializeAsync(
+            TimeSpan? channelPopulationTimeout = null,
+            CancellationToken cancellationToken = default)
         {
             // Capture pre-init state so we can skip the USB step on repeated calls
             // (base.InitializeAsync() guards with _isInitialized and returns early on repeats).
             var needsUsbInit = IsUsbConnection && State != DeviceState.Ready;
 
-            await base.InitializeAsync();
+            await base.InitializeAsync(channelPopulationTimeout, cancellationToken).ConfigureAwait(false);
 
             if (needsUsbInit)
             {
@@ -131,7 +138,7 @@ namespace Daqifi.Core.Device
                 var lines = await ExecuteTextCommandAsync(
                     () => Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.Usb)),
                     responseTimeoutMs: 500,
-                    cancellationToken: CancellationToken.None);
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 if (ContainsScpiError(lines))
                 {

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -103,9 +103,9 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
-        /// Initializes the device with the standard SCPI sequence and, for USB/serial connections,
-        /// additionally sets the streaming interface to USB so data is routed to the serial consumer
-        /// rather than to a previously-configured WiFi destination.
+        /// For USB/serial connections, sets the streaming interface to USB so data is routed to the
+        /// serial consumer rather than to a previously-configured WiFi destination. Runs as part of
+        /// <see cref="DaqifiDevice.InitializeAsync"/> after the standard SCPI sequence.
         /// </summary>
         /// <remarks>
         /// The DAQiFi firmware persists the last configured stream interface across sessions.
@@ -113,38 +113,32 @@ namespace Daqifi.Core.Device
         /// it will continue sending data over WiFi even when connected via USB — causing the serial
         /// consumer to receive nothing. Sending <c>SYSTem:STReam:INTerface 0</c> during USB
         /// initialization ensures data flows to the serial port.
+        ///
+        /// This runs inside the base <see cref="DaqifiDevice.InitializeAsync"/> exception handling
+        /// (before the device is marked initialized/ready), so a cancellation or SCPI error here
+        /// leaves the device in a consistent state and re-initializable, rather than falsely Ready.
         /// </remarks>
-        /// <param name="channelPopulationTimeout">
-        /// Maximum time to wait for the device to report its channel configuration before
-        /// failing. If <c>null</c>, the base implementation's default is used.
-        /// </param>
         /// <param name="cancellationToken">A cancellation token to observe while initializing.</param>
         /// <returns>A task representing the asynchronous initialization operation.</returns>
-        public override async Task InitializeAsync(
-            TimeSpan? channelPopulationTimeout = null,
-            CancellationToken cancellationToken = default)
+        protected override async Task OnDeviceInitializingAsync(CancellationToken cancellationToken)
         {
-            // Capture pre-init state so we can skip the USB step on repeated calls
-            // (base.InitializeAsync() guards with _isInitialized and returns early on repeats).
-            var needsUsbInit = IsUsbConnection && State != DeviceState.Ready;
-
-            await base.InitializeAsync(channelPopulationTimeout, cancellationToken).ConfigureAwait(false);
-
-            if (needsUsbInit)
+            if (!IsUsbConnection)
             {
-                // Direct streaming to the USB interface. Uses ExecuteTextCommandAsync so the
-                // command is sent in text mode (protobuf consumer temporarily stopped) and any
-                // SCPI error response is captured rather than garbling the protobuf stream.
-                var lines = await ExecuteTextCommandAsync(
-                    () => Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.Usb)),
-                    responseTimeoutMs: 500,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                return;
+            }
 
-                if (ContainsScpiError(lines))
-                {
-                    throw new InvalidOperationException(
-                        "Device returned a SCPI error while setting stream interface to USB.");
-                }
+            // Direct streaming to the USB interface. Uses ExecuteTextCommandAsync so the
+            // command is sent in text mode (protobuf consumer temporarily stopped) and any
+            // SCPI error response is captured rather than garbling the protobuf stream.
+            var lines = await ExecuteTextCommandAsync(
+                () => Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.Usb)),
+                responseTimeoutMs: 500,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (ContainsScpiError(lines))
+            {
+                throw new InvalidOperationException(
+                    "Device returned a SCPI error while setting stream interface to USB.");
             }
         }
 

--- a/src/Daqifi.Core/Device/DeviceConnectionOptions.cs
+++ b/src/Daqifi.Core/Device/DeviceConnectionOptions.cs
@@ -30,7 +30,9 @@ public class DeviceConnectionOptions
     /// <summary>
     /// Gets or sets the maximum time device initialization waits for the device to report its
     /// channel configuration before failing with a <see cref="TimeoutException"/>.
-    /// Only applies when <see cref="InitializeDevice"/> is true. Default is 8 seconds.
+    /// Only applies when <see cref="InitializeDevice"/> is true. Must be positive; a non-positive
+    /// value causes initialization (and the connecting call) to throw
+    /// <see cref="ArgumentOutOfRangeException"/>. Default is 8 seconds.
     /// </summary>
     public TimeSpan ChannelPopulationTimeout { get; set; } = TimeSpan.FromSeconds(8);
 

--- a/src/Daqifi.Core/Device/DeviceConnectionOptions.cs
+++ b/src/Daqifi.Core/Device/DeviceConnectionOptions.cs
@@ -28,6 +28,13 @@ public class DeviceConnectionOptions
     public bool InitializeDevice { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the maximum time device initialization waits for the device to report its
+    /// channel configuration before failing with a <see cref="TimeoutException"/>.
+    /// Only applies when <see cref="InitializeDevice"/> is true. Default is 8 seconds.
+    /// </summary>
+    public TimeSpan ChannelPopulationTimeout { get; set; } = TimeSpan.FromSeconds(8);
+
+    /// <summary>
     /// Creates a default configuration with default retry behavior and device initialization enabled.
     /// </summary>
     public static DeviceConnectionOptions Default => new();

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -1045,7 +1045,9 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             _logger.LogInformation("Waking post-reset device via InitializeAsync.");
             try
             {
-                await initializableDevice.InitializeAsync().ConfigureAwait(false);
+                // Pass the update's token so a cancel during the post-reset wake isn't ignored
+                // while InitializeAsync waits (up to ChannelPopulationTimeout) for channels.
+                await initializableDevice.InitializeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

Closes #247.

For serial/CDC, `DaqifiDevice.InitializeAsync` previously returned after a fixed ~500ms delay following `GetDeviceInfo` — before the device's first status message arrived — so callers received an **unpopulated** device.

`InitializeAsync` now **blocks until the device reports its channel configuration** (the `ChannelsPopulated` event) or fails with a clear `TimeoutException`. This ports the poll-until-populated workaround out of daqifi-desktop so it can become a thin wrapper over Core (unblocks daqifi/daqifi-desktop#618).

## What changed

- **`DaqifiDevice.InitializeAsync(TimeSpan? channelPopulationTimeout = null, CancellationToken = default)`** — replaces the fixed `Task.Delay(500)` with a wait that:
  - subscribes to `ChannelsPopulated` **before** sending `GetDeviceInfo` (race-free),
  - re-sends `GetDeviceInfo` every ~1s while waiting (serial/CDC devices can miss the first request during port settling),
  - throws `TimeoutException` on timeout (the repo's established convention; the existing `catch` sets `State = Error`),
  - threads the real `CancellationToken` through (previously hardcoded `CancellationToken.None`).
- **`DaqifiStreamingDevice.InitializeAsync`** — override updated to match and pass through.
- **`DeviceConnectionOptions.ChannelPopulationTimeout`** — new option (default **8s**, matching daqifi-desktop's workaround); propagated through `DaqifiDeviceFactory`.

## Design notes

- **Applies to all transports.** The mechanism (`SYSInfoPB?` → status → channels) is identical across transports, so this is strictly better than the fixed delay: healthy TCP devices return sooner, slow serial devices are waited on correctly, and the wait is now cancellable.
- **Fresh-only completion.** The wait is gated on a fresh `ChannelsPopulated` event (via a `TaskCompletionSource`), **not** `_channels.Count`. Since `Disconnect()` does not clear `_channels`, reconnecting and re-initializing the same instance (e.g. `FirmwareUpdateService`'s post-reset wake) now waits for a new status instead of short-circuiting on the prior session's stale channels. This also removes a latent data race on `_channels`.
- **`FirmwareUpdateService` impact:** its post-reset `InitializeAsync()` is already wrapped in try/catch and falls through to a 30s readiness probe — success returns faster than before, and any timeout is bounded and logged.

## Tests

`DaqifiDeviceInitializeTests` now covers: populated → `Ready` + channels exposed, never-populate → `TimeoutException` + `Error` + re-send, reconnect waits for fresh status (not stale channels), and cancellation during the wait.

- Build: **0 warnings / 0 errors** (`TreatWarningsAsErrors` on).
- Tests: **1017 passed, 2 skipped (pre-existing), 0 failed** on both `net9.0` and `net10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)