### PR TITLE
feat(firmware): own the WiFi flash lifecycle and verify success from tool output

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -466,7 +466,7 @@ public class FirmwareUpdateServiceTests
                 0,
                 timedOut: false,
                 TimeSpan.FromMilliseconds(10),
-                ["begin write operation", "67%", "begin verify operation"],
+                ["begin write operation", "67%", "begin verify operation", "verify passed", "Operation completed successfully"],
                 [])
         };
 
@@ -557,6 +557,137 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateWifiModuleAsync_WhenToolExitsZeroButNeverReportsSuccess_FailsFromOutput()
+    {
+        // The port-not-released / "false success" case: the WINC tool couldn't open the serial
+        // port, produced no programming output, and exited 0. Success is verified from the tool's
+        // output (the success marker), NOT its exit code, so this must fail rather than report done.
+        var device = new FakeStreamingDevice("COM7");
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(0, timedOut: false, TimeSpan.FromSeconds(30), [], [])
+        };
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            CreateFastOptions());
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            var exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir));
+
+            Assert.Equal(FirmwareUpdateState.Programming, exception.FailedState);
+            Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+            // No retry for a non-transient failure (no bridge-init markers).
+            Assert.Equal(1, externalProcessRunner.RunCount);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenTransientBridgeFailureThenSuccess_RetriesAndCompletes()
+    {
+        var device = new FakeStreamingDevice("COM7");
+        var externalProcessRunner = new FakeExternalProcessRunner();
+        // Attempt 1: device hadn't settled into bridge mode — transient failure markers, exit 1.
+        externalProcessRunner.ResultSequence.Enqueue(new ExternalProcessResult(
+            1,
+            timedOut: false,
+            TimeSpan.FromSeconds(5),
+            ["software WINC serial bridge found", "Programming device failed"],
+            ["error: failed to read serial bridge ID query response"]));
+        // Attempt 2: succeeds.
+        externalProcessRunner.ResultSequence.Enqueue(new ExternalProcessResult(
+            0,
+            timedOut: false,
+            TimeSpan.FromSeconds(40),
+            ["begin write operation", "verify passed", "Operation completed successfully"],
+            []));
+
+        var options = CreateFastOptions();
+        options.WifiFlashAttempts = 2;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(device, firmwareDir);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(2, externalProcessRunner.RunCount);
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_FiresBridgeActivationCallbackAtWincPrompt()
+    {
+        var device = new FakeStreamingDevice("COM7");
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(
+                0,
+                timedOut: false,
+                TimeSpan.FromSeconds(40),
+                ["Power cycle WINC and set to bootloader mode", "verify passed", "Operation completed successfully"],
+                [])
+        };
+
+        var bridgeActivations = 0;
+        var options = CreateFastOptions();
+        options.WifiBridgeActivationCallback = () => bridgeActivations++;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(device, firmwareDir);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(1, bridgeActivations);
+    }
+
+    [Fact]
     public async Task UpdateWifiModuleAsync_WhenDeviceVersionMatchesLatest_SkipsFlashAndReportsComplete()
     {
         var wifiRelease = new FirmwareReleaseInfo
@@ -627,7 +758,7 @@ public class FirmwareUpdateServiceTests
 
         var externalProcessRunner = new FakeExternalProcessRunner
         {
-            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), [], [])
+            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), ["verify passed", "Operation completed successfully"], [])
         };
 
         var options = CreateFastOptions();
@@ -668,7 +799,7 @@ public class FirmwareUpdateServiceTests
 
         var externalProcessRunner = new FakeExternalProcessRunner
         {
-            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), [], [])
+            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), ["verify passed", "Operation completed successfully"], [])
         };
 
         var options = CreateFastOptions();
@@ -1225,7 +1356,7 @@ public class FirmwareUpdateServiceTests
 
         var externalProcessRunner = new FakeExternalProcessRunner
         {
-            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), [], [])
+            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), ["verify passed", "Operation completed successfully"], [])
         };
 
         var options = CreateFastOptions();
@@ -1293,7 +1424,7 @@ public class FirmwareUpdateServiceTests
 
         var externalProcessRunner = new FakeExternalProcessRunner
         {
-            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), [], [])
+            NextResult = new ExternalProcessResult(0, false, TimeSpan.FromMilliseconds(10), ["verify passed", "Operation completed successfully"], [])
         };
 
         var options = CreateFastOptions();
@@ -1587,6 +1718,12 @@ public class FirmwareUpdateServiceTests
             HidConnectRetryDelay = TimeSpan.FromMilliseconds(5),
             FlashWriteRetryDelay = TimeSpan.FromMilliseconds(5),
             WifiProcessTimeout = TimeSpan.FromSeconds(2),
+            // Collapse the WiFi-flash lifecycle waits for unit tests: the fake transport
+            // releases its port synchronously and the fake process runner needs no
+            // prompt/bridge-init window, so these delays are pure latency here.
+            PostLanDisconnectPortReleaseDelay = TimeSpan.Zero,
+            WincBootPromptResponseDelay = TimeSpan.Zero,
+            WifiFlashRetryDelay = TimeSpan.FromMilliseconds(5),
             // Disable the macOS USB CDC stale-handle settling delay for unit
             // tests — FakeStreamingDevice doesn't reproduce the re-enum race,
             // so the dance is pure latency that would blow the fast budgets.
@@ -1978,7 +2115,16 @@ public class FirmwareUpdateServiceTests
     private sealed class FakeExternalProcessRunner : IExternalProcessRunner
     {
         public ExternalProcessResult NextResult { get; set; } = new(0, false, TimeSpan.Zero, [], []);
+
+        /// <summary>
+        /// Optional per-attempt results. When non-empty each <see cref="RunAsync"/> call dequeues
+        /// the next result (the last one repeats once drained), letting tests model the WINC flash
+        /// retry path (transient failure → success).
+        /// </summary>
+        public Queue<ExternalProcessResult> ResultSequence { get; } = new();
+
         public ExternalProcessRequest? LastRequest { get; private set; }
+        public int RunCount { get; private set; }
 
         public Task<ExternalProcessResult> RunAsync(
             ExternalProcessRequest request,
@@ -1986,19 +2132,22 @@ public class FirmwareUpdateServiceTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             LastRequest = request;
+            RunCount++;
 
-            foreach (var line in NextResult.StandardOutputLines)
+            var result = ResultSequence.Count > 0 ? ResultSequence.Dequeue() : NextResult;
+
+            foreach (var line in result.StandardOutputLines)
             {
                 request.OnStandardOutputLine?.Invoke(line);
                 request.StandardInputResponseFactory?.Invoke(line);
             }
 
-            foreach (var line in NextResult.StandardErrorLines)
+            foreach (var line in result.StandardErrorLines)
             {
                 request.OnStandardErrorLine?.Invoke(line);
             }
 
-            return Task.FromResult(NextResult);
+            return Task.FromResult(result);
         }
     }
 

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -688,6 +688,57 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public void WifiFlashProgressParser_IgnoresImageBuildPercentAndAdvancesAcrossDeviceFlashPhases()
+    {
+        var parser = new FirmwareUpdateService.WifiFlashProgressParser();
+
+        // The local image-build phase reaches 100% per region; those must NOT move the bar,
+        // otherwise the monotonic max latches before the on-device flash even starts.
+        Assert.Null(parser.Observe("written 235472 of 237036 bytes to image (100%)"));
+        Assert.Null(parser.Observe("written 77304 of 765952 bytes to image (11%)"));
+
+        // Device flash phases advance the bar, each monotonically forward.
+        var writeStart = parser.Observe("begin write operation");
+        Assert.NotNull(writeStart);
+
+        var writeMid = parser.Observe(" 0x040000:[wwwwwwww] 0x048000:[wwwwwwww] 0x050000:[wwwwwwww] 0x058000:[wwwwwwww]");
+        Assert.NotNull(writeMid);
+        Assert.True(writeMid > writeStart);
+
+        var readStart = parser.Observe("begin read operation");
+        Assert.NotNull(readStart);
+        Assert.True(readStart >= writeMid);
+
+        Assert.Null(parser.Observe("verify range 0x000000 to 0x080000"));
+        var verifyStart = parser.Observe("begin verify operation");
+        Assert.NotNull(verifyStart);
+        Assert.True(verifyStart >= readStart);
+
+        var verifyEnd = parser.Observe(" 0x060000:[vvvvvvvv] 0x068000:[vvvvvvvv] 0x070000:[vvvvvvvv] 0x078000:[vvvvvvvv]");
+        Assert.NotNull(verifyEnd);
+        Assert.True(verifyEnd > verifyStart);
+        Assert.True(verifyEnd <= 100);
+    }
+
+    [Fact]
+    public void WifiFlashProgressParser_NeverMovesBackward_WhenAddressesResetBetweenPhases()
+    {
+        var parser = new FirmwareUpdateService.WifiFlashProgressParser();
+
+        parser.Observe("begin write operation");
+        var writeEnd = parser.Observe(" 0x060000:[wwwwwwww] 0x068000:[wwwwwwww] 0x070000:[wwwwwwww] 0x078000:[wwwwwwww]");
+        Assert.NotNull(writeEnd);
+
+        // Read restarts addresses at 0x0; the reported percent must not regress below the write end.
+        parser.Observe("begin read operation");
+        var readLow = parser.Observe(" 0x000000:[rrrrrrrr]");
+        if (readLow.HasValue)
+        {
+            Assert.True(readLow.Value >= writeEnd.Value);
+        }
+    }
+
+    [Fact]
     public async Task UpdateWifiModuleAsync_WhenDeviceVersionMatchesLatest_SkipsFlashAndReportsComplete()
     {
         var wifiRelease = new FirmwareReleaseInfo

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -721,6 +721,28 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public void WifiFlashProgressParser_MeasuresFromRangeBase_ForNonZeroVerifyRange()
+    {
+        var parser = new FirmwareUpdateService.WifiFlashProgressParser();
+
+        // Range base 0x40000 (span 0x40000). Absolute block addresses must be measured relative to
+        // the base; otherwise the first block saturates the fraction to ~100% immediately.
+        parser.Observe("verify range 0x040000 to 0x080000");
+        var verifyStart = parser.Observe("begin verify operation");
+        Assert.NotNull(verifyStart);
+
+        var firstBlock = parser.Observe(" 0x040000:[vvvvvvvv]");
+        Assert.NotNull(firstBlock);
+
+        var lastBlock = parser.Observe(" 0x078000:[vvvvvvvv]");
+        Assert.NotNull(lastBlock);
+
+        // The bar advances across the range (the first block was not already saturated).
+        Assert.True(lastBlock > firstBlock);
+        Assert.True(lastBlock <= 100);
+    }
+
+    [Fact]
     public void WifiFlashProgressParser_NeverMovesBackward_WhenAddressesResetBetweenPhases()
     {
         var parser = new FirmwareUpdateService.WifiFlashProgressParser();

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -597,6 +597,49 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateWifiModuleAsync_WhenProgrammingFailsWithoutBridgeMarkers_DoesNotRetry()
+    {
+        // A genuine programming failure (no bridge-init markers) must NOT be retried — retrying
+        // only delays the real error and needlessly re-fires bridge activation.
+        var device = new FakeStreamingDevice("COM7");
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(
+                1,
+                timedOut: false,
+                TimeSpan.FromSeconds(30),
+                ["software WINC serial bridge found", "Programming device failed"],
+                [])
+        };
+
+        var options = CreateFastOptions();
+        options.WifiFlashAttempts = 2; // retry is allowed but must not trigger for this failure
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir));
+            Assert.Equal(1, externalProcessRunner.RunCount);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task UpdateWifiModuleAsync_WhenTransientBridgeFailureThenSuccess_RetriesAndCompletes()
     {
         var device = new FakeStreamingDevice("COM7");
@@ -2191,15 +2234,15 @@ public class FirmwareUpdateServiceTests
 
         /// <summary>
         /// Optional per-attempt results. When non-empty each <see cref="RunAsync"/> call dequeues
-        /// the next result (the last one repeats once drained), letting tests model the WINC flash
-        /// retry path (transient failure → success).
+        /// the next result, letting tests model the WINC flash retry path (transient failure →
+        /// success). Once the sequence is drained, subsequent calls return <see cref="NextResult"/>
+        /// — kept deliberately distinct from the scripted results so a test asserting
+        /// <see cref="RunCount"/> can still catch unexpected extra attempts.
         /// </summary>
         public Queue<ExternalProcessResult> ResultSequence { get; } = new();
 
         public ExternalProcessRequest? LastRequest { get; private set; }
         public int RunCount { get; private set; }
-
-        private ExternalProcessResult? _lastDequeued;
 
         public Task<ExternalProcessResult> RunAsync(
             ExternalProcessRequest request,
@@ -2209,14 +2252,7 @@ public class FirmwareUpdateServiceTests
             LastRequest = request;
             RunCount++;
 
-            if (ResultSequence.Count > 0)
-            {
-                _lastDequeued = ResultSequence.Dequeue();
-            }
-
-            // Once the sequence drains, repeat the last dequeued result; if the sequence was never
-            // used, fall back to NextResult.
-            var result = _lastDequeued ?? NextResult;
+            var result = ResultSequence.Count > 0 ? ResultSequence.Dequeue() : NextResult;
 
             foreach (var line in result.StandardOutputLines)
             {

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2199,6 +2199,8 @@ public class FirmwareUpdateServiceTests
         public ExternalProcessRequest? LastRequest { get; private set; }
         public int RunCount { get; private set; }
 
+        private ExternalProcessResult? _lastDequeued;
+
         public Task<ExternalProcessResult> RunAsync(
             ExternalProcessRequest request,
             CancellationToken cancellationToken = default)
@@ -2207,7 +2209,14 @@ public class FirmwareUpdateServiceTests
             LastRequest = request;
             RunCount++;
 
-            var result = ResultSequence.Count > 0 ? ResultSequence.Dequeue() : NextResult;
+            if (ResultSequence.Count > 0)
+            {
+                _lastDequeued = ResultSequence.Dequeue();
+            }
+
+            // Once the sequence drains, repeat the last dequeued result; if the sequence was never
+            // used, fall back to NextResult.
+            var result = _lastDequeued ?? NextResult;
 
             foreach (var line in result.StandardOutputLines)
             {

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -940,12 +940,19 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     /// </summary>
     private static string DescribeWifiFlashFailure(ExternalProcessResult result)
     {
+        // Scan both streams for the full failure-marker set — tool/script versions route these to
+        // stdout vs stderr inconsistently (mirrors IsTransientWifiFlashFailure).
         if (ContainsAny(
                 result.StandardErrorLines,
                 WifiBridgeIdQueryFailureMarker,
-                WifiProgrammerInitFailureMarker) ||
+                WifiProgrammerInitFailureMarker,
+                WifiProgrammingFailedMarker,
+                WifiReadXoFailedMarker,
+                WifiBuildImageFailedMarker) ||
             ContainsAny(
                 result.StandardOutputLines,
+                WifiBridgeIdQueryFailureMarker,
+                WifiProgrammerInitFailureMarker,
                 WifiProgrammingFailedMarker,
                 WifiReadXoFailedMarker,
                 WifiBuildImageFailedMarker))

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -13,10 +13,6 @@ namespace Daqifi.Core.Firmware;
 /// </summary>
 public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 {
-    private static readonly Regex PercentRegex = new(
-        @"(?<percent>\d{1,3})\s*%",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
     // WINC flash tool prompt markers (stdin handshake).
     private const string WincBootPromptMarker = "Power cycle WINC and set to bootloader mode";
     private const string WincContinuePromptMarker = "Press any key to continue";
@@ -451,9 +447,10 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
             // Build a fresh request per attempt: the stdin prompt responder carries one-shot
             // state (it answers the WINC prompt exactly once), so reusing a request across a
-            // retry would leave the responder already "spent".
+            // retry would leave the responder already "spent". The factory takes the per-attempt
+            // linked token so the prompt-delay wait stays cancellable.
             var processResult = await RunWifiFlashToolWithRetryAsync(
-                () => BuildWifiProcessRequest(device, firmwarePath, progress),
+                ct => BuildWifiProcessRequest(device, firmwarePath, progress, ct),
                 cancellationToken).ConfigureAwait(false);
 
             if (processResult.TimedOut)
@@ -734,7 +731,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     private ExternalProcessRequest BuildWifiProcessRequest(
         IStreamingDevice device,
         string firmwarePath,
-        IProgress<FirmwareUpdateProgress>? progress)
+        IProgress<FirmwareUpdateProgress>? progress,
+        CancellationToken cancellationToken)
     {
         var toolPath = ResolveWifiToolPath(firmwarePath);
         var port = ResolveWifiPort(device);
@@ -755,7 +753,10 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             executableArguments = $"/c \"{toolPath}\" {toolArguments}";
         }
 
-        var lastProcessPercent = 0;
+        // Tracks the live device-flash phase (write/read/verify) from the tool's block-address
+        // output so the bar advances across the multi-minute flash, instead of latching to the
+        // image-build phase's "100%" lines and freezing. See WifiFlashProgressParser.
+        var progressParser = new WifiFlashProgressParser();
         var progressLock = new object();
 
         return new ExternalProcessRequest
@@ -768,36 +769,30 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             {
                 _logger.LogInformation("WiFi flash output: {Line}", line);
 
-                var parsedPercent = TryParseWifiToolPercent(line);
-                if (!parsedPercent.HasValue)
-                {
-                    return;
-                }
-
-                var processPercent = parsedPercent.Value;
+                double processPercent;
                 lock (progressLock)
                 {
-                    if (processPercent < lastProcessPercent)
+                    var updated = progressParser.Observe(line);
+                    if (!updated.HasValue)
                     {
-                        processPercent = lastProcessPercent;
+                        return;
                     }
-                    else
-                    {
-                        lastProcessPercent = processPercent;
-                    }
+
+                    processPercent = updated.Value;
                 }
 
+                // Map the 0-100 device-flash percent into the Programming state's 20-90 overall band.
                 var overallPercent = 20 + (processPercent * 0.70);
                 ReportProgress(
                     progress,
                     FirmwareUpdateState.Programming,
                     overallPercent,
                     line,
-                    processPercent,
+                    (long)Math.Round(processPercent),
                     100);
             },
             OnStandardErrorLine = line => _logger.LogWarning("WiFi flash stderr: {Line}", line),
-            StandardInputResponseFactory = BuildWifiPromptResponder()
+            StandardInputResponseFactory = BuildWifiPromptResponder(cancellationToken)
         };
     }
 
@@ -808,7 +803,12 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     /// finish bridge-mode init, then sends the empty continue line. The returned delegate carries
     /// one-shot state, so a fresh responder must be built for each flash attempt.
     /// </summary>
-    private Func<string, string?> BuildWifiPromptResponder()
+    /// <param name="cancellationToken">
+    /// The flash run's linked token (state timeout + caller cancellation). The prompt-response wait
+    /// observes it so a timeout or cancel unblocks the output-pump thread promptly instead of
+    /// sleeping out the full delay after the process has been killed.
+    /// </param>
+    private Func<string, string?> BuildWifiPromptResponder(CancellationToken cancellationToken)
     {
         var continueSignalSent = false;
 
@@ -844,9 +844,22 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
                 if (_options.WincBootPromptResponseDelay > TimeSpan.Zero)
                 {
-                    // Synchronous wait: the responder runs on the process output-reading thread,
-                    // and the tool blocks on stdin until we return — a Task.Delay would not pause it.
-                    Thread.Sleep(_options.WincBootPromptResponseDelay);
+                    // The responder runs inline on the process output-pump thread and the tool
+                    // blocks on stdin until we return, so the wait must be synchronous (a fire-and-
+                    // forget Task.Delay would not pause it). Block on a cancellable delay so a run
+                    // timeout / cancel unblocks the pump immediately; if canceled, skip the continue
+                    // signal — the process is being torn down anyway.
+                    try
+                    {
+                        Task.Delay(_options.WincBootPromptResponseDelay, cancellationToken)
+                            .GetAwaiter()
+                            .GetResult();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        _logger.LogDebug("WINC prompt-response wait canceled; skipping the continue signal.");
+                        return null;
+                    }
                 }
 
                 continueSignalSent = true;
@@ -867,7 +880,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     }
 
     private async Task<ExternalProcessResult> RunWifiFlashToolWithRetryAsync(
-        Func<ExternalProcessRequest> requestFactory,
+        Func<CancellationToken, ExternalProcessRequest> requestFactory,
         CancellationToken cancellationToken)
     {
         var attempts = Math.Max(1, _options.WifiFlashAttempts);
@@ -875,11 +888,13 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
         for (var attempt = 1; attempt <= attempts; attempt++)
         {
-            var request = requestFactory();
+            // Build the request inside the state-timeout lambda so the responder closes over the
+            // linked token (state timeout + caller cancellation) and its prompt-delay wait unblocks
+            // when the run is canceled or times out.
             result = await ExecuteWithStateTimeoutAsync(
                 FirmwareUpdateState.Programming,
                 "execute WiFi flash process",
-                ct => _externalProcessRunner.RunAsync(request, ct),
+                ct => _externalProcessRunner.RunAsync(requestFactory(ct), ct),
                 cancellationToken).ConfigureAwait(false);
 
             // A timeout or a verified success ends the loop; so does a non-transient failure,
@@ -934,10 +949,17 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             return "The flash tool reached the device but reported a programming failure.";
         }
 
-        if (result.StandardOutputLines.Count == 0)
+        // "No output" must consider BOTH streams — some failure modes (tool/port errors) print
+        // only to stderr, so checking stdout alone would mislabel them as "no output".
+        if (result.StandardOutputLines.Count == 0 && result.StandardErrorLines.Count == 0)
         {
             return "The flash tool produced no output — it likely could not open the serial port " +
                    "(the device may not have released it).";
+        }
+
+        if (result.StandardOutputLines.Count == 0 && result.StandardErrorLines.Count > 0)
+        {
+            return $"The flash tool wrote only to stderr and never programmed the device (exit code {result.ExitCode}).";
         }
 
         return $"The flash tool exited with code {result.ExitCode} without completing the program.";
@@ -1604,36 +1626,146 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         return builder.ToString();
     }
 
-    private static int? TryParseWifiToolPercent(string line)
+    /// <summary>
+    /// Derives a 0-100 progress percentage for the WiFi (WINC) flash from the flash tool's live
+    /// stdout. The tool runs a fast local image-build phase (whose "written … (NN%)" lines reach
+    /// 100% and must be ignored, or they latch the bar near the top before the real flash starts)
+    /// followed by the multi-minute on-device write → read → verify phases. Those phases emit
+    /// block-address lines like <c>0x000000:[wwwwwwww] 0x008000:[wwwwwwww] …</c> with no percent,
+    /// so this parser advances the bar from the highest block address seen relative to the flashed
+    /// range. Each phase occupies its own monotonically increasing band; <see cref="Observe"/>
+    /// returns the new percent when it advances, or <c>null</c> when a line carries no progress.
+    /// </summary>
+    internal sealed class WifiFlashProgressParser
     {
-        if (string.IsNullOrWhiteSpace(line))
+        private static readonly Regex BlockAddressRegex = new(
+            @"0x(?<addr>[0-9a-fA-F]+)\s*:",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex VerifyRangeRegex = new(
+            @"verify range\s+0x(?<start>[0-9a-fA-F]+)\s+to\s+0x(?<end>[0-9a-fA-F]+)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        // Block size between consecutive addresses in the tool's progress lines (0x8000).
+        private const long BlockSize = 0x8000;
+
+        // Default flashed range when the tool hasn't yet announced "verify range" (the WINC
+        // programmed region is 0x80000 = 512 KB); expanded if a larger address is observed.
+        private long _totalRange = 0x80000;
+
+        private Phase _phase = Phase.PreFlash;
+        private double _lastPercent;
+
+        private enum Phase
         {
+            PreFlash,
+            Write,
+            Read,
+            Verify
+        }
+
+        // Per-phase overall bands (write is weighted heaviest — it is by far the longest phase).
+        private static (double Start, double End) BandFor(Phase phase) => phase switch
+        {
+            Phase.Write => (5, 60),
+            Phase.Read => (60, 78),
+            Phase.Verify => (78, 100),
+            _ => (0, 0)
+        };
+
+        public double? Observe(string line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return null;
+            }
+
+            if (line.Contains("begin write operation", StringComparison.OrdinalIgnoreCase))
+            {
+                return Advance(Phase.Write, BandFor(Phase.Write).Start);
+            }
+
+            if (line.Contains("begin read operation", StringComparison.OrdinalIgnoreCase))
+            {
+                return Advance(Phase.Read, BandFor(Phase.Read).Start);
+            }
+
+            var verifyRange = VerifyRangeRegex.Match(line);
+            if (verifyRange.Success &&
+                long.TryParse(verifyRange.Groups["start"].Value, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out var rangeStart) &&
+                long.TryParse(verifyRange.Groups["end"].Value, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out var rangeEnd) &&
+                rangeEnd > rangeStart)
+            {
+                _totalRange = rangeEnd - rangeStart;
+                return null;
+            }
+
+            if (line.Contains("begin verify operation", StringComparison.OrdinalIgnoreCase))
+            {
+                return Advance(Phase.Verify, BandFor(Phase.Verify).Start);
+            }
+
+            // Block-address lines advance the current phase. Ignored before the device flash
+            // starts (PreFlash) so the image-build phase never moves the bar.
+            if (_phase != Phase.PreFlash)
+            {
+                var highestAddress = HighestBlockAddress(line);
+                if (highestAddress.HasValue)
+                {
+                    var covered = highestAddress.Value + BlockSize;
+                    if (covered > _totalRange)
+                    {
+                        _totalRange = covered;
+                    }
+
+                    var fraction = Math.Clamp(covered / (double)_totalRange, 0, 1);
+                    var (start, end) = BandFor(_phase);
+                    return Advance(_phase, start + (fraction * (end - start)));
+                }
+            }
+
             return null;
         }
 
-        var match = PercentRegex.Match(line);
-        if (match.Success &&
-            int.TryParse(match.Groups["percent"].Value, out var parsedPercent))
+        private double? Advance(Phase phase, double candidatePercent)
         {
-            return Math.Clamp(parsedPercent, 0, 100);
+            if (phase > _phase)
+            {
+                _phase = phase;
+            }
+
+            var clamped = Math.Clamp(candidatePercent, 0, 100);
+
+            // Monotonic: never let the bar move backward (e.g. address resets to 0 at each new phase).
+            if (clamped <= _lastPercent)
+            {
+                return null;
+            }
+
+            _lastPercent = clamped;
+            return clamped;
         }
 
-        if (line.Contains("begin write operation", StringComparison.OrdinalIgnoreCase))
+        private static long? HighestBlockAddress(string line)
         {
-            return 33;
-        }
+            long? highest = null;
+            foreach (Match match in BlockAddressRegex.Matches(line))
+            {
+                if (long.TryParse(
+                        match.Groups["addr"].Value,
+                        System.Globalization.NumberStyles.HexNumber,
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        out var address))
+                {
+                    if (highest is null || address > highest.Value)
+                    {
+                        highest = address;
+                    }
+                }
+            }
 
-        if (line.Contains("begin read operation", StringComparison.OrdinalIgnoreCase))
-        {
-            return 66;
+            return highest;
         }
-
-        if (line.Contains("begin verify operation", StringComparison.OrdinalIgnoreCase))
-        {
-            return 90;
-        }
-
-        return null;
     }
 
     private static string BuildProcessLogExcerpt(ExternalProcessResult result)

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -456,7 +456,9 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             if (processResult.TimedOut)
             {
                 throw new TimeoutException(
-                    $"WiFi flashing process timed out after {_options.WifiProcessTimeout.TotalSeconds:F0} seconds.");
+                    $"WiFi flashing process timed out after {_options.WifiProcessTimeout.TotalSeconds:F0} seconds " +
+                    $"(exit code {processResult.ExitCode}). " +
+                    BuildProcessLogExcerpt(processResult));
             }
 
             // Verify success from the tool's OWN output, not from its exit code or run duration.
@@ -926,8 +928,10 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     /// </summary>
     private static bool IsTransientWifiFlashFailure(ExternalProcessResult result)
     {
-        return ContainsAny(result.StandardErrorLines, WifiBridgeIdQueryFailureMarker, WifiProgrammerInitFailureMarker)
-            || ContainsAny(result.StandardOutputLines, WifiProgrammingFailedMarker, WifiReadXoFailedMarker);
+        // Scan both streams for every transient marker: different WINC tool/script versions route
+        // these lines to stdout vs stderr inconsistently, so don't assume a fixed stream per marker.
+        return ContainsAny(result.StandardErrorLines, WifiBridgeIdQueryFailureMarker, WifiProgrammerInitFailureMarker, WifiProgrammingFailedMarker, WifiReadXoFailedMarker)
+            || ContainsAny(result.StandardOutputLines, WifiBridgeIdQueryFailureMarker, WifiProgrammerInitFailureMarker, WifiProgrammingFailedMarker, WifiReadXoFailedMarker);
     }
 
     /// <summary>
@@ -1653,6 +1657,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         // programmed region is 0x80000 = 512 KB); expanded if a larger address is observed.
         private long _totalRange = 0x80000;
 
+        // Base address of the flashed range. Block addresses in the tool output are absolute, so
+        // the covered fraction is measured relative to this start (0 unless "verify range" reports
+        // a non-zero base).
+        private long _rangeStart;
+
         private Phase _phase = Phase.PreFlash;
         private double _lastPercent;
 
@@ -1696,6 +1705,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 long.TryParse(verifyRange.Groups["end"].Value, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out var rangeEnd) &&
                 rangeEnd > rangeStart)
             {
+                _rangeStart = rangeStart;
                 _totalRange = rangeEnd - rangeStart;
                 return null;
             }
@@ -1712,7 +1722,9 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 var highestAddress = HighestBlockAddress(line);
                 if (highestAddress.HasValue)
                 {
-                    var covered = highestAddress.Value + BlockSize;
+                    // Block addresses are absolute; measure coverage from the range base so a
+                    // non-zero start doesn't make the fraction saturate to 1 immediately.
+                    var covered = highestAddress.Value - _rangeStart + BlockSize;
                     if (covered > _totalRange)
                     {
                         _totalRange = covered;

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -17,6 +17,18 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         @"(?<percent>\d{1,3})\s*%",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    // WINC flash tool prompt markers (stdin handshake).
+    private const string WincBootPromptMarker = "Power cycle WINC and set to bootloader mode";
+    private const string WincContinuePromptMarker = "Press any key to continue";
+
+    // WINC flash tool failure markers. The "transient" set is recoverable by re-running the
+    // tool once the device has settled into bridge mode; the full set forces a failure verdict.
+    private const string WifiBridgeIdQueryFailureMarker = "failed to read serial bridge ID query response";
+    private const string WifiProgrammerInitFailureMarker = "failed to initialise programming firmware";
+    private const string WifiProgrammingFailedMarker = "Programming device failed";
+    private const string WifiReadXoFailedMarker = "Reading XO (offset) failed";
+    private const string WifiBuildImageFailedMarker = "Building programming image failed";
+
     private static readonly IReadOnlyDictionary<FirmwareUpdateState, IReadOnlySet<FirmwareUpdateState>> AllowedTransitions
         = new Dictionary<FirmwareUpdateState, IReadOnlySet<FirmwareUpdateState>>
         {
@@ -422,34 +434,45 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                     device.Send(ScpiMessageProducer.SetLanFirmwareUpdateMode);
                     await Task.Delay(_options.PostLanFirmwareModeDelay, stateToken).ConfigureAwait(false);
                     device.Disconnect();
+
+                    // The OS does not free the USB-CDC COM handle the instant Disconnect returns.
+                    // Wait so the external WINC flash tool can open the port; without this the tool
+                    // fails to open it and exits in ~1s producing no programming output (caught by
+                    // the output-based success verification below as a failure).
+                    if (_options.PostLanDisconnectPortReleaseDelay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(_options.PostLanDisconnectPortReleaseDelay, stateToken).ConfigureAwait(false);
+                    }
                 },
                 cancellationToken).ConfigureAwait(false);
 
             TransitionToState(FirmwareUpdateState.Programming, "Running WiFi module flash tool.");
             ReportProgress(progress, FirmwareUpdateState.Programming, 20, _currentOperation, 0, totalBytes);
 
-            var request = BuildWifiProcessRequest(device, firmwarePath, progress);
-            var processResult = await ExecuteWithStateTimeoutAsync(
-                FirmwareUpdateState.Programming,
-                "execute WiFi flash process",
-                ct => _externalProcessRunner.RunAsync(request, ct),
+            // Build a fresh request per attempt: the stdin prompt responder carries one-shot
+            // state (it answers the WINC prompt exactly once), so reusing a request across a
+            // retry would leave the responder already "spent".
+            var processResult = await RunWifiFlashToolWithRetryAsync(
+                () => BuildWifiProcessRequest(device, firmwarePath, progress),
                 cancellationToken).ConfigureAwait(false);
 
             if (processResult.TimedOut)
             {
                 throw new TimeoutException(
-                    $"WiFi flashing process timed out after {request.Timeout.TotalSeconds:F0} seconds.");
+                    $"WiFi flashing process timed out after {_options.WifiProcessTimeout.TotalSeconds:F0} seconds.");
             }
 
-            if (ContainsWifiProgrammingFailure(processResult.StandardOutputLines))
-            {
-                throw new IOException("WiFi flashing tool reported a programming failure.");
-            }
-
-            if (processResult.ExitCode != 0)
+            // Verify success from the tool's OWN output, not from its exit code or run duration.
+            // A genuine flash ends with "verify passed" then the success marker; when the tool
+            // cannot reach the WINC — most often because the device never released the serial port,
+            // so the tool couldn't open it and bailed in ~1s — it produces none of these. The exit
+            // code is unreliable in both directions (some WINC script/tool combinations emit failure
+            // markers yet still exit 0), so the success marker is the authority.
+            if (!ContainsAny(processResult.StandardOutputLines, _options.WifiFlashSuccessMarker))
             {
                 throw new IOException(
-                    $"WiFi flashing process exited with code {processResult.ExitCode}. " +
+                    $"WiFi flashing did not complete successfully — the flash tool never reported " +
+                    $"'{_options.WifiFlashSuccessMarker}'. {DescribeWifiFlashFailure(processResult)} " +
                     BuildProcessLogExcerpt(processResult));
             }
 
@@ -774,20 +797,162 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                     100);
             },
             OnStandardErrorLine = line => _logger.LogWarning("WiFi flash stderr: {Line}", line),
-            StandardInputResponseFactory = line =>
-                line.Contains("Power cycle WINC and set to bootloader mode", StringComparison.OrdinalIgnoreCase)
-                    ? string.Empty
-                    : null
+            StandardInputResponseFactory = BuildWifiPromptResponder()
         };
     }
 
-    private static bool ContainsWifiProgrammingFailure(IEnumerable<string> outputLines)
+    /// <summary>
+    /// Builds the stdin responder for the WINC flash tool's interactive prompts. At the
+    /// "Power cycle WINC" prompt it fires the optional bridge-activation callback, waits
+    /// <see cref="FirmwareUpdateServiceOptions.WincBootPromptResponseDelay"/> so the firmware can
+    /// finish bridge-mode init, then sends the empty continue line. The returned delegate carries
+    /// one-shot state, so a fresh responder must be built for each flash attempt.
+    /// </summary>
+    private Func<string, string?> BuildWifiPromptResponder()
     {
-        foreach (var line in outputLines)
+        var continueSignalSent = false;
+
+        return line =>
         {
-            if (line.Contains("Programming device failed", StringComparison.OrdinalIgnoreCase))
+            if (line.Contains(WincBootPromptMarker, StringComparison.OrdinalIgnoreCase))
             {
-                return true;
+                if (continueSignalSent)
+                {
+                    return null;
+                }
+
+                if (_options.WifiBridgeActivationCallback is { } activate)
+                {
+                    _logger.LogInformation("Activating WiFi bridge mode before WINC programming.");
+                    try
+                    {
+                        activate();
+                        _logger.LogInformation("Bridge activation callback completed; waiting for firmware bridge init.");
+                    }
+                    catch (Exception ex)
+                    {
+                        // The bridge activation is best-effort — a failure here must not abort the
+                        // flash; the tool may still reach the WINC and the success verification is
+                        // the source of truth for the outcome.
+                        _logger.LogWarning(ex, "WiFi bridge activation callback threw; continuing with the flash.");
+                    }
+                }
+                else
+                {
+                    _logger.LogInformation("WiFi flash tool requested WINC power-cycle; waiting before sending continue signal.");
+                }
+
+                if (_options.WincBootPromptResponseDelay > TimeSpan.Zero)
+                {
+                    // Synchronous wait: the responder runs on the process output-reading thread,
+                    // and the tool blocks on stdin until we return — a Task.Delay would not pause it.
+                    Thread.Sleep(_options.WincBootPromptResponseDelay);
+                }
+
+                continueSignalSent = true;
+                _logger.LogInformation("Sending continue signal to WiFi flash tool.");
+                return string.Empty;
+            }
+
+            if (!continueSignalSent &&
+                line.Contains(WincContinuePromptMarker, StringComparison.OrdinalIgnoreCase))
+            {
+                continueSignalSent = true;
+                _logger.LogInformation("Sending continue signal to WiFi flash tool.");
+                return string.Empty;
+            }
+
+            return null;
+        };
+    }
+
+    private async Task<ExternalProcessResult> RunWifiFlashToolWithRetryAsync(
+        Func<ExternalProcessRequest> requestFactory,
+        CancellationToken cancellationToken)
+    {
+        var attempts = Math.Max(1, _options.WifiFlashAttempts);
+        ExternalProcessResult result = null!;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            var request = requestFactory();
+            result = await ExecuteWithStateTimeoutAsync(
+                FirmwareUpdateState.Programming,
+                "execute WiFi flash process",
+                ct => _externalProcessRunner.RunAsync(request, ct),
+                cancellationToken).ConfigureAwait(false);
+
+            // A timeout or a verified success ends the loop; so does a non-transient failure,
+            // since re-running the tool only helps when the device hadn't yet settled into bridge
+            // mode. Only a transient bridge-init failure with attempts remaining triggers a retry.
+            if (result.TimedOut ||
+                ContainsAny(result.StandardOutputLines, _options.WifiFlashSuccessMarker) ||
+                attempt >= attempts ||
+                !IsTransientWifiFlashFailure(result))
+            {
+                return result;
+            }
+
+            _logger.LogWarning(
+                "WiFi flash tool reported a transient bridge-init failure on attempt {Attempt}/{Attempts}; retrying in {DelayMs} ms.",
+                attempt,
+                attempts,
+                _options.WifiFlashRetryDelay.TotalMilliseconds);
+            await Task.Delay(_options.WifiFlashRetryDelay, cancellationToken).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// True when the result shows a transient bridge-init failure — the device hadn't finished
+    /// entering bridge mode when the tool issued its first query. Re-running the tool once the
+    /// device has settled typically succeeds, so these (and only these) are retried.
+    /// </summary>
+    private static bool IsTransientWifiFlashFailure(ExternalProcessResult result)
+    {
+        return ContainsAny(result.StandardErrorLines, WifiBridgeIdQueryFailureMarker, WifiProgrammerInitFailureMarker)
+            || ContainsAny(result.StandardOutputLines, WifiProgrammingFailedMarker, WifiReadXoFailedMarker);
+    }
+
+    /// <summary>
+    /// Produces a short human-readable reason for a flash that did not report the success marker,
+    /// distinguishing "the tool never opened the port" from a device-reported programming failure.
+    /// </summary>
+    private static string DescribeWifiFlashFailure(ExternalProcessResult result)
+    {
+        if (ContainsAny(
+                result.StandardErrorLines,
+                WifiBridgeIdQueryFailureMarker,
+                WifiProgrammerInitFailureMarker) ||
+            ContainsAny(
+                result.StandardOutputLines,
+                WifiProgrammingFailedMarker,
+                WifiReadXoFailedMarker,
+                WifiBuildImageFailedMarker))
+        {
+            return "The flash tool reached the device but reported a programming failure.";
+        }
+
+        if (result.StandardOutputLines.Count == 0)
+        {
+            return "The flash tool produced no output — it likely could not open the serial port " +
+                   "(the device may not have released it).";
+        }
+
+        return $"The flash tool exited with code {result.ExitCode} without completing the program.";
+    }
+
+    private static bool ContainsAny(IReadOnlyList<string> lines, params string[] markers)
+    {
+        foreach (var line in lines)
+        {
+            foreach (var marker in markers)
+            {
+                if (line.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
             }
         }
 

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -928,10 +928,15 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     /// </summary>
     private static bool IsTransientWifiFlashFailure(ExternalProcessResult result)
     {
-        // Scan both streams for every transient marker: different WINC tool/script versions route
-        // these lines to stdout vs stderr inconsistently, so don't assume a fixed stream per marker.
-        return ContainsAny(result.StandardErrorLines, WifiBridgeIdQueryFailureMarker, WifiProgrammerInitFailureMarker, WifiProgrammingFailedMarker, WifiReadXoFailedMarker)
-            || ContainsAny(result.StandardOutputLines, WifiBridgeIdQueryFailureMarker, WifiProgrammerInitFailureMarker, WifiProgrammingFailedMarker, WifiReadXoFailedMarker);
+        // Retry ONLY on the bridge-init markers — the device hadn't finished entering bridge mode
+        // when the tool issued its first query, which a re-run fixes. These markers co-occur with
+        // the generic "Programming device failed" / "Reading XO failed" lines in the real failure
+        // output, so keying on them alone still catches the transient case without retrying a
+        // genuine (non-recoverable) programming failure — which would only delay the real error and
+        // needlessly re-fire the bridge-activation callback. Scan both streams since tool/script
+        // versions route these lines inconsistently.
+        return ContainsAny(result.StandardErrorLines, WifiBridgeIdQueryFailureMarker, WifiProgrammerInitFailureMarker)
+            || ContainsAny(result.StandardOutputLines, WifiBridgeIdQueryFailureMarker, WifiProgrammerInitFailureMarker);
     }
 
     /// <summary>
@@ -940,22 +945,28 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     /// </summary>
     private static string DescribeWifiFlashFailure(ExternalProcessResult result)
     {
-        // Scan both streams for the full failure-marker set — tool/script versions route these to
-        // stdout vs stderr inconsistently (mirrors IsTransientWifiFlashFailure).
+        // A "Building programming image failed" is a LOCAL image-build failure that happens before
+        // any on-device flashing, so it must not be reported as a device-reachability failure.
+        if (ContainsAny(result.StandardErrorLines, WifiBuildImageFailedMarker) ||
+            ContainsAny(result.StandardOutputLines, WifiBuildImageFailedMarker))
+        {
+            return "The flash tool failed to build the programming image (before contacting the device).";
+        }
+
+        // Markers that imply the tool actually reached the device. Scan both streams — tool/script
+        // versions route these to stdout vs stderr inconsistently.
         if (ContainsAny(
                 result.StandardErrorLines,
                 WifiBridgeIdQueryFailureMarker,
                 WifiProgrammerInitFailureMarker,
                 WifiProgrammingFailedMarker,
-                WifiReadXoFailedMarker,
-                WifiBuildImageFailedMarker) ||
+                WifiReadXoFailedMarker) ||
             ContainsAny(
                 result.StandardOutputLines,
                 WifiBridgeIdQueryFailureMarker,
                 WifiProgrammerInitFailureMarker,
                 WifiProgrammingFailedMarker,
-                WifiReadXoFailedMarker,
-                WifiBuildImageFailedMarker))
+                WifiReadXoFailedMarker))
         {
             return "The flash tool reached the device but reported a programming failure.";
         }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -73,9 +73,64 @@ public sealed class FirmwareUpdateServiceOptions
     public TimeSpan PostLanFirmwareModeDelay { get; set; } = TimeSpan.FromSeconds(2);
 
     /// <summary>
+    /// Delay after the managed serial connection is disconnected (entering WiFi update mode)
+    /// and before the external WINC flash tool is launched. The OS does not free the USB-CDC
+    /// COM handle the instant the device's serial connection is disconnected; without this pause
+    /// the flash tool tries to open the port before it is released, fails to open it,
+    /// and exits within ~1s producing no programming output — which the output-based success
+    /// verification (see <see cref="WifiFlashSuccessMarker"/>) then correctly reports as a
+    /// failure. Set to <see cref="TimeSpan.Zero"/> to skip the wait (e.g. unit tests, or
+    /// transports that release the port synchronously).
+    /// </summary>
+    public TimeSpan PostLanDisconnectPortReleaseDelay { get; set; } = TimeSpan.FromSeconds(1.5);
+
+    /// <summary>
     /// Delay before attempting to reconnect serial after WiFi tool execution.
     /// </summary>
     public TimeSpan PostWifiReconnectDelay { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Delay observed at the WINC "Power cycle WINC and set to bootloader mode" prompt before the
+    /// empty continue line is sent to the flash tool. Gives the WiFi firmware time to finish its
+    /// bridge-mode initialization — especially after <see cref="WifiBridgeActivationCallback"/>
+    /// fires — before the tool issues its first serial bridge query. Set to
+    /// <see cref="TimeSpan.Zero"/> to respond immediately.
+    /// </summary>
+    public TimeSpan WincBootPromptResponseDelay { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Optional callback invoked synchronously when the WINC "Power cycle WINC" prompt is detected,
+    /// before the <see cref="WincBootPromptResponseDelay"/> wait. Intended for the host to open a
+    /// raw serial port and send the bridge-activation commands (LAN:FWUpdate / LAN:APPLY) that
+    /// trigger the device's bridge-mode state machine immediately before the tool starts
+    /// programming. Kept injectable so the raw-serial specifics stay in the host while Core owns
+    /// the flash lifecycle, prompt detection, and response timing. Exceptions thrown by the
+    /// callback are logged and swallowed — they must not abort the flash.
+    /// </summary>
+    public Action? WifiBridgeActivationCallback { get; set; }
+
+    /// <summary>
+    /// Total attempts (initial + retries) for the external WINC flash process when an attempt fails
+    /// with a transient bridge-init failure (e.g. "failed to read serial bridge ID query response"
+    /// or "failed to initialise programming firmware"). A second attempt typically succeeds because
+    /// the device has since settled into bridge mode. Must be at least 1.
+    /// </summary>
+    public int WifiFlashAttempts { get; set; } = 2;
+
+    /// <summary>
+    /// Delay between WINC flash retry attempts. Only consulted when <see cref="WifiFlashAttempts"/>
+    /// is greater than 1.
+    /// </summary>
+    public TimeSpan WifiFlashRetryDelay { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Output line (case-insensitive substring) that the WINC flash tool emits on a fully
+    /// successful program. Success is verified from the tool's own output rather than from its exit
+    /// code or run duration: a genuine flash ends with "verify passed" then this marker, whereas a
+    /// tool that cannot reach the WINC (e.g. because the device never released the serial port)
+    /// produces none of these. Defaults to the shipped WINC Programming Tool 2.0.1 terminal line.
+    /// </summary>
+    public string WifiFlashSuccessMarker { get; set; } = "Operation completed successfully";
 
     /// <summary>
     /// Maximum HID connection attempts during bootloader connect, including the initial attempt.
@@ -249,6 +304,24 @@ public sealed class FirmwareUpdateServiceOptions
         ValidatePositive(HidConnectRetryDelay, nameof(HidConnectRetryDelay));
         ValidatePositive(FlashWriteRetryDelay, nameof(FlashWriteRetryDelay));
         ValidatePositive(WifiProcessTimeout, nameof(WifiProcessTimeout));
+        ValidatePositive(WifiFlashRetryDelay, nameof(WifiFlashRetryDelay));
+
+        // These two permit Zero (= "skip the wait"); only reject negatives.
+        ValidateNonNegative(PostLanDisconnectPortReleaseDelay, nameof(PostLanDisconnectPortReleaseDelay));
+        ValidateNonNegative(WincBootPromptResponseDelay, nameof(WincBootPromptResponseDelay));
+
+        if (WifiFlashAttempts < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(WifiFlashAttempts),
+                WifiFlashAttempts,
+                "WiFi flash attempts must be at least 1.");
+        }
+
+        if (string.IsNullOrWhiteSpace(WifiFlashSuccessMarker))
+        {
+            throw new ArgumentException("WiFi flash success marker cannot be empty.", nameof(WifiFlashSuccessMarker));
+        }
 
         // The readiness options only matter when a probe is configured —
         // gate every readiness validation behind that, both the positive
@@ -328,6 +401,14 @@ public sealed class FirmwareUpdateServiceOptions
         if (value <= TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(parameterName, value, "Timeouts and delays must be greater than zero.");
+        }
+    }
+
+    private static void ValidateNonNegative(TimeSpan value, string parameterName)
+    {
+        if (value < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value, "Delay must not be negative.");
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the WiFi firmware Core-split (#269): move the WiFi-flash robustness that currently lives in the desktop app into `FirmwareUpdateService` so **every** Core consumer gets a reliable flash. "Core has the meat and potatoes; the app just has the UI."

The headline change is **output-based success verification**. Previously the WiFi flash was judged by exit code + (in the desktop) a duration heuristic. Both are unreliable:

- The WINC flash tool can emit failure markers yet still exit `0`.
- When the device never releases the serial port, the tool can't open it and bails in ~1 s producing **no output at all** — which the desktop only caught with a "returned implausibly fast" duration guard.

Captured tool logs confirm a genuine flash always ends with `verify passed` then `Operation completed successfully`, and the failure case produces none of these. So Core now **verifies success from the tool's own output**: a flash succeeds only when the configured success marker appears. That single check correctly rejects the port-not-released case, `Programming device failed`, and partial failures — no heuristics.

## Changes

- **Output-based success verification** — replaces the exit-code check; the success marker (`Operation completed successfully`, configurable via `WifiFlashSuccessMarker`) is the authority. Failures carry a diagnostic that distinguishes "tool never opened the port" from "device reported a programming failure".
- **`PostLanDisconnectPortReleaseDelay`** (default 1.5 s) — Core waits for the OS to free the USB-CDC COM handle after `Disconnect()` before launching the flash tool, so the tool can actually open the port. Removes the desktop's pre-launch delay workaround.
- **WINC prompt handling folded into Core** — `WincBootPromptResponseDelay` plus an injectable `WifiBridgeActivationCallback` fired at the "Power cycle WINC" prompt. The raw-serial bridge-activation specifics stay host-side; Core owns the prompt detection and timing.
- **Retry on transient bridge-init failures** — `WifiFlashAttempts` (default 2) / `WifiFlashRetryDelay`. A second attempt typically succeeds once the device has settled into bridge mode. Non-transient failures do not retry.

## Tests

3 new tests (full suite: **1266 passed, 2 skipped**):
- Exit-0 with no success marker → fails from output (no retry; the port-not-released case).
- Transient bridge-init failure → retries → completes (`RunCount == 2`).
- Bridge-activation callback fires at the WINC prompt.

Existing WiFi happy-path tests updated to include the realistic success markers in their fake tool output.

## Follow-up

Desktop adoption (drop its `WifiPromptDelayProcessRunner`, Stopwatch guard, and duplicated checks; pass the bridge-activation callback) lands in the desktop Phase 4 PR after this releases. The raw transparent-mode-exit / `EnableLanUpdateMode` / `ResetLanAfterUpdate` steps remain host-side for now (they need a raw-serial seam through the transport abstraction) and are tracked for a later phase.

Refs #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)