### PR TITLE
chore(scpi)!: remove dead GetSdLoggingState producer (#255)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -79,14 +79,6 @@ public class ScpiMessageProducerTests
     }
 
     [Fact]
-    public void GetSdLoggingState_ReturnsCorrectCommand()
-    {
-        var message = ScpiMessageProducer.GetSdLoggingState;
-        Assert.Equal("SYSTem:STORage:SD:LOGging?", message.Data);
-        AssertMessageFormat(message);
-    }
-
-    [Fact]
     public void GetSdFileList_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.GetSdFileList;

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -109,15 +109,6 @@ public class ScpiMessageProducer
     public static IOutboundMessage<string> DisableStorageSd => new ScpiMessage("SYSTem:STORage:SD:ENAble 0");
 
     /// <summary>
-    /// Creates a query message to get the current SD card logging state.
-    /// </summary>
-    /// <remarks>
-    /// Command: SYSTem:STORage:SD:LOGging?
-    /// Example: messageProducer.Send(ScpiMessageProducer.GetSdLoggingState);
-    /// </remarks>
-    public static IOutboundMessage<string> GetSdLoggingState => new ScpiMessage("SYSTem:STORage:SD:LOGging?");
-
-    /// <summary>
     /// Creates a query message to get the list of files on the SD card.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
## What

Removes `ScpiMessageProducer.GetSdLoggingState` and its test.

The property emitted `SYSTem:STORage:SD:LOGging?`, a query that **never existed in the firmware SCPI command table** (confirmed during the #251 audit; the *set* form `SD:LOGging` was hard-renamed to `SD:FILE` in firmware #323, and the query form was never present). Per **ADR 0001**, this is dead code.

Kept separate from the #253 runtime fix to avoid mixing a behavior fix with an API change.

## Breaking change?

Technically yes — it removes a `public static` member — but **verified unused by every real consumer**:

| Consumer | References `GetSdLoggingState`? |
|---|---|
| `daqifi-core-example-app` | None |
| `daqifi-desktop` (consumes `Daqifi.Core` 0.22.0) | None — uses only `EnableStorageSd` / `DisableStorageSd` |

(The `core-and-desktop` checkout's matches are inside an embedded older clone of daqifi-core itself, not an external consumer.)

## Validation

- `dotnet build` with `-warnaserror` (net9.0 + net10.0): **0 warnings, 0 errors**
- `dotnet test`: **1132 passed, 0 failed, 2 skipped**

## Notes

The two references in `docs/adr/0001-firmware-feature-gating.md` are intentionally left untouched — that's the historical decision record documenting *why* this code is removed and tracking #255 as the follow-up.

Refs ADR 0001 / #252, #251, #253.

Closes #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)