### PR TITLE
fix(scpi)!: send SYST:STORage:SD:FILE for SD logging (firmware v3.5.0+)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -105,7 +105,7 @@ public class ScpiMessageProducerTests
     public void SetSdLoggingFileName_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.SetSdLoggingFileName("log.bin");
-        Assert.Equal("SYSTem:STORage:SD:LOGging \"log.bin\"", message.Data);
+        Assert.Equal("SYSTem:STORage:SD:FILE \"log.bin\"", message.Data);
         AssertMessageFormat(message);
     }
 

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -285,7 +285,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal("SYSTem:COMMunicate:LAN:ENAbled 0", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 1", sentCommands[1]);
             Assert.Equal("SYSTem:STReam:INTerface 2", sentCommands[2]);
-            Assert.Equal("SYSTem:STORage:SD:LOGging \"mylog.bin\"", sentCommands[3]);
+            Assert.Equal("SYSTem:STORage:SD:FILE \"mylog.bin\"", sentCommands[3]);
             Assert.Equal("SYSTem:STReam:FORmat 0", sentCommands[4]);
             Assert.Equal("SYSTem:StartStreamData 100", sentCommands[5]);
         }
@@ -315,7 +315,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Contains("SYSTem:STORage:SD:LOGging \"custom_data.bin\"", sentCommands);
+            Assert.Contains("SYSTem:STORage:SD:FILE \"custom_data.bin\"", sentCommands);
         }
 
         [Fact]
@@ -330,7 +330,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
             Assert.Contains(".bin", loggingCommand);
@@ -438,7 +438,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
         }
@@ -455,7 +455,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
         }
@@ -492,7 +492,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal("SYSTem:COMMunicate:LAN:ENAbled 0", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 1", sentCommands[1]);
             Assert.Equal("SYSTem:STReam:INTerface 2", sentCommands[2]);
-            Assert.Equal("SYSTem:STORage:SD:LOGging \"mylog.json\"", sentCommands[3]);
+            Assert.Equal("SYSTem:STORage:SD:FILE \"mylog.json\"", sentCommands[3]);
             Assert.Equal("SYSTem:STReam:FORmat 1", sentCommands[4]);
             Assert.Equal("SYSTem:StartStreamData 100", sentCommands[5]);
         }
@@ -513,7 +513,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal("SYSTem:COMMunicate:LAN:ENAbled 0", sentCommands[0]);
             Assert.Equal("SYSTem:STORage:SD:ENAble 1", sentCommands[1]);
             Assert.Equal("SYSTem:STReam:INTerface 2", sentCommands[2]);
-            Assert.Equal("SYSTem:STORage:SD:LOGging \"mylog.csv\"", sentCommands[3]);
+            Assert.Equal("SYSTem:STORage:SD:FILE \"mylog.csv\"", sentCommands[3]);
             Assert.Equal("SYSTem:STReam:FORmat 2", sentCommands[4]);
             Assert.Equal("SYSTem:StartStreamData 100", sentCommands[5]);
         }
@@ -530,7 +530,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
             Assert.Contains(".json", loggingCommand);
@@ -549,7 +549,7 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             // Assert
             var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:LOGging"));
+            var loggingCommand = sentCommands.FirstOrDefault(c => c.StartsWith("SYSTem:STORage:SD:FILE"));
             Assert.NotNull(loggingCommand);
             Assert.Contains("log_", loggingCommand);
             Assert.Contains(".csv", loggingCommand);

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -129,7 +129,7 @@ public class ScpiMessageProducer
     /// <summary>
     /// Creates a query message to retrieve a specific file from the SD card.
     /// </summary>
-    /// <param name="fileName">The name of the file to retrieve. Must be enclosed in quotes.</param>
+    /// <param name="fileName">The name of the file to retrieve. Provide the bare name without surrounding quotes; they are added automatically.</param>
     /// <remarks>
     /// Command: SYSTem:STORage:SD:GET "filename.bin"
     /// Example: messageProducer.Send(ScpiMessageProducer.GetSdFile("data.bin"));
@@ -142,7 +142,7 @@ public class ScpiMessageProducer
     /// <summary>
     /// Creates a command message to set the logging file name on the SD card.
     /// </summary>
-    /// <param name="fileName">The name of the file to create or append to. Must be enclosed in quotes.</param>
+    /// <param name="fileName">The name of the file to create or append to. Provide the bare name without surrounding quotes; they are added automatically.</param>
     /// <remarks>
     /// The specified file will be created if it doesn't exist, or appended to if it already exists.
     /// Command: SYSTem:STORage:SD:FILE "filename.bin"

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -144,12 +144,14 @@ public class ScpiMessageProducer
     /// <param name="fileName">The name of the file to create or append to. Must be enclosed in quotes.</param>
     /// <remarks>
     /// The specified file will be created if it doesn't exist, or appended to if it already exists.
-    /// Command: SYSTem:STORage:SD:LOGging "filename.bin"
+    /// Command: SYSTem:STORage:SD:FILE "filename.bin"
+    /// Requires firmware v3.5.0 or newer; the command was renamed from
+    /// <c>SYSTem:STORage:SD:LOGging</c> and older firmware does not accept it (see daqifi-core#251).
     /// Example: messageProducer.Send(ScpiMessageProducer.SetSdLoggingFileName("data.bin"));
     /// </remarks>
     public static IOutboundMessage<string> SetSdLoggingFileName(string fileName)
     {
-        return new ScpiMessage($"SYSTem:STORage:SD:LOGging \"{fileName}\"");
+        return new ScpiMessage($"SYSTem:STORage:SD:FILE \"{fileName}\"");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes silently-broken SD card logging against current firmware.

Firmware **v3.5.0** hard-renamed the SD logging filename command from `SYSTem:STORage:SD:LOGging "file"` to `SYSTem:STORage:SD:FILE "file"` **with no backward-compatible alias** ([daqifi-nyquist-firmware#323](https://github.com/daqifi/daqifi-nyquist-firmware/pull/323)). daqifi-core's `SetSdLoggingFileName` has been emitting the old name ever since, so on any v3.5.0+ device the firmware rejects it with `-113 "Undefined header"`.

Because `StartSdCardLoggingAsync` issues the command **fire-and-forget** (no response check), the failure is **silent** — logging appears to start but the device records nothing.

This PR switches the single producer string to `SYSTem:STORage:SD:FILE`. No .NET API changes.

> Note: the three other renames in the abandoned #168 (`StartStreamData`→`STReam:START`, `StopStreamData`→`STReam:STOP`, `USB:SetTransparentMode`→`USB:TRANSparent:MODE`) are **not** included — firmware kept those old names as aliases, so they work on all firmware and need no change. This PR is only the one command that has no alias.

## Verified on hardware

Probed the connected device's SCPI error queue under identical conditions:

| Command | Firmware response | Error queue |
|---|---|---|
| `SYSTem:STORage:SD:LOGging "f"` (old) | `**ERROR: -113, "Undefined header"` | `-113,"Undefined header"` |
| `SYSTem:STORage:SD:FILE "f"` (new) | (none) | `0,"No error"` |

## Testing

- `dotnet build -c Release`: **0 warnings, 0 errors** (TreatWarningsAsErrors).
- Full suite (net9.0): **1053 passed, 0 failed, 2 skipped**.

## ⚠️ Breaking change / firmware floor

SD card logging now requires device firmware **v3.5.0 or newer**. There is **no single command name that works on both** sides of the v3.5.0 cutover (old firmware only accepts `SD:LOGging`, new firmware only accepts `SD:FILE`), so this intentionally drops < v3.5.0 support for SD logging rather than version-gating.

Per discussion, universal firmware-version capability gating (which would let this select the command per device version instead of requiring a floor) is tracked in **#251**. The producer XML doc references it inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
