### PR TITLE
feat: device-level channel-management API (ADC/DIO/DAC enable, direction, output)

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -240,6 +240,45 @@ device.Send(ScpiMessageProducer.StopStreaming);
 Console.WriteLine($"Received {sampleCount} samples");
 ```
 
+### Channel Management
+
+`IStreamingDevice` exposes device-level channel methods that operate over the device's own
+`Channels` collection, so callers no longer need to hand-encode the ADC enable bitmask. Enabling
+or disabling analog channels recomputes the full `ENAble:VOLTage:DC` bitmask internally; digital
+channels are toggled via the global DIO enable.
+
+```csharp
+using Daqifi.Core.Channel;
+
+// Channels are populated after a status message is received from the device.
+var ai0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+var ai2 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 2);
+
+// Enable analog input channels (the device receives the combined bitmask, e.g. "5").
+device.EnableChannels(new[] { ai0, ai2 });
+
+// Disable a single channel — the recomputed mask reflects the remaining enabled channels.
+device.DisableChannel(ai0);
+
+// Turn everything off.
+device.DisableAllChannels();
+
+// Digital I/O: set direction and drive an output.
+var dio1 = device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
+device.SetDioDirection(dio1, ChannelDirection.Output);
+device.SetDioValue(dio1, true); // drive high
+
+// Analog output (NQ3 only) — addressed by channel number; staged value is applied immediately.
+device.SetAnalogOutput(0, 2.5); // DAC channel 0 to 2.5 V
+
+// Reboot the device (also disconnects, since the device drops its link while restarting).
+device.Reboot();
+```
+
+> Channel objects passed to the enable/disable and DIO methods must belong to the device's
+> `Channels` collection (so the internal state and bitmask stay in sync). Analog-output (DAC)
+> channels are not part of `Channels`, so `SetAnalogOutput` takes a channel number directly.
+
 ## SCPI Commands
 
 Use `ScpiMessageProducer` for device commands:

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Net;
 using System.Text;
 using Daqifi.Core.Communication;
@@ -507,6 +508,63 @@ public class ScpiMessageProducerTests
     {
         var message = ScpiMessageProducer.ForceBootloader;
         Assert.Equal("SYSTem:FORceBoot", message.Data);
+    }
+
+    [Fact]
+    public void SetAnalogOutputVoltage_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetAnalogOutputVoltage(0, 5.0);
+        Assert.Equal("SOURce:VOLTage:LEVel 0,5", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetAnalogOutputVoltage_FormatsFractionalVoltageWithInvariantDecimalPoint()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            // A culture whose decimal separator is a comma must not corrupt the SCPI argument.
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var message = ScpiMessageProducer.SetAnalogOutputVoltage(2, 2.5);
+            Assert.Equal("SOURce:VOLTage:LEVel 2,2.5", message.Data);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void SetAnalogOutputVoltage_WithNegativeVoltage_FormatsLeadingMinus()
+    {
+        // Negative channel is rejected, but negative voltage is valid and must render correctly.
+        var message = ScpiMessageProducer.SetAnalogOutputVoltage(0, -3.3);
+        Assert.Equal("SOURce:VOLTage:LEVel 0,-3.3", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetAnalogOutputVoltage_WithNegativeChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAnalogOutputVoltage(-1, 1.0));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void SetAnalogOutputVoltage_WithNonFiniteVoltage_Throws(double voltage)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAnalogOutputVoltage(0, voltage));
+    }
+
+    [Fact]
+    public void UpdateDacOutputs_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.UpdateDacOutputs;
+        Assert.Equal("CONFigure:DAC:UPDATE", message.Data);
+        AssertMessageFormat(message);
     }
 
     private static void AssertMessageFormat(IOutboundMessage<string> message)

--- a/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
@@ -73,6 +73,39 @@ public class ChannelPopulationTests
         Assert.IsAssignableFrom<IReadOnlyList<IChannel>>(device.Channels);
     }
 
+    [Fact]
+    public void PopulateChannelsFromStatus_PreservesEnableDirectionAndOutputAcrossRepopulation()
+    {
+        // A later status refresh (e.g. reconnect / metadata re-query) recreates channel
+        // instances; previously-applied configuration must survive, keyed by (type, number),
+        // so the device-level channel API does not silently lose enable/direction/output state.
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage { AnalogInPortNum = 2, AnalogInRes = 65535, DigitalPortNum = 2 };
+        device.PopulateChannelsFromStatus(message);
+
+        var analog0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+        analog0.IsEnabled = true;
+        var digital1 = (IDigitalChannel)device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
+        digital1.IsEnabled = true;
+        digital1.Direction = ChannelDirection.Output;
+        digital1.OutputValue = true;
+
+        // Repopulate with the same shape — produces a fresh generation of channel instances.
+        device.PopulateChannelsFromStatus(message);
+
+        var newAnalog0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+        Assert.True(newAnalog0.IsEnabled);
+
+        var newDigital1 = (IDigitalChannel)device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
+        Assert.True(newDigital1.IsEnabled);
+        Assert.Equal(ChannelDirection.Output, newDigital1.Direction);
+        Assert.True(newDigital1.OutputValue);
+
+        // A channel that was never configured keeps its defaults.
+        var newAnalog1 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 1);
+        Assert.False(newAnalog1.IsEnabled);
+    }
+
     #endregion
 
     #region Analog Channel Population

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
@@ -497,6 +497,36 @@ namespace Daqifi.Core.Tests.Device
 
         #endregion
 
+        #region State preservation across status refresh
+
+        [Fact]
+        public void EnableState_SurvivesStatusRefresh_AndMaskStaysCorrect()
+        {
+            var device = CreateConnectedDevice(analogChannels: 4, digitalChannels: 4);
+            device.EnableChannel(AnalogChannelAt(device, 0));
+            device.EnableChannel(AnalogChannelAt(device, 1));
+            device.SentMessages.Clear();
+
+            // Simulate a later status refresh (e.g. reconnect / metadata re-query), which
+            // recreates the channel instances. Previously-enabled channels must remain enabled.
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 4,
+                AnalogInRes = 65535,
+                DigitalPortNum = 4
+            });
+
+            Assert.True(AnalogChannelAt(device, 0).IsEnabled);
+            Assert.True(AnalogChannelAt(device, 1).IsEnabled);
+
+            // Enabling another channel still yields the full set-replace mask (0,1,2 => 1+2+4 = 7),
+            // not a mask that dropped the channels enabled before the refresh.
+            device.EnableChannel(AnalogChannelAt(device, 2));
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("7").Data, device.SentMessages.Last().Data);
+        }
+
+        #endregion
+
         #region Reboot
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
@@ -1,0 +1,563 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    /// <summary>
+    /// Unit tests for the device-level channel-management API on <see cref="DaqifiStreamingDevice"/>
+    /// (ADC enable bitmask, DIO direction/value, analog output, reboot).
+    /// </summary>
+    public class DaqifiStreamingDeviceChannelManagementTests
+    {
+        private static TestableDaqifiStreamingDevice CreateConnectedDevice(int analogChannels = 4, int digitalChannels = 4)
+        {
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = (uint)analogChannels,
+                AnalogInRes = 65535,
+                DigitalPortNum = (uint)digitalChannels
+            });
+            device.Connect();
+            device.SentMessages.Clear();
+            return device;
+        }
+
+        private static IChannel AnalogChannelAt(DaqifiStreamingDevice device, int channelNumber) =>
+            device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == channelNumber);
+
+        private static IChannel DigitalChannelAt(DaqifiStreamingDevice device, int channelNumber) =>
+            device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == channelNumber);
+
+        #region EnableChannel / DisableChannel - Analog bitmask
+
+        [Fact]
+        public void EnableChannel_Analog_SetsIsEnabledAndSendsBitmask()
+        {
+            var device = CreateConnectedDevice();
+            var channel = AnalogChannelAt(device, 0);
+
+            device.EnableChannel(channel);
+
+            Assert.True(channel.IsEnabled);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("1").Data, sent.Data);
+        }
+
+        [Fact]
+        public void EnableChannel_Analog_AccumulatesFullBitmaskAcrossCalls()
+        {
+            var device = CreateConnectedDevice();
+
+            device.EnableChannel(AnalogChannelAt(device, 1)); // bit 1 = 2
+            device.EnableChannel(AnalogChannelAt(device, 3)); // bit 3 = 8
+
+            // The firmware mask is a set-replace, so the last command must carry the full set (2 + 8 = 10).
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("10").Data, device.SentMessages.Last().Data);
+        }
+
+        [Fact]
+        public void DisableChannel_Analog_SendsBitmaskWithoutThatChannel()
+        {
+            var device = CreateConnectedDevice();
+            device.EnableChannel(AnalogChannelAt(device, 0));
+            device.EnableChannel(AnalogChannelAt(device, 1));
+            device.EnableChannel(AnalogChannelAt(device, 2));
+            device.SentMessages.Clear();
+
+            device.DisableChannel(AnalogChannelAt(device, 1)); // remaining: 0 and 2 => 1 + 4 = 5
+
+            Assert.False(AnalogChannelAt(device, 1).IsEnabled);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("5").Data, sent.Data);
+        }
+
+        [Fact]
+        public void EnableChannel_Analog_DoesNotSendDioCommand()
+        {
+            var device = CreateConnectedDevice();
+
+            device.EnableChannel(AnalogChannelAt(device, 0));
+
+            Assert.DoesNotContain(device.SentMessages, m =>
+                m.Data == ScpiMessageProducer.EnableDioPorts().Data ||
+                m.Data == ScpiMessageProducer.DisableDioPorts().Data);
+        }
+
+        [Fact]
+        public void EnableChannel_Analog_AtBitmaskBoundary_ProducesHighBitMask()
+        {
+            // Channel 31 is the widest bit representable in the 32-bit (1u << n) mask.
+            var device = CreateConnectedDevice(analogChannels: 32, digitalChannels: 0);
+            var channel = AnalogChannelAt(device, 31);
+
+            device.EnableChannel(channel);
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("2147483648").Data, sent.Data);
+        }
+
+        [Fact]
+        public void EnableChannel_Analog_BeyondBitmaskRange_ThrowsInvalidOperationException()
+        {
+            // Channel 32 cannot be encoded in the 32-bit mask, so the deliberate overflow guard fires.
+            var device = CreateConnectedDevice(analogChannels: 33, digitalChannels: 0);
+            var channel = AnalogChannelAt(device, 32);
+
+            Assert.Throws<InvalidOperationException>(() => device.EnableChannel(channel));
+        }
+
+        #endregion
+
+        #region EnableChannels - mixed and batching
+
+        [Fact]
+        public void EnableChannels_MultipleAnalog_SendsSingleBitmaskCommand()
+        {
+            var device = CreateConnectedDevice();
+            var channels = new[] { AnalogChannelAt(device, 0), AnalogChannelAt(device, 2) }; // 1 + 4 = 5
+
+            device.EnableChannels(channels);
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("5").Data, sent.Data);
+        }
+
+        [Fact]
+        public void EnableChannels_Mixed_SendsAdcMaskAndDioEnable()
+        {
+            var device = CreateConnectedDevice();
+            var channels = new[] { AnalogChannelAt(device, 0), DigitalChannelAt(device, 1) };
+
+            device.EnableChannels(channels);
+
+            Assert.Equal(2, device.SentMessages.Count);
+            Assert.Contains(device.SentMessages, m => m.Data == ScpiMessageProducer.EnableAdcChannels("1").Data);
+            Assert.Contains(device.SentMessages, m => m.Data == ScpiMessageProducer.EnableDioPorts().Data);
+        }
+
+        [Fact]
+        public void EnableChannels_WithNullCollection_ThrowsArgumentNullException()
+        {
+            var device = CreateConnectedDevice();
+
+            Assert.Throws<ArgumentNullException>(() => device.EnableChannels(null!));
+        }
+
+        [Fact]
+        public void EnableChannels_WithNullEntry_ThrowsAndSendsNothing()
+        {
+            var device = CreateConnectedDevice();
+            var channels = new List<IChannel> { AnalogChannelAt(device, 0), null! };
+
+            Assert.Throws<ArgumentException>(() => device.EnableChannels(channels));
+            // Validation runs before any mutation, so no command is sent and no state changes.
+            Assert.Empty(device.SentMessages);
+            Assert.False(AnalogChannelAt(device, 0).IsEnabled);
+        }
+
+        [Fact]
+        public void EnableChannels_DeferredSequence_IsEnumeratedExactlyOnce()
+        {
+            var device = CreateConnectedDevice();
+            // A single-use sequence throws on a second enumeration; this pins the contract that
+            // EnableChannels materializes the input once (validation pass + mutation pass must not
+            // re-enumerate the caller's sequence).
+            var sequence = new SingleEnumerationSequence(
+                AnalogChannelAt(device, 0), AnalogChannelAt(device, 2)); // 1 + 4 = 5
+
+            device.EnableChannels(sequence);
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("5").Data, sent.Data);
+        }
+
+        [Fact]
+        public void EnableChannels_WithDuplicateChannels_SendsSingleCorrectBitmask()
+        {
+            var device = CreateConnectedDevice();
+            var channel = AnalogChannelAt(device, 2); // bit 2 = 4
+
+            device.EnableChannels(new[] { channel, channel });
+
+            // The mask is recomputed over the device's channel set, so duplicates are idempotent.
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("4").Data, sent.Data);
+        }
+
+        #endregion
+
+        #region Digital enable (global)
+
+        [Fact]
+        public void EnableChannel_Digital_SendsGlobalDioEnable()
+        {
+            var device = CreateConnectedDevice();
+            var channel = DigitalChannelAt(device, 0);
+
+            device.EnableChannel(channel);
+
+            Assert.True(channel.IsEnabled);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableDioPorts().Data, sent.Data);
+        }
+
+        [Fact]
+        public void DisableChannel_Digital_KeepsDioEnabledWhileOthersRemain()
+        {
+            var device = CreateConnectedDevice();
+            device.EnableChannel(DigitalChannelAt(device, 0));
+            device.EnableChannel(DigitalChannelAt(device, 1));
+            device.SentMessages.Clear();
+
+            device.DisableChannel(DigitalChannelAt(device, 0));
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableDioPorts().Data, sent.Data);
+        }
+
+        [Fact]
+        public void DisableChannel_LastDigital_SendsGlobalDioDisable()
+        {
+            var device = CreateConnectedDevice();
+            device.EnableChannel(DigitalChannelAt(device, 0));
+            device.SentMessages.Clear();
+
+            device.DisableChannel(DigitalChannelAt(device, 0));
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.DisableDioPorts().Data, sent.Data);
+        }
+
+        #endregion
+
+        #region DisableAllChannels
+
+        [Fact]
+        public void DisableAllChannels_ClearsStateAndSendsZeroMaskAndDioDisable()
+        {
+            var device = CreateConnectedDevice();
+            device.EnableChannel(AnalogChannelAt(device, 0));
+            device.EnableChannel(DigitalChannelAt(device, 0));
+            device.SentMessages.Clear();
+
+            device.DisableAllChannels();
+
+            Assert.All(device.Channels, c => Assert.False(c.IsEnabled));
+            Assert.Contains(device.SentMessages, m => m.Data == ScpiMessageProducer.EnableAdcChannels("0").Data);
+            Assert.Contains(device.SentMessages, m => m.Data == ScpiMessageProducer.DisableDioPorts().Data);
+        }
+
+        [Fact]
+        public void DisableAllChannels_AnalogOnlyDevice_DoesNotSendDioCommand()
+        {
+            var device = CreateConnectedDevice(analogChannels: 4, digitalChannels: 0);
+            device.EnableChannel(AnalogChannelAt(device, 0));
+            device.SentMessages.Clear();
+
+            device.DisableAllChannels();
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("0").Data, sent.Data);
+        }
+
+        [Fact]
+        public void DisableAllChannels_DigitalOnlyDevice_DoesNotSendAdcCommand()
+        {
+            var device = CreateConnectedDevice(analogChannels: 0, digitalChannels: 4);
+            device.EnableChannel(DigitalChannelAt(device, 0));
+            device.SentMessages.Clear();
+
+            device.DisableAllChannels();
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.DisableDioPorts().Data, sent.Data);
+        }
+
+        #endregion
+
+        #region SetDioDirection
+
+        [Fact]
+        public void SetDioDirection_Output_SetsDirectionAndSendsCommand()
+        {
+            var device = CreateConnectedDevice();
+            var channel = DigitalChannelAt(device, 2);
+
+            device.SetDioDirection(channel, ChannelDirection.Output);
+
+            Assert.Equal(ChannelDirection.Output, channel.Direction);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.SetDioPortDirection(2, 1).Data, sent.Data);
+        }
+
+        [Fact]
+        public void SetDioDirection_Input_SendsZeroDirection()
+        {
+            var device = CreateConnectedDevice();
+            var channel = DigitalChannelAt(device, 1);
+
+            device.SetDioDirection(channel, ChannelDirection.Input);
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.SetDioPortDirection(1, 0).Data, sent.Data);
+        }
+
+        [Fact]
+        public void SetDioDirection_OnAnalogChannel_ThrowsArgumentException()
+        {
+            var device = CreateConnectedDevice();
+            var channel = AnalogChannelAt(device, 0);
+
+            Assert.Throws<ArgumentException>(() => device.SetDioDirection(channel, ChannelDirection.Output));
+        }
+
+        [Fact]
+        public void SetDioDirection_WithUnknownDirection_ThrowsArgumentOutOfRangeException()
+        {
+            var device = CreateConnectedDevice();
+            var channel = DigitalChannelAt(device, 0);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetDioDirection(channel, ChannelDirection.Unknown));
+        }
+
+        [Fact]
+        public void SetDioDirection_WithForeignDigitalChannel_ThrowsArgumentException()
+        {
+            var device = CreateConnectedDevice();
+            var foreign = new DigitalChannel(1); // correctly typed, but not a member of Channels
+
+            Assert.Throws<ArgumentException>(() => device.SetDioDirection(foreign, ChannelDirection.Output));
+        }
+
+        #endregion
+
+        #region SetDioValue
+
+        [Fact]
+        public void SetDioValue_High_SetsOutputValueAndSendsCommand()
+        {
+            var device = CreateConnectedDevice();
+            var channel = (IDigitalChannel)DigitalChannelAt(device, 1);
+
+            device.SetDioValue(channel, true);
+
+            Assert.True(channel.OutputValue);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.SetDioPortState(1, 1).Data, sent.Data);
+        }
+
+        [Fact]
+        public void SetDioValue_Low_SendsZeroState()
+        {
+            var device = CreateConnectedDevice();
+            var channel = (IDigitalChannel)DigitalChannelAt(device, 3);
+            channel.OutputValue = true;
+
+            device.SetDioValue(channel, false);
+
+            Assert.False(channel.OutputValue);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.SetDioPortState(3, 0).Data, sent.Data);
+        }
+
+        [Fact]
+        public void SetDioValue_OnAnalogChannel_ThrowsArgumentException()
+        {
+            var device = CreateConnectedDevice();
+            var channel = AnalogChannelAt(device, 0);
+
+            Assert.Throws<ArgumentException>(() => device.SetDioValue(channel, true));
+        }
+
+        [Fact]
+        public void SetDioValue_WithForeignDigitalChannel_ThrowsArgumentException()
+        {
+            var device = CreateConnectedDevice();
+            var foreign = new DigitalChannel(1); // correctly typed, but not a member of Channels
+
+            Assert.Throws<ArgumentException>(() => device.SetDioValue(foreign, true));
+        }
+
+        #endregion
+
+        #region SetAnalogOutput
+
+        [Fact]
+        public void SetAnalogOutput_SendsLevelThenUpdate()
+        {
+            var device = CreateConnectedDevice();
+
+            device.SetAnalogOutput(1, 5.0);
+
+            Assert.Equal(2, device.SentMessages.Count);
+            Assert.Equal(ScpiMessageProducer.SetAnalogOutputVoltage(1, 5.0).Data, device.SentMessages[0].Data);
+            Assert.Equal(ScpiMessageProducer.UpdateDacOutputs.Data, device.SentMessages[1].Data);
+        }
+
+        [Fact]
+        public void SetAnalogOutput_AddressesDacByChannelNumber()
+        {
+            var device = CreateConnectedDevice();
+            // DAC channels are addressed by number and are not part of the populated input collection;
+            // a channel number with no corresponding entry in Channels must still work and latch.
+            device.SetAnalogOutput(7, 1.25);
+
+            Assert.Equal(2, device.SentMessages.Count);
+            Assert.Equal(ScpiMessageProducer.SetAnalogOutputVoltage(7, 1.25).Data, device.SentMessages[0].Data);
+            Assert.Equal(ScpiMessageProducer.UpdateDacOutputs.Data, device.SentMessages[1].Data);
+        }
+
+        [Fact]
+        public void SetAnalogOutput_NegativeChannel_ThrowsArgumentOutOfRangeException()
+        {
+            var device = CreateConnectedDevice();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetAnalogOutput(-1, 1.0));
+        }
+
+        [Fact]
+        public void SetAnalogOutput_NonFiniteVoltage_ThrowsArgumentOutOfRangeException()
+        {
+            var device = CreateConnectedDevice();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetAnalogOutput(0, double.NaN));
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetAnalogOutput(0, double.PositiveInfinity));
+        }
+
+        #endregion
+
+        #region Membership and connection validation
+
+        [Fact]
+        public void EnableChannel_WithForeignChannel_ThrowsArgumentException()
+        {
+            var device = CreateConnectedDevice();
+            var foreign = new AnalogChannel(0); // same number, but a different instance not in Channels
+
+            Assert.Throws<ArgumentException>(() => device.EnableChannel(foreign));
+        }
+
+        [Fact]
+        public void EnableChannel_WithNullChannel_ThrowsArgumentNullException()
+        {
+            var device = CreateConnectedDevice();
+
+            Assert.Throws<ArgumentNullException>(() => device.EnableChannel(null!));
+        }
+
+        [Fact]
+        public void DisableChannel_WithForeignChannel_ThrowsArgumentException()
+        {
+            var device = CreateConnectedDevice();
+            var foreign = new AnalogChannel(0);
+
+            Assert.Throws<ArgumentException>(() => device.DisableChannel(foreign));
+        }
+
+        [Fact]
+        public void DisableChannel_WithNullChannel_ThrowsArgumentNullException()
+        {
+            var device = CreateConnectedDevice();
+
+            Assert.Throws<ArgumentNullException>(() => device.DisableChannel(null!));
+        }
+
+        [Fact]
+        public void ChannelManagement_WhenDisconnected_ThrowsInvalidOperationException()
+        {
+            // Populate channels but do not connect.
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 2,
+                AnalogInRes = 65535,
+                DigitalPortNum = 2
+            });
+            var analog = AnalogChannelAt(device, 0);
+            var digital = DigitalChannelAt(device, 0);
+
+            Assert.Throws<InvalidOperationException>(() => device.EnableChannel(analog));
+            Assert.Throws<InvalidOperationException>(() => device.EnableChannels(new[] { analog }));
+            Assert.Throws<InvalidOperationException>(() => device.DisableChannel(analog));
+            Assert.Throws<InvalidOperationException>(() => device.DisableAllChannels());
+            Assert.Throws<InvalidOperationException>(() => device.SetDioDirection(digital, ChannelDirection.Output));
+            Assert.Throws<InvalidOperationException>(() => device.SetDioValue(digital, true));
+            Assert.Throws<InvalidOperationException>(() => device.SetAnalogOutput(0, 1.0));
+            Assert.Throws<InvalidOperationException>(() => device.Reboot());
+        }
+
+        #endregion
+
+        #region Reboot
+
+        [Fact]
+        public void Reboot_SendsRebootCommandAndDisconnects()
+        {
+            var device = CreateConnectedDevice();
+
+            device.Reboot();
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.RebootDevice.Data, sent.Data);
+            Assert.False(device.IsConnected);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// An <see cref="IEnumerable{T}"/> that permits exactly one enumeration, throwing on any
+        /// subsequent attempt. Used to prove EnableChannels materializes its input only once.
+        /// </summary>
+        private sealed class SingleEnumerationSequence : IEnumerable<IChannel>
+        {
+            private readonly IChannel[] _items;
+            private bool _enumerated;
+
+            public SingleEnumerationSequence(params IChannel[] items) => _items = items;
+
+            public IEnumerator<IChannel> GetEnumerator()
+            {
+                if (_enumerated)
+                {
+                    throw new InvalidOperationException("Sequence was enumerated more than once.");
+                }
+
+                _enumerated = true;
+                return ((IEnumerable<IChannel>)_items).GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        /// <summary>
+        /// A testable <see cref="DaqifiStreamingDevice"/> that captures sent messages instead of
+        /// writing to a transport, mirroring the pattern in <see cref="DaqifiStreamingDeviceTests"/>.
+        /// </summary>
+        private sealed class TestableDaqifiStreamingDevice : DaqifiStreamingDevice
+        {
+            public List<IOutboundMessage<string>> SentMessages { get; } = new();
+
+            public TestableDaqifiStreamingDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)
+            {
+            }
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                // Capture instead of sending so tests run without a real connection.
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    SentMessages.Add(stringMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
@@ -1300,6 +1301,14 @@ public class FirmwareUpdateServiceTests
         public void Send<T>(IOutboundMessage<T> message) { }
         public void StartStreaming() => IsStreaming = true;
         public void StopStreaming() => IsStreaming = false;
+        public void EnableChannel(IChannel channel) { }
+        public void EnableChannels(IEnumerable<IChannel> channels) { }
+        public void DisableChannel(IChannel channel) { }
+        public void DisableAllChannels() { }
+        public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
+        public void SetDioValue(IChannel channel, bool value) { }
+        public void SetAnalogOutput(int channelNumber, double voltage) { }
+        public void Reboot() => IsConnected = false;
         public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
             await Task.Delay(_attemptLatency, cancellationToken).ConfigureAwait(false);
@@ -1460,6 +1469,15 @@ public class FirmwareUpdateServiceTests
         {
             IsStreaming = false;
         }
+
+        public void EnableChannel(IChannel channel) { }
+        public void EnableChannels(IEnumerable<IChannel> channels) { }
+        public void DisableChannel(IChannel channel) { }
+        public void DisableAllChannels() { }
+        public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
+        public void SetDioValue(IChannel channel, bool value) { }
+        public void SetAnalogOutput(int channelNumber, double voltage) { }
+        public void Reboot() => Disconnect();
     }
 
     private sealed class FakeLanChipInfoStreamingDevice : IStreamingDevice, ILanChipInfoProvider
@@ -1518,6 +1536,14 @@ public class FirmwareUpdateServiceTests
 
         public void StartStreaming() => IsStreaming = true;
         public void StopStreaming() => IsStreaming = false;
+        public void EnableChannel(IChannel channel) { }
+        public void EnableChannels(IEnumerable<IChannel> channels) { }
+        public void DisableChannel(IChannel channel) { }
+        public void DisableAllChannels() { }
+        public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
+        public void SetDioValue(IChannel channel, bool value) { }
+        public void SetAnalogOutput(int channelNumber, double voltage) { }
+        public void Reboot() => Disconnect();
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 using Daqifi.Core.Communication.Messages;
@@ -403,6 +404,46 @@ public class ScpiMessageProducer
     {
         return new ScpiMessage("DIO:PORt:ENAble 0");
     }
+
+    /// <summary>
+    /// Creates a command message to stage an analog output (DAC) voltage on a channel.
+    /// </summary>
+    /// <param name="channel">The analog output channel number.</param>
+    /// <param name="voltage">The output voltage, in volts.</param>
+    /// <remarks>
+    /// Analog output is available on NQ3 hardware only. The staged value is applied on
+    /// the next <see cref="UpdateDacOutputs"/>, allowing multiple channels to be updated
+    /// together. The voltage is formatted with an invariant decimal point so the command
+    /// is locale-independent.
+    /// Command: SOURce:VOLTage:LEVel channel,voltage
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetAnalogOutputVoltage(0, 5.0)); // Channel 0 to 5 V
+    /// </remarks>
+    public static IOutboundMessage<string> SetAnalogOutputVoltage(int channel, double voltage)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        if (!double.IsFinite(voltage))
+        {
+            // NaN/Infinity would render as "NaN"/"Infinity" — tokens the firmware cannot parse.
+            throw new ArgumentOutOfRangeException(nameof(voltage), voltage, "Voltage must be a finite number.");
+        }
+
+        return new ScpiMessage($"SOURce:VOLTage:LEVel {channel},{voltage.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    /// <summary>
+    /// Creates a command message to apply all staged analog output (DAC) voltages.
+    /// </summary>
+    /// <remarks>
+    /// Latches the values previously staged via <see cref="SetAnalogOutputVoltage"/> so they
+    /// take effect on the hardware. Analog output is available on NQ3 hardware only.
+    /// Command: CONFigure:DAC:UPDATE
+    /// Example: messageProducer.Send(ScpiMessageProducer.UpdateDacOutputs);
+    /// </remarks>
+    public static IOutboundMessage<string> UpdateDacOutputs => new ScpiMessage("CONFigure:DAC:UPDATE");
 
     /// <summary>
     /// Creates a command message to set the device to create its own WiFi network (Self-Hosted mode).

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -53,6 +53,25 @@ namespace Daqifi.Core.Device
         public IReadOnlyList<IChannel> Channels => _channels.AsReadOnly();
 
         /// <summary>
+        /// Returns a point-in-time snapshot of the channel collection, taken under the
+        /// channels lock so it is safe to enumerate even when a status message repopulates
+        /// the collection concurrently on the consumer thread.
+        /// </summary>
+        /// <remarks>
+        /// The public <see cref="Channels"/> property exposes a live view over the backing list;
+        /// callers that fold over channels off the consumer thread (e.g. the device-level
+        /// channel-management API) should use this snapshot instead to avoid a concurrent-mutation
+        /// <see cref="InvalidOperationException"/> or a torn read.
+        /// </remarks>
+        protected IReadOnlyList<IChannel> SnapshotChannels()
+        {
+            lock (_channelsLock)
+            {
+                return _channels.ToArray();
+            }
+        }
+
+        /// <summary>
         /// Gets the device's timestamp clock frequency in Hz.
         /// Populated from the <c>TimestampFreq</c> field of the status message.
         /// Used as the fallback frequency for SD card log file parsing when no
@@ -80,6 +99,11 @@ namespace Daqifi.Core.Device
         private bool _isDisconnecting;
         private bool _isInitialized;
         private readonly List<IChannel> _channels = new();
+
+        // Guards structural access to _channels: the consumer thread repopulates it
+        // (Clear/Add in PopulateChannelsFromStatus) while caller threads fold over a
+        // snapshot via SnapshotChannels for the device-level channel-management API.
+        private readonly object _channelsLock = new();
 
         // Serializes ExecuteTextCommandAsync calls device-wide (closes #186).
         // Multiple callers — e.g. concurrent GetSdCardFilesAsync /
@@ -920,26 +944,36 @@ namespace Daqifi.Core.Device
                 TimestampFrequency = message.TimestampFreq;
             }
 
-            // Clear existing channels before repopulating
-            _channels.Clear();
-
             var analogCount = 0;
             var digitalCount = 0;
+            IChannel[] channelsSnapshot;
 
-            // Populate analog input channels
-            if (message.AnalogInPortNum > 0)
+            // Repopulate under the channels lock so a caller folding over a snapshot on
+            // another thread (the device-level channel-management API) never observes a
+            // half-cleared or torn list.
+            lock (_channelsLock)
             {
-                analogCount = PopulateAnalogChannels(message);
+                // Clear existing channels before repopulating
+                _channels.Clear();
+
+                // Populate analog input channels
+                if (message.AnalogInPortNum > 0)
+                {
+                    analogCount = PopulateAnalogChannels(message);
+                }
+
+                // Populate digital channels
+                if (message.DigitalPortNum > 0)
+                {
+                    digitalCount = PopulateDigitalChannels(message);
+                }
+
+                channelsSnapshot = _channels.ToArray();
             }
 
-            // Populate digital channels
-            if (message.DigitalPortNum > 0)
-            {
-                digitalCount = PopulateDigitalChannels(message);
-            }
-
-            // Raise the ChannelsPopulated event with a snapshot to prevent mutations affecting handlers
-            var channelsSnapshot = _channels.ToArray();
+            // Raise the ChannelsPopulated event with a snapshot to prevent mutations affecting
+            // handlers — and outside the lock so a handler that calls back into a channel method
+            // (which takes the same lock) cannot deadlock.
             ChannelsPopulated?.Invoke(this, new ChannelsPopulatedEventArgs(
                 Array.AsReadOnly(channelsSnapshot),
                 analogCount,

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -953,6 +953,19 @@ namespace Daqifi.Core.Device
             // half-cleared or torn list.
             lock (_channelsLock)
             {
+                // Capture the prior per-channel configuration before recreating instances.
+                // A status refresh (e.g. a later GetDeviceInfo on reconnect / metadata refresh)
+                // would otherwise reset every channel to IsEnabled=false, silently discarding
+                // the enable/direction/output state the device-level channel-management API
+                // computes its ADC mask and DIO state from. Keyed by (type, number) since the
+                // channel instances themselves are replaced.
+                var priorState = new Dictionary<(ChannelType, int), (bool IsEnabled, ChannelDirection Direction, bool OutputValue)>();
+                foreach (var existing in _channels)
+                {
+                    var outputValue = existing is IDigitalChannel digitalExisting && digitalExisting.OutputValue;
+                    priorState[(existing.Type, existing.ChannelNumber)] = (existing.IsEnabled, existing.Direction, outputValue);
+                }
+
                 // Clear existing channels before repopulating
                 _channels.Clear();
 
@@ -966,6 +979,23 @@ namespace Daqifi.Core.Device
                 if (message.DigitalPortNum > 0)
                 {
                     digitalCount = PopulateDigitalChannels(message);
+                }
+
+                // Reapply the captured state to the freshly created channels so configuration
+                // survives the refresh. Channels with no prior entry keep their defaults.
+                foreach (var channel in _channels)
+                {
+                    if (!priorState.TryGetValue((channel.Type, channel.ChannelNumber), out var state))
+                    {
+                        continue;
+                    }
+
+                    channel.IsEnabled = state.IsEnabled;
+                    channel.Direction = state.Direction;
+                    if (channel is IDigitalChannel digitalChannel)
+                    {
+                        digitalChannel.OutputValue = state.OutputValue;
+                    }
                 }
 
                 channelsSnapshot = _channels.ToArray();

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1,3 +1,4 @@
+using Daqifi.Core.Channel;
 using Daqifi.Core.Communication;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
@@ -8,6 +9,7 @@ using Daqifi.Core.Firmware;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -173,6 +175,283 @@ namespace Daqifi.Core.Device
 
             IsStreaming = false;
             Send(ScpiMessageProducer.StopStreaming);
+        }
+
+        /// <summary>
+        /// The maximum analog channel number that can be encoded in the ADC enable bitmask.
+        /// The mask is a 32-bit value (<c>1u &lt;&lt; ChannelNumber</c>), so channel numbers must be 0-31.
+        /// </summary>
+        private const int MaxAdcBitmaskChannel = 31;
+
+        /// <inheritdoc />
+        public void EnableChannel(IChannel channel)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+            SetChannelsEnabled(new[] { channel }, enabled: true);
+        }
+
+        /// <inheritdoc />
+        public void EnableChannels(IEnumerable<IChannel> channels)
+        {
+            ArgumentNullException.ThrowIfNull(channels);
+            SetChannelsEnabled(channels as IReadOnlyList<IChannel> ?? channels.ToList(), enabled: true);
+        }
+
+        /// <inheritdoc />
+        public void DisableChannel(IChannel channel)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+            SetChannelsEnabled(new[] { channel }, enabled: false);
+        }
+
+        /// <inheritdoc />
+        public void DisableAllChannels()
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            foreach (var channel in SnapshotChannels())
+            {
+                channel.IsEnabled = false;
+            }
+
+            // Push the cleared state for whichever channel types this device actually has.
+            SendAdcEnableMask();
+            SendDioEnableState();
+        }
+
+        /// <inheritdoc />
+        public void SetDioDirection(IChannel channel, ChannelDirection direction)
+        {
+            // Argument validation precedes the connection (state) check so misuse surfaces
+            // the same exception type regardless of connection state.
+            ArgumentNullException.ThrowIfNull(channel);
+
+            if (channel.Type != ChannelType.Digital)
+            {
+                throw new ArgumentException("Direction can only be set on digital channels.", nameof(channel));
+            }
+
+            if (direction != ChannelDirection.Input && direction != ChannelDirection.Output)
+            {
+                throw new ArgumentOutOfRangeException(nameof(direction), direction, "Direction must be Input or Output.");
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            EnsureChannelBelongs(channel);
+
+            channel.Direction = direction;
+            Send(ScpiMessageProducer.SetDioPortDirection(
+                channel.ChannelNumber,
+                direction == ChannelDirection.Output ? 1 : 0));
+        }
+
+        /// <inheritdoc />
+        public void SetDioValue(IChannel channel, bool value)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+
+            // Gate on Type (matching SetDioDirection) rather than the IDigitalChannel interface,
+            // so both DIO methods accept the same set of channels. The SCPI command only needs
+            // the channel number; OutputValue mirroring is best-effort local bookkeeping.
+            if (channel.Type != ChannelType.Digital)
+            {
+                throw new ArgumentException("A digital output value can only be set on digital channels.", nameof(channel));
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            EnsureChannelBelongs(channel);
+
+            if (channel is IDigitalChannel digitalChannel)
+            {
+                digitalChannel.OutputValue = value;
+            }
+
+            Send(ScpiMessageProducer.SetDioPortState(channel.ChannelNumber, value ? 1 : 0));
+        }
+
+        /// <inheritdoc />
+        public void SetAnalogOutput(int channelNumber, double voltage)
+        {
+            if (channelNumber < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            // Analog-output (DAC) channels are addressed by number; they are not part of the
+            // populated Channels collection (PopulateChannelsFromStatus creates analog *input*
+            // channels only). Stage the level, then latch it.
+            Send(ScpiMessageProducer.SetAnalogOutputVoltage(channelNumber, voltage));
+            Send(ScpiMessageProducer.UpdateDacOutputs);
+        }
+
+        /// <inheritdoc />
+        public void Reboot()
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.RebootDevice);
+
+            // The device drops its link while restarting, so tear down the local
+            // connection rather than leaving a stale one that reports Connected.
+            Disconnect();
+        }
+
+        /// <summary>
+        /// Sets the enabled state for a set of channels, then sends one device command per affected
+        /// channel type (the ADC enable bitmask for analog, the global DIO enable for digital).
+        /// Validation runs before any mutation so an invalid entry leaves device state untouched.
+        /// </summary>
+        private void SetChannelsEnabled(IReadOnlyList<IChannel> channels, bool enabled)
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            // Validate everything up front so a bad entry can't leave a partially-applied state.
+            foreach (var channel in channels)
+            {
+                if (channel is null)
+                {
+                    throw new ArgumentException("The channel collection contains a null entry.", nameof(channels));
+                }
+
+                EnsureChannelBelongs(channel);
+            }
+
+            var touchedAnalog = false;
+            var touchedDigital = false;
+
+            foreach (var channel in channels)
+            {
+                channel.IsEnabled = enabled;
+
+                if (channel.Type == ChannelType.Analog)
+                {
+                    touchedAnalog = true;
+                }
+                else if (channel.Type == ChannelType.Digital)
+                {
+                    touchedDigital = true;
+                }
+            }
+
+            if (touchedAnalog)
+            {
+                SendAdcEnableMask();
+            }
+
+            if (touchedDigital)
+            {
+                SendDioEnableState();
+            }
+        }
+
+        /// <summary>
+        /// Recomputes the ADC enable bitmask over all currently-enabled analog channels and sends it.
+        /// Does nothing when the device has no analog channels. The firmware treats the value as a
+        /// set-replace, so the full mask of enabled analog channels is sent every time.
+        /// </summary>
+        private void SendAdcEnableMask()
+        {
+            uint mask = 0;
+            var hasAnalogChannels = false;
+
+            foreach (var channel in SnapshotChannels())
+            {
+                if (channel.Type != ChannelType.Analog)
+                {
+                    continue;
+                }
+
+                hasAnalogChannels = true;
+
+                if (!channel.IsEnabled)
+                {
+                    continue;
+                }
+
+                if (channel.ChannelNumber > MaxAdcBitmaskChannel)
+                {
+                    throw new InvalidOperationException(
+                        $"Analog channel number {channel.ChannelNumber} exceeds the maximum ({MaxAdcBitmaskChannel}) that can be encoded in the ADC enable bitmask.");
+                }
+
+                mask |= 1u << channel.ChannelNumber;
+            }
+
+            if (!hasAnalogChannels)
+            {
+                return;
+            }
+
+            Send(ScpiMessageProducer.EnableAdcChannels(mask.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        /// <summary>
+        /// Sends the global DIO enable command reflecting whether any digital channel is enabled.
+        /// Does nothing when the device has no digital channels. The firmware exposes only a global
+        /// DIO enable, so per-channel digital enabling is collapsed to this aggregate state.
+        /// </summary>
+        private void SendDioEnableState()
+        {
+            var hasDigitalChannels = false;
+            var anyEnabled = false;
+
+            foreach (var channel in SnapshotChannels())
+            {
+                if (channel.Type != ChannelType.Digital)
+                {
+                    continue;
+                }
+
+                hasDigitalChannels = true;
+
+                if (channel.IsEnabled)
+                {
+                    anyEnabled = true;
+                }
+            }
+
+            if (!hasDigitalChannels)
+            {
+                return;
+            }
+
+            Send(anyEnabled
+                ? ScpiMessageProducer.EnableDioPorts()
+                : ScpiMessageProducer.DisableDioPorts());
+        }
+
+        /// <summary>
+        /// Throws when the supplied channel is not part of this device's populated channel collection,
+        /// which would mean mutating it could not affect the device-level enable state.
+        /// </summary>
+        private void EnsureChannelBelongs(IChannel channel)
+        {
+            if (!SnapshotChannels().Contains(channel))
+            {
+                throw new ArgumentException("The specified channel does not belong to this device.", nameof(channel));
+            }
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using Daqifi.Core.Channel;
+
 namespace Daqifi.Core.Device
 {
     /// <summary>
@@ -24,5 +27,78 @@ namespace Daqifi.Core.Device
         /// Stops streaming data from the device.
         /// </summary>
         void StopStreaming();
+
+        /// <summary>
+        /// Enables a single channel and reconfigures the device accordingly.
+        /// </summary>
+        /// <param name="channel">The channel to enable. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <remarks>
+        /// For analog channels the device-level ADC enable bitmask is recomputed over all enabled
+        /// analog channels and sent to the device. For digital channels the global DIO enable state
+        /// is updated. The channel's <see cref="IChannel.IsEnabled"/> flag is set to <c>true</c>.
+        /// </remarks>
+        void EnableChannel(IChannel channel);
+
+        /// <summary>
+        /// Enables multiple channels in a single operation, sending at most one command per channel type.
+        /// </summary>
+        /// <param name="channels">The channels to enable. Each must belong to this device's <c>Channels</c> collection.</param>
+        /// <remarks>
+        /// Each channel's <see cref="IChannel.IsEnabled"/> flag is set to <c>true</c>. The device then
+        /// receives at most one command per affected channel type: the recomputed ADC enable bitmask for
+        /// analog channels and the global DIO enable for digital channels. The input is enumerated once.
+        /// </remarks>
+        void EnableChannels(IEnumerable<IChannel> channels);
+
+        /// <summary>
+        /// Disables a single channel and reconfigures the device accordingly.
+        /// </summary>
+        /// <param name="channel">The channel to disable. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <remarks>
+        /// Sets the channel's <see cref="IChannel.IsEnabled"/> flag to <c>false</c>. For analog channels the
+        /// ADC enable bitmask is recomputed over the remaining enabled analog channels; for digital channels
+        /// the global DIO enable state is updated.
+        /// </remarks>
+        void DisableChannel(IChannel channel);
+
+        /// <summary>
+        /// Disables all channels on the device.
+        /// </summary>
+        void DisableAllChannels();
+
+        /// <summary>
+        /// Sets the direction (input or output) of a digital I/O channel.
+        /// </summary>
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="direction">The direction to apply. Must be <see cref="ChannelDirection.Input"/> or <see cref="ChannelDirection.Output"/>.</param>
+        void SetDioDirection(IChannel channel, ChannelDirection direction);
+
+        /// <summary>
+        /// Sets the output state (high or low) of a digital I/O channel.
+        /// </summary>
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="value"><c>true</c> to drive the output high; <c>false</c> to drive it low.</param>
+        void SetDioValue(IChannel channel, bool value);
+
+        /// <summary>
+        /// Sets the analog output (DAC) voltage of a channel and applies it immediately.
+        /// </summary>
+        /// <param name="channelNumber">The analog output channel number. DAC channels are addressed by
+        /// number; they are not part of the <c>Channels</c> collection (which holds analog inputs).</param>
+        /// <param name="voltage">The output voltage, in volts. Must be a finite number.</param>
+        /// <remarks>
+        /// Analog output is available on NQ3 hardware only. Each call stages the level and then latches it
+        /// immediately, so it is not suitable for synchronized multi-channel updates.
+        /// </remarks>
+        void SetAnalogOutput(int channelNumber, double voltage);
+
+        /// <summary>
+        /// Reboots the device and disconnects from it.
+        /// </summary>
+        /// <remarks>
+        /// Sends the reboot command and then tears down the local connection, since the device
+        /// drops its link while restarting. Reconnect once the device is back online.
+        /// </remarks>
+        void Reboot();
     }
-} 
+}


### PR DESCRIPTION
Closes #241.

## Summary

Adds a device-level channel-management API on `IStreamingDevice` / `DaqifiStreamingDevice` that operates over the device's own `Channels` collection, so consumers (notably daqifi-desktop) no longer re-implement the ADC enable-bitmask encoding by hand.

### New methods
- `EnableChannel` / `EnableChannels` / `DisableChannel` / `DisableAllChannels` — maintain `IsEnabled` and encode the `ENAble:VOLTage:DC` bitmask internally over the enabled **analog** channels (the firmware treats the mask as a set-replace, so the full mask is sent each time). For **digital** channels, the global `DIO:PORt:ENAble` is toggled based on aggregate state.
- `SetDioDirection(IChannel, ChannelDirection)` → `DIO:PORt:DIRection`
- `SetDioValue(IChannel, bool)` → `DIO:PORt:STATe`
- `SetAnalogOutput(int channelNumber, double voltage)` → `SOURce:VOLTage:LEVel` + `CONFigure:DAC:UPDATE` (NQ3 only)
- `Reboot()` → `SYSTem:REboot` then `Disconnect()`

### New SCPI builders
`ScpiMessageProducer.SetAnalogOutputVoltage(int, double)` (invariant-culture decimal; rejects non-finite voltage) and `UpdateDacOutputs`.

## Design notes
- **ADC enable stays a bitmask.** Confirmed against the firmware SCPI wiki (`ENAble:VOLTage:DC 65535` = all 16 channels) and Core's existing builder.
- **Analog output is addressed by channel number.** DAC channels are not populated into `Channels` (only analog *inputs* are), so `SetAnalogOutput` takes an `int` rather than an `IChannel` — this avoids a footgun where an analog *input* channel could silently drive a DAC output.
- **Membership is enforced** for the enable/disable and DIO methods (the channel must belong to `Channels`) so internal state and the bitmask stay in sync.

## Thread-safety
The fold methods previously enumerated the live `Channels` view on the caller thread while the consumer thread can repopulate `_channels` (`Clear()`/`Add()`) on each status message — a concurrent-modification crash / torn-mask read. Repopulation is now guarded by a lock (event raised outside the lock to avoid handler deadlock), and the device-level methods fold over a locked snapshot via a new `protected SnapshotChannels()`.

## ⚠️ Breaking change
`IStreamingDevice` gains 8 new members. Any external implementer or test double must implement them (the three firmware-update test fakes in this repo were updated accordingly).

## Testing
- `dotnet build Daqifi.Core.sln`: **0 warnings, 0 errors**
- Full suite: **1058 passed, 2 skipped** (net9.0); affected suites green on net10.0.
- New tests in `DaqifiStreamingDeviceChannelManagementTests.cs` cover bitmask accumulation/set-replace, the 32-bit boundary (channel 31) and overflow guard (channel >31), single-enumeration of deferred inputs, mixed/duplicate/empty channel sets, DIO direction/value, foreign-channel + disconnected guards, analog output (incl. negative-channel and non-finite-voltage rejection), and reboot.

## Review
This PR was self-reviewed via a multi-dimension adversarial pass (correctness, edge-cases, API design, test quality, consistency, firmware/SCPI). Confirmed findings — the concurrency race, the AO signature footgun, validation ordering, DIO type-gating, non-finite voltage, and several dead-branch test gaps — were all addressed here.

## Notes / possible follow-ups
- A batch `SetAnalogOutputs(...)` overload could use the firmware's atomic multi-channel latch (each `SetAnalogOutput` call currently latches immediately); documented as immediate-apply for now.
- If `IStreamingDevice` cohesion becomes a concern, channel management could later move to capability interfaces — kept on `IStreamingDevice` here per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)