### PR TITLE
chore: wire ILogger into MessageProducer (closes #222)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
@@ -248,6 +248,31 @@ public class MessageProducerTests
         Assert.True(infoLogged, "Expected an information log when the background loop exits cleanly.");
     }
 
+    [Fact]
+    public void MessageProducer_WhenLoggerThrows_ShouldKeepDrainingAndStopCleanly()
+    {
+        // Arrange - a logger that always throws, combined with writes that always fail,
+        // exercises the logging path on the background thread on every message.
+        using var stream = new ThrowOnWriteStream();
+        var logger = new ThrowingLogger<MessageProducer<string>>();
+        using var producer = new MessageProducer<string>(stream, logger);
+        producer.Start();
+
+        // Act - queue several messages; each failed write triggers a logging call that throws.
+        for (int i = 0; i < 5; i++)
+        {
+            producer.Send(new ScpiMessage($"CMD{i}"));
+        }
+
+        var stopped = producer.StopSafely(2000);
+
+        // Assert - a faulting logger must not kill the loop: the queue still drains, the
+        // producer stops within the timeout, and it never reports a stale running state.
+        Assert.True(stopped, "StopSafely should not hang when the logger throws.");
+        Assert.False(producer.IsRunning);
+        Assert.Equal(0, producer.QueuedMessageCount);
+    }
+
     /// <summary>
     /// Captures log entries in-memory so tests can assert that the producer logs as expected.
     /// </summary>
@@ -272,6 +297,25 @@ public class MessageProducerTests
         }
 
         public sealed record LogEntry(LogLevel Level, Exception? Exception, string Message);
+    }
+
+    /// <summary>
+    /// A logger whose every <see cref="Log"/> call throws, used to verify the producer's
+    /// background loop survives a faulting logging provider.
+    /// </summary>
+    private sealed class ThrowingLogger<TCategory> : ILogger<TCategory>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            throw new InvalidOperationException("Simulated logger failure.");
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
@@ -1,5 +1,7 @@
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 using System.Text;
 
 namespace Daqifi.Core.Tests.Communication.Producers;
@@ -188,5 +190,110 @@ public class MessageProducerTests
         // Assert
         var written = Encoding.UTF8.GetString(stream.ToArray());
         Assert.Contains("TEST", written);
+    }
+
+    [Fact]
+    public void MessageProducer_WhenWriteThrows_ShouldLogWarning()
+    {
+        // Arrange
+        using var stream = new ThrowOnWriteStream();
+        var logger = new CaptureLogger<MessageProducer<string>>();
+        using var producer = new MessageProducer<string>(stream, logger);
+        producer.Start();
+
+        // Act - the background thread will attempt to write and fail
+        producer.Send(new ScpiMessage("TEST:COMMAND"));
+        var warningLogged = SpinWait.SpinUntil(
+            () => logger.Entries.Any(e => e.Level == LogLevel.Warning),
+            TimeSpan.FromSeconds(2));
+        producer.StopSafely();
+
+        // Assert - the write failure is surfaced through the logger, not swallowed
+        Assert.True(warningLogged, "Expected a warning to be logged when the stream write throws.");
+        var warning = logger.Entries.First(e => e.Level == LogLevel.Warning);
+        Assert.IsType<IOException>(warning.Exception);
+    }
+
+    [Fact]
+    public void MessageProducer_WithNoLogger_WhenWriteThrows_ShouldNotThrowToCaller()
+    {
+        // Arrange - omitting the logger must preserve the original silent-continue behavior
+        using var stream = new ThrowOnWriteStream();
+        using var producer = new MessageProducer<string>(stream);
+        producer.Start();
+
+        // Act & Assert - a failing write on the background thread must not surface to the caller
+        producer.Send(new ScpiMessage("TEST:COMMAND"));
+        Thread.Sleep(50);
+        Assert.True(producer.IsRunning);
+        Assert.True(producer.StopSafely());
+    }
+
+    [Fact]
+    public void MessageProducer_WhenStoppedNormally_ShouldLogCleanExit()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        var logger = new CaptureLogger<MessageProducer<string>>();
+        using var producer = new MessageProducer<string>(stream, logger);
+        producer.Start();
+
+        // Act
+        producer.StopSafely();
+
+        // Assert - the background loop reports a clean lifecycle exit
+        var infoLogged = SpinWait.SpinUntil(
+            () => logger.Entries.Any(e => e.Level == LogLevel.Information),
+            TimeSpan.FromSeconds(2));
+        Assert.True(infoLogged, "Expected an information log when the background loop exits cleanly.");
+    }
+
+    /// <summary>
+    /// Captures log entries in-memory so tests can assert that the producer logs as expected.
+    /// </summary>
+    private sealed class CaptureLogger<TCategory> : ILogger<TCategory>
+    {
+        private readonly ConcurrentQueue<LogEntry> _entries = new();
+
+        public IReadOnlyList<LogEntry> Entries => _entries.ToArray();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _entries.Enqueue(new LogEntry(logLevel, exception, formatter(state, exception)));
+        }
+
+        public sealed record LogEntry(LogLevel Level, Exception? Exception, string Message);
+    }
+
+    /// <summary>
+    /// A write-only stream whose <see cref="Write"/> always throws, simulating a mid-stream failure.
+    /// </summary>
+    private sealed class ThrowOnWriteStream : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new IOException("Simulated write failure for error-handling test.");
     }
 }

--- a/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
@@ -1,4 +1,6 @@
 using Daqifi.Core.Communication.Messages;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Concurrent;
 
 namespace Daqifi.Core.Communication.Producers;
@@ -11,6 +13,7 @@ namespace Daqifi.Core.Communication.Producers;
 public class MessageProducer<T> : IMessageProducer<T>
 {
     private readonly Stream _stream;
+    private readonly ILogger<MessageProducer<T>> _logger;
     private readonly ConcurrentQueue<IOutboundMessage<T>> _messageQueue;
     private readonly ManualResetEventSlim _messageAvailable = new(false);
     private volatile bool _isRunning;
@@ -21,10 +24,16 @@ public class MessageProducer<T> : IMessageProducer<T>
     /// Initializes a new instance of the MessageProducer class.
     /// </summary>
     /// <param name="stream">The stream to write messages to.</param>
+    /// <param name="logger">
+    /// Optional logger used to surface write failures and background-loop lifecycle
+    /// events. When omitted, a <see cref="NullLogger{T}"/> is used so existing
+    /// consumers behave exactly as before.
+    /// </param>
     /// <exception cref="ArgumentNullException">Thrown when stream is null.</exception>
-    public MessageProducer(Stream stream)
+    public MessageProducer(Stream stream, ILogger<MessageProducer<T>>? logger = null)
     {
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _logger = logger ?? NullLogger<MessageProducer<T>>.Instance;
         _messageQueue = new ConcurrentQueue<IOutboundMessage<T>>();
     }
 
@@ -136,33 +145,54 @@ public class MessageProducer<T> : IMessageProducer<T>
     /// </summary>
     private void ProcessMessages()
     {
-        while (_isRunning)
+        try
         {
-            try
+            while (_isRunning)
             {
-                // Wait for a message to be enqueued or timeout after 100ms
-                _messageAvailable.Wait(100);
-                _messageAvailable.Reset();
-
-                // Process all available messages
-                while (_messageQueue.TryDequeue(out var message))
+                try
                 {
-                    try
+                    // Wait for a message to be enqueued or timeout after 100ms
+                    _messageAvailable.Wait(100);
+                    _messageAvailable.Reset();
+
+                    // Process all available messages
+                    while (_messageQueue.TryDequeue(out var message))
                     {
-                        WriteMessageToStream(message);
-                    }
-                    catch (Exception)
-                    {
-                        // Log error but continue processing other messages
-                        // TODO: Add proper logging system in future step
-                        // For now, silently continue to match desktop behavior during shutdown
+                        try
+                        {
+                            WriteMessageToStream(message);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Surface the failure but keep draining the queue so a single
+                            // bad write doesn't stall the remaining messages.
+                            _logger.LogWarning(ex, "Failed to write message to the stream; continuing with remaining queued messages.");
+                        }
                     }
                 }
+                catch (Exception ex)
+                {
+                    // Protect the background thread from unexpected exceptions so the
+                    // producer keeps running rather than dying silently.
+                    _logger.LogError(ex, "Unexpected error in the MessageProducer background loop; the loop will continue running.");
+                }
             }
-            catch (Exception)
+
+            _logger.LogInformation("MessageProducer background loop exited cleanly after a stop was requested.");
+        }
+        catch (Exception ex)
+        {
+            // Reaching here means an exception escaped the inner guards (most likely
+            // the logger itself faulted). The background thread is ending abnormally.
+            // This is the thread's last-resort handler: an unhandled exception here
+            // would crash the host process, so logging must never be allowed to throw.
+            try
             {
-                // Protect the background thread from unexpected exceptions
-                // TODO: Add proper logging system in future step
+                _logger.LogError(ex, "MessageProducer background loop terminated abnormally.");
+            }
+            catch
+            {
+                // Nothing safe left to do from a dying background thread.
             }
         }
     }

--- a/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
@@ -166,7 +166,7 @@ public class MessageProducer<T> : IMessageProducer<T>
                         {
                             // Surface the failure but keep draining the queue so a single
                             // bad write doesn't stall the remaining messages.
-                            _logger.LogWarning(ex, "Failed to write message to the stream; continuing with remaining queued messages.");
+                            SafeLog(() => _logger.LogWarning(ex, "Failed to write message to the stream; continuing with remaining queued messages."));
                         }
                     }
                 }
@@ -174,26 +174,39 @@ public class MessageProducer<T> : IMessageProducer<T>
                 {
                     // Protect the background thread from unexpected exceptions so the
                     // producer keeps running rather than dying silently.
-                    _logger.LogError(ex, "Unexpected error in the MessageProducer background loop; the loop will continue running.");
+                    SafeLog(() => _logger.LogError(ex, "Unexpected error in the MessageProducer background loop; the loop will continue running."));
                 }
             }
 
-            _logger.LogInformation("MessageProducer background loop exited cleanly after a stop was requested.");
+            SafeLog(() => _logger.LogInformation("MessageProducer background loop exited cleanly after a stop was requested."));
         }
         catch (Exception ex)
         {
-            // Reaching here means an exception escaped the inner guards (most likely
-            // the logger itself faulted). The background thread is ending abnormally.
-            // This is the thread's last-resort handler: an unhandled exception here
-            // would crash the host process, so logging must never be allowed to throw.
-            try
-            {
-                _logger.LogError(ex, "MessageProducer background loop terminated abnormally.");
-            }
-            catch
-            {
-                // Nothing safe left to do from a dying background thread.
-            }
+            // Last-resort handler. Every logging call in the loop is routed through
+            // SafeLog, so a faulting logger can no longer unwind the loop and this
+            // should be unreachable. If anything ever does escape, we must not leave
+            // the producer advertising IsRunning=true while the background thread is
+            // dead: that would let Send() enqueue messages that never drain and make
+            // StopSafely() block until timeout.
+            _isRunning = false;
+            SafeLog(() => _logger.LogError(ex, "MessageProducer background loop terminated abnormally."));
+        }
+    }
+
+    /// <summary>
+    /// Invokes a logging action, swallowing any exception thrown by the logger
+    /// itself. A faulting logger must never be allowed to terminate the background
+    /// processing loop or leave the producer in an inconsistent state.
+    /// </summary>
+    private static void SafeLog(Action logAction)
+    {
+        try
+        {
+            logAction();
+        }
+        catch
+        {
+            // A logger that throws is not permitted to take down the producer.
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #222.

`MessageProducer<T>` swallowed two distinct exception paths behind placeholder `// TODO: Add proper logging system in future step` comments — the per-message write failure and the background-thread loop guard. That "future step" has effectively happened: the project already references `Microsoft.Extensions.Logging.Abstractions` and injects `ILogger<FirmwareUpdateService>`. `MessageProducer` was the last major component still silently swallowing.

Silent swallowing here is a debugging black hole: if writes start failing mid-stream, the only signal a desktop client sees is "samples stopped flowing." This surfaces those exceptions through `ILogger<MessageProducer<T>>` without changing the public API for existing callers.

## Changes

- **Optional logger injection** — constructor now accepts `ILogger<MessageProducer<T>>? logger = null`, defaulting to `NullLogger<MessageProducer<T>>.Instance`. Nullable + default keeps the three existing single-arg call sites (`DaqifiDevice`, `SerialDeviceFinder`) source-compatible and behaviourally unchanged.
- **Both TODOs replaced** — per-message write failure → `LogWarning(ex, …)` (keeps draining the queue); background-loop guard → `LogError(ex, …)` (keeps the loop running).
- **Lifecycle visibility (bonus)** — `LogInformation` on a clean loop exit, `LogError` on an abnormal one. The last-resort handler wraps its own logging call so a faulting logger can never escalate into an unhandled background-thread exception (which would crash the host process).

## Tests

- `MessageProducer_WhenWriteThrows_ShouldLogWarning` — a throwing stream causes a `Warning` carrying the original `IOException`.
- `MessageProducer_WithNoLogger_WhenWriteThrows_ShouldNotThrowToCaller` — the default (no-logger) path still silently continues, proving unchanged behaviour for existing consumers.
- `MessageProducer_WhenStoppedNormally_ShouldLogCleanExit` — a normal stop emits the clean-exit `Information` log.

No Moq in this project, so the tests use a small hand-written `CaptureLogger` + throwing stream, matching the existing `ErrorThrowingStream` pattern.

## Out of scope

Plumbing `ILogger` through every other class (e.g. `DaqifiDevice`, `SerialDeviceFinder`) — this PR is specifically about closing the `MessageProducer` TODOs, per the issue.

## Validation

- `dotnet build` — clean (0 warnings / 0 errors; the project builds with `TreatWarningsAsErrors`).
- `dotnet test` (net10.0) — **1167 passed, 2 skipped, 0 failed**.

## Acceptance criteria

- [x] Both TODO comments removed; exceptions are logged.
- [x] `MessageProducer` constructor accepts an optional `ILogger<MessageProducer<T>>`.
- [x] Default behaviour (no logger passed) is unchanged for existing consumers.
- [x] Tests cover the case where a write throws — assert the logger is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)