### PR TITLE
fix(discovery): disable echo before the serial identity probe so echo-on devices are found

### DIFF
--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -388,6 +388,12 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             // Port is in use by another application
             return null;
         }
+        catch (OperationCanceledException)
+        {
+            // Caller cancelled (e.g. during the wake / echo-disable delays). Propagate so the
+            // DiscoverAsync Task.WhenAll cancellation path runs — don't convert it into a probe-miss.
+            throw;
+        }
         catch (Exception)
         {
             // Any other error - not a valid DAQiFi device or port unavailable

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -35,6 +35,10 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     private const int MaxRetries = 2;
     private const int RetryIntervalMs = 300;
     private const int PollIntervalMs = 50;
+    // Time to let the device process the echo-disable command (and echo it one last time) before we
+    // flush the receive buffer, so the probe reads a clean protobuf stream. See the echo-disable note
+    // in TryGetDeviceInfoAsync.
+    private const int EchoDisableSettleMs = 250;
     // Upper bound on concurrent SerialPort opens during a single discovery
     // pass. Most OS serial stacks tolerate 4-8 simultaneous opens cleanly;
     // beyond that, IO failures and slow opens stack up. Common case (with
@@ -285,6 +289,26 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             producer = new MessageProducer<string>(stream);
             producer.Start();
 
+            // Disable echo before probing. A freshly-booted / never-connected device sits in its
+            // interactive shell with echo ON (at the "DAQIFI>" prompt). With echo on it prefixes the
+            // SYSInfoPB? reply with the echoed command text and trails it with a prompt, so the protobuf
+            // parser can't frame a message out of the stream and the device is silently missed even
+            // though it answered. Turn echo off, give the device a moment to process it (and echo this
+            // command one last time), then flush so the probe consumer below reads a clean protobuf
+            // stream. Identity-only otherwise — no power/stream-format changes (the connect handshake
+            // owns those).
+            producer.Send(ScpiMessageProducer.DisableDeviceEcho);
+            await Task.Delay(EchoDisableSettleMs, cancellationToken);
+            try
+            {
+                port.DiscardInBuffer();
+            }
+            catch
+            {
+                // Best-effort flush of the echoed command + prompt; if it throws, the retry loop and
+                // parser resync still give the probe additional chances on a clean(er) follow-up reply.
+            }
+
             var parser = new ProtobufMessageParser();
             consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
 
@@ -307,13 +331,12 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
 
             consumer.Start();
 
-            // Identity-only probe: just GetDeviceInfo (closes #157). The
-            // previous DisableEcho / StopStreaming / TurnDeviceOn /
-            // SetProtobufStreamFormat sequence was for connection setup,
-            // not identification — a healthy DAQiFi answers SYSTem:SYSInfoPB?
-            // immediately regardless of stream format or power state. Caller
-            // (the consumer setting up an actual connection) is responsible
-            // for any setup commands they need.
+            // Identity probe: DisableEcho (above) + GetDeviceInfo. The rest of the old setup sequence
+            // (StopStreaming / TurnDeviceOn / SetProtobufStreamFormat) is connection setup, not
+            // identification — a healthy DAQiFi answers SYSTem:SYSInfoPB? regardless of stream format or
+            // power state, so the caller setting up an actual connection still owns those. Echo is the
+            // exception: an echo-on device corrupts the reply stream, so the probe must disable it to
+            // identify the device at all (closes #157 follow-up: echo-on units were undiscoverable).
             // Send GetDeviceInfo command with retry logic
             var timeout = DateTime.UtcNow.AddMilliseconds(ResponseTimeoutMs);
             var lastRequestTime = DateTime.MinValue;


### PR DESCRIPTION
## Problem

A freshly-booted / never-connected DAQiFi device sits in its interactive shell with **echo ON** (at the `DAQIFI>` prompt). With echo on it prefixes its `SYSInfoPB?` reply with the echoed command text and trails it with a prompt, so `ProtobufMessageParser` can't frame a message out of the stream and `SerialDeviceFinder` silently drops the device **even though it answered**. A device connected before has echo off (the connect handshake sends `SYSTem:ECHO -1`), so its probe stream is clean and it's found. Net effect: fresh units, and any device sitting at the `daqifi>` prompt, are undiscoverable.

## Root cause

PR #201 (`closes #157`, "VID/PID-filter serial ports + minimal probe") tightened the probe to `GetDeviceInfo`-only for speed and removed the `SYSTem:ECHO -1` the previous probe sent — load-bearing for echo-on devices. Regression has shipped since v0.22.0. This PR restores the echo-disable while keeping #201's VID/PID prefilter + parallel probing.

## Fix

Send `DisableDeviceEcho`, let the device process it (and echo it one last time), then `DiscardInBuffer()` before the probe consumer reads — so the `SYSInfoPB?` reply is a clean protobuf stream. Identity-only otherwise.

## Verified on hardware (Nq1)

| | reply starts with |
|---|---|
| Before (echo on) | `53 59 53 54 65 6D…` ("SYSTem…") → can't frame → **missed** |
| After (DisableEcho + flush) | `A9 04 40 01…` clean protobuf → **found** |

End-to-end in the desktop app (local build of this branch): an echo-on unit discovers natively with its real serial/model/firmware. All 10 `SerialDeviceFinder` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)