### PR TITLE
feat(sdcard): warn on low SD free space before logging (closes #230)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -484,6 +484,29 @@ public class ScpiMessageProducerTests
         AssertMessageFormat(message);
     }
 
+    [Fact]
+    public void SetSdMinFreeSpace_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetSdMinFreeSpace(52428800);
+        Assert.Equal("SYSTem:STORage:SD:MINFree 52428800", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetSdMinFreeSpace_WithZero_DisablesGate()
+    {
+        var message = ScpiMessageProducer.SetSdMinFreeSpace(0);
+        Assert.Equal("SYSTem:STORage:SD:MINFree 0", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetSdMinFreeSpace_WithNegativeValue_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ScpiMessageProducer.SetSdMinFreeSpace(-1));
+    }
+
     [Theory]
     [InlineData(StreamInterface.Usb, 0)]
     [InlineData(StreamInterface.WiFi, 1)]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardCaptureEstimateTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardCaptureEstimateTests.cs
@@ -1,0 +1,61 @@
+using System;
+using Daqifi.Core.Device.SdCard;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard
+{
+    public class SdCardCaptureEstimateTests
+    {
+        [Fact]
+        public void Constructor_ComputesBytesPerSecondAndEstimatedBytes()
+        {
+            // 1000 Hz × 4 channels × 2 bytes = 8000 B/s; over 60 s = 480000 B.
+            var estimate = new SdCardCaptureEstimate(1000, 4, TimeSpan.FromSeconds(60), bytesPerSamplePerChannel: 2);
+
+            Assert.Equal(8000, estimate.BytesPerSecond);
+            Assert.Equal(480000, estimate.EstimatedBytes);
+        }
+
+        [Fact]
+        public void Constructor_DefaultsBytesPerSampleToRawAdcWidth()
+        {
+            var estimate = new SdCardCaptureEstimate(100, 1, TimeSpan.FromSeconds(1));
+
+            Assert.Equal(SdCardCaptureEstimate.DefaultBytesPerSamplePerChannel, estimate.BytesPerSamplePerChannel);
+            Assert.Equal(2, estimate.BytesPerSamplePerChannel);
+            Assert.Equal(200, estimate.BytesPerSecond);
+        }
+
+        [Theory]
+        [InlineData(0, 1, 1)]
+        [InlineData(-1, 1, 1)]
+        [InlineData(100, 0, 1)]
+        [InlineData(100, -1, 1)]
+        [InlineData(100, 1, 0)]
+        [InlineData(100, 1, -1)]
+        public void Constructor_WithNonPositiveArgument_Throws(int frequencyHz, int channelCount, int bytesPerSample)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new SdCardCaptureEstimate(frequencyHz, channelCount, TimeSpan.FromSeconds(1), bytesPerSample));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Constructor_WithNonPositiveDuration_Throws(int seconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new SdCardCaptureEstimate(100, 1, TimeSpan.FromSeconds(seconds)));
+        }
+
+        [Fact]
+        public void EstimatedBytes_WhenOverflowing_ClampsToMaxValue()
+        {
+            // An astronomically long capture at high rate would overflow a long; the property clamps instead.
+            // BytesPerSecond ≈ 2.6e8 × TimeSpan.MaxValue (~9.2e11 s) ≈ 2.4e20 > long.MaxValue (~9.2e18).
+            var estimate = new SdCardCaptureEstimate(1_000_000, 32, TimeSpan.MaxValue, bytesPerSamplePerChannel: 8);
+
+            Assert.Equal(long.MaxValue, estimate.EstimatedBytes);
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardCaptureEstimateTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardCaptureEstimateTests.cs
@@ -49,6 +49,18 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public void BytesPerSecond_WhenProductOverflowsLong_ClampsToMaxValue()
+        {
+            // frequency × channels × bytesPerSample overflows a long; the property clamps instead of
+            // wrapping to a negative value that would corrupt the warning decision.
+            var estimate = new SdCardCaptureEstimate(int.MaxValue, int.MaxValue, TimeSpan.FromSeconds(1), int.MaxValue);
+
+            Assert.Equal(long.MaxValue, estimate.BytesPerSecond);
+            // EstimatedBytes derives from the clamped rate and stays clamped (not wrapped negative).
+            Assert.Equal(long.MaxValue, estimate.EstimatedBytes);
+        }
+
+        [Fact]
         public void EstimatedBytes_WhenOverflowing_ClampsToMaxValue()
         {
             // An astronomically long capture at high rate would overflow a long; the property clamps instead.

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -1208,6 +1208,121 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
         #endregion
 
+        #region CheckSdCardSpaceAsync Tests
+
+        [Fact]
+        public async Task CheckSdCardSpaceAsync_WhenNearlyFull_RaisesWarningAndReturnsResult()
+        {
+            // 50 MB free of a 4 GB card — below the 100 MB default floor.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "52428800,4294967296" };
+            device.Connect();
+
+            LowSdSpaceWarningEventArgs? raised = null;
+            device.LowSdSpaceWarning += (_, e) => raised = e;
+
+            var result = await device.CheckSdCardSpaceAsync();
+
+            Assert.True(result.ShouldWarn);
+            Assert.True(result.IsNearlyFull);
+            Assert.NotNull(raised);
+            Assert.Same(result, raised!.Result);
+        }
+
+        [Fact]
+        public async Task CheckSdCardSpaceAsync_WhenPlentyOfSpace_DoesNotRaiseWarning()
+        {
+            // ~3.7 GB free of a 4 GB card.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "4000000000,4294967296" };
+            device.Connect();
+
+            var raisedCount = 0;
+            device.LowSdSpaceWarning += (_, _) => raisedCount++;
+
+            var result = await device.CheckSdCardSpaceAsync();
+
+            Assert.False(result.ShouldWarn);
+            Assert.Equal(0, raisedCount);
+        }
+
+        [Fact]
+        public async Task CheckSdCardSpaceAsync_WithEstimateThatWontFit_RaisesWarning()
+        {
+            // 200 MB free; an 8 h capture at 8000 B/s (~220 MB) won't fit.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "209715200,4294967296" };
+            device.Connect();
+
+            LowSdSpaceWarningEventArgs? raised = null;
+            device.LowSdSpaceWarning += (_, e) => raised = e;
+
+            var estimate = new SdCardCaptureEstimate(1000, 4, TimeSpan.FromHours(8), bytesPerSamplePerChannel: 2);
+            var result = await device.CheckSdCardSpaceAsync(estimate);
+
+            Assert.True(result.IsInsufficientForCapture);
+            Assert.False(result.IsNearlyFull);
+            Assert.NotNull(raised);
+            Assert.NotNull(result.EstimatedTimeUntilFull);
+        }
+
+        [Fact]
+        public async Task CheckSdCardSpaceAsync_WhenDisconnected_Throws()
+        {
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.CheckSdCardSpaceAsync());
+        }
+
+        [Fact]
+        public async Task CheckSdCardSpaceAsync_QueriesSdSpace()
+        {
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "52428800,4294967296" };
+            device.Connect();
+
+            await device.CheckSdCardSpaceAsync();
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:STORage:SD:SPACe?", sentCommands);
+        }
+
+        #endregion
+
+        #region SetSdCardMinimumFreeSpace Tests
+
+        [Fact]
+        public void SetSdCardMinimumFreeSpace_WhenConnected_SendsCommand()
+        {
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.Connect();
+
+            device.SetSdCardMinimumFreeSpace(52428800);
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:STORage:SD:MINFree 52428800", sentCommands);
+        }
+
+        [Fact]
+        public void SetSdCardMinimumFreeSpace_WhenDisconnected_Throws()
+        {
+            var device = new DaqifiStreamingDevice("TestDevice");
+
+            Assert.Throws<InvalidOperationException>(() => device.SetSdCardMinimumFreeSpace(52428800));
+        }
+
+        [Fact]
+        public void SetSdCardMinimumFreeSpace_WithNegativeValue_Throws()
+        {
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.Connect();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetSdCardMinimumFreeSpace(-1));
+        }
+
+        #endregion
+
         #region DownloadSdCardFileAsync Tests
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardSpaceCheckTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardSpaceCheckTests.cs
@@ -1,0 +1,132 @@
+using System;
+using Daqifi.Core.Device.SdCard;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard
+{
+    public class SdCardSpaceCheckTests
+    {
+        private const long FourGib = 4L * 1024 * 1024 * 1024;
+        private const long OneHundredMib = 100L * 1024 * 1024;
+
+        [Fact]
+        public void DefaultMinimumFreeBytes_Is100Mb()
+        {
+            Assert.Equal(OneHundredMib, SdCardSpaceCheck.DefaultMinimumFreeBytes);
+        }
+
+        [Fact]
+        public void Evaluate_WhenPlentyOfSpaceAndNoEstimate_DoesNotWarn()
+        {
+            var storage = new SdCardStorageInfo(FreeBytes: 2L * 1024 * 1024 * 1024, TotalBytes: FourGib);
+
+            var result = SdCardSpaceCheck.Evaluate(storage);
+
+            Assert.False(result.ShouldWarn);
+            Assert.False(result.IsNearlyFull);
+            Assert.False(result.IsInsufficientForCapture);
+            Assert.Null(result.EstimatedCaptureBytes);
+            Assert.Null(result.EstimatedTimeUntilFull);
+            Assert.Null(result.Message);
+        }
+
+        [Fact]
+        public void Evaluate_WhenBelowMinimum_FlagsNearlyFull()
+        {
+            // 50 MB free — below the 100 MB default floor.
+            var storage = new SdCardStorageInfo(FreeBytes: 50L * 1024 * 1024, TotalBytes: FourGib);
+
+            var result = SdCardSpaceCheck.Evaluate(storage);
+
+            Assert.True(result.ShouldWarn);
+            Assert.True(result.IsNearlyFull);
+            Assert.False(result.IsInsufficientForCapture);
+            Assert.NotNull(result.Message);
+            Assert.Contains("nearly full", result.Message);
+        }
+
+        [Fact]
+        public void Evaluate_WhenCaptureWontFit_FlagsInsufficientWithTruncationEta()
+        {
+            // 200 MB free; capture estimate ~220 MB (8 h at 8000 B/s) won't fit.
+            var storage = new SdCardStorageInfo(FreeBytes: 200L * 1024 * 1024, TotalBytes: FourGib);
+            var estimate = new SdCardCaptureEstimate(1000, 4, TimeSpan.FromHours(8), bytesPerSamplePerChannel: 2);
+
+            var result = SdCardSpaceCheck.Evaluate(storage, estimate);
+
+            Assert.True(result.ShouldWarn);
+            Assert.False(result.IsNearlyFull);
+            Assert.True(result.IsInsufficientForCapture);
+            Assert.Equal(estimate.EstimatedBytes, result.EstimatedCaptureBytes);
+            Assert.NotNull(result.EstimatedTimeUntilFull);
+            // free / rate = (200 * 1024 * 1024) / 8000 ≈ 26214 s.
+            Assert.Equal(
+                (double)(200L * 1024 * 1024) / 8000,
+                result.EstimatedTimeUntilFull!.Value.TotalSeconds,
+                precision: 0);
+            Assert.Contains("will not fit", result.Message);
+            Assert.Contains("truncating", result.Message);
+        }
+
+        [Fact]
+        public void Evaluate_WhenCaptureFitsAndSpaceAmple_DoesNotWarn()
+        {
+            // 2 GB free; capture estimate ~28 MB (1 h at 8000 B/s) fits comfortably.
+            var storage = new SdCardStorageInfo(FreeBytes: 2L * 1024 * 1024 * 1024, TotalBytes: FourGib);
+            var estimate = new SdCardCaptureEstimate(1000, 4, TimeSpan.FromHours(1), bytesPerSamplePerChannel: 2);
+
+            var result = SdCardSpaceCheck.Evaluate(storage, estimate);
+
+            Assert.False(result.ShouldWarn);
+            Assert.False(result.IsNearlyFull);
+            Assert.False(result.IsInsufficientForCapture);
+            Assert.Equal(estimate.EstimatedBytes, result.EstimatedCaptureBytes);
+            // The time-until-full figure is still reported for informational use.
+            Assert.NotNull(result.EstimatedTimeUntilFull);
+            Assert.Null(result.Message);
+        }
+
+        [Fact]
+        public void Evaluate_WhenBothNearlyFullAndWontFit_FlagsBothInMessage()
+        {
+            // 50 MB free (below floor) and a 1 h capture (~28 MB)... that fits. Use a bigger capture so both trip.
+            var storage = new SdCardStorageInfo(FreeBytes: 50L * 1024 * 1024, TotalBytes: FourGib);
+            var estimate = new SdCardCaptureEstimate(1000, 4, TimeSpan.FromHours(4), bytesPerSamplePerChannel: 2);
+
+            var result = SdCardSpaceCheck.Evaluate(storage, estimate);
+
+            Assert.True(result.ShouldWarn);
+            Assert.True(result.IsNearlyFull);
+            Assert.True(result.IsInsufficientForCapture);
+            Assert.Contains("will not fit", result.Message);
+            Assert.Contains("nearly full", result.Message);
+        }
+
+        [Fact]
+        public void Evaluate_RespectsCustomMinimumFreeBytes()
+        {
+            // 200 MB free is fine under the 100 MB default but flagged when the floor is raised to 500 MB.
+            var storage = new SdCardStorageInfo(FreeBytes: 200L * 1024 * 1024, TotalBytes: FourGib);
+
+            var result = SdCardSpaceCheck.Evaluate(storage, minimumFreeBytes: 500L * 1024 * 1024);
+
+            Assert.True(result.IsNearlyFull);
+            Assert.True(result.ShouldWarn);
+        }
+
+        [Fact]
+        public void Evaluate_WithNullStorage_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => SdCardSpaceCheck.Evaluate(null!));
+        }
+
+        [Fact]
+        public void Evaluate_WithNegativeMinimum_Throws()
+        {
+            var storage = new SdCardStorageInfo(FreeBytes: 1024, TotalBytes: FourGib);
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => SdCardSpaceCheck.Evaluate(storage, minimumFreeBytes: -1));
+        }
+    }
+}

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -222,6 +222,30 @@ public class ScpiMessageProducer
     public static IOutboundMessage<string> GetSdSpace => new ScpiMessage("SYSTem:STORage:SD:SPACe?");
 
     /// <summary>
+    /// Creates a command message to set the firmware-enforced minimum free-space floor on the SD card.
+    /// When the free space would drop below this threshold, the firmware refuses to start an SD-output
+    /// stream (responding with <c>-200 "Execution error"</c>) rather than silently truncating the capture.
+    /// </summary>
+    /// <param name="bytes">The minimum free space to keep available, in bytes. Use 0 to disable the gate
+    /// (the firmware default).</param>
+    /// <remarks>
+    /// First available on firmware v3.5.0 — at or below the v3.5.0 supported floor, so safe to send
+    /// unconditionally. The firmware gate is a safety mechanism; client software is responsible for the
+    /// user-facing low-space warning (see <see cref="Device.SdCard.SdCardSpaceCheck"/>).
+    /// Command: SYSTem:STORage:SD:MINFree bytes
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetSdMinFreeSpace(52428800)); // 50 MB floor
+    /// </remarks>
+    public static IOutboundMessage<string> SetSdMinFreeSpace(long bytes)
+    {
+        if (bytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bytes), bytes, "Minimum free space cannot be negative.");
+        }
+
+        return new ScpiMessage($"SYSTem:STORage:SD:MINFree {bytes}");
+    }
+
+    /// <summary>
     /// Creates a command message to run an SD card write speed benchmark.
     /// </summary>
     /// <param name="size">The size in bytes to benchmark.</param>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -73,6 +73,9 @@ namespace Daqifi.Core.Device
         /// </summary>
         public IReadOnlyList<SdCardFileInfo> SdCardFiles => _sdCardFiles;
 
+        /// <inheritdoc />
+        public event EventHandler<LowSdSpaceWarningEventArgs>? LowSdSpaceWarning;
+
         private readonly NetworkConfiguration _networkConfiguration = new NetworkConfiguration();
 
         /// <summary>
@@ -771,6 +774,54 @@ namespace Daqifi.Core.Device
         private static bool ContainsNoSdCardMarker(IReadOnlyList<string> lines)
         {
             return lines.Any(l => l.IndexOf("No SD Card Detected", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        /// <inheritdoc />
+        public async Task<SdCardSpaceCheckResult> CheckSdCardSpaceAsync(
+            SdCardCaptureEstimate? plannedCapture = null,
+            long minimumFreeBytes = SdCardSpaceCheck.DefaultMinimumFreeBytes,
+            CancellationToken cancellationToken = default)
+        {
+            // Delegates connection / logging-state validation and the typed SD exceptions
+            // (no card, old firmware, unparseable response) to GetSdCardStorageAsync.
+            var storage = await GetSdCardStorageAsync(cancellationToken).ConfigureAwait(false);
+
+            var result = SdCardSpaceCheck.Evaluate(storage, plannedCapture, minimumFreeBytes);
+
+            // Advisory only — raise the warning but never block the caller from starting logging.
+            if (result.ShouldWarn)
+            {
+                OnLowSdSpaceWarning(new LowSdSpaceWarningEventArgs(result));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Raises the <see cref="LowSdSpaceWarning"/> event.
+        /// </summary>
+        /// <param name="e">The warning event arguments.</param>
+        protected virtual void OnLowSdSpaceWarning(LowSdSpaceWarningEventArgs e)
+        {
+            LowSdSpaceWarning?.Invoke(this, e);
+        }
+
+        /// <inheritdoc />
+        public void SetSdCardMinimumFreeSpace(long bytes)
+        {
+            // Argument validation precedes the connection (state) check so misuse surfaces the same
+            // exception type regardless of connection state (matches SetAnalogOutput / SetDioDirection).
+            if (bytes < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bytes), bytes, "Minimum free space cannot be negative.");
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.SetSdMinFreeSpace(bytes));
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -14,6 +14,14 @@ namespace Daqifi.Core.Device.SdCard
     public interface ISdCardOperations
     {
         /// <summary>
+        /// Raised before SD-card logging starts when a low-free-space condition is detected by
+        /// <see cref="CheckSdCardSpaceAsync"/> — either the card is nearly full or the planned capture
+        /// will not fit. The warning is advisory: it does not block logging. Subscribers can surface a
+        /// confirmable prompt and let the user proceed.
+        /// </summary>
+        event EventHandler<LowSdSpaceWarningEventArgs> LowSdSpaceWarning;
+
+        /// <summary>
         /// Gets a value indicating whether the device is currently logging data to the SD card.
         /// </summary>
         bool IsLoggingToSdCard { get; }
@@ -45,8 +53,49 @@ namespace Daqifi.Core.Device.SdCard
         Task<SdCardStorageInfo> GetSdCardStorageAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Queries the SD card's free space and evaluates it against the optional planned capture, raising
+        /// <see cref="LowSdSpaceWarning"/> when the card is nearly full or the capture will not fit.
+        /// Intended to be called immediately before <see cref="StartSdCardLoggingAsync"/> as a pre-flight check.
+        /// </summary>
+        /// <param name="plannedCapture">
+        /// An optional estimate of the upcoming capture. When supplied, the result includes a "won't fit"
+        /// check and a truncation ETA. When omitted, only the "nearly full" threshold is applied.
+        /// </param>
+        /// <param name="minimumFreeBytes">
+        /// The "nearly full" threshold in bytes. Defaults to <see cref="SdCardSpaceCheck.DefaultMinimumFreeBytes"/> (100 MB).
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>
+        /// A task that resolves to the evaluated <see cref="SdCardSpaceCheckResult"/>. The check never blocks
+        /// logging; callers decide whether to proceed based on <see cref="SdCardSpaceCheckResult.ShouldWarn"/>.
+        /// </returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected or is currently logging to SD card.</exception>
+        /// <exception cref="SdCardNotPresentException">Thrown when no SD card is installed in the device.</exception>
+        /// <exception cref="SdCardOperationException">Thrown when the device returned an SCPI error or an unparseable response.</exception>
+        Task<SdCardSpaceCheckResult> CheckSdCardSpaceAsync(
+            SdCardCaptureEstimate? plannedCapture = null,
+            long minimumFreeBytes = SdCardSpaceCheck.DefaultMinimumFreeBytes,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sets the firmware-enforced minimum free-space floor on the SD card. When set, the firmware refuses
+        /// to start an SD-output stream once free space would drop below the floor, surfacing a
+        /// <c>-200 "Execution error"</c> rather than silently truncating. This is the optional hand-off to the
+        /// firmware gate; the client-side <see cref="LowSdSpaceWarning"/> remains the primary UX surface.
+        /// </summary>
+        /// <param name="bytes">The minimum free space to keep available, in bytes. Use 0 to disable the gate.</param>
+        /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when <paramref name="bytes"/> is negative.</exception>
+        void SetSdCardMinimumFreeSpace(long bytes);
+
+        /// <summary>
         /// Starts logging data to the SD card.
         /// </summary>
+        /// <remarks>
+        /// This method does not perform a free-space pre-flight. To warn the user about a near-full card
+        /// before committing to a capture, call <see cref="CheckSdCardSpaceAsync"/> first and let the user
+        /// decide whether to proceed.
+        /// </remarks>
         /// <param name="fileName">
         /// The name of the log file. If null or empty, a timestamped name is generated automatically
         /// using the pattern "log_YYYYMMDD_HHMMSS" with an extension matching <paramref name="format"/>

--- a/src/Daqifi.Core/Device/SdCard/LowSdSpaceWarningEventArgs.cs
+++ b/src/Daqifi.Core/Device/SdCard/LowSdSpaceWarningEventArgs.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Provides data for the low-SD-free-space warning raised before SD-card logging starts.
+/// Subscribers (e.g. a desktop client) can surface a confirmable dialog and let the user proceed.
+/// </summary>
+public sealed class LowSdSpaceWarningEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the evaluated space-check result behind the warning, including the device storage figures,
+    /// the capture estimate (if any), and a human-readable <see cref="SdCardSpaceCheckResult.Message"/>.
+    /// </summary>
+    public SdCardSpaceCheckResult Result { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LowSdSpaceWarningEventArgs"/> class.
+    /// </summary>
+    /// <param name="result">The evaluated space-check result. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="result"/> is <see langword="null"/>.</exception>
+    public LowSdSpaceWarningEventArgs(SdCardSpaceCheckResult result)
+    {
+        Result = result ?? throw new ArgumentNullException(nameof(result));
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardCaptureEstimate.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCaptureEstimate.cs
@@ -1,0 +1,96 @@
+using System;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Describes a planned SD-card logging capture and estimates how much space it will consume.
+/// Used by <see cref="SdCardSpaceCheck"/> to decide whether to warn the user before logging starts.
+/// </summary>
+/// <remarks>
+/// The estimate is intentionally best-effort. <see cref="DefaultBytesPerSamplePerChannel"/> reflects the
+/// raw ADC sample width; the on-card footprint of a Protobuf- or JSON-encoded stream is larger because of
+/// per-message framing and timestamps. Callers that know their encoding overhead should pass a larger
+/// <c>bytesPerSamplePerChannel</c> so the warning errs on the side of caution.
+/// </remarks>
+public sealed class SdCardCaptureEstimate
+{
+    /// <summary>
+    /// The default per-channel sample width in bytes: the raw 16-bit ADC resolution. Real encoded logs
+    /// are larger; this is a floor, not an exact figure.
+    /// </summary>
+    public const int DefaultBytesPerSamplePerChannel = 2;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SdCardCaptureEstimate"/> class.
+    /// </summary>
+    /// <param name="frequencyHz">The streaming/sampling frequency in samples-per-second per channel. Must be positive.</param>
+    /// <param name="channelCount">The number of enabled channels being recorded. Must be at least 1.</param>
+    /// <param name="duration">The planned capture duration. Must be positive.</param>
+    /// <param name="bytesPerSamplePerChannel">
+    /// The number of bytes each channel contributes per sample. Defaults to
+    /// <see cref="DefaultBytesPerSamplePerChannel"/> (the raw 16-bit ADC width). Must be positive.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when any parameter is non-positive.</exception>
+    public SdCardCaptureEstimate(
+        int frequencyHz,
+        int channelCount,
+        TimeSpan duration,
+        int bytesPerSamplePerChannel = DefaultBytesPerSamplePerChannel)
+    {
+        if (frequencyHz <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(frequencyHz), frequencyHz, "Frequency must be positive.");
+        }
+
+        if (channelCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channelCount), channelCount, "Channel count must be at least 1.");
+        }
+
+        if (bytesPerSamplePerChannel <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bytesPerSamplePerChannel), bytesPerSamplePerChannel, "Bytes per sample must be positive.");
+        }
+
+        if (duration <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(duration), duration, "Duration must be positive.");
+        }
+
+        FrequencyHz = frequencyHz;
+        ChannelCount = channelCount;
+        Duration = duration;
+        BytesPerSamplePerChannel = bytesPerSamplePerChannel;
+    }
+
+    /// <summary>Gets the streaming/sampling frequency in samples-per-second per channel.</summary>
+    public int FrequencyHz { get; }
+
+    /// <summary>Gets the number of enabled channels being recorded.</summary>
+    public int ChannelCount { get; }
+
+    /// <summary>Gets the planned capture duration.</summary>
+    public TimeSpan Duration { get; }
+
+    /// <summary>Gets the number of bytes each channel contributes per sample.</summary>
+    public int BytesPerSamplePerChannel { get; }
+
+    /// <summary>
+    /// Gets the estimated write rate in bytes per second:
+    /// <c>FrequencyHz × ChannelCount × BytesPerSamplePerChannel</c>.
+    /// </summary>
+    public long BytesPerSecond => (long)FrequencyHz * ChannelCount * BytesPerSamplePerChannel;
+
+    /// <summary>
+    /// Gets the estimated total bytes the capture will write, clamped to <see cref="long.MaxValue"/> if it
+    /// would otherwise overflow.
+    /// </summary>
+    public long EstimatedBytes
+    {
+        get
+        {
+            var bytes = BytesPerSecond * Duration.TotalSeconds;
+            return bytes >= long.MaxValue ? long.MaxValue : (long)bytes;
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardCaptureEstimate.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCaptureEstimate.cs
@@ -77,9 +77,24 @@ public sealed class SdCardCaptureEstimate
 
     /// <summary>
     /// Gets the estimated write rate in bytes per second:
-    /// <c>FrequencyHz × ChannelCount × BytesPerSamplePerChannel</c>.
+    /// <c>FrequencyHz × ChannelCount × BytesPerSamplePerChannel</c>, clamped to <see cref="long.MaxValue"/>
+    /// if the product would overflow. Clamping keeps the warning layer correct: an overflow that wrapped
+    /// negative would make a capture wrongly appear to fit and suppress the truncation ETA.
     /// </summary>
-    public long BytesPerSecond => (long)FrequencyHz * ChannelCount * BytesPerSamplePerChannel;
+    public long BytesPerSecond
+    {
+        get
+        {
+            try
+            {
+                return checked((long)FrequencyHz * ChannelCount * BytesPerSamplePerChannel);
+            }
+            catch (OverflowException)
+            {
+                return long.MaxValue;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets the estimated total bytes the capture will write, clamped to <see cref="long.MaxValue"/> if it

--- a/src/Daqifi.Core/Device/SdCard/SdCardSpaceCheck.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardSpaceCheck.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Evaluates SD-card free space against a planned capture and decides whether to warn the user before
+/// SD logging starts. This is the client-side UX half of issue #230: the firmware provides a safe
+/// mechanism (the <c>SYSTem:STORage:SD:MINFree</c> gate), while the client surfaces the warning.
+/// </summary>
+/// <remarks>
+/// Pure and side-effect free, so it can be unit-tested without a device. The two rules mirror the issue:
+/// warn when the planned capture won't fit, and warn when the card is nearly full regardless of estimate.
+/// </remarks>
+public static class SdCardSpaceCheck
+{
+    /// <summary>
+    /// The default "nearly full" threshold: 100 MB. A capture starting with less free space than this is
+    /// flagged regardless of any capture estimate.
+    /// </summary>
+    public const long DefaultMinimumFreeBytes = 100L * 1024 * 1024;
+
+    /// <summary>
+    /// Evaluates the supplied storage info (and optional capture estimate) against the warning rules.
+    /// </summary>
+    /// <param name="storage">The free/total byte counts reported by the device.</param>
+    /// <param name="plannedCapture">
+    /// An optional estimate of the upcoming capture. When supplied, the result includes a "won't fit"
+    /// check and a truncation ETA.
+    /// </param>
+    /// <param name="minimumFreeBytes">
+    /// The "nearly full" threshold in bytes. Defaults to <see cref="DefaultMinimumFreeBytes"/>.
+    /// </param>
+    /// <returns>A <see cref="SdCardSpaceCheckResult"/> describing whether and why a warning applies.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="storage"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="minimumFreeBytes"/> is negative.</exception>
+    public static SdCardSpaceCheckResult Evaluate(
+        SdCardStorageInfo storage,
+        SdCardCaptureEstimate? plannedCapture = null,
+        long minimumFreeBytes = DefaultMinimumFreeBytes)
+    {
+        ArgumentNullException.ThrowIfNull(storage);
+
+        if (minimumFreeBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumFreeBytes), minimumFreeBytes, "Minimum free space cannot be negative.");
+        }
+
+        var free = storage.FreeBytes;
+        long? estimatedBytes = plannedCapture?.EstimatedBytes;
+
+        var isNearlyFull = free < minimumFreeBytes;
+        var isInsufficient = estimatedBytes.HasValue && free < estimatedBytes.Value;
+
+        TimeSpan? timeUntilFull = null;
+        if (plannedCapture is { BytesPerSecond: > 0 })
+        {
+            // Wall-clock the card can record before it fills, derived from the free space and the
+            // estimated write rate. Surfaced primarily as the "truncate after ~N" figure.
+            timeUntilFull = TimeSpan.FromSeconds((double)free / plannedCapture.BytesPerSecond);
+        }
+
+        var message = BuildMessage(free, estimatedBytes, minimumFreeBytes, isNearlyFull, isInsufficient, timeUntilFull);
+
+        return new SdCardSpaceCheckResult(
+            storage,
+            estimatedBytes,
+            minimumFreeBytes,
+            isNearlyFull,
+            isInsufficient,
+            timeUntilFull,
+            message);
+    }
+
+    private static string? BuildMessage(
+        long freeBytes,
+        long? estimatedBytes,
+        long minimumFreeBytes,
+        bool isNearlyFull,
+        bool isInsufficient,
+        TimeSpan? timeUntilFull)
+    {
+        if (!isNearlyFull && !isInsufficient)
+        {
+            return null;
+        }
+
+        var parts = new List<string>(2);
+
+        if (isInsufficient && estimatedBytes.HasValue)
+        {
+            var truncation = timeUntilFull.HasValue
+                ? $", truncating after about {FormatDuration(timeUntilFull.Value)}"
+                : string.Empty;
+            parts.Add(
+                $"The planned capture (~{FormatBytes(estimatedBytes.Value)}) will not fit in the {FormatBytes(freeBytes)} free on the SD card{truncation}.");
+        }
+
+        if (isNearlyFull)
+        {
+            parts.Add(
+                $"The SD card is nearly full ({FormatBytes(freeBytes)} free, below the {FormatBytes(minimumFreeBytes)} minimum); consider freeing space first.");
+        }
+
+        return string.Join(" ", parts);
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        const long kib = 1024;
+        const long mib = kib * 1024;
+        const long gib = mib * 1024;
+
+        if (bytes >= gib)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{(double)bytes / gib:0.##} GB");
+        }
+        if (bytes >= mib)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{(double)bytes / mib:0.##} MB");
+        }
+        if (bytes >= kib)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{(double)bytes / kib:0.##} KB");
+        }
+        return string.Create(CultureInfo.InvariantCulture, $"{bytes} bytes");
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalHours >= 1)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalHours:0.#} hours");
+        }
+        if (duration.TotalMinutes >= 1)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalMinutes:0.#} minutes");
+        }
+        return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalSeconds:0.#} seconds");
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardSpaceCheckResult.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardSpaceCheckResult.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// The outcome of evaluating SD-card free space against a planned capture, as produced by
+/// <see cref="SdCardSpaceCheck.Evaluate"/>. Carries the structured facts behind a low-space warning so
+/// consumers can render their own message or rely on <see cref="Message"/>.
+/// </summary>
+/// <param name="Storage">The free/total byte counts reported by the device.</param>
+/// <param name="EstimatedCaptureBytes">
+/// The estimated size of the planned capture in bytes, or <see langword="null"/> if no capture estimate
+/// was supplied.
+/// </param>
+/// <param name="MinimumFreeBytes">The "nearly full" threshold that was applied, in bytes.</param>
+/// <param name="IsNearlyFull">
+/// <see langword="true"/> when free space is below <paramref name="MinimumFreeBytes"/>.
+/// </param>
+/// <param name="IsInsufficientForCapture">
+/// <see langword="true"/> when a capture estimate was supplied and free space is below it.
+/// </param>
+/// <param name="EstimatedTimeUntilFull">
+/// When a capture estimate with a positive write rate was supplied, the approximate time the card can
+/// keep recording before it fills; otherwise <see langword="null"/>.
+/// </param>
+/// <param name="Message">A human-readable summary of the warning, or <see langword="null"/> when no warning applies.</param>
+public sealed record SdCardSpaceCheckResult(
+    SdCardStorageInfo Storage,
+    long? EstimatedCaptureBytes,
+    long MinimumFreeBytes,
+    bool IsNearlyFull,
+    bool IsInsufficientForCapture,
+    TimeSpan? EstimatedTimeUntilFull,
+    string? Message)
+{
+    /// <summary>
+    /// <see langword="true"/> when the user should be warned before starting the capture — i.e. the card
+    /// is nearly full or the planned capture will not fit.
+    /// </summary>
+    public bool ShouldWarn => IsNearlyFull || IsInsufficientForCapture;
+}


### PR DESCRIPTION
## Summary

Implements [#230](https://github.com/daqifi/daqifi-core/issues/230) — a client-side pre-flight that **warns** (never blocks) the user before starting an SD-output capture when the card is nearly full or the planned capture won't fit. Per the firmware/client split recorded in [ADR 0001](docs/adr/0001-firmware-feature-gating.md): the firmware owns the safe `SD:MINFree` gate, the client owns the UX warning.

The SD space query (`GetSdCardStorageAsync` → `SdCardStorageInfo`) already landed in #214; this PR builds the warning layer on top.

## What's added

- **`SdCardCaptureEstimate`** — a pure, best-effort size estimator (`rate × channels × bytes/sample × duration`) with `BytesPerSecond` / `EstimatedBytes` (overflow-clamped). Defaults `BytesPerSamplePerChannel` to the raw 16-bit ADC width, documented as a floor (encoded logs are larger).
- **`SdCardSpaceCheck` + `SdCardSpaceCheckResult`** — pure evaluator applying the two rules from the issue: free < estimate → "won't fit" (+ truncation ETA), and free < 100 MB (configurable) → "nearly full". Produces a human-readable message.
- **`LowSdSpaceWarningEventArgs`** + **`LowSdSpaceWarning`** event on `ISdCardOperations` / `DaqifiStreamingDevice`.
- **`CheckSdCardSpaceAsync(plannedCapture?, minimumFreeBytes?, ct)`** — queries SD space, evaluates, raises the event when warranted, returns the structured result. Advisory only; the caller decides whether to proceed before `StartSdCardLoggingAsync`.
- **`SetSdCardMinimumFreeSpace(bytes)`** + SCPI `SetSdMinFreeSpace` — optional hand-off to the firmware `SD:MINFree` gate (v3.5.0+, at/below the supported floor, so safe to send unconditionally).

## Design note

The pre-flight is a **separate method**, not auto-run inside `StartSdCardLoggingAsync`. The issue requires "let the user proceed if they want" — the user must see the warning and decide *before* start commits, which is only possible as a distinct step (an internal check that raised mid-start couldn't let them abort, since the warning must not block). `StartSdCardLoggingAsync`'s docs cross-reference `CheckSdCardSpaceAsync` for discoverability.

## Testing

- **Unit:** estimator, evaluator (all rule combinations, custom floor, null/negative guards), the device method (event raised/not raised, disconnected, command emitted), and the SCPI producer. Full suite: **1164 passed, 0 failed** on both `net9.0` and `net10.0`.
- **Real hardware (USB):** built the example CLI against this worktree's core and ran a streaming smoke test, plus an isolated harness exercising the new API directly:
  - 7.8 GB free, no estimate → no warning ✓
  - ~12.87 GB estimate > 7.27 GB free → "won't fit" warning + event, truncation ETA ✓
  - floor raised to 8 GB → "nearly full" warning + event ✓
  - `SetSdCardMinimumFreeSpace(52428800)` accepted by firmware, no error (reset to 0 afterward) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)