### PR TITLE
feat(firmware): safe failure cleanup — re-erase to a clean bootloader state (closes #208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ More examples at [daqifi.com](https://daqifi.com).
 | **PWM outputs** | Drive PWM on capable DIO pins with per-channel duty cycle and a shared, device-wide frequency |
 | **SD card operations** | List, download, delete, format, and start/stop SD logging over USB / serial |
 | **Network configuration** | Push WiFi credentials and static LAN IPs from your app |
-| **Firmware updates** | PIC32 and WiFi-module flashing with progress and cancellation |
+| **Firmware updates** | PIC32 and WiFi-module flashing with progress, cancellation, and automatic recovery to a clean re-flashable bootloader state on mid-flash failure |
 | **Cross-platform** | .NET 9.0 and 10.0 on Windows, macOS, Linux |
 
 ## Quick recipes
@@ -231,6 +231,13 @@ if (device is INetworkConfigurable networkDevice)
 
 - `UpdateFirmwareAsync(...)` — PIC32 firmware flashing from a local Intel HEX file
 - `UpdateWifiModuleAsync(...)` — WiFi module flashing via an external tool runner. Automatically checks the device's current WiFi-chip firmware against the latest GitHub release and skips the flash if already up to date.
+
+**Safe failure cleanup (PIC32).** If a PIC32 update fails — or is canceled — after flash has been written (`ErasingFlash`, `Programming`, or `Verifying`) and the HID bootloader is still connected, the service automatically re-erases the application flash so the device is never abandoned half-flashed: a half-flashed image would otherwise boot into garbage on the next power cycle, recoverable only by the physical button-hold procedure. The flow surfaces two extra states:
+
+- `CleaningUp` — the re-erase is running; progress percent stays frozen at the failure point (never 100) so a percent-only UI can't mistake cleanup for success
+- `Recovered` — terminal: the update **failed** (the call still throws), but the device is in a clean bootloader state and safe to simply re-flash
+
+`FirmwareUpdateException.RecoveryGuidance` tells the operator whether to just re-run the update (`Recovered`) or power-cycle into bootloader mode first (cleanup couldn't run — the device may be half-flashed). `FirmwareUpdateException.FailedState` always reports where the original failure occurred, independent of cleanup outcome.
 
 > **Note:** The default WiFi flash tool config uses `winc_flash_tool.cmd` conventions. On macOS / Linux, supply a compatible executable and argument template via `FirmwareUpdateServiceOptions`.
 

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -211,11 +211,14 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
-    public async Task UpdateFirmwareAsync_WhenFlashCrcMismatches_FailsVerificationIntoFailedState()
+    public async Task UpdateFirmwareAsync_WhenFlashCrcMismatches_ReErasesAndRecoversToCleanBootloaderState()
     {
-        // Closes #213: a bit-flipped / partially-programmed flash is detected by
-        // the CRC compare and must fail in Verifying (routing through the
-        // failure/cleanup path) rather than jumping to a bad application image.
+        // Closes #208 (with #213): a bit-flipped / partially-programmed flash is
+        // detected by the CRC compare in Verifying. Rather than abandoning the
+        // device half-flashed, the service re-erases the application flash
+        // (CleaningUp → Recovered), leaving a clean bootloader state that can be
+        // re-flashed. The update still fails (the firmware was not installed),
+        // but the device is safe.
         var device = new FakeStreamingDevice("COM3");
         var hidTransport = new FakeHidTransport();
         hidTransport.EnqueueRead([0x01, 0x10]); // version
@@ -223,6 +226,7 @@ public class FirmwareUpdateServiceTests
         hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
         hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
         hidTransport.EnqueueRead([0x34, 0x12]); // READ_CRC response → 0x1234 (mismatch vs 0xABCD)
+        hidTransport.EnqueueRead([0x01, 0x02]); // cleanup re-erase ack
 
         var enumerator = new FakeHidDeviceEnumerator([
             Array.Empty<HidDeviceInfo>(),
@@ -242,6 +246,88 @@ public class FirmwareUpdateServiceTests
             enumerator,
             CreateFastOptions());
 
+        var stateTransitions = new List<FirmwareUpdateState>();
+        service.StateChanged += (_, args) => stateTransitions.Add(args.CurrentState);
+
+        var progressEvents = new List<FirmwareUpdateProgress>();
+        var progress = new CapturingProgress<FirmwareUpdateProgress>(progressEvents);
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath, progress));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        // FailedState reports where it actually broke; terminal state is Recovered.
+        Assert.Equal(FirmwareUpdateState.Verifying, exception.FailedState);
+        Assert.Equal(FirmwareUpdateState.Recovered, service.CurrentState);
+
+        var inner = Assert.IsType<InvalidDataException>(exception.InnerException);
+        Assert.Contains("CRC mismatch", inner.Message);
+
+        // Cleanup must be observable as CleaningUp → Recovered, in that order.
+        Assert.Contains(FirmwareUpdateState.CleaningUp, stateTransitions);
+        Assert.Contains(FirmwareUpdateState.Recovered, stateTransitions);
+        Assert.True(
+            stateTransitions.IndexOf(FirmwareUpdateState.CleaningUp)
+            < stateTransitions.IndexOf(FirmwareUpdateState.Recovered));
+        Assert.DoesNotContain(FirmwareUpdateState.Failed, stateTransitions);
+
+        // Two erase commands: the original erase plus the cleanup re-erase.
+        Assert.Equal(2, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x22));
+        // Must NOT have jumped to the application after a failed verification.
+        Assert.DoesNotContain(hidTransport.Writes, w => w.Length > 0 && w[0] == 0x55);
+
+        // Recovery guidance tells the operator the device is safe to re-flash.
+        Assert.NotNull(exception.RecoveryGuidance);
+        Assert.Contains("clean bootloader state", exception.RecoveryGuidance);
+
+        // Both cleanup states are surfaced via progress, too.
+        Assert.Contains(progressEvents, p => p.State == FirmwareUpdateState.CleaningUp);
+        var recoveredProgress = Assert.Single(progressEvents, p => p.State == FirmwareUpdateState.Recovered);
+        // Recovered must NOT report 100% (it is not success — that would let a
+        // percent-only UI misread cleanup as a completed install) and must NOT
+        // reset to 0 (it freezes at the failure point).
+        Assert.True(recoveredProgress.PercentComplete is > 0 and < 100);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenProgrammingFails_ReErasesAndRecovers()
+    {
+        // #208: a failure during Programming (flash already partly written, HID
+        // still connected) re-erases to a clean bootloader state.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x00]);       // program ack 1 → invalid (non-retryable at retry count 1)
+        hidTransport.EnqueueRead([0x01, 0x02]); // cleanup re-erase ack
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]);
+
+        var options = CreateFastOptions();
+        options.FlashWriteRetryCount = 1; // fail fast so Programming terminates
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
         var hexPath = CreateTempFile();
         FirmwareUpdateException exception;
         try
@@ -254,12 +340,176 @@ public class FirmwareUpdateServiceTests
             File.Delete(hexPath);
         }
 
+        Assert.Equal(FirmwareUpdateState.Programming, exception.FailedState);
+        Assert.Equal(FirmwareUpdateState.Recovered, service.CurrentState);
+        Assert.Equal(2, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x22));
+        Assert.DoesNotContain(hidTransport.Writes, w => w.Length > 0 && w[0] == 0x55);
+        Assert.Contains("clean bootloader state", exception.RecoveryGuidance);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenErasingFlashFails_ReErasesAndRecovers()
+    {
+        // #208: even an ErasingFlash failure is cleanup-eligible — re-erasing
+        // leaves a clean bootloader state.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x00]);       // erase ack → invalid (non-retryable at retry count 1)
+        hidTransport.EnqueueRead([0x01, 0x02]); // cleanup re-erase ack
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]);
+
+        var options = CreateFastOptions();
+        options.FlashWriteRetryCount = 1;
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.ErasingFlash, exception.FailedState);
+        Assert.Equal(FirmwareUpdateState.Recovered, service.CurrentState);
+        // Original (failed) erase + cleanup re-erase = two erase commands.
+        Assert.Equal(2, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x22));
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenCleanupReEraseAlsoFails_TransitionsToFailedNotStuck()
+    {
+        // #208: if the cleanup re-erase itself fails, the device may be
+        // half-flashed — the service must end in Failed (not stuck in CleaningUp)
+        // and the guidance must warn the operator to power-cycle and retry.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0x34, 0x12]); // READ_CRC → mismatch
+        hidTransport.EnqueueRead([0x00]);       // cleanup re-erase ack → invalid → cleanup fails
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var options = CreateFastOptions();
+        options.FlashWriteRetryCount = 1; // cleanup erase fails fast on the bad ack
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
+        var stateTransitions = new List<FirmwareUpdateState>();
+        service.StateChanged += (_, args) => stateTransitions.Add(args.CurrentState);
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        // Original failure context preserved; terminal state is Failed (cleanup failed).
         Assert.Equal(FirmwareUpdateState.Verifying, exception.FailedState);
         Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
         var inner = Assert.IsType<InvalidDataException>(exception.InnerException);
         Assert.Contains("CRC mismatch", inner.Message);
-        // Must NOT have jumped to the application after a failed verification.
-        Assert.DoesNotContain(hidTransport.Writes, w => w.Length > 0 && w[0] == 0x55);
+
+        // We attempted cleanup (CleaningUp seen) then fell through to Failed.
+        Assert.Contains(FirmwareUpdateState.CleaningUp, stateTransitions);
+        Assert.Equal(FirmwareUpdateState.Failed, stateTransitions[^1]);
+        Assert.DoesNotContain(FirmwareUpdateState.Recovered, stateTransitions);
+
+        Assert.NotNull(exception.RecoveryGuidance);
+        Assert.Contains("half-flashed", exception.RecoveryGuidance);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenFailureBeforeFlashTouched_SkipsCleanup()
+    {
+        // #208: failures before any flash write (here WaitingForBootloader) are
+        // NOT cleanup-eligible — the device was never touched, so the service
+        // must go straight to Failed without a CleaningUp/Recovered detour.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        var enumerator = new FakeHidDeviceEnumerator([], Array.Empty<HidDeviceInfo>());
+        var bootloaderProtocol = new FakeBootloaderProtocol([[0x10]]);
+
+        var options = CreateFastOptions();
+        options.WaitingForBootloaderTimeout = TimeSpan.FromMilliseconds(180);
+        options.PollInterval = TimeSpan.FromMilliseconds(25);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
+        var stateTransitions = new List<FirmwareUpdateState>();
+        service.StateChanged += (_, args) => stateTransitions.Add(args.CurrentState);
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.WaitingForBootloader, exception.FailedState);
+        Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+        Assert.DoesNotContain(FirmwareUpdateState.CleaningUp, stateTransitions);
+        Assert.DoesNotContain(FirmwareUpdateState.Recovered, stateTransitions);
+        // No flash erase was ever issued.
+        Assert.DoesNotContain(hidTransport.Writes, w => w.Length > 0 && w[0] == 0x22);
+        // Guidance is the per-state advice, not the cleanup/half-flashed text.
+        Assert.NotNull(exception.RecoveryGuidance);
+        Assert.DoesNotContain("clean bootloader state", exception.RecoveryGuidance);
+        Assert.DoesNotContain("half-flashed", exception.RecoveryGuidance);
     }
 
     [Fact]
@@ -411,6 +661,8 @@ public class FirmwareUpdateServiceTests
     [Fact]
     public async Task UpdateFirmwareAsync_WhenCanceled_ThrowsOperationCanceledExceptionAndTransitionsToFailed()
     {
+        // Cancellation BEFORE flash is touched (here during WaitingForBootloader)
+        // is not cleanup-eligible — nothing to re-erase — so it ends in Failed.
         var device = new FakeStreamingDevice("COM3");
         var hidTransport = new FakeHidTransport();
         var enumerator = new FakeHidDeviceEnumerator([], Array.Empty<HidDeviceInfo>());
@@ -440,6 +692,67 @@ public class FirmwareUpdateServiceTests
         }
 
         Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenCanceledMidFlash_ReErasesAndRecovers()
+    {
+        // #208 acceptance criterion: a cancel mid-flash still leaves the device
+        // half-flashed, so the service must re-erase to a clean bootloader state
+        // (Recovered) before surfacing the cancellation — never strand the device.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x02]); // cleanup re-erase ack
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions());
+
+        // Deterministically cancel the moment Programming begins: StateChanged
+        // fires synchronously inside the transition, before the first record is
+        // written, so the next per-record token check throws OCE.
+        using var cts = new CancellationTokenSource();
+        var stateTransitions = new List<FirmwareUpdateState>();
+        service.StateChanged += (_, args) =>
+        {
+            stateTransitions.Add(args.CurrentState);
+            if (args.CurrentState == FirmwareUpdateState.Programming)
+            {
+                cts.Cancel();
+            }
+        };
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => service.UpdateFirmwareAsync(device, hexPath, cancellationToken: cts.Token));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Recovered, service.CurrentState);
+        Assert.Contains(FirmwareUpdateState.CleaningUp, stateTransitions);
+        Assert.Contains(FirmwareUpdateState.Recovered, stateTransitions);
+        // Original erase + cleanup re-erase = two erase commands; no jump.
+        Assert.Equal(2, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x22));
+        Assert.DoesNotContain(hidTransport.Writes, w => w.Length > 0 && w[0] == 0x55);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -756,6 +756,237 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateFirmwareAsync_WhenCanceledBeforeFlash_SurfacesCanceledOperationToObservers()
+    {
+        // The rethrown OperationCanceledException carries no context, so the
+        // terminal StateChanged/progress text is the only channel telling a UI
+        // "the user canceled" apart from a device failure.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        var enumerator = new FakeHidDeviceEnumerator([], Array.Empty<HidDeviceInfo>());
+        var bootloaderProtocol = new FakeBootloaderProtocol([[0x10]]);
+        var options = CreateFastOptions();
+        options.WaitingForBootloaderTimeout = TimeSpan.FromSeconds(5);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
+        var stateEvents = new List<FirmwareUpdateStateChangedEventArgs>();
+        service.StateChanged += (_, args) => stateEvents.Add(args);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(120));
+        var hexPath = CreateTempFile();
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => service.UpdateFirmwareAsync(device, hexPath, cancellationToken: cts.Token));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        var terminal = stateEvents[^1];
+        Assert.Equal(FirmwareUpdateState.Failed, terminal.CurrentState);
+        Assert.Equal("PIC32 firmware update canceled.", terminal.Operation);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenTransportDropsMidFlash_SurfacesHalfFlashedWarningToObservers()
+    {
+        // A flash-touching failure where the HID transport itself dropped is
+        // cleanup-eligible but cleanup CANNOT run. Observers must still get the
+        // half-flashed warning in the terminal event (not a stale in-flight
+        // message), because on this path it may be their only signal.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.DropWhenReadQueueEmpty();  // program ack 2 → transport drops
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]);
+
+        var options = CreateFastOptions();
+        options.FlashWriteRetryCount = 1;
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
+        var stateEvents = new List<FirmwareUpdateStateChangedEventArgs>();
+        service.StateChanged += (_, args) => stateEvents.Add(args);
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Programming, exception.FailedState);
+        Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+        // No CleaningUp detour — the transport is gone, so no re-erase was possible.
+        Assert.DoesNotContain(stateEvents, e => e.CurrentState == FirmwareUpdateState.CleaningUp);
+        Assert.Equal(1, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x22));
+        // Both the exception guidance AND the terminal event text warn half-flashed.
+        Assert.NotNull(exception.RecoveryGuidance);
+        Assert.Contains("half-flashed", exception.RecoveryGuidance);
+        var terminal = stateEvents[^1];
+        Assert.Equal(FirmwareUpdateState.Failed, terminal.CurrentState);
+        Assert.Contains("half-flashed", terminal.Operation);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenObserverThrowsOnCleaningUp_EndsInFailedNotWedged()
+    {
+        // A throwing StateChanged subscriber at the CleaningUp transition must
+        // not strand the machine in the non-terminal CleaningUp state (which has
+        // no reset path) or replace the original failure exception.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0x34, 0x12]); // READ_CRC → mismatch
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var options = CreateFastOptions();
+        options.FlashWriteRetryCount = 1;
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
+        service.StateChanged += (_, args) =>
+        {
+            if (args.CurrentState == FirmwareUpdateState.CleaningUp)
+            {
+                throw new InvalidOperationException("Subscriber failure on CleaningUp.");
+            }
+        };
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        // Terminal Failed (resettable), original failure context preserved, and
+        // guidance reflects that the cleanup did not complete.
+        Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+        Assert.Equal(FirmwareUpdateState.Verifying, exception.FailedState);
+        Assert.IsType<InvalidDataException>(exception.InnerException);
+        Assert.NotNull(exception.RecoveryGuidance);
+        Assert.Contains("half-flashed", exception.RecoveryGuidance);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenObserverThrowsOnRecovered_KeepsRecoveredOutcome()
+    {
+        // If the re-erase itself succeeded, a consumer callback throwing on the
+        // Recovered notification must not flip the outcome to half-flashed (and
+        // Recovered → Failed is not a legal transition anyway).
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0x34, 0x12]); // READ_CRC → mismatch
+        hidTransport.EnqueueRead([0x01, 0x02]); // cleanup re-erase ack
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader")]
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var options = CreateFastOptions();
+        options.FlashWriteRetryCount = 1;
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            options);
+
+        service.StateChanged += (_, args) =>
+        {
+            if (args.CurrentState == FirmwareUpdateState.Recovered)
+            {
+                throw new InvalidOperationException("Subscriber failure on Recovered.");
+            }
+        };
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        // The device WAS re-erased: outcome stays Recovered end-to-end.
+        Assert.Equal(FirmwareUpdateState.Recovered, service.CurrentState);
+        Assert.Equal(FirmwareUpdateState.Verifying, exception.FailedState);
+        Assert.Equal(2, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x22));
+        Assert.NotNull(exception.RecoveryGuidance);
+        Assert.Contains("clean bootloader state", exception.RecoveryGuidance);
+    }
+
+    [Fact]
     public async Task UpdateFirmwareAsync_WhenProgramAckFails_RetriesAndCompletes()
     {
         var device = new FakeStreamingDevice("COM3");
@@ -2496,6 +2727,15 @@ public class FirmwareUpdateServiceTests
             WriteAsync(data).GetAwaiter().GetResult();
         }
 
+        private bool _dropWhenReadQueueEmpty;
+
+        /// <summary>
+        /// Makes the first ReadAsync after the queued responses are exhausted
+        /// throw and drop the connection, simulating the device disappearing
+        /// from the bus mid-operation.
+        /// </summary>
+        public void DropWhenReadQueueEmpty() => _dropWhenReadQueueEmpty = true;
+
         public Task<byte[]> ReadAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -2506,6 +2746,13 @@ public class FirmwareUpdateServiceTests
 
             if (_readQueue.Count == 0)
             {
+                if (_dropWhenReadQueueEmpty)
+                {
+                    _dropWhenReadQueueEmpty = false;
+                    IsConnected = false;
+                    throw new IOException("Simulated HID transport drop.");
+                }
+
                 throw new InvalidOperationException("No queued HID response available.");
             }
 

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -435,7 +435,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             // (acceptance criterion #208: never leave a half-flashed device). The
             // cleanup runs on its own token, so the already-canceled operation
             // token does not abort it. We still rethrow the cancellation.
-            await CleanUpAfterPic32FailureAsync(canceledState, progress, totalBytes).ConfigureAwait(false);
+            await CleanUpAfterPic32FailureAsync(canceledState, progress, totalBytes, canceled: true)
+                .ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
@@ -497,7 +498,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     private async Task<Pic32CleanupOutcome> CleanUpAfterPic32FailureAsync(
         FirmwareUpdateState failedState,
         IProgress<FirmwareUpdateProgress>? progress,
-        long totalBytes)
+        long totalBytes,
+        bool canceled = false)
     {
         var frozenPercent = _lastReportedPercent;
         var eligible = CleanupEligibleStates.Contains(failedState);
@@ -508,31 +510,48 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             // device is past HID (NotEligible — keep the per-state guidance), or
             // a flash-touching failure left the HID transport unusable so we
             // cannot re-erase (CleanupFailed — warn that it may be half-flashed).
-            // Both terminate in Failed.
+            // Both terminate in Failed. On the cancel path the rethrown
+            // OperationCanceledException carries no recovery guidance, so this
+            // terminal event text is the only channel observers get.
             var outcome = eligible ? Pic32CleanupOutcome.CleanupFailed : Pic32CleanupOutcome.NotEligible;
 
+            string failedOperation;
             if (outcome == Pic32CleanupOutcome.CleanupFailed)
             {
+                failedOperation = canceled
+                    ? "PIC32 firmware update canceled; cleanup re-erase skipped because the HID transport " +
+                      "disconnected — device may be in a half-flashed state."
+                    : "Cleanup re-erase skipped: HID transport disconnected; device may be in a half-flashed state.";
                 _logger.LogWarning(
                     "Cannot run firmware re-erase cleanup after failure in {State}: HID transport is no longer " +
                     "connected; device may be in a half-flashed state.",
                     failedState);
             }
+            else
+            {
+                failedOperation = canceled ? "PIC32 firmware update canceled." : _currentOperation;
+            }
 
-            TransitionToState(FirmwareUpdateState.Failed, _currentOperation);
-            ReportProgress(progress, FirmwareUpdateState.Failed, frozenPercent, _currentOperation, 0, totalBytes);
+            TransitionToState(FirmwareUpdateState.Failed, failedOperation);
+            ReportProgress(progress, FirmwareUpdateState.Failed, frozenPercent, failedOperation, 0, totalBytes);
             return outcome;
         }
 
-        const string cleaningOperation =
-            "Re-erasing flash to leave the device in a clean bootloader state.";
-        TransitionToState(FirmwareUpdateState.CleaningUp, cleaningOperation);
-        ReportProgress(progress, FirmwareUpdateState.CleaningUp, frozenPercent, cleaningOperation, 0, totalBytes);
-        _logger.LogInformation(
-            "Attempting firmware re-erase cleanup after failure in {State}.", failedState);
+        var cleaningOperation = canceled
+            ? "Update canceled; re-erasing flash to leave the device in a clean bootloader state."
+            : "Re-erasing flash to leave the device in a clean bootloader state.";
 
         try
         {
+            // The CleaningUp notification runs inside the try: a throwing
+            // StateChanged subscriber or progress sink must land in the catch
+            // below (CleaningUp → Failed) rather than stranding the machine in
+            // the non-terminal CleaningUp state, which has no reset path.
+            TransitionToState(FirmwareUpdateState.CleaningUp, cleaningOperation);
+            ReportProgress(progress, FirmwareUpdateState.CleaningUp, frozenPercent, cleaningOperation, 0, totalBytes);
+            _logger.LogInformation(
+                "Attempting firmware re-erase cleanup after failure in {State}.", failedState);
+
             // Reuse the same retry-wrapped erase path as the main flow, but on a
             // fresh timeout token: the cleanup must run on a best-effort basis
             // even if the original operation token was already canceled, and it
@@ -541,8 +560,9 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 _options.GetStateTimeout(FirmwareUpdateState.CleaningUp));
             await EraseFlashWithRetryAsync(cleanupCts.Token).ConfigureAwait(false);
 
-            const string recoveredOperation =
-                "Flash re-erased; device is in a clean bootloader state and can be re-flashed.";
+            var recoveredOperation = canceled
+                ? "Update canceled; flash re-erased — device is in a clean bootloader state and can be re-flashed."
+                : "Flash re-erased; device is in a clean bootloader state and can be re-flashed.";
             TransitionToState(FirmwareUpdateState.Recovered, recoveredOperation);
             ReportProgress(progress, FirmwareUpdateState.Recovered, frozenPercent, recoveredOperation, 0, totalBytes);
             _logger.LogInformation(
@@ -551,6 +571,19 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         }
         catch (Exception cleanupEx)
         {
+            if (CurrentState == FirmwareUpdateState.Recovered)
+            {
+                // The re-erase itself succeeded — a StateChanged subscriber or
+                // progress sink threw after the Recovered transition committed.
+                // The device is clean; a consumer callback must not turn that
+                // into a half-flashed verdict (and Recovered → Failed is not a
+                // legal transition).
+                _logger.LogWarning(
+                    cleanupEx,
+                    "A state/progress observer threw after the Recovered transition; cleanup itself succeeded.");
+                return Pic32CleanupOutcome.Recovered;
+            }
+
             const string cleanupFailedOperation =
                 "Cleanup re-erase failed; device may be in a half-flashed state.";
             TransitionToState(FirmwareUpdateState.Failed, cleanupFailedOperation);

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -53,23 +53,34 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             [FirmwareUpdateState.ErasingFlash] = new HashSet<FirmwareUpdateState>
             {
                 FirmwareUpdateState.Programming,
+                FirmwareUpdateState.CleaningUp,
                 FirmwareUpdateState.Failed
             },
             [FirmwareUpdateState.Programming] = new HashSet<FirmwareUpdateState>
             {
                 FirmwareUpdateState.Verifying,
                 FirmwareUpdateState.JumpingToApp,
+                FirmwareUpdateState.CleaningUp,
                 FirmwareUpdateState.Failed
             },
             [FirmwareUpdateState.Verifying] = new HashSet<FirmwareUpdateState>
             {
                 FirmwareUpdateState.JumpingToApp,
                 FirmwareUpdateState.Complete,
+                FirmwareUpdateState.CleaningUp,
                 FirmwareUpdateState.Failed
             },
             [FirmwareUpdateState.JumpingToApp] = new HashSet<FirmwareUpdateState>
             {
                 FirmwareUpdateState.Complete,
+                FirmwareUpdateState.Failed
+            },
+            // Cleanup (re-erase) runs after a failure in a flash-touching state.
+            // It either leaves the device in a clean bootloader state (Recovered)
+            // or, if the re-erase itself fails, falls through to Failed.
+            [FirmwareUpdateState.CleaningUp] = new HashSet<FirmwareUpdateState>
+            {
+                FirmwareUpdateState.Recovered,
                 FirmwareUpdateState.Failed
             },
             [FirmwareUpdateState.Complete] = new HashSet<FirmwareUpdateState>
@@ -79,7 +90,27 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             [FirmwareUpdateState.Failed] = new HashSet<FirmwareUpdateState>
             {
                 FirmwareUpdateState.Idle
+            },
+            // Recovered is a terminal failure state (the update did not install
+            // firmware) but the device is safe; it only resets for the next run.
+            [FirmwareUpdateState.Recovered] = new HashSet<FirmwareUpdateState>
+            {
+                FirmwareUpdateState.Idle
             }
+        };
+
+    // States where a failure may have left the application flash partially
+    // written AND the HID bootloader is still connected, so re-erasing to a
+    // clean bootloader state is both necessary and possible. Failures in
+    // PreparingDevice/WaitingForBootloader/Connecting happen before any flash
+    // write; a JumpingToApp failure happens after HID has already been
+    // disconnected — neither is eligible for cleanup.
+    private static readonly IReadOnlySet<FirmwareUpdateState> CleanupEligibleStates
+        = new HashSet<FirmwareUpdateState>
+        {
+            FirmwareUpdateState.ErasingFlash,
+            FirmwareUpdateState.Programming,
+            FirmwareUpdateState.Verifying
         };
 
     private readonly SemaphoreSlim _operationLock = new(1, 1);
@@ -396,24 +427,139 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            TransitionToState(FirmwareUpdateState.Failed, "PIC32 firmware update canceled.");
-            ReportProgress(progress, FirmwareUpdateState.Failed, _lastReportedPercent, _currentOperation, 0, totalBytes);
-            _logger.LogWarning("PIC32 firmware update canceled.");
+            var canceledState = CurrentState;
+            _logger.LogWarning("PIC32 firmware update canceled in state {State}.", canceledState);
+
+            // A cancel mid-flash still leaves the device half-flashed, so it must
+            // be cleaned up just like any other failure in a flash-touching state
+            // (acceptance criterion #208: never leave a half-flashed device). The
+            // cleanup runs on its own token, so the already-canceled operation
+            // token does not abort it. We still rethrow the cancellation.
+            await CleanUpAfterPic32FailureAsync(canceledState, progress, totalBytes).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
         {
+            // Capture the state/operation at the moment of failure BEFORE any
+            // cleanup transitions move us off it — these stay the diagnostic
+            // "where it broke" context on the thrown exception.
             var failedState = CurrentState;
             var failedOperation = _currentOperation;
-            TransitionToState(FirmwareUpdateState.Failed, failedOperation);
-            ReportProgress(progress, FirmwareUpdateState.Failed, _lastReportedPercent, failedOperation, 0, totalBytes);
             _logger.LogError(ex, "PIC32 firmware update failed in state {State}.", failedState);
 
-            throw CreateFirmwareUpdateException(failedState, failedOperation, ex);
+            var cleanupOutcome = await CleanUpAfterPic32FailureAsync(
+                failedState, progress, totalBytes).ConfigureAwait(false);
+
+            throw CreateFirmwareUpdateException(failedState, failedOperation, ex, cleanupOutcome);
         }
         finally
         {
             await SafeDisconnectHidAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Describes the terminal disposition of a failed PIC32 update after the
+    /// optional re-erase cleanup pass, used to tailor the recovery guidance and
+    /// reflected by the service's terminal state.
+    /// </summary>
+    private enum Pic32CleanupOutcome
+    {
+        /// <summary>
+        /// Cleanup did not apply: the failure occurred before flash was written
+        /// (PreparingDevice/WaitingForBootloader/Connecting) or after the HID
+        /// bootloader was disconnected (JumpingToApp). Terminal state: Failed.
+        /// </summary>
+        NotEligible,
+
+        /// <summary>
+        /// The application flash was re-erased successfully; the device is in a
+        /// clean bootloader state and can be re-flashed. Terminal state: Recovered.
+        /// </summary>
+        Recovered,
+
+        /// <summary>
+        /// Cleanup was eligible but could not complete (the HID transport had
+        /// dropped, or the re-erase itself failed), so the device may be in a
+        /// half-flashed state. Terminal state: Failed.
+        /// </summary>
+        CleanupFailed
+    }
+
+    /// <summary>
+    /// After a PIC32 update failure, re-erases the application flash when the
+    /// failure left the device half-flashed but still reachable over HID, so it
+    /// is never abandoned in a partially-programmed state. Drives the
+    /// CleaningUp → Recovered (success) or → Failed (cleanup failed) terminal
+    /// transitions and reports them via state/progress events. The update has
+    /// already failed; this only determines how safely it ends.
+    /// </summary>
+    private async Task<Pic32CleanupOutcome> CleanUpAfterPic32FailureAsync(
+        FirmwareUpdateState failedState,
+        IProgress<FirmwareUpdateProgress>? progress,
+        long totalBytes)
+    {
+        var frozenPercent = _lastReportedPercent;
+        var eligible = CleanupEligibleStates.Contains(failedState);
+
+        if (!eligible || !_hidTransport.IsConnected)
+        {
+            // No re-erase will run. Either the failure never touched flash / the
+            // device is past HID (NotEligible — keep the per-state guidance), or
+            // a flash-touching failure left the HID transport unusable so we
+            // cannot re-erase (CleanupFailed — warn that it may be half-flashed).
+            // Both terminate in Failed.
+            var outcome = eligible ? Pic32CleanupOutcome.CleanupFailed : Pic32CleanupOutcome.NotEligible;
+
+            if (outcome == Pic32CleanupOutcome.CleanupFailed)
+            {
+                _logger.LogWarning(
+                    "Cannot run firmware re-erase cleanup after failure in {State}: HID transport is no longer " +
+                    "connected; device may be in a half-flashed state.",
+                    failedState);
+            }
+
+            TransitionToState(FirmwareUpdateState.Failed, _currentOperation);
+            ReportProgress(progress, FirmwareUpdateState.Failed, frozenPercent, _currentOperation, 0, totalBytes);
+            return outcome;
+        }
+
+        const string cleaningOperation =
+            "Re-erasing flash to leave the device in a clean bootloader state.";
+        TransitionToState(FirmwareUpdateState.CleaningUp, cleaningOperation);
+        ReportProgress(progress, FirmwareUpdateState.CleaningUp, frozenPercent, cleaningOperation, 0, totalBytes);
+        _logger.LogInformation(
+            "Attempting firmware re-erase cleanup after failure in {State}.", failedState);
+
+        try
+        {
+            // Reuse the same retry-wrapped erase path as the main flow, but on a
+            // fresh timeout token: the cleanup must run on a best-effort basis
+            // even if the original operation token was already canceled, and it
+            // is bounded by the same budget as a normal erase.
+            using var cleanupCts = new CancellationTokenSource(
+                _options.GetStateTimeout(FirmwareUpdateState.CleaningUp));
+            await EraseFlashWithRetryAsync(cleanupCts.Token).ConfigureAwait(false);
+
+            const string recoveredOperation =
+                "Flash re-erased; device is in a clean bootloader state and can be re-flashed.";
+            TransitionToState(FirmwareUpdateState.Recovered, recoveredOperation);
+            ReportProgress(progress, FirmwareUpdateState.Recovered, frozenPercent, recoveredOperation, 0, totalBytes);
+            _logger.LogInformation(
+                "Firmware re-erase cleanup succeeded; device is in a clean bootloader state.");
+            return Pic32CleanupOutcome.Recovered;
+        }
+        catch (Exception cleanupEx)
+        {
+            const string cleanupFailedOperation =
+                "Cleanup re-erase failed; device may be in a half-flashed state.";
+            TransitionToState(FirmwareUpdateState.Failed, cleanupFailedOperation);
+            ReportProgress(progress, FirmwareUpdateState.Failed, frozenPercent, cleanupFailedOperation, 0, totalBytes);
+            _logger.LogError(
+                cleanupEx,
+                "Firmware re-erase cleanup failed after failure in {State}; device may be half-flashed.",
+                failedState);
+            return Pic32CleanupOutcome.CleanupFailed;
         }
     }
 
@@ -1875,14 +2021,18 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     private FirmwareUpdateException CreateFirmwareUpdateException(
         FirmwareUpdateState failedState,
         string failedOperation,
-        Exception exception)
+        Exception exception,
+        Pic32CleanupOutcome cleanupOutcome = Pic32CleanupOutcome.NotEligible)
     {
         if (exception is FirmwareUpdateException firmwareUpdateException)
         {
+            // Already a fully-contextualized firmware exception (carries its own
+            // guidance). No flash-path operation throws one today, so the
+            // cleanupOutcome guidance below never has to be merged in here.
             return firmwareUpdateException;
         }
 
-        var recoveryGuidance = BuildRecoveryGuidance(failedState);
+        var recoveryGuidance = BuildRecoveryGuidance(failedState, cleanupOutcome);
         var message = $"Firmware update failed in state '{failedState}' while {failedOperation}.";
 
         return new FirmwareUpdateException(
@@ -1891,6 +2041,29 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             message,
             recoveryGuidance,
             exception);
+    }
+
+    private static string BuildRecoveryGuidance(
+        FirmwareUpdateState failedState,
+        Pic32CleanupOutcome cleanupOutcome)
+    {
+        // When a re-erase cleanup ran, its outcome — not the original failure
+        // state — drives the guidance: the operator needs to know whether the
+        // device is safe to simply re-flash or may be half-flashed.
+        switch (cleanupOutcome)
+        {
+            case Pic32CleanupOutcome.Recovered:
+                return "The update did not complete, but the device's application flash was automatically " +
+                       "re-erased and it is now in a clean bootloader state — safe to re-flash. " +
+                       "Simply re-run the firmware update.";
+            case Pic32CleanupOutcome.CleanupFailed:
+                return "The update failed and the automatic re-erase cleanup could not complete, so the device " +
+                       "may be in a half-flashed state. Power-cycle the device into bootloader mode and re-run " +
+                       "the firmware update; the next erase will restore a clean state.";
+            case Pic32CleanupOutcome.NotEligible:
+            default:
+                return BuildRecoveryGuidance(failedState);
+        }
     }
 
     private static string BuildRecoveryGuidance(FirmwareUpdateState failedState)
@@ -1968,7 +2141,9 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
     private void ResetIfTerminalState()
     {
-        if (CurrentState is FirmwareUpdateState.Complete or FirmwareUpdateState.Failed)
+        if (CurrentState is FirmwareUpdateState.Complete
+            or FirmwareUpdateState.Failed
+            or FirmwareUpdateState.Recovered)
         {
             TransitionToState(FirmwareUpdateState.Idle, "Resetting state for next firmware update operation.");
         }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -280,6 +280,9 @@ public sealed class FirmwareUpdateServiceOptions
             FirmwareUpdateState.Programming => ProgrammingTimeout,
             FirmwareUpdateState.Verifying => VerifyingTimeout,
             FirmwareUpdateState.JumpingToApp => JumpingToApplicationTimeout,
+            // Cleanup re-erases the application flash, so it is bounded by the
+            // same budget as a normal erase.
+            FirmwareUpdateState.CleaningUp => ErasingFlashTimeout,
             _ => TimeSpan.FromMinutes(5)
         };
     }

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateState.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateState.cs
@@ -53,5 +53,23 @@ public enum FirmwareUpdateState
     /// <summary>
     /// Update terminated with an error or cancellation.
     /// </summary>
-    Failed = 9
+    Failed = 9,
+
+    /// <summary>
+    /// Recovering from a failure by re-erasing the application flash so the
+    /// device is left in a clean bootloader state rather than a half-flashed
+    /// one. Entered only on failures during <see cref="ErasingFlash"/>,
+    /// <see cref="Programming"/>, or <see cref="Verifying"/>, where the HID
+    /// bootloader is still connected and the flash may have been modified.
+    /// </summary>
+    CleaningUp = 10,
+
+    /// <summary>
+    /// The update failed, but cleanup succeeded: the application flash was
+    /// re-erased and the device is in a clean bootloader state, ready to be
+    /// re-flashed. This is a terminal failure state — the firmware was not
+    /// installed — but the device is safe and recoverable by re-running the
+    /// update.
+    /// </summary>
+    Recovered = 11
 }

--- a/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
@@ -25,6 +25,20 @@ public interface IFirmwareUpdateService
     /// <param name="hexFilePath">Path to an Intel HEX firmware file.</param>
     /// <param name="progress">Optional progress reporter.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// On failure this throws <see cref="FirmwareUpdateException"/>. If the failure
+    /// occurs after flash has been written (while the HID bootloader is still
+    /// connected), the service automatically re-erases the application flash so the
+    /// device is left in a clean, re-flashable bootloader state rather than a
+    /// half-flashed one. In that case <see cref="CurrentState"/> ends at
+    /// <see cref="FirmwareUpdateState.Recovered"/> (preceded by a
+    /// <see cref="FirmwareUpdateState.CleaningUp"/> transition) and the exception's
+    /// recovery guidance reflects that the device is safe to re-flash; if the
+    /// re-erase itself cannot complete, <see cref="CurrentState"/> ends at
+    /// <see cref="FirmwareUpdateState.Failed"/>. The exception's
+    /// <see cref="FirmwareUpdateException.FailedState"/> always reports where the
+    /// original failure occurred, regardless of cleanup outcome.
+    /// </remarks>
     Task UpdateFirmwareAsync(
         IStreamingDevice device,
         string hexFilePath,


### PR DESCRIPTION
## Summary

Closes #208. When a PIC32 firmware update fails in a flash-touching state where the HID bootloader is still reachable (`ErasingFlash`/`Programming`/`Verifying`), the service now re-issues `ERASE_FLASH` so the device is left in a **clean, re-flashable bootloader state** instead of being abandoned half-flashed.

This is *not* rollback — the bootloader has no flash readback and the app partition is a single contiguous bank, so there's no previous image to restore. Re-erasing to a safe terminal state is the only recovery the hardware supports (see the issue for the full feasibility analysis).

This became materially more relevant after #261 (READ_CRC verification, #213): that PR wired real `Verifying`-stage CRC-mismatch failures into the terminal `Failed` path and explicitly deferred safe termination to "#208's cleanup once that merges." This is that cleanup.

## State machine

- Add `CleaningUp` and `Recovered` states (appended — existing public enum numeric values preserved).
- On failure in `ErasingFlash`/`Programming`/`Verifying`: `→ CleaningUp → Recovered` on a successful re-erase, or `→ CleaningUp → Failed` if the re-erase itself fails.
- Failures in `PreparingDevice`/`WaitingForBootloader`/`Connecting` (flash untouched) and `JumpingToApp` (HID already disconnected) skip cleanup.
- A **cancel mid-flash** is treated like a failure: it re-erases, then rethrows the `OperationCanceledException` — honoring the acceptance criterion that a half-flashed device is never left stranded. Pre-flash cancels still terminate in `Failed`.

## UX

- The update **still throws** on `Recovered` (the firmware was not installed) — callers must not treat it as success.
- `service.CurrentState` (`Recovered` vs `Failed`) and **outcome-aware `RecoveryGuidance`** tell the operator whether the device is safe to simply re-flash, or may be half-flashed and needs a power-cycle.
- `FirmwareUpdateException.FailedState` always reports where the *original* failure occurred (e.g. `Verifying`), independent of cleanup outcome.
- `CleaningUp`/`Recovered` are surfaced via both `StateChanged` and `IProgress`. Progress percent **freezes at the failure point (never 100)** so a percent-only UI can't misread cleanup as a completed install — the `State` field disambiguates, consistent with how `Failed` already behaves.

Reuses `EraseFlashWithRetryAsync` on a fresh timeout token (bounded by `ErasingFlashTimeout`) so cleanup runs even when the operation token is already canceled. No new public config option; the WiFi update path is untouched.

## Tests

All pass on **net9.0 + net10.0** (1275 passed, 2 pre-existing skips, 0 failed; solution builds warning-free with `TreatWarningsAsErrors`):

- Recovery to a clean bootloader state on `ErasingFlash`, `Programming`, `Verifying`, and cancel-mid-flash failures.
- Cleanup re-erase itself fails → `Failed` (not stuck in `CleaningUp`), with half-flashed guidance.
- Failure before flash is touched (`WaitingForBootloader`) skips cleanup — no `CleaningUp`/`Recovered`, no erase issued.
- `CleaningUp`+`Recovered` ordering asserted via both state events and progress; recovery-guidance text and progress-percent bounds asserted.

## Acceptance criteria

- [x] Add `CleaningUp` and `Recovered` states.
- [x] On failure in flash-touching, HID-connected states → `CleaningUp → Recovered`; cleanup failure → `Failed`.
- [x] `Recovered` terminal, resets only to `Idle`.
- [x] Failures outside cleanup-eligible states skip cleanup.
- [x] Re-issue `ERASE_FLASH` via `EraseFlashWithRetryAsync` before HID is disconnected.
- [x] Surface cleanup progress; update `RecoveryGuidance`.
- [x] State-machine tests for each path.
- [x] Device is never left half-flashed after a failed (or canceled) update.

## Reviewer note

Routing cancel-mid-flash through cleanup adds a brief re-erase (~1s, bounded by `ErasingFlashTimeout`) after an operator hits cancel. This was a deliberate choice — a stranded half-flashed device is the worse outcome — but flag if the desktop UX wants cancel to be instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Revision 2 (2026-07-03)

Rebased onto main (past #275 device-path addressing and #281) — the only conflict was the rewritten CRC-mismatch test name. Verified the premise against the firmware repo before proceeding: the PIC32 bootloader's only boot-time app-validity check is whether the first word at `APP_RESET_ADDRESS` reads erased (`bootloader/.../app.c` — no boot-time CRC), and Core programs hex records in ascending address order, so the reset vector is written early in Programming. A half-flashed device therefore boots into garbage on the next power cycle, recoverable only via the physical button-hold window; re-erasing restores the erased-word check so the device parks in the bootloader and a plain retry works. This is also what makes #261's READ_CRC verification actionable.

Hardening applied after a fresh review pass:

- **Wedge fix:** the `CleaningUp` notification now runs inside the try — a throwing `StateChanged` subscriber or progress sink previously escaped with the machine stranded in non-terminal `CleaningUp` (no reset path) and masked the original failure exception.
- **State-aware cleanup catch:** a consumer callback throwing after the `Recovered` transition committed no longer triggers an illegal `Recovered → Failed` transition; the outcome stays `Recovered` (the re-erase did succeed).
- **Qodo finding fixed:** when a flash-touching failure coincides with a dropped HID transport (cleanup eligible but impossible), the terminal `Failed` event/progress text now carries the half-flashed warning instead of the stale in-flight operation string — on the cancel path, observers are the only channel.
- **Cancel observability restored:** cancel-before-flash again surfaces `"PIC32 firmware update canceled."` to observers (parity with the WiFi path), and cleanup transitions after a canceled update use cancel-aware wording.
- **Docs:** README feature table + Firmware updates section now document safe failure cleanup, `CleaningUp`/`Recovered`, the frozen progress percent, and outcome-aware `RecoveryGuidance`.
- **Tests:** 4 new (transport-drop observability, cancel observability, throwing observer on `CleaningUp`/`Recovered`); suite now 1331 passed on net9.0 + net10.0, build warning-free.
