### PR TITLE
feat(mcp): MCP server for agent-driven DAQiFi device control

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       run: dotnet pack src/Daqifi.Core/Daqifi.Core.csproj --configuration Release --no-build -p:PackageVersion=${VERSION} --output nupkgs
 
     - name: Push to NuGet
-      run: dotnet nuget push nupkgs/Daqifi.Core.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push nupkgs/Daqifi.Core.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Pack MCP server (dotnet tool)
       run: dotnet pack src/Daqifi.Mcp/Daqifi.Mcp.csproj --configuration Release --no-build -p:PackageVersion=${VERSION} --output nupkgs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,12 @@ jobs:
     
     - name: Pack
       run: dotnet pack src/Daqifi.Core/Daqifi.Core.csproj --configuration Release --no-build -p:PackageVersion=${VERSION} --output nupkgs
-    
+
     - name: Push to NuGet
-      run: dotnet nuget push nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json 
+      run: dotnet nuget push nupkgs/Daqifi.Core.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+    - name: Pack MCP server (dotnet tool)
+      run: dotnet pack src/Daqifi.Mcp/Daqifi.Mcp.csproj --configuration Release --no-build -p:PackageVersion=${VERSION} --output nupkgs
+
+    - name: Push MCP server to NuGet
+      run: dotnet nuget push nupkgs/Daqifi.Mcp.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Daqifi.Core.sln
+++ b/Daqifi.Core.sln
@@ -9,26 +9,76 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Core", "src\Daqifi.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Core.Tests", "src\Daqifi.Core.Tests\Daqifi.Core.Tests.csproj", "{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Mcp", "src\Daqifi.Mcp\Daqifi.Mcp.csproj", "{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Mcp.Tests", "src\Daqifi.Mcp.Tests\Daqifi.Mcp.Tests.csproj", "{209097AD-D34D-425B-8F22-0936F26C83D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Debug|x64.Build.0 = Debug|Any CPU
+		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Debug|x86.Build.0 = Debug|Any CPU
 		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Release|x64.ActiveCfg = Release|Any CPU
+		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Release|x64.Build.0 = Release|Any CPU
+		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Release|x86.ActiveCfg = Release|Any CPU
+		{F30FE70B-E858-46F1-8BDA-16859680FE56}.Release|x86.Build.0 = Release|Any CPU
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Debug|x64.Build.0 = Debug|Any CPU
+		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Debug|x86.Build.0 = Debug|Any CPU
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Release|x64.ActiveCfg = Release|Any CPU
+		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Release|x64.Build.0 = Release|Any CPU
+		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Release|x86.ActiveCfg = Release|Any CPU
+		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128}.Release|x86.Build.0 = Release|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Debug|x64.Build.0 = Debug|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Release|x64.ActiveCfg = Release|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Release|x64.Build.0 = Release|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D}.Release|x86.Build.0 = Release|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Debug|x64.Build.0 = Debug|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Debug|x86.Build.0 = Debug|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|x64.ActiveCfg = Release|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|x64.Build.0 = Release|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|x86.ActiveCfg = Release|Any CPU
+		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F30FE70B-E858-46F1-8BDA-16859680FE56} = {5412868F-5B63-486D-8EA6-ED8C83418517}
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128} = {5412868F-5B63-486D-8EA6-ED8C83418517}
+		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D} = {5412868F-5B63-486D-8EA6-ED8C83418517}
+		{209097AD-D34D-425B-8F22-0936F26C83D3} = {5412868F-5B63-486D-8EA6-ED8C83418517}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ DAQiFi builds wireless data acquisition hardware designed to get out of the way 
 
 Prefer a ready-made GUI? Check out [DAQiFi Desktop](https://github.com/daqifi/daqifi-desktop), which is built on top of this library.
 
+Want to drive a device from an AI assistant? The repo also ships an **[MCP server](src/Daqifi.Mcp)** — point Claude, Cursor, Codex, or any MCP-aware client at it to discover, configure channels, set the sample rate, and run SD-card logging through plain conversation.
+
 ## See it in 30 seconds
 
 ```shell
@@ -69,6 +71,7 @@ More examples at [daqifi.com](https://daqifi.com).
 | Hardware | Nyquist 1 / Nyquist 3 — wireless DAQ devices (and their on-device firmware) |
 | **SDK** | **DAQiFi Core — this library** |
 | App | [DAQiFi Desktop](https://github.com/daqifi/daqifi-desktop) — GUI built on this SDK |
+| Agent | [MCP server](src/Daqifi.Mcp) — drive a device from Claude / Cursor / any MCP client |
 | Your code | Custom apps, dashboards, pipelines, test rigs |
 
 ## What you can do
@@ -224,6 +227,8 @@ This library follows semantic versioning. Releases are automated via GitHub Acti
 1. Create a new GitHub Release
 2. Tag it `vX.Y.Z` (pre-releases use `-alpha.1`, `-beta.1`, `-rc.1` suffixes)
 3. Publishing to NuGet happens automatically on release
+
+The same release also packs and publishes the **`Daqifi.Mcp`** MCP server as a .NET tool (`dotnet tool install -g Daqifi.Mcp`).
 
 ---
 

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -60,16 +60,20 @@ namespace Daqifi.Core.Device
         /// <remarks>
         /// The public <see cref="Channels"/> property exposes a live view over the backing list;
         /// callers that fold over channels off the consumer thread (e.g. the device-level
-        /// channel-management API) should use this snapshot instead to avoid a concurrent-mutation
-        /// <see cref="InvalidOperationException"/> or a torn read.
+        /// channel-management API, or an out-of-process control surface) should use this snapshot
+        /// instead to avoid a concurrent-mutation <see cref="InvalidOperationException"/> or a torn read.
         /// </remarks>
-        protected IReadOnlyList<IChannel> SnapshotChannels()
+        /// <returns>A lock-protected copy of the current channel collection.</returns>
+        public IReadOnlyList<IChannel> GetChannelsSnapshot()
         {
             lock (_channelsLock)
             {
                 return _channels.ToArray();
             }
         }
+
+        /// <inheritdoc cref="GetChannelsSnapshot"/>
+        protected IReadOnlyList<IChannel> SnapshotChannels() => GetChannelsSnapshot();
 
         /// <summary>
         /// Gets the device's timestamp clock frequency in Hz.

--- a/src/Daqifi.Mcp.Tests/Daqifi.Mcp.Tests.csproj
+++ b/src/Daqifi.Mcp.Tests/Daqifi.Mcp.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Daqifi.Mcp\Daqifi.Mcp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
+++ b/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
@@ -1,0 +1,89 @@
+using Daqifi.Mcp;
+
+namespace Daqifi.Mcp.Tests;
+
+public class ServerOptionsTests
+{
+    [Fact]
+    public void Parse_NoArgs_DefaultsToControlWithNoClamp()
+    {
+        var options = ServerOptions.Parse(Array.Empty<string>());
+        Assert.False(options.ReadOnly);
+        Assert.Null(options.MaxSampleRateHz);
+    }
+
+    [Fact]
+    public void Parse_ReadOnlyFlag_SetsReadOnly()
+    {
+        Assert.True(ServerOptions.Parse(new[] { "--read-only" }).ReadOnly);
+    }
+
+    [Fact]
+    public void Parse_MaxSampleRate_SetsClamp()
+    {
+        Assert.Equal(500, ServerOptions.Parse(new[] { "--max-sample-rate-hz", "500" }).MaxSampleRateHz);
+    }
+
+    [Fact]
+    public void Parse_MaxSampleRate_NonNumeric_IsIgnored()
+    {
+        Assert.Null(ServerOptions.Parse(new[] { "--max-sample-rate-hz", "fast" }).MaxSampleRateHz);
+    }
+}
+
+public class DaqifiAgentTests
+{
+    private static DaqifiAgent NewAgent(bool readOnly = false) =>
+        new(new ServerOptions { ReadOnly = readOnly });
+
+    [Fact]
+    public void ListConnected_StartsEmpty()
+    {
+        Assert.Empty(NewAgent().ListConnected());
+    }
+
+    [Fact]
+    public void GetStatus_UnknownDevice_ThrowsWithActionableMessage()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => NewAgent().GetStatus("serial:NOPE"));
+        Assert.Contains("not connected", ex.Message);
+        Assert.Contains("connect_device", ex.Message);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_UnknownDeviceId_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent().ConnectAsync("never-discovered", CancellationToken.None));
+        Assert.Contains("discover_devices", ex.Message);
+    }
+
+    [Fact]
+    public async Task Disconnect_UnknownDevice_ReturnsMessageRatherThanThrows()
+    {
+        Assert.Contains("was not connected", await NewAgent().DisconnectAsync("serial:NOPE"));
+    }
+
+    [Fact]
+    public async Task SetSampleRate_BelowOne_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => NewAgent().SetSampleRateAsync("x", 0));
+        Assert.Contains(">= 1", ex.Message);
+    }
+
+    [Fact]
+    public async Task SetSampleRate_InReadOnlyMode_IsBlocked()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent(readOnly: true).SetSampleRateAsync("x", 100));
+        Assert.Contains("read-only", ex.Message);
+    }
+
+    [Fact]
+    public async Task ConfigureAnalogChannels_InReadOnlyMode_IsBlocked()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent(readOnly: true).ConfigureAnalogChannelsAsync("x", new[] { 0, 1 }));
+        Assert.Contains("read-only", ex.Message);
+    }
+}

--- a/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
+++ b/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
@@ -29,6 +29,14 @@ public class ServerOptionsTests
     {
         Assert.Null(ServerOptions.Parse(new[] { "--max-sample-rate-hz", "fast" }).MaxSampleRateHz);
     }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-5")]
+    public void Parse_MaxSampleRate_NonPositive_IsIgnored(string value)
+    {
+        Assert.Null(ServerOptions.Parse(new[] { "--max-sample-rate-hz", value }).MaxSampleRateHz);
+    }
 }
 
 public class DaqifiAgentTests

--- a/src/Daqifi.Mcp/Daqifi.Mcp.csproj
+++ b/src/Daqifi.Mcp/Daqifi.Mcp.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Daqifi.Mcp</RootNamespace>
+    <AssemblyName>daqifi-mcp</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <!-- Distribution: `dotnet tool install -g Daqifi.Mcp` exposes the `daqifi-mcp` command. -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>daqifi-mcp</ToolCommandName>
+    <PackageId>Daqifi.Mcp</PackageId>
+    <Authors>DAQiFi</Authors>
+    <Description>Model Context Protocol (MCP) server for DAQiFi Nyquist data-acquisition devices. Lets an AI agent discover, connect, configure channels, and run on-device SD-card logging.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Daqifi.Core\Daqifi.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="ModelContextProtocol" Version="2.0.0-preview.1" />
+  </ItemGroup>
+
+  <!-- ModelContextProtocol + Microsoft.Extensions.Hosting are added via `dotnet add package`
+       so the restored versions are pinned to whatever is current. -->
+
+</Project>

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -1,0 +1,374 @@
+using System.Collections.Concurrent;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Discovery;
+using Daqifi.Core.Device.SdCard;
+
+namespace Daqifi.Mcp;
+
+/// <summary>
+/// Agent-facing facade over <c>Daqifi.Core</c>. Owns device discovery results and the set of
+/// connected devices, and translates the high-level tool surface into the real SDK calls
+/// (static <see cref="DaqifiDeviceFactory"/>, <see cref="IStreamingDevice"/> channel APIs,
+/// <see cref="ISdCardOperations"/>). One instance is shared by all tool calls.
+/// </summary>
+/// <remarks>
+/// The MCP transport may dispatch tool calls concurrently, so every operation that connects,
+/// disconnects, or mutates device state is serialized behind <see cref="_gate"/>. Read-only
+/// introspection snapshots the channel collection instead, so it never blocks and never folds the
+/// live <c>Channels</c> view while the device's consumer thread repopulates it.
+/// </remarks>
+public sealed class DaqifiAgent
+{
+    /// <summary>The maximum sample rate the Nyquist hardware accepts (SCPI range is 1–1000 Hz).</summary>
+    public const int HardwareMaxSampleRateHz = 1000;
+
+    private readonly ServerOptions _options;
+    private readonly ConcurrentDictionary<string, IDeviceInfo> _discovered = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, DaqifiDevice> _connected = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public DaqifiAgent(ServerOptions options) => _options = options;
+
+    // ---------------------------------------------------------------- discovery
+
+    public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverAsync(
+        int timeoutMs, bool wifi, bool serial, CancellationToken cancellationToken)
+    {
+        var timeout = TimeSpan.FromMilliseconds(Math.Clamp(timeoutMs, 250, 30_000));
+        var infos = new List<IDeviceInfo>();
+
+        if (wifi)
+        {
+            using var finder = new WiFiDeviceFinder();
+            infos.AddRange(await finder.DiscoverAsync(timeout).ConfigureAwait(false));
+        }
+
+        if (serial)
+        {
+            using var finder = new SerialDeviceFinder();
+            infos.AddRange(await finder.DiscoverAsync(timeout).ConfigureAwait(false));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var result = new List<DiscoveredDevice>();
+        foreach (var info in infos)
+        {
+            var id = MintId(info);
+            _discovered[id] = info;
+            result.Add(DiscoveredDevice.From(id, info));
+        }
+        return result;
+    }
+
+    // ------------------------------------------------------------- connection
+
+    public async Task<ConnectedDeviceInfo> ConnectAsync(string deviceId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_connected.TryGetValue(deviceId, out var already))
+            {
+                if (already.IsConnected)
+                {
+                    return ConnectedDeviceInfo.From(deviceId, already);
+                }
+
+                // Stale handle (device dropped); discard it and reconnect.
+                _connected.TryRemove(new KeyValuePair<string, DaqifiDevice>(deviceId, already));
+                already.Dispose();
+            }
+
+            if (!_discovered.TryGetValue(deviceId, out var info))
+            {
+                throw new InvalidOperationException(
+                    $"Unknown device_id '{deviceId}'. Call discover_devices first and use a device_id from its result.");
+            }
+
+            var device = await DaqifiDeviceFactory
+                .ConnectFromDeviceInfoAsync(info, options: null, cancellationToken)
+                .ConfigureAwait(false);
+
+            _connected[deviceId] = device;
+            return ConnectedDeviceInfo.From(deviceId, device);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<string> DisconnectAsync(string deviceId)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_connected.TryRemove(deviceId, out var device))
+            {
+                try { device.Disconnect(); } catch { /* best effort */ }
+                device.Dispose();
+                return $"Disconnected '{deviceId}'.";
+            }
+            return $"Device '{deviceId}' was not connected.";
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public IReadOnlyList<ConnectedDeviceInfo> ListConnected() =>
+        _connected.Select(kvp => ConnectedDeviceInfo.From(kvp.Key, kvp.Value)).ToList();
+
+    // ----------------------------------------------------------- introspection
+
+    public DeviceStatus GetStatus(string deviceId) => DeviceStatus.From(deviceId, Require(deviceId));
+
+    public IReadOnlyList<ChannelInfo> ListChannels(string deviceId) =>
+        Snapshot(Require(deviceId)).Select(ChannelInfo.From).ToList();
+
+    // ----------------------------------------------------------- configuration
+
+    /// <summary>
+    /// Enables exactly the requested analog input channels (by channel number) and disables the
+    /// rest. Configuration is applied through <see cref="IStreamingDevice.EnableChannels"/> /
+    /// <see cref="IStreamingDevice.DisableChannel"/>, which recompute the device ADC enable bitmask.
+    /// </summary>
+    public async Task<ConfigureResult> ConfigureAnalogChannelsAsync(string deviceId, int[] enabledChannels)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (device, streaming) = RequireStreaming(deviceId);
+
+            var analog = Snapshot(device).Where(c => c.Type == ChannelType.Analog).ToList();
+            var validNumbers = analog.Select(c => c.ChannelNumber).ToHashSet();
+
+            var wanted = new HashSet<int>(enabledChannels ?? Array.Empty<int>());
+            var unknown = wanted.Where(n => !validNumbers.Contains(n)).OrderBy(n => n).ToList();
+            if (unknown.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Unknown analog channel(s): {string.Join(", ", unknown)}. " +
+                    $"This device has analog channels: {string.Join(", ", validNumbers.OrderBy(n => n))}.");
+            }
+
+            var toEnable = analog.Where(c => wanted.Contains(c.ChannelNumber)).ToList();
+            foreach (var ch in analog.Where(c => !wanted.Contains(c.ChannelNumber) && c.IsEnabled))
+            {
+                streaming.DisableChannel(ch);
+            }
+            if (toEnable.Count > 0)
+            {
+                streaming.EnableChannels(toEnable);
+            }
+
+            return new ConfigureResult(deviceId, EnabledAnalog(device), streaming.StreamingFrequency);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<SampleRateResult> SetSampleRateAsync(string deviceId, int rateHz)
+    {
+        if (rateHz < 1)
+        {
+            throw new InvalidOperationException("rate_hz must be >= 1.");
+        }
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (_, streaming) = RequireStreaming(deviceId);
+
+            // The hardware ceiling (1000 Hz) always applies; --max-sample-rate-hz can only lower it.
+            var cap = _options.MaxSampleRateHz is { } max
+                ? Math.Min(HardwareMaxSampleRateHz, max)
+                : HardwareMaxSampleRateHz;
+
+            var applied = Math.Min(rateHz, cap);
+            streaming.StreamingFrequency = applied;
+
+            var note = applied != rateHz
+                ? $"Requested {rateHz} Hz clamped to {applied} Hz (maximum {cap} Hz)."
+                : null;
+            return new SampleRateResult(deviceId, rateHz, applied, applied != rateHz, note);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    // --------------------------------------------------------- SD card logging
+
+    public async Task<StartLoggingResult> StartLoggingAsync(
+        string deviceId, string? fileName, string format, CancellationToken cancellationToken)
+    {
+        var fmt = ParseFormat(format);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (device, streaming) = RequireStreaming(deviceId);
+            var sd = RequireSdCard(device);
+
+            // Generate the name in this layer so the result reports the real on-card filename.
+            // Core honors a non-empty fileName verbatim; channels use the device's current config.
+            var effectiveName = string.IsNullOrWhiteSpace(fileName)
+                ? $"log_{DateTime.Now:yyyyMMdd_HHmmss}{ExtensionFor(fmt)}"
+                : fileName!;
+
+            await sd.StartSdCardLoggingAsync(effectiveName, channelMask: null, format: fmt, cancellationToken)
+                .ConfigureAwait(false);
+
+            return new StartLoggingResult(
+                deviceId, effectiveName, fmt.ToString(), streaming.StreamingFrequency, EnabledAnalog(device));
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<string> StopLoggingAsync(string deviceId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (device, _) = RequireStreaming(deviceId);
+            var sd = RequireSdCard(device);
+            await sd.StopSdCardLoggingAsync(cancellationToken).ConfigureAwait(false);
+            return $"Stopped SD-card logging on '{deviceId}'.";
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    // ------------------------------------------------------------------ shutdown
+
+    /// <summary>
+    /// Best-effort teardown of every connected device. Called on process shutdown so serial ports
+    /// are released (and an in-progress SD capture is stopped) instead of being left held.
+    /// </summary>
+    public async Task ShutdownAsync()
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            foreach (var device in _connected.Values)
+            {
+                try
+                {
+                    if (device is ISdCardOperations { IsLoggingToSdCard: true } sd)
+                    {
+                        await sd.StopSdCardLoggingAsync().ConfigureAwait(false);
+                    }
+                }
+                catch { /* best effort */ }
+
+                try { device.Disconnect(); } catch { /* best effort */ }
+                device.Dispose();
+            }
+            _connected.Clear();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private DaqifiDevice Require(string deviceId)
+    {
+        if (!_connected.TryGetValue(deviceId, out var device))
+        {
+            throw new InvalidOperationException(
+                $"Device '{deviceId}' is not connected. Call connect_device first.");
+        }
+        if (!device.IsConnected)
+        {
+            // Only evict the exact stale instance we inspected (a concurrent reconnect may have
+            // already replaced it with a live one under the same id).
+            _connected.TryRemove(new KeyValuePair<string, DaqifiDevice>(deviceId, device));
+            throw new InvalidOperationException($"Device '{deviceId}' is no longer connected.");
+        }
+        return device;
+    }
+
+    private (DaqifiDevice device, IStreamingDevice streaming) RequireStreaming(string deviceId)
+    {
+        var device = Require(deviceId);
+        if (device is not IStreamingDevice streaming)
+        {
+            throw new InvalidOperationException(
+                $"Device '{deviceId}' does not support streaming/configuration operations.");
+        }
+        return (device, streaming);
+    }
+
+    private static ISdCardOperations RequireSdCard(DaqifiDevice device)
+    {
+        if (device is not ISdCardOperations sd)
+        {
+            throw new InvalidOperationException("This device does not support SD-card operations.");
+        }
+        return sd;
+    }
+
+    private void RequireControl()
+    {
+        if (_options.ReadOnly)
+        {
+            throw new InvalidOperationException(
+                "Server is running in --read-only mode; configuration and logging are disabled.");
+        }
+    }
+
+    /// <summary>Snapshots the live channel view so callers never fold it while the consumer thread repopulates it.</summary>
+    private static IReadOnlyList<IChannel> Snapshot(DaqifiDevice device) => device.Channels.ToArray();
+
+    private static IReadOnlyList<int> EnabledAnalog(DaqifiDevice device) => Snapshot(device)
+        .Where(c => c.Type == ChannelType.Analog && c.IsEnabled)
+        .Select(c => c.ChannelNumber)
+        .OrderBy(n => n)
+        .ToList();
+
+    private static string ExtensionFor(SdCardLogFormat format) => format switch
+    {
+        SdCardLogFormat.Json => ".json",
+        SdCardLogFormat.Csv => ".csv",
+        _ => ".bin",
+    };
+
+    private static SdCardLogFormat ParseFormat(string? format) => (format ?? string.Empty).Trim().ToLowerInvariant() switch
+    {
+        "" or "protobuf" or "bin" or "binary" => SdCardLogFormat.Protobuf,
+        "json" => SdCardLogFormat.Json,
+        "csv" => SdCardLogFormat.Csv,
+        _ => throw new InvalidOperationException($"Unknown format '{format}'. Use 'protobuf', 'json', or 'csv'."),
+    };
+
+    private static string MintId(IDeviceInfo info)
+    {
+        var key = info.ConnectionType switch
+        {
+            ConnectionType.Serial => info.PortName ?? info.SerialNumber,
+            ConnectionType.WiFi => info.IPAddress?.ToString() ?? info.SerialNumber,
+            _ => info.SerialNumber,
+        };
+        var connection = info.ConnectionType.ToString().ToLowerInvariant();
+        return $"{connection}:{key}";
+    }
+}

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -88,7 +88,7 @@ public sealed class DaqifiAgent
             }
 
             var device = await DaqifiDeviceFactory
-                .ConnectFromDeviceInfoAsync(info, options: null, cancellationToken)
+                .ConnectFromDeviceInfoAsync(info, null, cancellationToken)
                 .ConfigureAwait(false);
 
             _connected[deviceId] = device;
@@ -188,8 +188,9 @@ public sealed class DaqifiAgent
             var (_, streaming) = RequireStreaming(deviceId);
 
             // The hardware ceiling (1000 Hz) always applies; --max-sample-rate-hz can only lower it.
+            // Guard against a non-positive cap so the applied rate is always a valid >= 1 value.
             var cap = _options.MaxSampleRateHz is { } max
-                ? Math.Min(HardwareMaxSampleRateHz, max)
+                ? Math.Clamp(max, 1, HardwareMaxSampleRateHz)
                 : HardwareMaxSampleRateHz;
 
             var applied = Math.Min(rateHz, cap);
@@ -336,8 +337,8 @@ public sealed class DaqifiAgent
         }
     }
 
-    /// <summary>Snapshots the live channel view so callers never fold it while the consumer thread repopulates it.</summary>
-    private static IReadOnlyList<IChannel> Snapshot(DaqifiDevice device) => device.Channels.ToArray();
+    /// <summary>Lock-protected channel snapshot so callers never fold the live view while the consumer thread repopulates it.</summary>
+    private static IReadOnlyList<IChannel> Snapshot(DaqifiDevice device) => device.GetChannelsSnapshot();
 
     private static IReadOnlyList<int> EnabledAnalog(DaqifiDevice device) => Snapshot(device)
         .Where(c => c.Type == ChannelType.Analog && c.IsEnabled)

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -37,7 +37,7 @@ public sealed record ConnectedDeviceInfo(
     {
         var analog = 0;
         var digital = 0;
-        foreach (var ch in device.Channels.ToArray())
+        foreach (var ch in device.GetChannelsSnapshot())
         {
             if (ch.Type == ChannelType.Analog) analog++;
             else if (ch.Type == ChannelType.Digital) digital++;
@@ -61,7 +61,7 @@ public sealed record DeviceStatus(
         var streaming = (device as IStreamingDevice)?.IsStreaming ?? false;
         var rate = (device as IStreamingDevice)?.StreamingFrequency ?? 0;
         var logging = (device as ISdCardOperations)?.IsLoggingToSdCard ?? false;
-        var enabled = device.Channels.ToArray()
+        var enabled = device.GetChannelsSnapshot()
             .Where(c => c.Type == ChannelType.Analog && c.IsEnabled)
             .Select(c => c.ChannelNumber)
             .OrderBy(n => n)

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -1,0 +1,96 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Discovery;
+using Daqifi.Core.Device.SdCard;
+
+namespace Daqifi.Mcp;
+
+/// <summary>A device seen during discovery. <see cref="DeviceId"/> is the handle used by other tools.</summary>
+public sealed record DiscoveredDevice(
+    string DeviceId,
+    string Name,
+    string ConnectionType,
+    string SerialNumber,
+    string FirmwareVersion,
+    string? Address,
+    string DeviceType)
+{
+    public static DiscoveredDevice From(string id, IDeviceInfo info) => new(
+        id,
+        info.Name,
+        info.ConnectionType.ToString(),
+        info.SerialNumber,
+        info.FirmwareVersion,
+        info.ConnectionType == Daqifi.Core.Device.Discovery.ConnectionType.Serial ? info.PortName : info.IPAddress?.ToString(),
+        info.Type.ToString());
+}
+
+/// <summary>Summary of a currently-connected device.</summary>
+public sealed record ConnectedDeviceInfo(
+    string DeviceId,
+    string Name,
+    bool Connected,
+    int AnalogChannelCount,
+    int DigitalChannelCount)
+{
+    public static ConnectedDeviceInfo From(string id, DaqifiDevice device)
+    {
+        var analog = 0;
+        var digital = 0;
+        foreach (var ch in device.Channels.ToArray())
+        {
+            if (ch.Type == ChannelType.Analog) analog++;
+            else if (ch.Type == ChannelType.Digital) digital++;
+        }
+        return new ConnectedDeviceInfo(id, device.Name, device.IsConnected, analog, digital);
+    }
+}
+
+/// <summary>Live status snapshot for a connected device.</summary>
+public sealed record DeviceStatus(
+    string DeviceId,
+    string Name,
+    string ConnectionStatus,
+    bool Streaming,
+    bool LoggingToSdCard,
+    int SampleRateHz,
+    IReadOnlyList<int> EnabledAnalogChannels)
+{
+    public static DeviceStatus From(string id, DaqifiDevice device)
+    {
+        var streaming = (device as IStreamingDevice)?.IsStreaming ?? false;
+        var rate = (device as IStreamingDevice)?.StreamingFrequency ?? 0;
+        var logging = (device as ISdCardOperations)?.IsLoggingToSdCard ?? false;
+        var enabled = device.Channels.ToArray()
+            .Where(c => c.Type == ChannelType.Analog && c.IsEnabled)
+            .Select(c => c.ChannelNumber)
+            .OrderBy(n => n)
+            .ToList();
+        return new DeviceStatus(id, device.Name, device.Status.ToString(), streaming, logging, rate, enabled);
+    }
+}
+
+/// <summary>A single channel on a device.</summary>
+public sealed record ChannelInfo(int ChannelNumber, string Type, string Name, bool Enabled, string Direction)
+{
+    public static ChannelInfo From(IChannel ch) =>
+        new(ch.ChannelNumber, ch.Type.ToString(), ch.Name, ch.IsEnabled, ch.Direction.ToString());
+}
+
+/// <summary>Result of a channel-configuration change.</summary>
+public sealed record ConfigureResult(string DeviceId, IReadOnlyList<int> EnabledAnalogChannels, int SampleRateHz);
+
+/// <summary>
+/// Result of a sample-rate change. <see cref="Clamped"/> is true when <see cref="RequestedRateHz"/>
+/// exceeded the effective ceiling (1000 Hz hardware limit, or a lower <c>--max-sample-rate-hz</c>),
+/// in which case <see cref="Note"/> explains the adjustment.
+/// </summary>
+public sealed record SampleRateResult(string DeviceId, int RequestedRateHz, int AppliedRateHz, bool Clamped, string? Note);
+
+/// <summary>Result of starting SD-card logging.</summary>
+public sealed record StartLoggingResult(
+    string DeviceId,
+    string FileName,
+    string Format,
+    int SampleRateHz,
+    IReadOnlyList<int> EnabledAnalogChannels);

--- a/src/Daqifi.Mcp/Program.cs
+++ b/src/Daqifi.Mcp/Program.cs
@@ -1,0 +1,46 @@
+using Daqifi.Mcp;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+if (args.Contains("--help") || args.Contains("-h"))
+{
+    Console.Error.WriteLine(ServerOptions.HelpText);
+    return;
+}
+
+var options = ServerOptions.Parse(args);
+
+// Do not pass args to the host builder: the command-line config provider would choke on
+// value-less switches like "--read-only". Options are parsed above instead.
+var builder = Host.CreateApplicationBuilder();
+
+// CRITICAL: stdout is reserved for the MCP JSON-RPC stream. Route ALL logging to stderr,
+// otherwise stray log lines corrupt the protocol and the client fails to connect.
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
+builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+builder.Services.AddSingleton(options);
+builder.Services.AddSingleton<DaqifiAgent>();
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+var host = builder.Build();
+
+// Resolve the agent before RunAsync: RunAsync disposes the host (and its service provider) in
+// its own finally, so the agent must be captured while the provider is still alive.
+var agent = host.Services.GetRequiredService<DaqifiAgent>();
+try
+{
+    await host.RunAsync();
+}
+finally
+{
+    // The client closing stdio ends RunAsync; drain connected devices so serial ports are
+    // released (and any in-progress SD capture is stopped) rather than left held until reap.
+    await agent.ShutdownAsync();
+}

--- a/src/Daqifi.Mcp/README.md
+++ b/src/Daqifi.Mcp/README.md
@@ -1,0 +1,88 @@
+# Daqifi.Mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets an AI agent
+(Claude Desktop, Claude Code, Cursor, Codex, …) drive a DAQiFi Nyquist data-acquisition device:
+discover it, connect, configure analog channels and sample rate, and run on-device SD-card logging.
+
+It is a thin layer over [`Daqifi.Core`](../Daqifi.Core) — all device/protocol logic lives there.
+The server speaks MCP over **stdio**, so the client launches it as a subprocess.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `discover_devices` | Find devices on USB/serial and WiFi. Call first; returns `device_id`s. |
+| `connect_device` | Connect to a discovered `device_id`. |
+| `list_connected_devices` | List currently-connected devices. |
+| `disconnect_device` | Disconnect and release a device. |
+| `get_device_status` | Connection state, streaming/logging flags, sample rate, enabled channels. |
+| `list_channels` | All channels with type/enabled/direction. |
+| `configure_analog_channels` | Enable exactly the given analog channels; disable the rest. |
+| `set_sample_rate` | Set sample rate in Hz (Nyquist hardware supports up to 1000 Hz). |
+| `start_sd_logging` | Start on-device SD logging (**requires a USB/serial connection**). |
+| `stop_sd_logging` | Stop SD logging. |
+
+> SD logging is on-device: the device writes to its own SD card. Data does not stream back to the
+> agent in this version (see the streaming-evolution plan).
+
+## Run it
+
+### Option A — install as a .NET global tool (recommended)
+
+```bash
+dotnet tool install -g Daqifi.Mcp     # provides the `daqifi-mcp` command (requires the .NET runtime)
+```
+
+### Option B — from source (development)
+
+```bash
+dotnet run --project src/Daqifi.Mcp
+```
+
+### Flags
+
+```
+--read-only               Expose discovery/introspection only; block configuration and logging.
+--max-sample-rate-hz <n>  Clamp set_sample_rate to at most <n> Hz.
+-h, --help                Show help.
+```
+
+## Point your agent at it
+
+An stdio MCP server is just a command the client launches. Every client config reduces to
+**command + args**.
+
+**Claude Desktop** — `claude_desktop_config.json`:
+```json
+{
+  "mcpServers": {
+    "daqifi": { "command": "daqifi-mcp", "args": [] }
+  }
+}
+```
+
+**Claude Code**:
+```bash
+claude mcp add daqifi -- daqifi-mcp
+```
+
+**Cursor** — `~/.cursor/mcp.json` (same shape as Claude Desktop).
+
+**Codex CLI** — `~/.codex/config.toml`:
+```toml
+[mcp_servers.daqifi]
+command = "daqifi-mcp"
+args = []
+```
+
+During development, point the client at the source build instead:
+`{ "command": "dotnet", "args": ["run", "--project", "/abs/path/to/src/Daqifi.Mcp"] }`.
+
+Then plug in a DAQiFi over USB (or join its WiFi) and ask, e.g.:
+*"Discover my DAQiFi, connect, enable analog channels 0–3 at 1 kHz, and start logging to the SD card."*
+
+## Notes
+
+- **stdout is reserved** for the MCP JSON-RPC stream; all logging goes to **stderr**.
+- The server runs **locally** and talks to the device exactly like `Daqifi.Core` does — nothing
+  is sent to the cloud.

--- a/src/Daqifi.Mcp/ServerOptions.cs
+++ b/src/Daqifi.Mcp/ServerOptions.cs
@@ -1,0 +1,58 @@
+namespace Daqifi.Mcp;
+
+/// <summary>
+/// Launch-time configuration for the MCP server, parsed from CLI flags.
+/// </summary>
+public sealed class ServerOptions
+{
+    /// <summary>
+    /// When true, mutating tools (configure, set sample rate, start/stop logging) are refused.
+    /// Discovery, connection, and read-only introspection remain available.
+    /// </summary>
+    public bool ReadOnly { get; init; }
+
+    /// <summary>
+    /// Optional upper bound applied to <c>set_sample_rate</c>. Null means no clamp.
+    /// </summary>
+    public int? MaxSampleRateHz { get; init; }
+
+    public static ServerOptions Parse(string[] args)
+    {
+        var readOnly = false;
+        int? maxRate = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--read-only":
+                    readOnly = true;
+                    break;
+                case "--max-sample-rate-hz" when i + 1 < args.Length:
+                    if (int.TryParse(args[++i], out var rate))
+                    {
+                        maxRate = rate;
+                    }
+                    break;
+            }
+        }
+
+        return new ServerOptions { ReadOnly = readOnly, MaxSampleRateHz = maxRate };
+    }
+
+    public const string HelpText =
+        """
+        daqifi-mcp — Model Context Protocol server for DAQiFi devices
+
+        Usage:
+          daqifi-mcp [options]
+
+        The server speaks MCP over stdio. Point an MCP-aware client (Claude Desktop,
+        Claude Code, Cursor, Codex, ...) at the `daqifi-mcp` command.
+
+        Options:
+          --read-only               Expose discovery/introspection only; block configuration and logging.
+          --max-sample-rate-hz <n>  Clamp set_sample_rate requests to at most <n> Hz.
+          -h, --help                Show this help and exit.
+        """;
+}

--- a/src/Daqifi.Mcp/ServerOptions.cs
+++ b/src/Daqifi.Mcp/ServerOptions.cs
@@ -29,7 +29,8 @@ public sealed class ServerOptions
                     readOnly = true;
                     break;
                 case "--max-sample-rate-hz" when i + 1 < args.Length:
-                    if (int.TryParse(args[++i], out var rate))
+                    // Ignore non-positive values; a clamp of <= 0 would otherwise force an invalid rate.
+                    if (int.TryParse(args[++i], out var rate) && rate >= 1)
                     {
                         maxRate = rate;
                     }

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -1,0 +1,136 @@
+using System.ComponentModel;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace Daqifi.Mcp.Tools;
+
+/// <summary>
+/// The MCP tool surface for controlling a DAQiFi device. Each tool is a thin wrapper over
+/// <see cref="DaqifiAgent"/>; the agent is supplied by dependency injection and is not part of
+/// the tool's input schema. Validation/runtime failures are surfaced to the agent as
+/// <see cref="McpException"/> so the human-readable message (e.g. "call connect_device first")
+/// reaches the model instead of a generic error.
+/// </summary>
+[McpServerToolType]
+public static class DaqifiTools
+{
+    [McpServerTool(Name = "discover_devices")]
+    [Description("Discover DAQiFi devices on USB/serial and WiFi. Returns a list whose device_id values are used by the other tools. Call this first.")]
+    public static Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevices(
+        DaqifiAgent agent,
+        [Description("Discovery timeout in milliseconds (default 2000; clamped to 250..30000).")] int timeoutMs = 2000,
+        [Description("Include WiFi/network discovery (default true).")] bool wifi = true,
+        [Description("Include USB/serial discovery (default true).")] bool serial = true,
+        CancellationToken cancellationToken = default)
+        => GuardAsync(() => agent.DiscoverAsync(timeoutMs, wifi, serial, cancellationToken));
+
+    [McpServerTool(Name = "connect_device")]
+    [Description("Connect to a previously-discovered device. Pass a device_id from discover_devices. Channels are populated on connect.")]
+    public static Task<ConnectedDeviceInfo> ConnectDevice(
+        DaqifiAgent agent,
+        [Description("The device_id from discover_devices.")] string deviceId,
+        CancellationToken cancellationToken = default)
+        => GuardAsync(() => agent.ConnectAsync(deviceId, cancellationToken));
+
+    [McpServerTool(Name = "disconnect_device")]
+    [Description("Disconnect from a connected device and release it.")]
+    public static Task<string> DisconnectDevice(
+        DaqifiAgent agent,
+        [Description("The device_id to disconnect.")] string deviceId)
+        => GuardAsync(() => agent.DisconnectAsync(deviceId));
+
+    [McpServerTool(Name = "list_connected_devices")]
+    [Description("List the devices currently connected to this server. Cheap; safe to call often.")]
+    public static IReadOnlyList<ConnectedDeviceInfo> ListConnectedDevices(DaqifiAgent agent)
+        => Guard(agent.ListConnected);
+
+    [McpServerTool(Name = "get_device_status")]
+    [Description("Get a live status snapshot for a connected device: connection state, streaming/logging flags, sample rate, and enabled analog channels.")]
+    public static DeviceStatus GetDeviceStatus(
+        DaqifiAgent agent,
+        [Description("The device_id to inspect.")] string deviceId)
+        => Guard(() => agent.GetStatus(deviceId));
+
+    [McpServerTool(Name = "list_channels")]
+    [Description("List all channels on a connected device with their type, enabled state, and direction.")]
+    public static IReadOnlyList<ChannelInfo> ListChannels(
+        DaqifiAgent agent,
+        [Description("The device_id to inspect.")] string deviceId)
+        => Guard(() => agent.ListChannels(deviceId));
+
+    [McpServerTool(Name = "configure_analog_channels")]
+    [Description("Enable exactly the given analog input channels (by channel number) and disable the rest. Pass an empty list to disable all analog channels.")]
+    public static Task<ConfigureResult> ConfigureAnalogChannels(
+        DaqifiAgent agent,
+        [Description("The device_id to configure.")] string deviceId,
+        [Description("Analog channel numbers to enable, e.g. [0,1,2,3]. Channels not listed are disabled.")] int[] enabledChannels)
+        => GuardAsync(() => agent.ConfigureAnalogChannelsAsync(deviceId, enabledChannels));
+
+    [McpServerTool(Name = "set_sample_rate")]
+    [Description("Set the device sample (streaming) rate in Hz, applied to streaming and SD-card logging. Nyquist hardware supports 1–1000 Hz; requests above 1000 Hz (or above --max-sample-rate-hz) are clamped and reported in the result.")]
+    public static Task<SampleRateResult> SetSampleRate(
+        DaqifiAgent agent,
+        [Description("The device_id to configure.")] string deviceId,
+        [Description("Sample rate in Hz (1–1000).")] int rateHz)
+        => GuardAsync(() => agent.SetSampleRateAsync(deviceId, rateHz));
+
+    [McpServerTool(Name = "start_sd_logging")]
+    [Description("Start on-device SD-card logging using the currently enabled channels and sample rate. Requires a USB/serial connection (the SD card and WiFi share a bus). Configure channels and sample rate first.")]
+    public static Task<StartLoggingResult> StartSdLogging(
+        DaqifiAgent agent,
+        [Description("The device_id to log on.")] string deviceId,
+        [Description("Optional log file name. If omitted, the device auto-generates log_<timestamp>.")] string? fileName = null,
+        [Description("Log format: 'protobuf' (default), 'json', or 'csv'.")] string format = "protobuf",
+        CancellationToken cancellationToken = default)
+        => GuardAsync(() => agent.StartLoggingAsync(deviceId, fileName, format, cancellationToken));
+
+    [McpServerTool(Name = "stop_sd_logging")]
+    [Description("Stop on-device SD-card logging on a device.")]
+    public static Task<string> StopSdLogging(
+        DaqifiAgent agent,
+        [Description("The device_id to stop logging on.")] string deviceId,
+        CancellationToken cancellationToken = default)
+        => GuardAsync(() => agent.StopLoggingAsync(deviceId, cancellationToken));
+
+    // Surface real exception messages (validation + Core errors) to the agent rather than a
+    // generic "An error occurred". Cancellation is allowed to propagate untouched.
+    private static T Guard<T>(Func<T> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (McpException)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new McpException(ex.Message);
+        }
+    }
+
+    private static async Task<T> GuardAsync<T>(Func<Task<T>> action)
+    {
+        try
+        {
+            return await action().ConfigureAwait(false);
+        }
+        catch (McpException)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new McpException(ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds **`Daqifi.Mcp`**, a [Model Context Protocol](https://modelcontextprotocol.io) server (stdio) that lets an AI agent — Claude Desktop/Code, Cursor, Codex, etc. — drive a DAQiFi Nyquist device through `Daqifi.Core` with no application code: discover → connect → configure analog channels + sample rate → start/stop on-device SD-card logging.

It's a thin facade over `Daqifi.Core` (in-process, no protocol re-implementation), distributed as a `dotnet tool`. Scope is intentionally the **basic control loop**; live data streaming and SD file list/download are deferred to follow-ups.

## What's in it

- **`src/Daqifi.Mcp`** — the server: a `DaqifiAgent` facade over the real Core surface (`DaqifiDeviceFactory.ConnectFromDeviceInfoAsync`, `IStreamingDevice.EnableChannels`, `ISdCardOperations`), 10 MCP tools, an stdio host with **all logging routed to stderr** (stdout is reserved for JSON-RPC).
- **`src/Daqifi.Mcp.Tests`** — xUnit coverage of option parsing and agent guard rails.
- **`release.yml`** — publishes the `dotnet tool` to NuGet on tagged releases (alongside the existing `Daqifi.Core` push).

### Tools

`discover_devices` · `connect_device` · `list_connected_devices` · `disconnect_device` · `get_device_status` · `list_channels` · `configure_analog_channels` · `set_sample_rate` · `start_sd_logging` · `stop_sd_logging`

### Notable design points

- **Faithful to the real Core API** — channel config goes through `IStreamingDevice.EnableChannels`/`DisableChannel` (+ the ADC bitmask), not the per-channel value interfaces.
- **Concurrency-safe** — connect/disconnect/configure/rate/logging are serialized behind a per-agent gate, since the transport can dispatch tool calls concurrently.
- **Clean lifecycle** — graceful shutdown drains connected devices so serial ports are released (and any in-progress SD capture is stopped) instead of being left held.
- **Honest contracts** — sample rate is clamped to the 1000 Hz hardware ceiling and the result reports the clamp; `start_sd_logging` returns the real on-card filename; errors surface Core's human-readable messages so the agent can self-correct.
- **Safety flags** — `--read-only` (block mutations) and `--max-sample-rate-hz`.

## How to run it

```bash
dotnet tool install -g Daqifi.Mcp     # exposes the `daqifi-mcp` command
```

Claude Desktop (`claude_desktop_config.json`):
```json
{ "mcpServers": { "daqifi": { "command": "daqifi-mcp", "args": [] } } }
```
Cursor (`~/.cursor/mcp.json`) is the same shape; Codex uses `[mcp_servers.daqifi]` in `~/.codex/config.toml`. See [`src/Daqifi.Mcp/README.md`](src/Daqifi.Mcp/README.md).

## Test plan / verification

- ✅ Solution builds in Release, 0 warnings; **11/11** unit tests pass
- ✅ MCP protocol smoke test: `initialize` + `tools/list` return all 10 tools with correct schemas
- ✅ **Live end-to-end on real hardware** (Nyquist1, FW 3.6.2, USB): discover → connect → configure analog `[0,1,2,3]` → set rate → `start_sd_logging` (`loggingToSdCard:true` confirmed) → `stop_sd_logging` → disconnect
- ✅ Sample-rate clamp verified live: `5000 → 1000`, `clamped:true` with an explanatory note
- ✅ `start_sd_logging` returns the real filename (`log_<timestamp>.bin`)
- ✅ **Port-release test**: connect then abruptly close the client (no `disconnect_device`) → a fresh server immediately reconnects (serial port released, not leaked)

## Out of scope (follow-ups)

- `list_sd_files` / `download_sd_file` (so the agent can see/retrieve what it logged)
- Live streaming evolution (host ring buffer + `get_channel_summary`)
- Read-only tool annotations / not registering mutating tools in `--read-only` mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
