### PR TITLE
feat(firmware): real flash verification via bootloader READ_CRC (#213)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -187,6 +187,59 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateFirmwareAsync_WhenReadCrcResponseMalformed_RetriesThenCompletes()
+    {
+        // A transiently malformed READ_CRC frame (decoder throws
+        // InvalidDataException for framing/CRC issues) must be retried like a
+        // HID read glitch — consistent with the erase/program steps — rather
+        // than failing the whole update. Only a real CRC mismatch fails fast.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0x00]);       // malformed READ_CRC response (first attempt)
+        hidTransport.EnqueueRead([0xCD, 0xAB]); // valid READ_CRC → 0xABCD (retry)
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var options = CreateFastOptions();
+        options.FlashWriteRetryCount = 2;
+        options.FlashWriteRetryDelay = TimeSpan.FromMilliseconds(5);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        // Two READ_CRC writes: the malformed first attempt plus the retry.
+        Assert.Equal(2, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x44));
+    }
+
+    [Fact]
     public async Task UpdateFirmwareAsync_VerifiesEveryCrcRegion()
     {
         // Multiple contiguous runs (e.g. split by a calibration gap) each get

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Net;
 using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
@@ -79,6 +80,160 @@ public class FirmwareUpdateServiceTests
 
         var terminalProgress = Assert.Single(progressEvents, p => p.State == FirmwareUpdateState.Complete);
         Assert.Equal(100, terminalProgress.PercentComplete);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenFlashCrcMatches_VerifiesViaReadCrcAndCompletes()
+    {
+        // Closes #213: the Verifying state issues READ_CRC per region and
+        // compares against the host-computed CRC. A matching CRC must pass
+        // verification and complete the update.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0xCD, 0xAB]); // READ_CRC response → decodes to 0xABCD (match)
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions());
+
+        var stateTransitions = new List<FirmwareUpdateState>();
+        service.StateChanged += (_, args) => stateTransitions.Add(args.CurrentState);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Contains(FirmwareUpdateState.Verifying, stateTransitions);
+        // The fake encodes READ_CRC commands with a leading 0x44 marker; with a
+        // region configured, the version-liveness fallback is NOT used.
+        Assert.Contains(hidTransport.Writes, w => w.Length > 0 && w[0] == 0x44);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenFlashCrcMismatches_FailsVerificationIntoFailedState()
+    {
+        // Closes #213: a bit-flipped / partially-programmed flash is detected by
+        // the CRC compare and must fail in Verifying (routing through the
+        // failure/cleanup path) rather than jumping to a bad application image.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0x34, 0x12]); // READ_CRC response → 0x1234 (mismatch vs 0xABCD)
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions());
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Verifying, exception.FailedState);
+        Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+        var inner = Assert.IsType<InvalidDataException>(exception.InnerException);
+        Assert.Contains("CRC mismatch", inner.Message);
+        // Must NOT have jumped to the application after a failed verification.
+        Assert.DoesNotContain(hidTransport.Writes, w => w.Length > 0 && w[0] == 0x55);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_VerifiesEveryCrcRegion()
+    {
+        // Multiple contiguous runs (e.g. split by a calibration gap) each get
+        // their own READ_CRC round-trip.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0x11, 0x00]); // region 1 → 0x0011
+        hidTransport.EnqueueRead([0x22, 0x00]); // region 2 → 0x0022
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions:
+            [
+                new FlashCrcRegion(0x9D000000, 16, 0x0011),
+                new FlashCrcRegion(0x9D000010, 16, 0x0022)
+            ]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions());
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(2, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x44));
     }
 
     [Fact]
@@ -1709,15 +1864,21 @@ public class FirmwareUpdateServiceTests
     private sealed class FakeBootloaderProtocol : IBootloaderProtocol
     {
         private readonly IReadOnlyList<byte[]> _hexRecords;
+        private readonly IReadOnlyList<FlashCrcRegion> _crcRegions;
 
-        public FakeBootloaderProtocol(IReadOnlyList<byte[]> hexRecords)
+        public FakeBootloaderProtocol(
+            IReadOnlyList<byte[]> hexRecords,
+            IReadOnlyList<FlashCrcRegion>? crcRegions = null)
         {
             _hexRecords = hexRecords;
+            _crcRegions = crcRegions ?? Array.Empty<FlashCrcRegion>();
         }
 
         public byte[] CreateRequestVersionMessage() => [0x11];
         public byte[] CreateEraseFlashMessage() => [0x22];
         public byte[] CreateProgramFlashMessage(byte[] hexRecord) => [0x33, .. hexRecord];
+        public byte[] CreateReadCrcMessage(uint address, uint length) =>
+            [0x44, .. BitConverter.GetBytes(address), .. BitConverter.GetBytes(length)];
         public byte[] CreateJumpToApplicationMessage() => [0x55];
 
         public string DecodeVersionResponse(byte[] data)
@@ -1739,6 +1900,21 @@ public class FirmwareUpdateServiceTests
         {
             return data.Length >= 2 && data[0] == 0x01 && data[1] == 0x02;
         }
+
+        // The enqueued READ_CRC HID response carries the device-reported CRC in
+        // its first two bytes (little-endian), so a test drives match/mismatch
+        // by enqueuing specific bytes.
+        public ushort DecodeReadCrcResponse(byte[] data)
+        {
+            if (data.Length < 2)
+            {
+                throw new InvalidDataException("Fake READ_CRC response was too short.");
+            }
+
+            return (ushort)(data[0] | (data[1] << 8));
+        }
+
+        public IReadOnlyList<FlashCrcRegion> ComputeCrcRegions(string[] hexFileLines) => _crcRegions;
 
         public List<byte[]> ParseHexFile(string[] hexFileLines)
         {

--- a/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderMessageConsumerTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderMessageConsumerTests.cs
@@ -5,6 +5,7 @@ namespace Daqifi.Core.Tests.Firmware;
 public class Pic32BootloaderMessageConsumerTests
 {
     private const byte SOH = 0x01;
+    private const byte EOT = 0x04;
     private const byte DLE = 0x10;
 
     #region DecodeVersionResponse
@@ -175,6 +176,100 @@ public class Pic32BootloaderMessageConsumerTests
     {
         // SOH + ProgramFlashCommand(0x03)
         Assert.False(Pic32BootloaderMessageConsumer.DecodeEraseFlashResponse([SOH, 0x03]));
+    }
+
+    #endregion
+
+    #region DecodeReadCrcResponse
+
+    // Mirrors the firmware's response framing: content = [0x04, crcLo, crcHi];
+    // a framing CRC-16 over that content is appended, then the whole thing is
+    // SOH/EOT-framed with DLE escaping of any SOH/EOT/DLE bytes.
+    private static byte[] FrameReadCrcResponse(ushort flashCrc, ushort? overrideFrameCrc = null)
+    {
+        byte[] content = [0x04, (byte)(flashCrc & 0xFF), (byte)(flashCrc >> 8)];
+        var frameCrc = overrideFrameCrc ?? new Crc16(content).Crc;
+
+        var body = new List<byte>(content)
+        {
+            (byte)(frameCrc & 0xFF),
+            (byte)(frameCrc >> 8)
+        };
+
+        var framed = new List<byte> { SOH };
+        foreach (var b in body)
+        {
+            if (b is SOH or EOT or DLE)
+            {
+                framed.Add(DLE);
+            }
+            framed.Add(b);
+        }
+        framed.Add(EOT);
+        return framed.ToArray();
+    }
+
+    [Theory]
+    [InlineData((ushort)0x0000)]
+    [InlineData((ushort)0xABCD)]
+    [InlineData((ushort)0x0104)] // bytes collide with SOH/EOT → exercises escaping
+    [InlineData((ushort)0x1004)] // bytes collide with DLE/EOT → exercises escaping
+    [InlineData((ushort)0xFFFF)]
+    public void DecodeReadCrcResponse_RoundTripsFlashCrc(ushort flashCrc)
+    {
+        var framed = FrameReadCrcResponse(flashCrc);
+
+        var decoded = Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(framed);
+
+        Assert.Equal(flashCrc, decoded);
+    }
+
+    [Fact]
+    public void DecodeReadCrcResponse_WithoutSohStart_Throws()
+    {
+        Assert.Throws<InvalidDataException>(
+            () => Pic32BootloaderMessageConsumer.DecodeReadCrcResponse([0x00, 0x04, 0x12, 0x34, EOT]));
+    }
+
+    [Fact]
+    public void DecodeReadCrcResponse_NotEotTerminated_Throws()
+    {
+        // SOH + DLE + cmd + crc bytes but no terminating EOT.
+        Assert.Throws<InvalidDataException>(
+            () => Pic32BootloaderMessageConsumer.DecodeReadCrcResponse([SOH, DLE, 0x04, 0xCD, 0xAB]));
+    }
+
+    [Fact]
+    public void DecodeReadCrcResponse_WrongCommandEcho_Throws()
+    {
+        // Frame a structurally-valid response whose command echo is 0x03, not 0x04.
+        byte[] content = [0x03, 0x12, 0x34];
+        var frameCrc = new Crc16(content).Crc;
+        var body = new List<byte>(content) { (byte)(frameCrc & 0xFF), (byte)(frameCrc >> 8) };
+        var framed = new List<byte> { SOH };
+        foreach (var b in body)
+        {
+            if (b is SOH or EOT or DLE)
+            {
+                framed.Add(DLE);
+            }
+            framed.Add(b);
+        }
+        framed.Add(EOT);
+
+        Assert.Throws<InvalidDataException>(
+            () => Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(framed.ToArray()));
+    }
+
+    [Fact]
+    public void DecodeReadCrcResponse_BadFramingCrc_Throws()
+    {
+        // Correct flash CRC but a corrupted framing CRC must be rejected.
+        var goodFrameCrc = new Crc16([0x04, 0xCD, 0xAB]).Crc;
+        var framed = FrameReadCrcResponse(0xABCD, overrideFrameCrc: (ushort)(goodFrameCrc ^ 0xFFFF));
+
+        Assert.Throws<InvalidDataException>(
+            () => Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(framed));
     }
 
     #endregion

--- a/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderMessageProducerTests.cs
@@ -217,6 +217,45 @@ public class Pic32BootloaderMessageProducerTests
     }
 
     [Fact]
+    public void CreateReadCrcMessage_StartsWithSohEndsWithEot()
+    {
+        var message = Pic32BootloaderMessageProducer.CreateReadCrcMessage(0x9D000000, 0x200000);
+
+        Assert.Equal(SOH, message[0]);
+        Assert.Equal(EOT, message[^1]);
+    }
+
+    [Fact]
+    public void CreateReadCrcMessage_EscapesCommandByte()
+    {
+        // READ_CRC command byte 0x04 matches EOT, so it must be DLE-escaped
+        // right after SOH.
+        var message = Pic32BootloaderMessageProducer.CreateReadCrcMessage(0x9D000000, 0x200000);
+
+        Assert.Equal(DLE, message[1]);
+        Assert.Equal(0x04, message[2]);
+    }
+
+    [Fact]
+    public void CreateReadCrcMessage_EncodesAddressAndLengthLittleEndian()
+    {
+        // Values chosen so none of the 8 address/length bytes collide with
+        // SOH/EOT/DLE, keeping their positions stable (no escaping inserted).
+        var message = Pic32BootloaderMessageProducer.CreateReadCrcMessage(0x9D0000A0, 0x000000C8);
+
+        // SOH(0), DLE(1), cmd 0x04(2), then little-endian address...
+        Assert.Equal(0xA0, message[3]);
+        Assert.Equal(0x00, message[4]);
+        Assert.Equal(0x00, message[5]);
+        Assert.Equal(0x9D, message[6]);
+        // ...then little-endian length (200 == 0x000000C8).
+        Assert.Equal(0xC8, message[7]);
+        Assert.Equal(0x00, message[8]);
+        Assert.Equal(0x00, message[9]);
+        Assert.Equal(0x00, message[10]);
+    }
+
+    [Fact]
     public void AllMessages_HaveValidFraming()
     {
         var messages = new[]
@@ -224,6 +263,7 @@ public class Pic32BootloaderMessageProducerTests
             Pic32BootloaderMessageProducer.CreateRequestVersionMessage(),
             Pic32BootloaderMessageProducer.CreateEraseFlashMessage(),
             Pic32BootloaderMessageProducer.CreateProgramFlashMessage([0xAA]),
+            Pic32BootloaderMessageProducer.CreateReadCrcMessage(0x9D000000, 0x200000),
             Pic32BootloaderMessageProducer.CreateJumpToApplicationMessage()
         };
 

--- a/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderProtocolTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderProtocolTests.cs
@@ -211,6 +211,28 @@ public class Pic32BootloaderProtocolTests
         Assert.Equal(8u, region.Length);
     }
 
+    [Fact]
+    public void ComputeCrcRegions_ExcludesRecordSpanningPastAppFlashEnd()
+    {
+        // A record whose start is in-window but whose byte span crosses the
+        // app-flash end (0x1D1FFFFF). The bootloader programs per byte and skips
+        // the out-of-window tail, so CRC'ing the whole record would mismatch.
+        // A custom protected range (elsewhere) keeps the protected-range filter
+        // out of the way, isolating the app-flash-span check.
+        var protocol = new Pic32BootloaderProtocol(0x00010000, 0x00020000);
+        var lines = new[]
+        {
+            ":020000041D1FBE",                            // base 0x1D1F0000
+            // 16 bytes @ 0x1D1FFFF8 -> spans 0x1D1FFFF8..0x1D200007 (past 0x1D1FFFFF)
+            ":10FFF800000102030405060708090A0B0C0D0E0F81",
+            ":00000001FF"
+        };
+
+        var regions = protocol.ComputeCrcRegions(lines);
+
+        Assert.Empty(regions);
+    }
+
     private static byte[] FrameReadCrcResponse(ushort flashCrc)
     {
         const byte soh = 0x01;

--- a/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderProtocolTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderProtocolTests.cs
@@ -105,4 +105,109 @@ public class Pic32BootloaderProtocolTests
         // Data record should be filtered by custom range
         Assert.Equal(2, result.Count);
     }
+
+    [Fact]
+    public void CreateReadCrcMessage_DelegatesToProducer()
+    {
+        var expected = Pic32BootloaderMessageProducer.CreateReadCrcMessage(0x9D000000, 0x200000);
+        var result = _protocol.CreateReadCrcMessage(0x9D000000, 0x200000);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void DecodeReadCrcResponse_DelegatesToConsumer()
+    {
+        var framed = FrameReadCrcResponse(0xABCD);
+        var expected = Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(framed);
+        var result = _protocol.DecodeReadCrcResponse(framed);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ComputeCrcRegions_ContiguousRecords_SingleRegionWithKseg0AddressAndCrc()
+    {
+        var lines = new[]
+        {
+            ":020000041D00DD",                  // base 0x1D000000
+            ":080000000001020304050607DC",      // 8 bytes @ 0x1D000000 (00..07)
+            ":0800080008090A0B0C0D0E0F94",      // 8 bytes @ 0x1D000008 (08..0F)
+            ":00000001FF"                       // EOF
+        };
+
+        var regions = _protocol.ComputeCrcRegions(lines);
+
+        var region = Assert.Single(regions);
+        // Physical 0x1D000000 → KSEG0 0x9D000000 (the address READ_CRC expects).
+        Assert.Equal(0x9D000000u, region.Address);
+        Assert.Equal(16u, region.Length);
+        var expectedCrc = new Crc16(Enumerable.Range(0, 16).Select(i => (byte)i).ToArray()).Crc;
+        Assert.Equal(expectedCrc, region.ExpectedCrc);
+    }
+
+    [Fact]
+    public void ComputeCrcRegions_NonContiguousRecords_ProducesSeparateRegions()
+    {
+        var lines = new[]
+        {
+            ":020000041D00DD",                  // base 0x1D000000
+            ":080000000001020304050607DC",      // 8 bytes @ 0x1D000000
+            ":0800100010111213141516174C",      // 8 bytes @ 0x1D000010 (gap at 0x08..0x0F)
+            ":00000001FF"
+        };
+
+        var regions = _protocol.ComputeCrcRegions(lines);
+
+        Assert.Equal(2, regions.Count);
+        Assert.Equal(0x9D000000u, regions[0].Address);
+        Assert.Equal(8u, regions[0].Length);
+        Assert.Equal(0x9D000010u, regions[1].Address);
+        Assert.Equal(8u, regions[1].Length);
+    }
+
+    [Fact]
+    public void ComputeCrcRegions_ExcludesProtectedCalibrationRecords()
+    {
+        // The bootloader never programs the protected calibration range, so its
+        // flash retains old contents — including it in a CRC region would make
+        // verification fail on every real device. It must be excluded.
+        var lines = new[]
+        {
+            ":020000041D00DD",                  // base 0x1D000000
+            ":080000000001020304050607DC",      // 8 bytes @ 0x1D000000 — normal
+            ":020000041D1EBF",                  // base 0x1D1E0000 (protected range)
+            ":080000000001020304050607DC",      // 8 bytes @ 0x1D1E0000 — protected, excluded
+            ":00000001FF"
+        };
+
+        var regions = _protocol.ComputeCrcRegions(lines);
+
+        var region = Assert.Single(regions);
+        Assert.Equal(0x9D000000u, region.Address);
+        Assert.Equal(8u, region.Length);
+    }
+
+    private static byte[] FrameReadCrcResponse(ushort flashCrc)
+    {
+        const byte soh = 0x01;
+        const byte eot = 0x04;
+        const byte dle = 0x10;
+
+        byte[] content = [0x04, (byte)(flashCrc & 0xFF), (byte)(flashCrc >> 8)];
+        var frameCrc = new Crc16(content).Crc;
+        var body = new List<byte>(content) { (byte)(frameCrc & 0xFF), (byte)(frameCrc >> 8) };
+
+        var framed = new List<byte> { soh };
+        foreach (var b in body)
+        {
+            if (b is soh or eot or dle)
+            {
+                framed.Add(dle);
+            }
+            framed.Add(b);
+        }
+        framed.Add(eot);
+        return framed.ToArray();
+    }
 }

--- a/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderProtocolTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderProtocolTests.cs
@@ -188,6 +188,29 @@ public class Pic32BootloaderProtocolTests
         Assert.Equal(8u, region.Length);
     }
 
+    [Fact]
+    public void ComputeCrcRegions_ExcludesRecordsOutsideAppFlashRange()
+    {
+        // Real firmware HEX files carry linker-emitted data outside the app-flash
+        // partition (e.g. at physical 0x00000000). The bootloader never programs
+        // those records, so including them would compare against flash the device
+        // never wrote and fail verification. They must be excluded.
+        var lines = new[]
+        {
+            ":020000040000FA",                  // base 0x00000000 (outside app flash)
+            ":080000000001020304050607DC",      // 8 bytes @ 0x00000000 — excluded
+            ":020000041D00DD",                  // base 0x1D000000 (app flash)
+            ":080000000001020304050607DC",      // 8 bytes @ 0x1D000000 — kept
+            ":00000001FF"
+        };
+
+        var regions = _protocol.ComputeCrcRegions(lines);
+
+        var region = Assert.Single(regions);
+        Assert.Equal(0x9D000000u, region.Address);
+        Assert.Equal(8u, region.Length);
+    }
+
     private static byte[] FrameReadCrcResponse(ushort flashCrc)
     {
         const byte soh = 0x01;

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -151,15 +151,21 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             throw new FileNotFoundException("Firmware HEX file was not found.", hexFilePath);
         }
 
-        var hexRecords = ParseHexRecords(hexFilePath);
+        var hexLines = File.ReadAllLines(hexFilePath);
+        var hexRecords = _bootloaderProtocol.ParseHexFile(hexLines);
         var totalBytes = hexRecords.Sum(record => (long)record.Length);
         if (totalBytes <= 0)
         {
             throw new InvalidDataException("Firmware HEX file did not contain any writable records.");
         }
 
+        // Computed up front (alongside parsing) so the post-programming Verifying
+        // state can checksum exactly the bytes we programmed via the bootloader
+        // READ_CRC command. See VerifyFlashContentsAsync.
+        var crcRegions = _bootloaderProtocol.ComputeCrcRegions(hexLines);
+
         await RunExclusiveAsync(
-            ct => RunPic32UpdateAsync(device, hexRecords, totalBytes, progress, ct),
+            ct => RunPic32UpdateAsync(device, hexRecords, crcRegions, totalBytes, progress, ct),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -265,6 +271,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     private async Task RunPic32UpdateAsync(
         IStreamingDevice device,
         IReadOnlyList<byte[]> hexRecords,
+        IReadOnlyList<FlashCrcRegion> crcRegions,
         long totalBytes,
         IProgress<FirmwareUpdateProgress>? progress,
         CancellationToken cancellationToken)
@@ -336,16 +343,14 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 ct => ProgramFlashAsync(hexRecords, totalBytes, progress, ct),
                 cancellationToken).ConfigureAwait(false);
 
-            TransitionToState(FirmwareUpdateState.Verifying, "Verifying bootloader response.");
+            TransitionToState(FirmwareUpdateState.Verifying, "Verifying flash contents via CRC.");
             ReportProgress(progress, FirmwareUpdateState.Verifying, 92, _currentOperation, totalBytes, totalBytes);
 
-            var verificationVersion = await ExecuteWithStateTimeoutAsync(
+            await ExecuteWithStateTimeoutAsync(
                 FirmwareUpdateState.Verifying,
-                "verify bootloader response",
-                RequestBootloaderVersionAsync,
+                "verify flash contents via CRC",
+                ct => VerifyFlashContentsAsync(crcRegions, progress, totalBytes, ct),
                 cancellationToken).ConfigureAwait(false);
-
-            _logger.LogInformation("Bootloader verification response: {BootloaderVersion}", verificationVersion);
 
             TransitionToState(FirmwareUpdateState.JumpingToApp, "Jumping to application firmware.");
             ReportProgress(progress, FirmwareUpdateState.JumpingToApp, 95, _currentOperation, totalBytes, totalBytes);
@@ -843,12 +848,6 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             : escaped;
     }
 
-    private IReadOnlyList<byte[]> ParseHexRecords(string hexFilePath)
-    {
-        var lines = File.ReadAllLines(hexFilePath);
-        return _bootloaderProtocol.ParseHexFile(lines);
-    }
-
     private async Task<HidDeviceInfo> WaitForBootloaderDeviceAsync(CancellationToken cancellationToken)
     {
         while (true)
@@ -998,6 +997,76 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 bytesWritten,
                 totalBytes);
         }
+    }
+
+    private async Task VerifyFlashContentsAsync(
+        IReadOnlyList<FlashCrcRegion> crcRegions,
+        IProgress<FirmwareUpdateProgress>? progress,
+        long totalBytes,
+        CancellationToken cancellationToken)
+    {
+        if (crcRegions.Count == 0)
+        {
+            // No flashable regions to verify (degenerate/empty image). Fall back
+            // to confirming the bootloader is still responsive so we never jump
+            // to an application we couldn't reach over HID.
+            var version = await RequestBootloaderVersionAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "No flash CRC regions to verify; confirmed bootloader liveness: {BootloaderVersion}.",
+                version);
+            return;
+        }
+
+        for (var index = 0; index < crcRegions.Count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var region = crcRegions[index];
+            await ExecuteWithRetryAsync(
+                $"read flash CRC for region {index + 1} at 0x{region.Address:X8}",
+                _options.FlashWriteRetryCount,
+                _options.FlashWriteRetryDelay,
+                async ct =>
+                {
+                    await _hidTransport
+                        .WriteAsync(_bootloaderProtocol.CreateReadCrcMessage(region.Address, region.Length), ct)
+                        .ConfigureAwait(false);
+
+                    var response = await _hidTransport
+                        .ReadAsync(_options.BootloaderResponseTimeout, ct)
+                        .ConfigureAwait(false);
+
+                    var actualCrc = _bootloaderProtocol.DecodeReadCrcResponse(response);
+                    if (actualCrc != region.ExpectedCrc)
+                    {
+                        throw new InvalidDataException(
+                            $"Flash CRC mismatch in region {index + 1} at 0x{region.Address:X8} " +
+                            $"(length {region.Length}): expected 0x{region.ExpectedCrc:X4}, " +
+                            $"device reported 0x{actualCrc:X4}.");
+                    }
+                },
+                // Retry only transient transport faults. A CRC mismatch — or a
+                // malformed response surfaced as InvalidDataException — is
+                // deterministic: retrying cannot change it, and verification must
+                // fail fast into the failure/cleanup path rather than mask a bad
+                // flash behind retries.
+                ex => ex is IOException or TimeoutException,
+                cancellationToken).ConfigureAwait(false);
+
+            // Verifying occupies the 92→94% band (JumpingToApp starts at 95%).
+            var verifyPercent = 92 + ((index + 1) / (double)crcRegions.Count * 2);
+            ReportProgress(
+                progress,
+                FirmwareUpdateState.Verifying,
+                verifyPercent,
+                $"Verified flash CRC region {index + 1} of {crcRegions.Count}",
+                totalBytes,
+                totalBytes);
+        }
+
+        _logger.LogInformation(
+            "Flash CRC verification passed for {RegionCount} region(s).",
+            crcRegions.Count);
     }
 
     private async Task JumpToApplicationAndReconnectAsync(
@@ -1440,7 +1509,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             FirmwareUpdateState.Programming =>
                 "Programming failed. Retry update while keeping USB connected; device may still be recoverable in bootloader mode.",
             FirmwareUpdateState.Verifying =>
-                "Verification failed. Retry update and confirm the expected firmware package was selected.",
+                "Flash verification failed — the device's flash CRC did not match the firmware image. " +
+                "Retry the update and confirm the expected firmware package was selected.",
             FirmwareUpdateState.JumpingToApp =>
                 "The device did not return to application mode. Power-cycle the device and reconnect.",
             _ =>

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -1036,20 +1036,42 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                         .ReadAsync(_options.BootloaderResponseTimeout, ct)
                         .ConfigureAwait(false);
 
-                    var actualCrc = _bootloaderProtocol.DecodeReadCrcResponse(response);
+                    ushort actualCrc;
+                    try
+                    {
+                        actualCrc = _bootloaderProtocol.DecodeReadCrcResponse(response);
+                    }
+                    catch (InvalidDataException ex)
+                    {
+                        // A malformed / framing-corrupt READ_CRC frame is a
+                        // transport-level fault, not evidence of bad flash. Surface
+                        // it as transient (like a HID read error) so a one-off USB
+                        // glitch is retried rather than failing the whole update —
+                        // consistent with how the erase/program steps treat
+                        // InvalidDataException.
+                        throw new IOException(
+                            $"READ_CRC response for region {index + 1} at 0x{region.Address:X8} was malformed; " +
+                            "treating as a transient transport fault.",
+                            ex);
+                    }
+
                     if (actualCrc != region.ExpectedCrc)
                     {
+                        // A genuine CRC mismatch is deterministic — the flash does
+                        // not match the image. Throw InvalidDataException, which the
+                        // retry predicate excludes, so verification fails fast into
+                        // the failure/cleanup path rather than masking a bad flash
+                        // behind retries.
                         throw new InvalidDataException(
                             $"Flash CRC mismatch in region {index + 1} at 0x{region.Address:X8} " +
                             $"(length {region.Length}): expected 0x{region.ExpectedCrc:X4}, " +
                             $"device reported 0x{actualCrc:X4}.");
                     }
                 },
-                // Retry only transient transport faults. A CRC mismatch — or a
-                // malformed response surfaced as InvalidDataException — is
-                // deterministic: retrying cannot change it, and verification must
-                // fail fast into the failure/cleanup path rather than mask a bad
-                // flash behind retries.
+                // Retry transient transport faults: HID read errors, timeouts, and
+                // malformed frames (wrapped as IOException above). A CRC mismatch
+                // throws InvalidDataException, which is intentionally NOT retried —
+                // it is deterministic and must fail fast into the failure/cleanup path.
                 ex => ex is IOException or TimeoutException,
                 cancellationToken).ConfigureAwait(false);
 

--- a/src/Daqifi.Core/Firmware/FlashCrcRegion.cs
+++ b/src/Daqifi.Core/Firmware/FlashCrcRegion.cs
@@ -1,0 +1,48 @@
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// Describes a contiguous region of programmed application flash whose contents
+/// can be independently verified against the device using the bootloader
+/// <c>READ_CRC</c> (0x04) command.
+/// </summary>
+/// <remarks>
+/// The host computes <see cref="ExpectedCrc"/> over the same bytes the device
+/// just programmed; after programming, it asks the bootloader for the CRC-16 of
+/// the same <see cref="Address"/>/<see cref="Length"/> range and compares. A
+/// mismatch means the flash does not match the firmware image (bit flip,
+/// partially-programmed record, etc.).
+/// </remarks>
+public sealed class FlashCrcRegion
+{
+    /// <summary>
+    /// Gets the KSEG0 virtual flash address to send in the <c>READ_CRC</c>
+    /// command. The firmware applies <c>KVA0_TO_KVA1</c> to this value before
+    /// reading flash, so it must be the KSEG0 form (physical address with bit
+    /// 31 set), matching the address the bootloader programmed the record to.
+    /// </summary>
+    public uint Address { get; }
+
+    /// <summary>
+    /// Gets the number of contiguous flash bytes covered by this region.
+    /// </summary>
+    public uint Length { get; }
+
+    /// <summary>
+    /// Gets the host-computed CRC-16/XMODEM over the region's bytes, in the same
+    /// form the bootloader returns from <c>READ_CRC</c>.
+    /// </summary>
+    public ushort ExpectedCrc { get; }
+
+    /// <summary>
+    /// Creates a new flash CRC region descriptor.
+    /// </summary>
+    /// <param name="address">KSEG0 virtual flash address of the first byte.</param>
+    /// <param name="length">Number of contiguous bytes in the region.</param>
+    /// <param name="expectedCrc">Host-computed CRC-16/XMODEM over the region.</param>
+    public FlashCrcRegion(uint address, uint length, ushort expectedCrc)
+    {
+        Address = address;
+        Length = length;
+        ExpectedCrc = expectedCrc;
+    }
+}

--- a/src/Daqifi.Core/Firmware/IBootloaderProtocol.cs
+++ b/src/Daqifi.Core/Firmware/IBootloaderProtocol.cs
@@ -32,6 +32,17 @@ public interface IBootloaderProtocol
     byte[] CreateJumpToApplicationMessage();
 
     /// <summary>
+    /// Creates a <c>READ_CRC</c> (0x04) message asking the bootloader to compute
+    /// the CRC-16 of a flash region.
+    /// </summary>
+    /// <param name="address">
+    /// KSEG0 virtual flash address of the first byte (see <see cref="FlashCrcRegion.Address"/>).
+    /// </param>
+    /// <param name="length">Number of contiguous flash bytes to checksum.</param>
+    /// <returns>The framed message bytes ready for transmission.</returns>
+    byte[] CreateReadCrcMessage(uint address, uint length);
+
+    /// <summary>
     /// Decodes a version response from the bootloader.
     /// </summary>
     /// <param name="data">The raw response bytes.</param>
@@ -51,6 +62,31 @@ public interface IBootloaderProtocol
     /// <param name="data">The raw response bytes.</param>
     /// <returns>True if the response is a valid erase flash acknowledgment.</returns>
     bool DecodeEraseFlashResponse(byte[] data);
+
+    /// <summary>
+    /// Decodes a <c>READ_CRC</c> (0x04) response and returns the flash CRC-16
+    /// the bootloader computed.
+    /// </summary>
+    /// <param name="data">The raw, framed response bytes.</param>
+    /// <returns>The 16-bit CRC reported by the bootloader.</returns>
+    /// <exception cref="System.IO.InvalidDataException">
+    /// Thrown when the response is malformed, is not a <c>READ_CRC</c> response,
+    /// or fails its framing-CRC integrity check.
+    /// </exception>
+    ushort DecodeReadCrcResponse(byte[] data);
+
+    /// <summary>
+    /// Computes the set of contiguous flash regions covered by a parsed HEX
+    /// image, each with the host-side expected CRC-16, ready to verify against
+    /// the device via <see cref="CreateReadCrcMessage"/> after programming.
+    /// </summary>
+    /// <param name="hexFileLines">The lines from the HEX file.</param>
+    /// <returns>
+    /// One <see cref="FlashCrcRegion"/> per maximal contiguous run of programmed
+    /// bytes (records in the protected memory range are excluded, matching what
+    /// is actually written to flash).
+    /// </returns>
+    IReadOnlyList<FlashCrcRegion> ComputeCrcRegions(string[] hexFileLines);
 
     /// <summary>
     /// Parses an Intel HEX file into raw hex record byte arrays, filtering out

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderMessageConsumer.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderMessageConsumer.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Daqifi.Core.Firmware;
 
 /// <summary>
@@ -7,10 +9,12 @@ namespace Daqifi.Core.Firmware;
 public static class Pic32BootloaderMessageConsumer
 {
     private const byte START_OF_HEADER = 0x01;
+    private const byte END_OF_TRANSMISSION = 0x04;
     private const byte DATA_LINK_ESCAPE = 0x10;
     private const byte REQUEST_VERSION_COMMAND = 0x01;
     private const byte ERASE_FLASH_COMMAND = 0x02;
     private const byte PROGRAM_FLASH_COMMAND = 0x03;
+    private const byte READ_CRC_COMMAND = 0x04;
 
     /// <summary>
     /// Decodes a version response from the bootloader.
@@ -72,5 +76,88 @@ public static class Pic32BootloaderMessageConsumer
         if (data[0] != START_OF_HEADER) return false;
 
         return data[1] == ERASE_FLASH_COMMAND;
+    }
+
+    /// <summary>
+    /// Decodes a <c>READ_CRC</c> response and returns the flash CRC-16 the
+    /// bootloader computed. The wire frame is
+    /// <c>SOH DLE 0x04 &lt;crcLo&gt; &lt;crcHi&gt; &lt;frameCrcLo&gt; &lt;frameCrcHi&gt; EOT</c>,
+    /// with any of the payload bytes DLE-escaped when they collide with SOH/EOT/DLE.
+    /// </summary>
+    /// <param name="data">The raw, framed response bytes.</param>
+    /// <returns>The 16-bit CRC reported by the bootloader.</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="data"/> is null.</exception>
+    /// <exception cref="InvalidDataException">
+    /// Thrown when the response is malformed, is not a <c>READ_CRC</c> response,
+    /// or fails its framing-CRC integrity check.
+    /// </exception>
+    public static ushort DecodeReadCrcResponse(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        if (data.Length < 2 || data[0] != START_OF_HEADER)
+        {
+            throw new InvalidDataException("READ_CRC response did not begin with SOH framing.");
+        }
+
+        // Unescape the body: DLE marks the next byte as literal payload; an
+        // unescaped EOT terminates the frame. Yields [cmd, crcLo, crcHi,
+        // frameCrcLo, frameCrcHi] (the firmware appends a framing CRC-16 over
+        // the response content before framing).
+        var payload = new List<byte>(5);
+        var escaped = false;
+        var terminated = false;
+        for (var i = 1; i < data.Length; i++)
+        {
+            var b = data[i];
+            if (escaped)
+            {
+                payload.Add(b);
+                escaped = false;
+                continue;
+            }
+
+            if (b == DATA_LINK_ESCAPE)
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (b == END_OF_TRANSMISSION)
+            {
+                terminated = true;
+                break;
+            }
+
+            payload.Add(b);
+        }
+
+        if (!terminated)
+        {
+            throw new InvalidDataException("READ_CRC response was not EOT-terminated.");
+        }
+
+        if (payload.Count < 5)
+        {
+            throw new InvalidDataException(
+                $"READ_CRC response was too short ({payload.Count} payload byte(s); expected 5).");
+        }
+
+        if (payload[0] != READ_CRC_COMMAND)
+        {
+            throw new InvalidDataException(
+                $"READ_CRC response had unexpected command byte 0x{payload[0]:X2}.");
+        }
+
+        var flashCrc = (ushort)(payload[1] | (payload[2] << 8));
+        var frameCrc = (ushort)(payload[3] | (payload[4] << 8));
+        var expectedFrameCrc = new Crc16([payload[0], payload[1], payload[2]]).Crc;
+        if (frameCrc != expectedFrameCrc)
+        {
+            throw new InvalidDataException(
+                $"READ_CRC response framing CRC mismatch: frame=0x{frameCrc:X4}, computed=0x{expectedFrameCrc:X4}.");
+        }
+
+        return flashCrc;
     }
 }

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderMessageProducer.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderMessageProducer.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Binary;
+
 namespace Daqifi.Core.Firmware;
 
 /// <summary>
@@ -12,6 +14,7 @@ public static class Pic32BootloaderMessageProducer
     private const byte REQUEST_VERSION_COMMAND = 0x01;
     private const byte ERASE_FLASH_COMMAND = 0x02;
     private const byte PROGRAM_FLASH_COMMAND = 0x03;
+    private const byte READ_CRC_COMMAND = 0x04;
     private const byte JUMP_TO_APPLICATION_COMMAND = 0x05;
 
     /// <summary>
@@ -45,6 +48,24 @@ public static class Pic32BootloaderMessageProducer
         var command = new byte[1 + hexRecord.Length];
         command[0] = PROGRAM_FLASH_COMMAND;
         Array.Copy(hexRecord, 0, command, 1, hexRecord.Length);
+        return ConstructDataPacket(command);
+    }
+
+    /// <summary>
+    /// Creates a <c>READ_CRC</c> message asking the bootloader to checksum a
+    /// flash region. The payload is the command byte followed by the 4-byte
+    /// little-endian address and 4-byte little-endian length the firmware reads
+    /// from <c>buff2[1..4]</c> and <c>buff2[5..8]</c>.
+    /// </summary>
+    /// <param name="address">KSEG0 virtual flash address of the first byte.</param>
+    /// <param name="length">Number of contiguous flash bytes to checksum.</param>
+    /// <returns>The framed and escaped message bytes.</returns>
+    public static byte[] CreateReadCrcMessage(uint address, uint length)
+    {
+        var command = new byte[9];
+        command[0] = READ_CRC_COMMAND;
+        BinaryPrimitives.WriteUInt32LittleEndian(command.AsSpan(1, 4), address);
+        BinaryPrimitives.WriteUInt32LittleEndian(command.AsSpan(5, 4), length);
         return ConstructDataPacket(command);
     }
 

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderProtocol.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderProtocol.cs
@@ -118,8 +118,18 @@ public class Pic32BootloaderProtocol : IBootloaderProtocol
                         && r.Data.Length > 0
                         && r.Data[0] > 0
                         && r.Data.Length >= r.Data[0] + 5
+                        // The record's FULL byte span must lie within the
+                        // app-flash window. The bootloader filters per byte
+                        // (APP_ProgramHexRecord checks ProgAddress against
+                        // APP_FLASH_BASE/END for each write), so a record whose
+                        // span crosses the window boundary would have its
+                        // out-of-window bytes skipped by the device but still
+                        // CRC'd by the host — a guaranteed mismatch. Require the
+                        // whole span to be in range (overflow-safe form: the
+                        // byte count must fit in the bytes remaining to the end).
                         && r.Address >= AppFlashPhysicalStart
-                        && r.Address <= AppFlashPhysicalEnd)
+                        && r.Address <= AppFlashPhysicalEnd
+                        && (uint)r.Data[0] <= AppFlashPhysicalEnd - r.Address + 1)
             .OrderBy(r => r.Address)
             .ToList();
 

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderProtocol.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderProtocol.cs
@@ -7,6 +7,13 @@ namespace Daqifi.Core.Firmware;
 /// </summary>
 public class Pic32BootloaderProtocol : IBootloaderProtocol
 {
+    // PIC32 KSEG0 mask (PA_TO_KVA0): the bootloader programs records at
+    // PA_TO_KVA0(physicalAddress) and READ_CRC reads at KVA0_TO_KVA1(address),
+    // so the address we hand to READ_CRC must be the KSEG0 form of the HEX
+    // record's physical address (physical | 0x80000000).
+    private const uint Kseg0Mask = 0x80000000;
+    private const byte DataRecordType = 0x00;
+
     private readonly IntelHexParser _hexParser;
 
     /// <summary>
@@ -52,6 +59,12 @@ public class Pic32BootloaderProtocol : IBootloaderProtocol
     }
 
     /// <inheritdoc />
+    public byte[] CreateReadCrcMessage(uint address, uint length)
+    {
+        return Pic32BootloaderMessageProducer.CreateReadCrcMessage(address, length);
+    }
+
+    /// <inheritdoc />
     public string DecodeVersionResponse(byte[] data)
     {
         return Pic32BootloaderMessageConsumer.DecodeVersionResponse(data);
@@ -70,8 +83,75 @@ public class Pic32BootloaderProtocol : IBootloaderProtocol
     }
 
     /// <inheritdoc />
+    public ushort DecodeReadCrcResponse(byte[] data)
+    {
+        return Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(data);
+    }
+
+    /// <inheritdoc />
     public List<byte[]> ParseHexFile(string[] hexFileLines)
     {
         return _hexParser.ParseHexRecords(hexFileLines);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<FlashCrcRegion> ComputeCrcRegions(string[] hexFileLines)
+    {
+        // Order data records by physical address so adjacent records coalesce
+        // regardless of file order. The device computes its flash CRC over the
+        // address-ordered bytes in a region, so this matches what READ_CRC will
+        // return. Protected-range records are already excluded by ParseRecords,
+        // exactly as they are excluded from programming.
+        var dataRecords = _hexParser.ParseRecords(hexFileLines)
+            .Where(r => r.RecordType == DataRecordType
+                        && r.Data.Length > 0
+                        && r.Data[0] > 0
+                        && r.Data.Length >= r.Data[0] + 5)
+            .OrderBy(r => r.Address)
+            .ToList();
+
+        var regions = new List<FlashCrcRegion>();
+        var buffer = new List<byte>();
+        uint regionStart = 0;
+        uint nextAddress = 0;
+
+        foreach (var record in dataRecords)
+        {
+            int dataLen = record.Data[0];
+
+            // A gap (or, defensively, an overlap) ends the current contiguous
+            // run; flush it and start a new region at this record's address.
+            if (buffer.Count > 0 && record.Address != nextAddress)
+            {
+                regions.Add(BuildRegion(regionStart, buffer));
+                buffer.Clear();
+            }
+
+            if (buffer.Count == 0)
+            {
+                regionStart = record.Address;
+            }
+
+            for (var i = 0; i < dataLen; i++)
+            {
+                buffer.Add(record.Data[4 + i]);
+            }
+
+            nextAddress = record.Address + (uint)dataLen;
+        }
+
+        if (buffer.Count > 0)
+        {
+            regions.Add(BuildRegion(regionStart, buffer));
+        }
+
+        return regions;
+    }
+
+    private static FlashCrcRegion BuildRegion(uint physicalStart, List<byte> data)
+    {
+        var bytes = data.ToArray();
+        var crc = new Crc16(bytes).Crc;
+        return new FlashCrcRegion(physicalStart | Kseg0Mask, (uint)bytes.Length, crc);
     }
 }

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderProtocol.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderProtocol.cs
@@ -14,6 +14,17 @@ public class Pic32BootloaderProtocol : IBootloaderProtocol
     private const uint Kseg0Mask = 0x80000000;
     private const byte DataRecordType = 0x00;
 
+    // Application flash partition the bootloader will actually program
+    // (APP_FLASH_BASE_ADDRESS..APP_FLASH_END_ADDRESS in the firmware: 2 MB at
+    // KSEG0 0x9D000000, i.e. physical 0x1D000000..0x1D1FFFFF). The bootloader
+    // silently skips records outside this window — real firmware HEX files carry
+    // linker-emitted data at e.g. physical 0x00000000 that is never flashed — so
+    // those records must be excluded from CRC regions, mirroring exactly what is
+    // programmed. Otherwise verification would compare against flash the device
+    // never wrote and fail every time.
+    private const uint AppFlashPhysicalStart = 0x1D000000;
+    private const uint AppFlashPhysicalEnd = 0x1D1FFFFF;
+
     private readonly IntelHexParser _hexParser;
 
     /// <summary>
@@ -106,7 +117,9 @@ public class Pic32BootloaderProtocol : IBootloaderProtocol
             .Where(r => r.RecordType == DataRecordType
                         && r.Data.Length > 0
                         && r.Data[0] > 0
-                        && r.Data.Length >= r.Data[0] + 5)
+                        && r.Data.Length >= r.Data[0] + 5
+                        && r.Address >= AppFlashPhysicalStart
+                        && r.Address <= AppFlashPhysicalEnd)
             .OrderBy(r => r.Address)
             .ToList();
 


### PR DESCRIPTION
Closes #213.

## Problem

The firmware-update `Verifying` state previously just re-issued `READ_BOOT_INFO` and confirmed the bootloader was still responsive. That proves the device is *alive* but says nothing about whether the flash contents match the HEX we just programmed — a bit flip or a partially-programmed record would sail through to `JumpingToApp`.

The PIC32 HID bootloader already supports a real CRC check (`READ_CRC`, 0x04); the host just wasn't using it.

## What changed

`Verifying` now checksums the programmed flash and compares it against a host-computed CRC:

- **`IBootloaderProtocol`** gains `CreateReadCrcMessage(address, length)`, `DecodeReadCrcResponse(data)`, and `ComputeCrcRegions(lines)`.
- **Producer** builds the framed command: command byte `0x04` (DLE-escaped, since `0x04` == EOT) + 4-byte LE address + 4-byte LE length + framing CRC.
- **Consumer** de-frames, DLE-unescapes, validates the command echo and the firmware's framing CRC, and returns the device's flash CRC.
- **`ComputeCrcRegions`** coalesces contiguous HEX data records into regions, **excludes the protected calibration range** (the bootloader never reprograms it, so including it would fail verification on every real device), and translates physical → KSEG0 (`physical | 0x80000000`).
- **`FirmwareUpdateService`** computes regions up front, then verifies each region after programming with transient-only retry. A CRC mismatch throws `InvalidDataException` → lands in the existing `Failed` path (and will route through #208's cleanup once that merges, since `Verifying` is a cleanup-eligible state). When there are no flashable regions it falls back to a bootloader liveness check.

CRC-16/XMODEM reuses the existing `Crc16`, verified byte-for-byte against the firmware's `APP_CalculateCrc`.

## Address contract (verified against firmware source)

The firmware programs records at `PA_TO_KVA0(physicalAddr)` and `READ_CRC` reads at `KVA0_TO_KVA1(addr)`. HEX records carry physical addresses (`0x1D…`), so the address sent to `READ_CRC` must be the KSEG0 form (`0x9D…` = `physical | 0x80000000`). The conditional `BOOTLOADER_LIVE_UPDATE_STATE_SAVE` offset branch in the firmware is dead (the flag is never defined), so the plain path applies.

## Tests

All 1184 tests pass on net9.0 and net10.0 (0 warnings, `TreatWarningsAsErrors` on):

- **Producer** — SOH/EOT framing, `0x04` command escaping, little-endian address/length encoding.
- **Consumer** — flash-CRC round-trip including DLE-escaped CRC bytes; rejects missing SOH, missing EOT, wrong command echo, bad framing CRC.
- **Protocol** — `ComputeCrcRegions` for contiguous (single region, KSEG0 address + correct CRC), non-contiguous (split into two regions), and protected-range-excluded inputs.
- **Service** — CRC match completes; CRC mismatch fails into `Verifying`→`Failed` and never sends the jump command; multi-region issues one `READ_CRC` per region.

## Acceptance criteria

- [x] `Verifying` actually verifies flash contents, not just bootloader liveness.
- [x] A bit-flipped / partially-programmed flash is detected before `JumpingToApp`.

## Notes for reviewers

- The HEX file is parsed twice (`ParseHexFile` for program records, `ComputeCrcRegions` for verification regions). Minor waste on a run-once cold path; kept for a clean `lines → result` interface that mirrors `ParseHexFile`.
- `DecodeReadCrcResponse` validates the firmware's framing CRC and throws on mismatch — stricter than the existing version/erase/program decoders (which ignore it). Deliberate integrity improvement; a false positive only ever fails *safe* (re-erase + re-run), never passes a bad flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)