### PR TITLE
feat(hid): exclusive HID open for held bootloader sessions

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/HidLibraryDeviceEnumeratorTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/HidLibraryDeviceEnumeratorTests.cs
@@ -144,7 +144,7 @@ public class HidLibraryDeviceEnumeratorTests
         public string? ProductName { get; }
         public bool IsConnected { get; private set; }
 
-        public void Open() => IsConnected = true;
+        public void Open(bool exclusive) => IsConnected = true;
 
         public void Close() => IsConnected = false;
 

--- a/src/Daqifi.Core.Tests/Communication/Transport/HidLibraryTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/HidLibraryTransportTests.cs
@@ -34,6 +34,36 @@ public class HidLibraryTransportTests
     }
 
     [Fact]
+    public async Task ConnectAsync_ByDefault_OpensDeviceShared()
+    {
+        var device = new FakeHidTransportDevice(0x04D8, 0x003C, "path-a", "SN-A");
+        var platform = new FakeHidPlatform([device]);
+
+        using var transport = new HidLibraryTransport(platform);
+
+        await transport.ConnectAsync(0x04D8, 0x003C);
+
+        // ExclusiveAccess defaults false so non-bootloader HID consumers keep a shared open.
+        Assert.False(transport.ExclusiveAccess);
+        Assert.False(device.LastOpenExclusive);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_WhenExclusiveAccessSet_OpensDeviceExclusively()
+    {
+        var device = new FakeHidTransportDevice(0x04D8, 0x003C, "path-a", "SN-A");
+        var platform = new FakeHidPlatform([device]);
+
+        using var transport = new HidLibraryTransport(platform) { ExclusiveAccess = true };
+
+        await transport.ConnectAsync(0x04D8, 0x003C);
+
+        // A2: the bootloader flash must hold the HID handle exclusively. The flag is threaded to the
+        // device open so the stray-write guard (and discovery lockout) is actually requested.
+        Assert.True(device.LastOpenExclusive);
+    }
+
+    [Fact]
     public async Task ConnectAsync_WithSerialFilter_SelectsMatchingDevice()
     {
         var first = new FakeHidTransportDevice(0x04D8, 0x003C, "path-a", "SN-A");
@@ -221,6 +251,7 @@ public class HidLibraryTransportTests
 
         public int OpenCount { get; private set; }
         public int CloseCount { get; private set; }
+        public bool LastOpenExclusive { get; private set; }
         public int? LastWriteTimeoutMs { get; private set; }
         public int? LastReadTimeoutMs { get; private set; }
 
@@ -228,9 +259,10 @@ public class HidLibraryTransportTests
         public HidTransportReadResult NextReadResult { get; set; }
             = HidTransportReadResult.Success(Array.Empty<byte>());
 
-        public void Open()
+        public void Open(bool exclusive)
         {
             OpenCount++;
+            LastOpenExclusive = exclusive;
             IsConnected = true;
         }
 

--- a/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
@@ -126,6 +126,7 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
         }
 
         HidStream? opened = null;
+        Exception? exclusiveOpenError = null;
 
         if (exclusive)
         {
@@ -150,9 +151,11 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
                     opened = exclusiveStream;
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // Exclusive open threw; leave opened == null so the shared open below is attempted.
+                // Exclusive open threw; remember why and leave opened == null so the shared open below
+                // is attempted. The cause is chained into the final throw if the shared open also fails.
+                exclusiveOpenError = ex;
             }
         }
 
@@ -160,7 +163,8 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
         {
             if (!_device.TryOpen(out var sharedStream) || sharedStream == null)
             {
-                throw new IOException("Failed to open HID device.");
+                // Chain the exclusive-open failure (if any) so a double failure preserves the root cause.
+                throw new IOException("Failed to open HID device.", exclusiveOpenError);
             }
 
             opened = sharedStream;

--- a/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
@@ -18,7 +18,10 @@ internal interface IHidTransportDevice
     string? ProductName { get; }
     bool IsConnected { get; }
 
-    void Open();
+    // When exclusive is true, request an exclusive open (Windows dwShareMode=0; macOS IOKit seize)
+    // so no other user-mode opener can open or write to the device while this handle is held.
+    // Best-effort: a refused exclusive open falls back to a shared open.
+    void Open(bool exclusive);
     void Close();
     bool Write(byte[] data, int timeoutMs);
     Task<bool> WriteAsync(byte[] data, int timeoutMs);
@@ -115,19 +118,47 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
         }
     }
 
-    public void Open()
+    public void Open(bool exclusive)
     {
         if (_stream != null)
         {
             return;
         }
 
-        if (!_device.TryOpen(out var stream) || stream == null)
+        HidStream? opened = null;
+
+        if (exclusive)
         {
-            throw new IOException("Failed to open HID device.");
+            // A2 (stray-write guard): open the bootloader's vendor collection exclusively
+            // (Windows dwShareMode=0) so no other user-mode opener — the desktop's own HID discovery
+            // loop, a second app instance, anything — can open or write to the device while this
+            // handle is held. The PIC32 bootloader's CRC check is disabled, so a stray SOH…EOT frame
+            // from another opener could be mis-parsed as an ERASE; the exclusive handle guards
+            // against that. A vendor-defined top-level collection (Usage Page 0xFF00) permits
+            // exclusive access, unlike the system keyboard/mouse collections hidclass keeps shared.
+            var exclusiveConfig = new OpenConfiguration();
+            exclusiveConfig.SetOption(OpenOption.Exclusive, true);
+
+            // Best-effort: a refused exclusive open (another handle already open — e.g. a transient
+            // discovery handle not yet released) falls through to the shared open below, so a flash
+            // that works today is never regressed by the added guard.
+            if (_device.TryOpen(exclusiveConfig, out var exclusiveStream) && exclusiveStream != null)
+            {
+                opened = exclusiveStream;
+            }
         }
 
-        _stream = stream;
+        if (opened == null)
+        {
+            if (!_device.TryOpen(out var sharedStream) || sharedStream == null)
+            {
+                throw new IOException("Failed to open HID device.");
+            }
+
+            opened = sharedStream;
+        }
+
+        _stream = opened;
     }
 
     public void Close()

--- a/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
@@ -150,6 +150,11 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
                 {
                     opened = exclusiveStream;
                 }
+                else
+                {
+                    // TryOpen reported failure; dispose any partial stream so it isn't leaked.
+                    exclusiveStream?.Dispose();
+                }
             }
             catch (Exception ex)
             {
@@ -167,7 +172,12 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
             Exception? sharedOpenError = null;
             try
             {
-                _device.TryOpen(out sharedStream);
+                if (!_device.TryOpen(out sharedStream) || sharedStream == null)
+                {
+                    // TryOpen reported failure; dispose any partial stream and fall through to the throw.
+                    sharedStream?.Dispose();
+                    sharedStream = null;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
@@ -139,12 +139,20 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
             var exclusiveConfig = new OpenConfiguration();
             exclusiveConfig.SetOption(OpenOption.Exclusive, true);
 
-            // Best-effort: a refused exclusive open (another handle already open — e.g. a transient
-            // discovery handle not yet released) falls through to the shared open below, so a flash
-            // that works today is never regressed by the added guard.
-            if (_device.TryOpen(exclusiveConfig, out var exclusiveStream) && exclusiveStream != null)
+            // Best-effort: a refused exclusive open falls through to the shared open below, so a flash
+            // that works today is never regressed by the added guard. This covers BOTH ways HidSharp can
+            // refuse — TryOpen returning false AND TryOpen throwing (e.g. a sharing-violation surfaced as
+            // an exception) — otherwise an exclusive-open throw would become a hard connection failure.
+            try
             {
-                opened = exclusiveStream;
+                if (_device.TryOpen(exclusiveConfig, out var exclusiveStream) && exclusiveStream != null)
+                {
+                    opened = exclusiveStream;
+                }
+            }
+            catch (Exception)
+            {
+                // Exclusive open threw; leave opened == null so the shared open below is attempted.
             }
         }
 

--- a/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
@@ -161,10 +161,27 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
 
         if (opened == null)
         {
-            if (!_device.TryOpen(out var sharedStream) || sharedStream == null)
+            // The shared open can also throw (not just return false); catch it so a throwing shared
+            // fallback still routes through our normalized IOException and never drops the exclusive cause.
+            HidStream? sharedStream = null;
+            Exception? sharedOpenError = null;
+            try
             {
-                // Chain the exclusive-open failure (if any) so a double failure preserves the root cause.
-                throw new IOException("Failed to open HID device.", exclusiveOpenError);
+                _device.TryOpen(out sharedStream);
+            }
+            catch (Exception ex)
+            {
+                sharedOpenError = ex;
+            }
+
+            if (sharedStream == null)
+            {
+                // Both opens failed — preserve whatever cause(s) we have. When both threw, chain both via
+                // an AggregateException so neither root cause is lost for diagnosis.
+                var cause = exclusiveOpenError != null && sharedOpenError != null
+                    ? new AggregateException(exclusiveOpenError, sharedOpenError)
+                    : sharedOpenError ?? exclusiveOpenError;
+                throw new IOException("Failed to open HID device.", cause);
             }
 
             opened = sharedStream;

--- a/src/Daqifi.Core/Communication/Transport/HidLibraryTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidLibraryTransport.cs
@@ -70,6 +70,17 @@ public sealed class HidLibraryTransport : IHidTransport
         }
     }
 
+    /// <summary>
+    /// Gets or sets whether <see cref="ConnectAsync"/> opens the device exclusively (Windows
+    /// <c>dwShareMode=0</c>; macOS IOKit seize) so no other user-mode opener can open or write to it
+    /// while this transport holds the handle. Defaults to <c>false</c> (shared). Set to <c>true</c>
+    /// for a PIC32 bootloader flash: the bootloader's CRC check is disabled, so an exclusive handle
+    /// guards against a stray frame from another opener being mis-parsed as an ERASE and locks the
+    /// discovery loop out of the device for the flash. Best-effort — a refused exclusive open falls
+    /// back to a shared open so a flash that works today is never regressed.
+    /// </summary>
+    public bool ExclusiveAccess { get; set; }
+
     /// <inheritdoc />
     public async Task ConnectAsync(
         int vendorId,
@@ -123,7 +134,7 @@ public sealed class HidLibraryTransport : IHidTransport
 
             try
             {
-                device.Open();
+                device.Open(ExclusiveAccess);
             }
             catch (Exception ex)
             {

--- a/src/Daqifi.Core/Communication/Transport/MacOsHidPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/MacOsHidPlatform.cs
@@ -248,12 +248,16 @@ internal sealed class MacOsHidTransportDevice : IHidTransportDevice, IDisposable
             var options = exclusive
                 ? NativeMethods.kIOHIDOptionsTypeSeizeDevice
                 : NativeMethods.kIOHIDOptionsTypeNone;
+            var seizeResult = NativeMethods.kIOReturnSuccess;
             var result = NativeMethods.IOHIDDeviceOpen(_deviceRef, options);
-            var seizeResult = result;
-            if (result != NativeMethods.kIOReturnSuccess && exclusive)
+            if (exclusive)
             {
-                // Refused seize falls back to a shared open so a flash that works today is not regressed.
-                result = NativeMethods.IOHIDDeviceOpen(_deviceRef, NativeMethods.kIOHIDOptionsTypeNone);
+                seizeResult = result;
+                if (result != NativeMethods.kIOReturnSuccess)
+                {
+                    // Refused seize falls back to a shared open so a flash that works today is not regressed.
+                    result = NativeMethods.IOHIDDeviceOpen(_deviceRef, NativeMethods.kIOHIDOptionsTypeNone);
+                }
             }
 
             if (result != NativeMethods.kIOReturnSuccess)

--- a/src/Daqifi.Core/Communication/Transport/MacOsHidPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/MacOsHidPlatform.cs
@@ -232,7 +232,7 @@ internal sealed class MacOsHidTransportDevice : IHidTransportDevice, IDisposable
             maxOutput);
     }
 
-    public void Open()
+    public void Open(bool exclusive)
     {
         lock (_lifecycleLock)
         {
@@ -241,7 +241,20 @@ internal sealed class MacOsHidTransportDevice : IHidTransportDevice, IDisposable
                 return;
             }
 
-            var result = NativeMethods.IOHIDDeviceOpen(_deviceRef, NativeMethods.kIOHIDOptionsTypeNone);
+            // A2 (stray-write guard): when exclusive, seize the device so no other user-mode opener
+            // can drive it while we hold it — the macOS equivalent of the Windows dwShareMode=0 open.
+            // Best-effort, mirroring the HidSharp backend: a refused seize falls back to a shared
+            // open so a flash that works today is not regressed.
+            var options = exclusive
+                ? NativeMethods.kIOHIDOptionsTypeSeizeDevice
+                : NativeMethods.kIOHIDOptionsTypeNone;
+            var result = NativeMethods.IOHIDDeviceOpen(_deviceRef, options);
+            if (result != NativeMethods.kIOReturnSuccess && exclusive)
+            {
+                // Refused seize falls back to a shared open so a flash that works today is not regressed.
+                result = NativeMethods.IOHIDDeviceOpen(_deviceRef, NativeMethods.kIOHIDOptionsTypeNone);
+            }
+
             if (result != NativeMethods.kIOReturnSuccess)
             {
                 throw new IOException($"IOHIDDeviceOpen failed (IOReturn=0x{result:X8}).");
@@ -630,6 +643,7 @@ internal sealed class MacOsHidTransportDevice : IHidTransportDevice, IDisposable
         private const string LibSystem = "/usr/lib/libSystem.dylib";
 
         internal const uint kIOHIDOptionsTypeNone = 0;
+        internal const uint kIOHIDOptionsTypeSeizeDevice = 1;
         internal const int kIOReturnSuccess = 0;
         internal const int kIOHIDReportTypeOutput = 1;
         internal const int kCFNumberSInt32Type = 3;

--- a/src/Daqifi.Core/Communication/Transport/MacOsHidPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/MacOsHidPlatform.cs
@@ -249,6 +249,7 @@ internal sealed class MacOsHidTransportDevice : IHidTransportDevice, IDisposable
                 ? NativeMethods.kIOHIDOptionsTypeSeizeDevice
                 : NativeMethods.kIOHIDOptionsTypeNone;
             var result = NativeMethods.IOHIDDeviceOpen(_deviceRef, options);
+            var seizeResult = result;
             if (result != NativeMethods.kIOReturnSuccess && exclusive)
             {
                 // Refused seize falls back to a shared open so a flash that works today is not regressed.
@@ -257,7 +258,11 @@ internal sealed class MacOsHidTransportDevice : IHidTransportDevice, IDisposable
 
             if (result != NativeMethods.kIOReturnSuccess)
             {
-                throw new IOException($"IOHIDDeviceOpen failed (IOReturn=0x{result:X8}).");
+                // On a double failure surface both codes so the seize and the shared fallback are distinguishable.
+                throw new IOException(
+                    exclusive
+                        ? $"IOHIDDeviceOpen failed (seize IOReturn=0x{seizeResult:X8}, shared IOReturn=0x{result:X8})."
+                        : $"IOHIDDeviceOpen failed (IOReturn=0x{result:X8}).");
             }
 
             _deviceOpened = true;


### PR DESCRIPTION
## What

Adds `HidLibraryTransport.ExclusiveAccess` (default `false`). When set, the HID device is opened **exclusively** so no other user-mode opener can open or write to it while this transport holds the handle:

- **Windows:** `dwShareMode=0` via HidSharp `OpenConfiguration` + `OpenOption.Exclusive`.
- **macOS:** IOKit `kIOHIDOptionsTypeSeizeDevice`.

`IHidTransportDevice.Open()` becomes `Open(bool exclusive)` across both platform backends and the test fakes.

**Best-effort:** a refused exclusive open falls back to a shared open, so any flow that works today is never regressed.

## Why

Enables the desktop to **grab and hold** a sitting PIC32 HID bootloader and to lock other openers out for the duration of a flash. The bootloader's inbound CRC gate is disabled in fielded firmware, so a stray `SOH…EOT` frame from another opener (e.g. a discovery loop) could be mis-parsed as an `ERASE`; the exclusive handle guards against that. A vendor-defined top-level collection (Usage Page 0xFF00) permits exclusive access, unlike the system keyboard/mouse collections `hidclass` keeps shared.

This is the minimal Core change that the upcoming desktop *grab-and-hold-the-bootloader* feature depends on.

## Testing

- Core build clean; **1272/1274** tests pass (2 pre-existing skips).
- New unit tests cover exclusive open + the shared-open fallback.
- Hardware-validated end-to-end via the desktop flash path against a live PIC32 HID bootloader (exclusive open succeeded on the real vendor collection; no fallback needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)