### PR TITLE
fix(discovery): resync protobuf parser past echo/prompt noise so echo-on devices are found (#268)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserTests.cs
@@ -468,6 +468,48 @@ public class ProtobufMessageParserTests
     }
 
     [Fact]
+    public void ProtobufMessageParser_ParseMessages_RecoversFrameAfterLongAsciiNoise()
+    {
+        // Hardening for #268: the resync must recover a frame even when a large
+        // amount of ASCII noise precedes it (e.g. a verbose boot banner / log lines
+        // echoed before the real reply). Each ASCII byte forms a single-byte varint
+        // length prefix and many are followed by plausible-looking field-tag bytes,
+        // so the look-ahead's field-tag pre-filter + ParseFrom must scan through all
+        // of it and still find the real frame — the scan is intentionally NOT capped
+        // to a fixed window, so devices with long leading chatter aren't missed.
+
+        // Arrange
+        var parser = new ProtobufMessageParser();
+
+        // ~640 bytes of repeated ASCII log noise — well past any small fixed window.
+        var noise = Encoding.ASCII.GetBytes(string.Concat(
+            Enumerable.Repeat("DAQIFI boot: ok, waiting for command...\r\n", 16)));
+        Assert.True(noise.Length > 512, "Test precondition: noise must exceed a small scan window.");
+
+        var status = new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceSn = 99,
+            AnalogInPortNum = 16,
+        };
+        using var ms = new MemoryStream();
+        status.WriteDelimitedTo(ms);
+        var frame = ms.ToArray();
+
+        var data = noise.Concat(frame).ToArray();
+
+        // Act
+        var messages = parser.ParseMessages(data, out var consumedBytes).ToList();
+
+        // Assert — the frame is recovered despite the long leading noise.
+        Assert.Single(messages);
+        var parsed = Assert.IsType<DaqifiOutMessage>(messages[0].Data);
+        Assert.Equal("Nq1", parsed.DevicePn);
+        Assert.Equal(ProtobufMessageType.Status, ProtobufProtocolHandler.DetectMessageType(parsed));
+        Assert.Equal(data.Length, consumedBytes);
+    }
+
+    [Fact]
     public void ProtobufMessageParser_ParseMessages_CompleteFrameThenPartial_EmitsCompletePreservesPartial()
     {
         // Guards the look-ahead resync added for #268: when a complete frame is

--- a/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserTests.cs
@@ -1,5 +1,7 @@
+using System.Text;
 using Daqifi.Core.Communication.Consumers;
 using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device.Protocol;
 using Google.Protobuf;
 
 namespace Daqifi.Core.Tests.Communication.Consumers;
@@ -358,6 +360,146 @@ public class ProtobufMessageParserTests
         Assert.Empty(messages);
         Assert.True(consumedBytes >= 1,
             $"Expected parser to advance past garbage prefix, got consumedBytes={consumedBytes}");
+    }
+
+    [Fact]
+    public void ProtobufMessageParser_ParseMessages_RecoversFrameWrappedInEchoAndPrompt()
+    {
+        // Closes #268. A device booted with echo ON wraps its SYSInfoPB? reply in the
+        // echoed ASCII command text and a trailing "DAQIFI>" prompt:
+        //
+        //     SYSTem:SYSInfoPB?\r\n  <length-delimited protobuf status>  \r\nDAQIFI>
+        //
+        // The leading 'S' (0x53) varint-decodes to a length of 83 and the following
+        // 'Y' looks like a valid field tag, so the old parser waited forever for 83
+        // bytes that never came, consumed nothing, and the embedded status frame was
+        // never parsed — the device was silently missed even though it answered.
+        // The parser must now skip the ASCII echo/prompt noise and recover the frame.
+
+        // Arrange
+        var parser = new ProtobufMessageParser();
+
+        // A realistic status reply: channel-count fields make it classify as Status,
+        // which is exactly what serial discovery keys on.
+        var status = new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceSn = 1234567,
+            DeviceFwRev = "3.5.0",
+            AnalogInPortNum = 16,
+            DigitalPortNum = 16,
+        };
+        using var ms = new MemoryStream();
+        status.WriteDelimitedTo(ms);
+        var frame = ms.ToArray();
+
+        var echo = Encoding.ASCII.GetBytes("SYSTem:SYSInfoPB?\r\n");
+        var prompt = Encoding.ASCII.GetBytes("\r\nDAQIFI>");
+        var data = echo.Concat(frame).Concat(prompt).ToArray();
+
+        // Act
+        var messages = parser.ParseMessages(data, out var consumedBytes).ToList();
+
+        // Assert — the embedded status frame is recovered intact...
+        Assert.Single(messages);
+        var parsed = Assert.IsType<DaqifiOutMessage>(messages[0].Data);
+        Assert.Equal("Nq1", parsed.DevicePn);
+        Assert.Equal(1234567UL, parsed.DeviceSn);
+        Assert.Equal(ProtobufMessageType.Status, ProtobufProtocolHandler.DetectMessageType(parsed));
+
+        // ...and the parser consumed through the end of the frame. The trailing
+        // "DAQIFI>" prompt is left buffered (it looks like the start of another
+        // frame), but the status message has already been delivered.
+        Assert.Equal(echo.Length + frame.Length, consumedBytes);
+    }
+
+    [Fact]
+    public void ProtobufMessageParser_ParseMessages_EchoWrappedFedOneByteAtATime_RecoversExactlyOnce()
+    {
+        // Mirrors how StreamMessageConsumer drives the parser: bytes trickle in and
+        // the consumed prefix is trimmed between calls. Worst-case single-byte
+        // chunking must still recover the echo-wrapped status frame exactly once and
+        // not stall with an ever-growing buffer (the failure mode in #268).
+
+        // Arrange
+        var parser = new ProtobufMessageParser();
+        var status = new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceSn = 7,
+            AnalogInPortNum = 16,
+        };
+        using var ms = new MemoryStream();
+        status.WriteDelimitedTo(ms);
+        var frame = ms.ToArray();
+
+        var data = Encoding.ASCII.GetBytes("SYSTem:SYSInfoPB?\r\n")
+            .Concat(frame)
+            .Concat(Encoding.ASCII.GetBytes("\r\nDAQIFI>"))
+            .ToArray();
+
+        // Act — feed one byte at a time, trimming consumed exactly like the consumer.
+        var buffer = new List<byte>();
+        var statusMessages = 0;
+        foreach (var b in data)
+        {
+            buffer.Add(b);
+            var msgs = parser.ParseMessages(buffer.ToArray(), out var consumed).ToList();
+            if (consumed > 0)
+            {
+                buffer.RemoveRange(0, Math.Min(consumed, buffer.Count));
+            }
+
+            foreach (var m in msgs)
+            {
+                var d = Assert.IsType<DaqifiOutMessage>(m.Data);
+                if (ProtobufProtocolHandler.DetectMessageType(d) == ProtobufMessageType.Status)
+                {
+                    statusMessages++;
+                }
+            }
+        }
+
+        // Assert — the status frame was delivered exactly once and the leftover
+        // buffer never grew past the un-consumed trailing prompt.
+        Assert.Equal(1, statusMessages);
+        Assert.True(buffer.Count <= "\r\nDAQIFI>".Length,
+            $"Leftover buffer should be at most the trailing prompt, was {buffer.Count} bytes.");
+    }
+
+    [Fact]
+    public void ProtobufMessageParser_ParseMessages_CompleteFrameThenPartial_EmitsCompletePreservesPartial()
+    {
+        // Guards the look-ahead resync added for #268: when a complete frame is
+        // followed by the start of a second frame whose body hasn't fully arrived,
+        // the parser must emit the first frame and preserve the partial exactly at
+        // its boundary. The look-ahead must not scan into and corrupt the trailing
+        // partial — callers trim consumedBytes unconditionally.
+
+        // Arrange
+        var parser = new ProtobufMessageParser();
+
+        using var s1 = new MemoryStream();
+        new DaqifiOutMessage { MsgTimeStamp = 11 }.WriteDelimitedTo(s1);
+        var firstFrame = s1.ToArray();
+
+        using var s2 = new MemoryStream();
+        new DaqifiOutMessage { MsgTimeStamp = 22 }.WriteDelimitedTo(s2);
+        var secondFrame = s2.ToArray();
+        // Keep only the prefix + first body byte of the second frame.
+        var secondPartial = secondFrame.Take(2).ToArray();
+
+        var data = firstFrame.Concat(secondPartial).ToArray();
+
+        // Act
+        var messages = parser.ParseMessages(data, out var consumedBytes).ToList();
+
+        // Assert — only the complete first frame is emitted, and consumed stops at
+        // the partial's boundary so the caller retains it for the next read.
+        Assert.Single(messages);
+        var parsed = Assert.IsType<DaqifiOutMessage>(messages[0].Data);
+        Assert.Equal(11UL, parsed.MsgTimeStamp);
+        Assert.Equal(firstFrame.Length, consumedBytes);
     }
 
     private static int GetVarintLength(byte[] buffer)

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
@@ -1,5 +1,7 @@
+using System.Text;
 using Daqifi.Core.Communication.Consumers;
 using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device.Protocol;
 using Google.Protobuf;
 
 namespace Daqifi.Core.Tests.Communication.Consumers;
@@ -336,6 +338,58 @@ public class StreamMessageConsumerIntegrationTests
         Assert.False(consumer.IsRunning);
         Assert.Throws<ObjectDisposedException>(() => consumer.Start());
         Assert.Throws<ObjectDisposedException>(() => consumer.ClearBuffer());
+    }
+
+    /// <summary>
+    /// Closes #268 at the pipeline level: an echo-on device wraps its SYSInfoPB?
+    /// reply in the echoed ASCII command text and a trailing "DAQIFI>" prompt. The
+    /// full consumer + parser pipeline must skip that non-protobuf noise and still
+    /// deliver the embedded status message — this is what lets serial discovery stay
+    /// GetDeviceInfo-only without toggling device echo.
+    /// </summary>
+    [Fact]
+    public void FullPipeline_EchoWrappedStatusReply_StillDeliversStatusMessage()
+    {
+        // Arrange - status reply framed exactly as an echo-on device emits it.
+        var status = new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceSn = 4242,
+            DeviceFwRev = "3.5.0",
+            AnalogInPortNum = 16,
+            DigitalPortNum = 16,
+        };
+
+        var wireData = Encoding.ASCII.GetBytes("SYSTem:SYSInfoPB?\r\n")
+            .Concat(SerializeWithLengthPrefix(status))
+            .Concat(Encoding.ASCII.GetBytes("\r\nDAQIFI>"))
+            .ToArray();
+
+        using var stream = new MemoryStream(wireData);
+        var parser = new ProtobufMessageParser();
+        using var consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
+
+        DaqifiOutMessage? received = null;
+        var messageReceived = new ManualResetEventSlim(false);
+        consumer.MessageReceived += (sender, args) =>
+        {
+            if (ProtobufProtocolHandler.DetectMessageType(args.Message.Data) == ProtobufMessageType.Status)
+            {
+                received = args.Message.Data;
+                messageReceived.Set();
+            }
+        };
+
+        // Act
+        consumer.Start();
+        var eventFired = messageReceived.Wait(TimeSpan.FromSeconds(1));
+        consumer.Stop();
+
+        // Assert - the device is identified despite the echo/prompt wrapper.
+        Assert.True(eventFired, "Status message should be delivered despite echo/prompt wrapper");
+        Assert.NotNull(received);
+        Assert.Equal("Nq1", received!.DevicePn);
+        Assert.Equal(4242u, received.DeviceSn);
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
@@ -134,6 +134,49 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
                     continue;
                 }
 
+                // The declared frame isn't fully buffered. Normally that means a
+                // genuine frame split across reads — wait for the rest. But the
+                // same condition is reached by leading non-protobuf noise whose
+                // bytes happen to varint-decode to a plausible length with a
+                // plausible first body byte. The motivating case (issue #268): an
+                // echo-on device prefixes its SYSInfoPB? reply with the echoed
+                // ASCII command ("SYSTem:SYSInfoPB?\r\n") and trails it with a
+                // "DAQIFI>" prompt. The leading 'S' (0x53) decodes as length 83
+                // and the next byte 'Y' looks like a field tag, so a plain wait
+                // would block forever on 83 bytes that never arrive while the real
+                // frame sitting further along is never parsed — the device is
+                // silently missed.
+                //
+                // Tell the two apart structurally: a genuine partial frame runs
+                // past the end of the buffer, so nothing parseable can follow it;
+                // noise, by contrast, is followed by the real, complete frame. Scan
+                // ahead for the next fully-buffered, parseable frame. If one exists,
+                // the current position is noise — skip straight to it (everything
+                // before the first parseable frame is, by definition, not a frame
+                // start and holds no recoverable partial, since a partial would
+                // extend past the buffer end and thus past that frame). If none
+                // exists, this really is a partial: preserve it and wait.
+                //
+                // Only do this when no frame has been parsed yet in this call. Once
+                // we've emitted at least one frame from this buffer, a trailing
+                // under-buffered frame is overwhelmingly a genuine split frame to
+                // wait for (the normal streaming case) — not leading noise — so we
+                // skip the linear scan and keep that hot path cheap. Stray bytes
+                // appearing mid-stream are still recovered: the caller trims the
+                // preceding frame and those bytes lead the next call, where no frame
+                // has been parsed yet and the scan runs. Discovery always reaches
+                // here with zero frames parsed, so it recovers on the first reply.
+                if (messages.Count == 0)
+                {
+                    var nextFrameIndex = FindNextParseableFrameStart(data, currentIndex + 1);
+                    if (nextFrameIndex >= 0)
+                    {
+                        currentIndex = nextFrameIndex;
+                        consumedBytes = currentIndex;
+                        continue;
+                    }
+                }
+
                 break;
             }
 
@@ -155,6 +198,63 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
         }
 
         return messages;
+    }
+
+    /// <summary>
+    /// Scans forward from <paramref name="start"/> for the first index at which a
+    /// complete, fully-buffered, successfully-parseable length-delimited frame
+    /// begins, returning that index or -1 if none exists before the end of
+    /// <paramref name="data"/>. Used by the partial-frame wait path to tell leading
+    /// non-protobuf noise (echoed command text, a "DAQIFI>" prompt, stray bytes)
+    /// apart from a real frame split across reads: noise is followed by a parseable
+    /// frame, a genuine partial is not.
+    /// </summary>
+    /// <remarks>
+    /// The scan only recognizes frames whose declared length is fully present and
+    /// whose body parses — it never reports a partial and never emits a message, so
+    /// it cannot advance into (and corrupt) a real frame that is still arriving.
+    /// It is a bounded linear scan, and the caller only invokes it when no frame has
+    /// been parsed from the buffer yet (leading-noise recovery), so the normal
+    /// streaming path — which parses frames before reaching a trailing partial —
+    /// never pays for it.
+    /// </remarks>
+    private static int FindNextParseableFrameStart(byte[] data, int start)
+    {
+        for (var i = start; i < data.Length; i++)
+        {
+            var remaining = new ReadOnlySpan<byte>(data, i, data.Length - i);
+
+            if (!TryReadLengthPrefix(remaining, out var messageLength, out var prefixBytes, out _))
+            {
+                // Incomplete or malformed length prefix here — not a frame start.
+                continue;
+            }
+
+            if (messageLength <= 0 || messageLength > MaxMessageSizeBytes)
+            {
+                continue;
+            }
+
+            if (remaining.Length < prefixBytes + messageLength)
+            {
+                // Declared frame isn't fully buffered at i, so it can't be the
+                // complete, parseable frame we're scanning for.
+                continue;
+            }
+
+            try
+            {
+                DaqifiOutMessage.Parser.ParseFrom(remaining.Slice(prefixBytes, messageLength));
+                return i;
+            }
+            catch (Exception)
+            {
+                // A varint length that happens to fit but whose body isn't a valid
+                // message is not a real frame boundary — keep scanning.
+            }
+        }
+
+        return -1;
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
@@ -216,7 +216,9 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
     /// It is a bounded linear scan, and the caller only invokes it when no frame has
     /// been parsed from the buffer yet (leading-noise recovery), so the normal
     /// streaming path — which parses frames before reaching a trailing partial —
-    /// never pays for it.
+    /// never pays for it. A cheap field-tag pre-filter rejects most noise offsets
+    /// before the expensive ParseFrom, keeping the per-offset cost low even when the
+    /// scan covers a large noisy buffer.
     /// </remarks>
     private static int FindNextParseableFrameStart(byte[] data, int start)
     {
@@ -239,6 +241,19 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
             {
                 // Declared frame isn't fully buffered at i, so it can't be the
                 // complete, parseable frame we're scanning for.
+                continue;
+            }
+
+            // Cheap pre-filter before the comparatively expensive ParseFrom: the
+            // first body byte of a real DaqifiOutMessage is always a valid protobuf
+            // field tag, so an implausible tag byte here cannot begin a real frame.
+            // This skips the parse attempt at the vast majority of noise offsets
+            // (echoed ASCII command text, "DAQIFI>" prompt, stray bytes) and never
+            // skips a real frame — any byte that fails this check would also fail
+            // ParseFrom. messageLength is > 0 and fully buffered, so the indexed byte
+            // is in range.
+            if (!IsPlausibleFieldTagByte(remaining[prefixBytes]))
+            {
                 continue;
             }
 

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -35,10 +35,6 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     private const int MaxRetries = 2;
     private const int RetryIntervalMs = 300;
     private const int PollIntervalMs = 50;
-    // Time to let the device process the echo-disable command (and echo it one last time) before we
-    // flush the receive buffer, so the probe reads a clean protobuf stream. See the echo-disable note
-    // in TryGetDeviceInfoAsync.
-    private const int EchoDisableSettleMs = 250;
     // Upper bound on concurrent SerialPort opens during a single discovery
     // pass. Most OS serial stacks tolerate 4-8 simultaneous opens cleanly;
     // beyond that, IO failures and slow opens stack up. Common case (with
@@ -289,26 +285,6 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             producer = new MessageProducer<string>(stream);
             producer.Start();
 
-            // Disable echo before probing. A freshly-booted / never-connected device sits in its
-            // interactive shell with echo ON (at the "DAQIFI>" prompt). With echo on it prefixes the
-            // SYSInfoPB? reply with the echoed command text and trails it with a prompt, so the protobuf
-            // parser can't frame a message out of the stream and the device is silently missed even
-            // though it answered. Turn echo off, give the device a moment to process it (and echo this
-            // command one last time), then flush so the probe consumer below reads a clean protobuf
-            // stream. Identity-only otherwise — no power/stream-format changes (the connect handshake
-            // owns those).
-            producer.Send(ScpiMessageProducer.DisableDeviceEcho);
-            await Task.Delay(EchoDisableSettleMs, cancellationToken);
-            try
-            {
-                port.DiscardInBuffer();
-            }
-            catch
-            {
-                // Best-effort flush of the echoed command + prompt; if it throws, the retry loop and
-                // parser resync still give the probe additional chances on a clean(er) follow-up reply.
-            }
-
             var parser = new ProtobufMessageParser();
             consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
 
@@ -331,12 +307,14 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
 
             consumer.Start();
 
-            // Identity probe: DisableEcho (above) + GetDeviceInfo. The rest of the old setup sequence
+            // Identity probe: GetDeviceInfo only. The rest of the old setup sequence
             // (StopStreaming / TurnDeviceOn / SetProtobufStreamFormat) is connection setup, not
             // identification — a healthy DAQiFi answers SYSTem:SYSInfoPB? regardless of stream format or
-            // power state, so the caller setting up an actual connection still owns those. Echo is the
-            // exception: an echo-on device corrupts the reply stream, so the probe must disable it to
-            // identify the device at all (closes #157 follow-up: echo-on units were undiscoverable).
+            // power state, so the caller setting up an actual connection still owns those. Echo is left
+            // alone too: an echo-on device wraps its reply in the echoed command text plus a trailing
+            // "DAQIFI>" prompt, but ProtobufMessageParser now resyncs past that non-protobuf noise to
+            // the embedded frame (issue #268), so the probe stays GetDeviceInfo-only (closes #157)
+            // instead of toggling device echo.
             // Send GetDeviceInfo command with retry logic
             var timeout = DateTime.UtcNow.AddMilliseconds(ResponseTimeoutMs);
             var lastRequestTime = DateTime.MinValue;


### PR DESCRIPTION
## Summary

Makes serial-discovery protobuf parsing resilient to leading/trailing non-protobuf noise, so a device booted with **echo ON** is discovered without the probe having to disable device echo. This is the follow-up to the pragmatic fix in #267, and lets the probe stay `GetDeviceInfo`-only per #157.

Closes #268.

## Background

A device at the `DAQIFI>` prompt (fresh/just-rebooted, echo ON) wraps its `SYSInfoPB?` reply in the echoed command text plus a trailing prompt:

```
SYSTem:SYSInfoPB?\r\n   <protobuf status>   \r\nDAQIFI>
```

`ProtobufMessageParser` read the leading `S` (`0x53`) as a varint length prefix of **83**, saw the next byte `Y` as a plausible field tag, and entered its partial-frame *wait* path — blocking forever on 83 bytes that never arrive. It **consumed 0 bytes and emitted 0 messages**, so the embedded status frame was never reached and the device was silently missed even though it answered.

(Reproduced before fixing: feeding the exact echo-wrapped reply to the parser returned `messages=0, consumed=0`.)

## Change

**`ProtobufMessageParser`** — when a declared frame isn't fully buffered *and no frame has been parsed yet this pass*, scan ahead for the next fully-buffered, parseable frame:

- A **genuine partial** runs past the end of the buffer, so nothing parseable can follow it.
- **Leading noise** (echoed command, `DAQIFI>` prompt, stray bytes) is followed by the real, complete frame.

If a later parseable frame exists, the current position is noise — skip straight to it. If not, it's a real partial: preserve it and wait (unchanged behavior). Jumping to the *first* parseable frame is provably safe — it can't skip a frame or eat a trailing partial, since a partial would extend past the buffer end and thus past any complete frame.

The scan is gated on **zero-frames-parsed**, so the normal streaming hot path (which parses frames before reaching a trailing partial) never pays for it. Stray bytes appearing mid-stream are still recovered — on the next call, after the caller trims the preceding frame, when no frame has been parsed yet. Discovery always reaches this with zero frames parsed, so it recovers on the first reply.

**`SerialDeviceFinder.TryGetDeviceInfoAsync`** — drops the #267 workaround (`SYSTem:ECHO -1` send + 250 ms settle + `DiscardInBuffer`) and the now-unused `EchoDisableSettleMs` constant, reverting to a `GetDeviceInfo`-only probe (#157). `StreamMessageConsumer` needed no change.

## Tests

- `RecoversFrameWrappedInEchoAndPrompt` — full echo wire format, single read → status frame recovered (verified to **fail** without the parser fix).
- `EchoWrappedFedOneByteAtATime_RecoversExactlyOnce` — worst-case byte-by-byte consumer feed → status delivered exactly once, buffer never grows past the trailing prompt (fails without the fix).
- `FullPipeline_EchoWrappedStatusReply_StillDeliversStatusMessage` — end-to-end `StreamMessageConsumer` + parser (fails without the fix).
- `CompleteFrameThenPartial_EmitsCompletePreservesPartial` — guards the look-ahead against eating a genuine trailing partial.

All existing parser resync tests (leading garbage, oversized prefix, partial-frame preservation, multi-KB frame, continuation-bit garbage) remain green.

## Validation

- `dotnet build`: 0 warnings, 0 errors
- `dotnet test`: **1274 passed**, 2 skipped (pre-existing), 0 failed — on both `net9.0` and `net10.0`

## Known limitations (intentionally out of scope)

- The look-ahead trusts the first offset where `ParseFrom` succeeds — the same false-positive risk the existing byte-by-byte resync already accepts, bounded by `MaxMessageSizeBytes` and filtered by `DetectMessageType` at the discovery layer.
- Pure ASCII noise with *no* frame leaves the buffer un-drained (pre-existing behavior, bounded by the ~1 s probe timeout).

Refs: #267, #201, #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
