### PR TITLE
feat(dio): first-class digital output — correct stream bit mapping, MCP tools, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ immediately, and flipping back to input releases the pin to high-impedance.
 ```csharp
 using Daqifi.Core.Channel;
 
-var dio3 = device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 3);
+var channels = device.GetChannelsSnapshot();
+var dio3 = channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 3);
 
 device.SetDioDirection(dio3, ChannelDirection.Output);
 device.SetDioValue(dio3, true);   // drive high

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ More examples at [daqifi.com](https://daqifi.com).
 | **Auto-discovery** | Find any DAQiFi on WiFi or USB in seconds — no IP hunting, no config files |
 | **One-line connect** | `DaqifiDeviceFactory.ConnectTcpAsync(...)` wraps transport setup and device init; retries are opt-in via `DeviceConnectionOptions` |
 | **Real-time streaming** | Event-driven async API; no polling loops to write |
+| **Digital I/O** | Set any DIO pin as input or output and drive outputs high/low; inputs stream alongside analog data |
 | **SD card operations** | List, download, delete, format, and start/stop SD logging over USB / serial |
 | **Network configuration** | Push WiFi credentials and static LAN IPs from your app |
 | **Firmware updates** | PIC32 and WiFi-module flashing with progress and cancellation |
@@ -158,6 +159,23 @@ cts.CancelAfter(TimeSpan.FromSeconds(10));
 var devices = await wifiFinder.DiscoverAsync(cts.Token);
 
 using var customFinder = new WiFiDeviceFinder(discoveryPort: 12345);
+```
+
+### Digital output
+
+Digital channels default to inputs. Flip one to output and drive it — the level is applied
+immediately, and flipping back to input releases the pin to high-impedance.
+
+```csharp
+using Daqifi.Core.Channel;
+
+var dio3 = device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 3);
+
+device.SetDioDirection(dio3, ChannelDirection.Output);
+device.SetDioValue(dio3, true);   // drive high
+device.SetDioValue(dio3, false);  // drive low
+
+device.SetDioDirection(dio3, ChannelDirection.Input); // back to a streamed input
 ```
 
 ### Network configuration

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
@@ -148,6 +148,46 @@ public class DaqifiStreamingDeviceDecodeTests
     }
 
     [Fact]
+    public void Decode_Digital_MapsBitsByChannelNumberNotEnablePosition()
+    {
+        // The firmware streams the whole DIO port (the wire-level enable is global), so an
+        // enabled channel reads the bit at its channel number. Enable only DIO 5: a decoder
+        // that densely packed enabled channels would wrongly read bit 0.
+        var device = CreateStreamingDevice(analogCount: 0, digitalCount: 8);
+        var dio5 = DigitalChannel(device, 5);
+        dio5.IsEnabled = true;
+        device.StartStreaming();
+
+        var frame = new DaqifiOutMessage { MsgTimeStamp = 5 };
+        frame.DigitalData = ByteString.CopyFrom(new byte[] { 0b0010_0000 }); // only bit 5 high
+
+        device.InvokeStreamMessage(frame);
+
+        Assert.Equal(1.0, dio5.ActiveSample!.Value);
+    }
+
+    [Fact]
+    public void Decode_Digital_SubsetOfChannelsEnabled_EachReadsItsOwnBit()
+    {
+        // Loopback-style scenario: only DIO 3 and DIO 5 enabled, with other port bits set as
+        // noise. Positional decoding would read bits 0 and 1 (both high) for these channels.
+        var device = CreateStreamingDevice(analogCount: 0, digitalCount: 16);
+        var dio3 = DigitalChannel(device, 3);
+        var dio5 = DigitalChannel(device, 5);
+        dio3.IsEnabled = true;
+        dio5.IsEnabled = true;
+        device.StartStreaming();
+
+        var frame = new DaqifiOutMessage { MsgTimeStamp = 5 };
+        frame.DigitalData = ByteString.CopyFrom(new byte[] { 0b0010_0011, 0xFF }); // bit 3 low, bit 5 high
+
+        device.InvokeStreamMessage(frame);
+
+        Assert.Equal(0.0, dio3.ActiveSample!.Value);
+        Assert.Equal(1.0, dio5.ActiveSample!.Value);
+    }
+
+    [Fact]
     public void Decode_Digital_SkipsOutputDirectionChannels()
     {
         var device = CreateStreamingDevice(analogCount: 0, digitalCount: 2);

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -323,12 +323,13 @@ namespace Daqifi.Core.Device
 
         /// <summary>
         /// Unpacks a frame's digital byte(s) into per-channel high/low samples for the enabled
-        /// digital input channels, ordered by channel number. Bit position corresponds to the
-        /// channel's position within the active list (LSB first: position <c>i</c> -> byte
-        /// <c>i / 8</c>, bit <c>i % 8</c>), matching the device's dense packing of enabled channels
-        /// across however many payload bytes are present. Output channels occupy a bit position but
-        /// are not sampled. Decoding stops once the payload runs out of bits rather than wrapping
-        /// or forcing later channels low.
+        /// digital input channels. The firmware streams the whole DIO port as a raw pin-state
+        /// snapshot (the wire-level DIO enable is global, not per pin), so a channel's bit
+        /// position is its channel number — bit <c>n</c> lives at byte <c>n / 8</c>, bit
+        /// <c>n % 8</c> (LSB first) — independent of which channels the client has enabled.
+        /// Output-direction channels are not sampled (their state is client-driven via
+        /// <see cref="SetDioValue"/>). Channels whose number lies beyond the payload get no
+        /// sample rather than a bogus "low" reading.
         /// </summary>
         private static void DecodeDigital(
             DaqifiOutMessage message,
@@ -339,28 +340,26 @@ namespace Daqifi.Core.Device
             var digitalData = message.DigitalData;
             var bitCount = digitalData.Length * 8;
 
-            var activeDigital = new List<IChannel>();
             foreach (var channel in channels)
             {
-                if (channel.IsEnabled && channel.Type == ChannelType.Digital)
+                if (!channel.IsEnabled || channel.Type != ChannelType.Digital)
                 {
-                    activeDigital.Add(channel);
+                    continue;
                 }
-            }
-            activeDigital.Sort((a, b) => a.ChannelNumber.CompareTo(b.ChannelNumber));
 
-            for (var i = 0; i < activeDigital.Count && i < bitCount; i++)
-            {
-                var channel = activeDigital[i];
-
-                // Only input-direction channels carry a meaningful streamed reading; an output
-                // channel still occupies its bit position (so i advances), but is not sampled.
+                // Only input-direction channels carry a meaningful streamed reading.
                 if (channel.Direction != ChannelDirection.Input)
                 {
                     continue;
                 }
 
-                var bit = (digitalData[i / 8] & (1 << (i % 8))) != 0;
+                var bitIndex = channel.ChannelNumber;
+                if (bitIndex >= bitCount)
+                {
+                    continue;
+                }
+
+                var bit = (digitalData[bitIndex / 8] & (1 << (bitIndex % 8))) != 0;
 
                 channel.SetActiveSample(
                     new DataSample(hostTimestamp, bit ? 1.0 : 0.0, bit ? 1 : 0, deviceTimestamp));

--- a/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
+++ b/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
@@ -94,4 +94,48 @@ public class DaqifiAgentTests
             () => NewAgent(readOnly: true).ConfigureAnalogChannelsAsync("x", new[] { 0, 1 }));
         Assert.Contains("read-only", ex.Message);
     }
+
+    [Fact]
+    public async Task ConfigureDigitalChannels_InReadOnlyMode_IsBlocked()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent(readOnly: true).ConfigureDigitalChannelsAsync("x", new[] { 0, 1 }));
+        Assert.Contains("read-only", ex.Message);
+    }
+
+    [Fact]
+    public async Task SetDigitalDirection_InvalidDirection_ThrowsBeforeDeviceLookup()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent().SetDigitalDirectionAsync("x", 0, "sideways"));
+        Assert.Contains("'input' or 'output'", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("input")]
+    [InlineData("OUTPUT")]
+    [InlineData(" out ")]
+    public async Task SetDigitalDirection_ValidDirection_FailsOnUnknownDeviceNotParsing(string direction)
+    {
+        // Direction strings parse (case/whitespace-insensitive), so the failure is the missing device.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent().SetDigitalDirectionAsync("serial:NOPE", 0, direction));
+        Assert.Contains("not connected", ex.Message);
+    }
+
+    [Fact]
+    public async Task SetDigitalOutput_InReadOnlyMode_IsBlocked()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent(readOnly: true).SetDigitalOutputAsync("x", 0, high: true));
+        Assert.Contains("read-only", ex.Message);
+    }
+
+    [Fact]
+    public async Task SetDigitalOutput_UnknownDevice_ThrowsWithActionableMessage()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent().SetDigitalOutputAsync("serial:NOPE", 3, high: true));
+        Assert.Contains("connect_device", ex.Message);
+    }
 }

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -174,6 +174,102 @@ public sealed class DaqifiAgent
         }
     }
 
+    /// <summary>
+    /// Enables exactly the requested digital channels (by channel number) and disables the rest.
+    /// The wire-level DIO enable is global — enabling any digital channel turns the whole port
+    /// on — but per-channel enablement determines which channels the streaming decode samples.
+    /// </summary>
+    public async Task<ConfigureDigitalResult> ConfigureDigitalChannelsAsync(string deviceId, int[] enabledChannels)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (device, streaming) = RequireStreaming(deviceId);
+
+            var digital = Snapshot(device).Where(c => c.Type == ChannelType.Digital).ToList();
+            var validNumbers = digital.Select(c => c.ChannelNumber).ToHashSet();
+
+            var wanted = new HashSet<int>(enabledChannels ?? Array.Empty<int>());
+            var unknown = wanted.Where(n => !validNumbers.Contains(n)).OrderBy(n => n).ToList();
+            if (unknown.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Unknown digital channel(s): {string.Join(", ", unknown)}. " +
+                    $"This device has digital channels: {string.Join(", ", validNumbers.OrderBy(n => n))}.");
+            }
+
+            var toEnable = digital.Where(c => wanted.Contains(c.ChannelNumber)).ToList();
+            foreach (var ch in digital.Where(c => !wanted.Contains(c.ChannelNumber) && c.IsEnabled))
+            {
+                streaming.DisableChannel(ch);
+            }
+            if (toEnable.Count > 0)
+            {
+                streaming.EnableChannels(toEnable);
+            }
+
+            return new ConfigureDigitalResult(deviceId, EnabledDigital(device));
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Sets a digital channel's direction (input or output) via
+    /// <see cref="IStreamingDevice.SetDioDirection"/>.
+    /// </summary>
+    public async Task<DigitalPinResult> SetDigitalDirectionAsync(string deviceId, int channel, string direction)
+    {
+        var parsed = ParseDirection(direction);
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (device, streaming) = RequireStreaming(deviceId);
+            var ch = RequireDigitalChannel(device, channel);
+
+            streaming.SetDioDirection(ch, parsed);
+
+            return DigitalPinResult.From(deviceId, ch);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Drives a digital output channel high or low. A channel still in input direction is
+    /// switched to output first, so a single call is enough to drive a pin.
+    /// </summary>
+    public async Task<DigitalPinResult> SetDigitalOutputAsync(string deviceId, int channel, bool high)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (device, streaming) = RequireStreaming(deviceId);
+            var ch = RequireDigitalChannel(device, channel);
+
+            if (ch.Direction != ChannelDirection.Output)
+            {
+                streaming.SetDioDirection(ch, ChannelDirection.Output);
+            }
+
+            streaming.SetDioValue(ch, high);
+
+            return DigitalPinResult.From(deviceId, ch);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task<SampleRateResult> SetSampleRateAsync(string deviceId, int rateHz)
     {
         if (rateHz < 1)
@@ -345,6 +441,32 @@ public sealed class DaqifiAgent
         .Select(c => c.ChannelNumber)
         .OrderBy(n => n)
         .ToList();
+
+    private static IReadOnlyList<int> EnabledDigital(DaqifiDevice device) => Snapshot(device)
+        .Where(c => c.Type == ChannelType.Digital && c.IsEnabled)
+        .Select(c => c.ChannelNumber)
+        .OrderBy(n => n)
+        .ToList();
+
+    private static IChannel RequireDigitalChannel(DaqifiDevice device, int channelNumber)
+    {
+        var digital = Snapshot(device).Where(c => c.Type == ChannelType.Digital).ToList();
+        var match = digital.FirstOrDefault(c => c.ChannelNumber == channelNumber);
+        if (match is null)
+        {
+            throw new InvalidOperationException(
+                $"Unknown digital channel {channelNumber}. This device has digital channels: " +
+                $"{string.Join(", ", digital.Select(c => c.ChannelNumber).OrderBy(n => n))}.");
+        }
+        return match;
+    }
+
+    private static ChannelDirection ParseDirection(string? direction) => (direction ?? string.Empty).Trim().ToLowerInvariant() switch
+    {
+        "input" or "in" => ChannelDirection.Input,
+        "output" or "out" => ChannelDirection.Output,
+        _ => throw new InvalidOperationException($"Unknown direction '{direction}'. Use 'input' or 'output'."),
+    };
 
     private static string ExtensionFor(SdCardLogFormat format) => format switch
     {

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -54,31 +54,65 @@ public sealed record DeviceStatus(
     bool Streaming,
     bool LoggingToSdCard,
     int SampleRateHz,
-    IReadOnlyList<int> EnabledAnalogChannels)
+    IReadOnlyList<int> EnabledAnalogChannels,
+    IReadOnlyList<int> EnabledDigitalChannels)
 {
     public static DeviceStatus From(string id, DaqifiDevice device)
     {
         var streaming = (device as IStreamingDevice)?.IsStreaming ?? false;
         var rate = (device as IStreamingDevice)?.StreamingFrequency ?? 0;
         var logging = (device as ISdCardOperations)?.IsLoggingToSdCard ?? false;
-        var enabled = device.GetChannelsSnapshot()
+        var channels = device.GetChannelsSnapshot();
+        var enabledAnalog = channels
             .Where(c => c.Type == ChannelType.Analog && c.IsEnabled)
             .Select(c => c.ChannelNumber)
             .OrderBy(n => n)
             .ToList();
-        return new DeviceStatus(id, device.Name, device.Status.ToString(), streaming, logging, rate, enabled);
+        var enabledDigital = channels
+            .Where(c => c.Type == ChannelType.Digital && c.IsEnabled)
+            .Select(c => c.ChannelNumber)
+            .OrderBy(n => n)
+            .ToList();
+        return new DeviceStatus(
+            id, device.Name, device.Status.ToString(), streaming, logging, rate, enabledAnalog, enabledDigital);
     }
 }
 
-/// <summary>A single channel on a device.</summary>
-public sealed record ChannelInfo(int ChannelNumber, string Type, string Name, bool Enabled, string Direction)
+/// <summary>
+/// A single channel on a device. <see cref="OutputValue"/> is the last commanded output level
+/// for digital channels (null for analog channels).
+/// </summary>
+public sealed record ChannelInfo(int ChannelNumber, string Type, string Name, bool Enabled, string Direction, bool? OutputValue)
 {
     public static ChannelInfo From(IChannel ch) =>
-        new(ch.ChannelNumber, ch.Type.ToString(), ch.Name, ch.IsEnabled, ch.Direction.ToString());
+        new(
+            ch.ChannelNumber,
+            ch.Type.ToString(),
+            ch.Name,
+            ch.IsEnabled,
+            ch.Direction.ToString(),
+            ch is IDigitalChannel digital ? digital.OutputValue : null);
 }
 
 /// <summary>Result of a channel-configuration change.</summary>
 public sealed record ConfigureResult(string DeviceId, IReadOnlyList<int> EnabledAnalogChannels, int SampleRateHz);
+
+/// <summary>Result of a digital channel-configuration change.</summary>
+public sealed record ConfigureDigitalResult(string DeviceId, IReadOnlyList<int> EnabledDigitalChannels);
+
+/// <summary>
+/// Result of a digital direction or output change, reflecting the channel's state after the
+/// operation. <see cref="OutputValue"/> is the last commanded output level; it is meaningful
+/// only while <see cref="Direction"/> is Output.
+/// </summary>
+public sealed record DigitalPinResult(string DeviceId, int Channel, string Direction, bool OutputValue)
+{
+    public static DigitalPinResult From(string deviceId, IChannel ch) => new(
+        deviceId,
+        ch.ChannelNumber,
+        ch.Direction.ToString(),
+        ch is IDigitalChannel digital && digital.OutputValue);
+}
 
 /// <summary>
 /// Result of a sample-rate change. <see cref="Clamped"/> is true when <see cref="RequestedRateHz"/>

--- a/src/Daqifi.Mcp/README.md
+++ b/src/Daqifi.Mcp/README.md
@@ -18,6 +18,9 @@ The server speaks MCP over **stdio**, so the client launches it as a subprocess.
 | `get_device_status` | Connection state, streaming/logging flags, sample rate, enabled channels. |
 | `list_channels` | All channels with type/enabled/direction. |
 | `configure_analog_channels` | Enable exactly the given analog channels; disable the rest. |
+| `configure_digital_channels` | Enable exactly the given digital channels; disable the rest. |
+| `set_digital_direction` | Set a digital channel to `input` or `output`. |
+| `set_digital_output` | Drive a digital channel high or low (switches it to output if needed). |
 | `set_sample_rate` | Set sample rate in Hz (Nyquist hardware supports up to 1000 Hz). |
 | `start_sd_logging` | Start on-device SD logging (**requires a USB/serial connection**). |
 | `stop_sd_logging` | Stop SD logging. |

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -66,6 +66,32 @@ public static class DaqifiTools
         [Description("Analog channel numbers to enable, e.g. [0,1,2,3]. Channels not listed are disabled.")] int[] enabledChannels)
         => GuardAsync(() => agent.ConfigureAnalogChannelsAsync(deviceId, enabledChannels));
 
+    [McpServerTool(Name = "configure_digital_channels")]
+    [Description("Enable exactly the given digital channels (by channel number) and disable the rest. Enabled digital channels are sampled during streaming; the device's DIO enable is global, so enabling any digital channel powers the whole port. Pass an empty list to disable all digital channels.")]
+    public static Task<ConfigureDigitalResult> ConfigureDigitalChannels(
+        DaqifiAgent agent,
+        [Description("The device_id to configure.")] string deviceId,
+        [Description("Digital channel numbers to enable, e.g. [0,1,2]. Channels not listed are disabled.")] int[] enabledChannels)
+        => GuardAsync(() => agent.ConfigureDigitalChannelsAsync(deviceId, enabledChannels));
+
+    [McpServerTool(Name = "set_digital_direction")]
+    [Description("Set a digital channel's direction: 'input' (high-impedance, sampled during streaming) or 'output' (driven by the device; set the level with set_digital_output).")]
+    public static Task<DigitalPinResult> SetDigitalDirection(
+        DaqifiAgent agent,
+        [Description("The device_id to configure.")] string deviceId,
+        [Description("The digital channel number (e.g. 0-15 on Nyquist).")] int channel,
+        [Description("'input' or 'output'.")] string direction)
+        => GuardAsync(() => agent.SetDigitalDirectionAsync(deviceId, channel, direction));
+
+    [McpServerTool(Name = "set_digital_output")]
+    [Description("Drive a digital channel high or low. If the channel is currently an input it is switched to output direction first, so one call is enough to drive a pin.")]
+    public static Task<DigitalPinResult> SetDigitalOutput(
+        DaqifiAgent agent,
+        [Description("The device_id to control.")] string deviceId,
+        [Description("The digital channel number (e.g. 0-15 on Nyquist).")] int channel,
+        [Description("true to drive the pin high, false to drive it low.")] bool high)
+        => GuardAsync(() => agent.SetDigitalOutputAsync(deviceId, channel, high));
+
     [McpServerTool(Name = "set_sample_rate")]
     [Description("Set the device sample (streaming) rate in Hz, applied to streaming and SD-card logging. Nyquist hardware supports 1–1000 Hz; requests above 1000 Hz (or above --max-sample-rate-hz) are clamped and reported in the result.")]
     public static Task<SampleRateResult> SetSampleRate(


### PR DESCRIPTION
## Summary

Digital output (`SetDioDirection` / `SetDioValue`) existed in Core but was effectively invisible: undocumented, unexposed over MCP, and never verified against hardware. This PR makes digital out a first-class, hardware-validated capability.

### Stream decode fix (the load-bearing change)

`DecodeDigital` mapped stream bits by the channel's **position within the enabled-channel list** (dense packing, inherited from the desktop reference implementation). The firmware actually streams the whole DIO port as a raw pin-state snapshot — **bit N is pin N**, regardless of which channels the client enabled, because the wire-level DIO enable (`DIO:PORt:ENAble`) is global, not per pin (`DIO_StreamingTrigger` reads with mask `0xFFFF` and `digital_data` is a raw memcpy of the port value; see `NanoPB_Encoder.c` / `DIO.c` in daqifi-nyquist-firmware).

With a subset of digital channels enabled, the old decode read the wrong bits — e.g. enabling only DIO 4 read pin 0's state. Decode now indexes by channel number. Channels beyond the payload get no sample (unchanged), and output-direction channels remain unsampled (unchanged, matches desktop semantics).

### MCP server

- `configure_digital_channels` — enable exactly the given digital channels (mirrors `configure_analog_channels`)
- `set_digital_direction` — `input` / `output`
- `set_digital_output` — drive high/low; auto-switches an input channel to output so one call drives a pin
- `list_channels` now reports `OutputValue` for digital channels; `get_device_status` reports `EnabledDigitalChannels`

### Docs

README capability row + digital-output recipe; MCP README tool table.

## Hardware validation (Nyquist 1, USB serial)

Bench rig: +5 V into DIO pin 0, loopbacks pin 2→4 and pin 13→15. Two phases, 16/16 checks passed:

- **Raw SCPI** (exact command strings Core produces): direction set/readback (confirmed `1` = output on the wire), state set/query through both loopbacks, both levels.
- **Core end-to-end**: `SetDioDirection`/`SetDioValue` through `DaqifiDeviceFactory.ConnectSerialAsync`, streaming at 10 Hz with a strict **subset** of digital channels enabled ({0, 4, 15}) — each channel tracked its own pin (the old positional decode fails this exact scenario), through four drive combinations on two loopbacks.

Also observed while bench-testing (documented here for future reference, not addressed in this PR):

- The bench unit's firmware does not reliably start a stream when **zero analog channels** are enabled (DIO-only streaming). Streaming digital inputs alongside at least one analog channel works dependably. Likely a firmware-side issue; worth a daqifi-nyquist-firmware issue if reproducible on current firmware.
- The Nyquist 1 board terminal labels don't map 1:1 to firmware pin indices on this unit (first bank labeled "DIO 1..8" → firmware pins 0..7; the 13↔15-labeled terminals mapped to firmware pins 13/15). UI layers should surface firmware pin indices consistently.

## Tests

- 2 new decode tests that specifically discriminate channel-number mapping from positional mapping (subset enables with noise bits); all 15 decode tests pass.
- 5 new MCP agent tests (read-only blocking, direction parsing, unknown-device errors).
- Full suite: 1301 Core + 20 MCP tests green on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)