### PR TITLE
feat(pwm): PWM output support — device API, capability gating, MCP tools, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ More examples at [daqifi.com](https://daqifi.com).
 | **One-line connect** | `DaqifiDeviceFactory.ConnectTcpAsync(...)` wraps transport setup and device init; retries are opt-in via `DeviceConnectionOptions` |
 | **Real-time streaming** | Event-driven async API; no polling loops to write |
 | **Digital I/O** | Set any DIO pin as input or output and drive outputs high/low; inputs stream alongside analog data |
+| **PWM outputs** | Drive PWM on capable DIO pins with per-channel duty cycle and a shared, device-wide frequency |
 | **SD card operations** | List, download, delete, format, and start/stop SD logging over USB / serial |
 | **Network configuration** | Push WiFi credentials and static LAN IPs from your app |
 | **Firmware updates** | PIC32 and WiFi-module flashing with progress and cancellation |
@@ -177,6 +178,28 @@ device.SetDioValue(dio3, true);   // drive high
 device.SetDioValue(dio3, false);  // drive low
 
 device.SetDioDirection(dio3, ChannelDirection.Input); // back to a streamed input
+```
+
+### PWM output
+
+PWM runs on capable DIO pins (`IDigitalChannel.IsPwmCapable` — channels 0, 3, 4, 5, 6 and 7 on
+Nyquist hardware). Duty cycle is per channel; the frequency is shared by all PWM channels, since
+one hardware timer drives them all.
+
+```csharp
+using Daqifi.Core.Channel;
+
+var pwm = device.GetChannelsSnapshot()
+    .OfType<IDigitalChannel>()
+    .First(c => c.IsPwmCapable);
+
+device.SetPwmDutyCycle(pwm, 25);  // 1-100 percent
+device.SetPwmFrequency(1000);     // 6-50000 Hz, applies to every PWM channel
+device.SetPwmEnabled(pwm, true);  // start
+
+device.SetPwmDutyCycle(pwm, 75);  // duty changes take effect live
+
+device.SetPwmEnabled(pwm, false); // stop — the pin is left high-impedance
 ```
 
 ### Network configuration

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -305,6 +305,13 @@ var dio1 = device.Channels.First(c => c.Type == ChannelType.Digital && c.Channel
 device.SetDioDirection(dio1, ChannelDirection.Output);
 device.SetDioValue(dio1, true); // drive high
 
+// PWM on a capable channel (IDigitalChannel.IsPwmCapable). Duty is per channel; the
+// frequency is device-wide because one hardware timer drives every PWM channel.
+var pwm = device.Channels.OfType<IDigitalChannel>().First(c => c.IsPwmCapable);
+device.SetPwmDutyCycle(pwm, 25);  // 1-100 %
+device.SetPwmFrequency(1000);     // 6-50000 Hz, shared by all PWM channels
+device.SetPwmEnabled(pwm, true);  // start; SetPwmEnabled(pwm, false) stops (pin goes high-impedance)
+
 // Analog output (NQ3 only) — addressed by channel number; staged value is applied immediately.
 device.SetAnalogOutput(0, 2.5); // DAC channel 0 to 2.5 V
 

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -182,6 +182,42 @@ public class ScpiMessageProducerTests
         AssertMessageFormat(message);
     }
 
+    [Theory]
+    [InlineData(true, "PWM:CHannel:ENable 4,1")]
+    [InlineData(false, "PWM:CHannel:ENable 4,0")]
+    public void SetPwmChannelEnabled_ReturnsCorrectCommand(bool enabled, string expected)
+    {
+        var message = ScpiMessageProducer.SetPwmChannelEnabled(4, enabled);
+        Assert.Equal(expected, message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetPwmChannelFrequency_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetPwmChannelFrequency(0, 1000);
+        Assert.Equal("PWM:CHannel:FREQuency 0,1000", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetPwmChannelDutyCycle_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetPwmChannelDutyCycle(4, 50);
+        Assert.Equal("PWM:CHannel:DUTY 4,50", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void PwmProducers_RejectInvalidArguments()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetPwmChannelEnabled(-1, true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetPwmChannelFrequency(0, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetPwmChannelFrequency(-1, 100));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetPwmChannelDutyCycle(4, 101));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetPwmChannelDutyCycle(-1, 50));
+    }
+
     [Fact]
     public void SetNetworkWifiModeSelfHosted_ReturnsCorrectCommand()
     {

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
@@ -389,6 +389,187 @@ namespace Daqifi.Core.Tests.Device
 
         #endregion
 
+        #region PWM
+
+        // The device populates IsPwmCapable from the firmware board mask 0x00F9: channels
+        // 0, 3, 4, 5, 6, 7 are capable; 1, 2 and 8+ are not. Use 8 digital channels so both
+        // capable and non-capable channels exist.
+
+        [Fact]
+        public void PopulateChannels_SetsPwmCapabilityFromBoardMask()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 16);
+
+            var capable = device.Channels
+                .OfType<IDigitalChannel>()
+                .Where(c => c.IsPwmCapable)
+                .Select(c => c.ChannelNumber)
+                .OrderBy(n => n)
+                .ToList();
+
+            Assert.Equal(new[] { 0, 3, 4, 5, 6, 7 }, capable);
+        }
+
+        [Fact]
+        public void SetPwmDutyCycle_OnCapableChannel_SetsBookkeepingAndSendsCommand()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = (IDigitalChannel)DigitalChannelAt(device, 4);
+
+            device.SetPwmDutyCycle(channel, 50);
+
+            Assert.Equal(50, channel.PwmDutyCyclePercent);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.SetPwmChannelDutyCycle(4, 50).Data, sent.Data);
+        }
+
+        [Theory]
+        [InlineData(0)] // duty 0 is a firmware trap: stored but never applied; disable is the off switch
+        [InlineData(101)]
+        public void SetPwmDutyCycle_OutOfRange_ThrowsArgumentOutOfRangeException(int duty)
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = DigitalChannelAt(device, 4);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetPwmDutyCycle(channel, duty));
+        }
+
+        [Fact]
+        public void SetPwmDutyCycle_OnNonCapableChannel_ThrowsWithCapableList()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = DigitalChannelAt(device, 2);
+
+            var ex = Assert.Throws<ArgumentException>(() => device.SetPwmDutyCycle(channel, 50));
+            Assert.Contains("0, 3, 4, 5, 6, 7", ex.Message);
+        }
+
+        [Fact]
+        public void SetPwmEnabled_True_SetsFlagAndSendsCommand()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = (IDigitalChannel)DigitalChannelAt(device, 4);
+
+            device.SetPwmEnabled(channel, true);
+
+            Assert.True(channel.IsPwmEnabled);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.SetPwmChannelEnabled(4, true).Data, sent.Data);
+        }
+
+        [Fact]
+        public void SetPwmEnabled_True_OnNonCapableChannel_Throws()
+        {
+            // The firmware marks a channel PWM-active before its capability check fails and never
+            // rolls it back (bricking digital writes on the channel), so the client hard-blocks this.
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = DigitalChannelAt(device, 2);
+
+            var ex = Assert.Throws<ArgumentException>(() => device.SetPwmEnabled(channel, true));
+            Assert.Contains("0, 3, 4, 5, 6, 7", ex.Message);
+            Assert.Empty(device.SentMessages);
+        }
+
+        [Fact]
+        public void SetPwmEnabled_False_OnNonCapableChannel_IsAllowedAsRecovery()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = DigitalChannelAt(device, 2);
+
+            device.SetPwmEnabled(channel, false);
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.SetPwmChannelEnabled(2, false).Data, sent.Data);
+        }
+
+        [Fact]
+        public void SetPwmEnabled_False_ClearsOutputValueBookkeeping()
+        {
+            // Firmware zeroes the stored output value when PWM is disabled; local state mirrors it.
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = (IDigitalChannel)DigitalChannelAt(device, 4);
+            channel.OutputValue = true;
+            channel.IsPwmEnabled = true;
+
+            device.SetPwmEnabled(channel, false);
+
+            Assert.False(channel.IsPwmEnabled);
+            Assert.False(channel.OutputValue);
+        }
+
+        [Fact]
+        public void SetPwmEnabled_OnAnalogChannel_ThrowsArgumentException()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = AnalogChannelAt(device, 0);
+
+            Assert.Throws<ArgumentException>(() => device.SetPwmEnabled(channel, true));
+        }
+
+        [Fact]
+        public void SetPwmEnabled_WithForeignDigitalChannel_ThrowsArgumentException()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var foreign = new DigitalChannel(4, isPwmCapable: true);
+
+            Assert.Throws<ArgumentException>(() => device.SetPwmEnabled(foreign, true));
+        }
+
+        [Fact]
+        public void SetPwmFrequency_SendsCommandAddressedToChannelZeroAndTracksValue()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+
+            device.SetPwmFrequency(1000);
+
+            Assert.Equal(1000, device.PwmFrequencyHz);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.SetPwmChannelFrequency(0, 1000).Data, sent.Data);
+        }
+
+        [Theory]
+        [InlineData(5)]     // 1-5 Hz silently wrap the firmware's 16-bit period register
+        [InlineData(50001)] // above the advertised cap
+        public void SetPwmFrequency_OutOfRange_ThrowsArgumentOutOfRangeException(int frequency)
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetPwmFrequency(frequency));
+        }
+
+        [Fact]
+        public void SetPwmEnabled_WhenDisconnected_ThrowsInvalidOperationException()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = DigitalChannelAt(device, 4);
+            device.Disconnect();
+
+            Assert.Throws<InvalidOperationException>(() => device.SetPwmEnabled(channel, true));
+        }
+
+        [Fact]
+        public void PopulateChannelsFromStatus_PreservesPwmBookkeepingAcrossRefresh()
+        {
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = (IDigitalChannel)DigitalChannelAt(device, 4);
+            device.SetPwmDutyCycle(channel, 42);
+            device.SetPwmEnabled(channel, true);
+
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 4,
+                AnalogInRes = 65535,
+                DigitalPortNum = 8
+            });
+
+            var refreshed = (IDigitalChannel)DigitalChannelAt(device, 4);
+            Assert.NotSame(channel, refreshed);
+            Assert.True(refreshed.IsPwmEnabled);
+            Assert.Equal(42, refreshed.PwmDutyCyclePercent);
+        }
+
+        #endregion
+
         #region SetAnalogOutput
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1838,6 +1838,10 @@ public class FirmwareUpdateServiceTests
         public void DisableAllChannels() { }
         public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
         public void SetDioValue(IChannel channel, bool value) { }
+        public void SetPwmEnabled(IChannel channel, bool enabled) { }
+        public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent) { }
+        public void SetPwmFrequency(int frequencyHz) { }
+        public int PwmFrequencyHz => 0;
         public void SetAnalogOutput(int channelNumber, double voltage) { }
         public void Reboot() => IsConnected = false;
         public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
@@ -2013,6 +2017,10 @@ public class FirmwareUpdateServiceTests
         public void DisableAllChannels() { }
         public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
         public void SetDioValue(IChannel channel, bool value) { }
+        public void SetPwmEnabled(IChannel channel, bool enabled) { }
+        public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent) { }
+        public void SetPwmFrequency(int frequencyHz) { }
+        public int PwmFrequencyHz => 0;
         public void SetAnalogOutput(int channelNumber, double voltage) { }
         public void Reboot() => Disconnect();
     }
@@ -2079,6 +2087,10 @@ public class FirmwareUpdateServiceTests
         public void DisableAllChannels() { }
         public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
         public void SetDioValue(IChannel channel, bool value) { }
+        public void SetPwmEnabled(IChannel channel, bool enabled) { }
+        public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent) { }
+        public void SetPwmFrequency(int frequencyHz) { }
+        public int PwmFrequencyHz => 0;
         public void SetAnalogOutput(int channelNumber, double voltage) { }
         public void Reboot() => Disconnect();
 

--- a/src/Daqifi.Core/Channel/DigitalChannel.cs
+++ b/src/Daqifi.Core/Channel/DigitalChannel.cs
@@ -11,6 +11,8 @@ public class DigitalChannel : IDigitalChannel
     private bool _isEnabled;
     private ChannelDirection _direction;
     private bool _outputValue;
+    private bool _isPwmEnabled;
+    private int _pwmDutyCyclePercent;
 
     /// <summary>
     /// Gets the channel number/index.
@@ -95,6 +97,31 @@ public class DigitalChannel : IDigitalChannel
     }
 
     /// <summary>
+    /// Gets whether this channel's hardware supports PWM output.
+    /// </summary>
+    public bool IsPwmCapable { get; }
+
+    /// <summary>
+    /// Gets or sets whether PWM output is enabled on this channel (local bookkeeping mirroring
+    /// the last commanded state).
+    /// </summary>
+    public bool IsPwmEnabled
+    {
+        get { lock (_lock) { return _isPwmEnabled; } }
+        set { lock (_lock) { _isPwmEnabled = value; } }
+    }
+
+    /// <summary>
+    /// Gets or sets the last commanded PWM duty cycle in whole percent (0-100). Local
+    /// bookkeeping mirroring the last commanded state.
+    /// </summary>
+    public int PwmDutyCyclePercent
+    {
+        get { lock (_lock) { return _pwmDutyCyclePercent; } }
+        set { lock (_lock) { _pwmDutyCyclePercent = value; } }
+    }
+
+    /// <summary>
     /// Event raised when a new sample is received on this channel.
     /// </summary>
     public event EventHandler<SampleReceivedEventArgs>? SampleReceived;
@@ -103,16 +130,20 @@ public class DigitalChannel : IDigitalChannel
     /// Initializes a new instance of the <see cref="DigitalChannel"/> class.
     /// </summary>
     /// <param name="channelNumber">The channel number/index.</param>
-    public DigitalChannel(int channelNumber)
+    /// <param name="isPwmCapable">Whether this channel's hardware supports PWM output.</param>
+    public DigitalChannel(int channelNumber, bool isPwmCapable = false)
     {
         if (channelNumber < 0)
             throw new ArgumentOutOfRangeException(nameof(channelNumber), "Channel number must be non-negative.");
 
         ChannelNumber = channelNumber;
+        IsPwmCapable = isPwmCapable;
         _name = $"Digital Channel {channelNumber}";
         _isEnabled = false;
         _direction = ChannelDirection.Input;
         _outputValue = false;
+        _isPwmEnabled = false;
+        _pwmDutyCyclePercent = 0;
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Channel/IDigitalChannel.cs
+++ b/src/Daqifi.Core/Channel/IDigitalChannel.cs
@@ -14,4 +14,23 @@ public interface IDigitalChannel : IChannel
     /// Gets whether the digital input is currently high (true) or low (false).
     /// </summary>
     bool IsHigh { get; }
+
+    /// <summary>
+    /// Gets whether this channel's hardware supports PWM output.
+    /// </summary>
+    bool IsPwmCapable { get; }
+
+    /// <summary>
+    /// Gets or sets whether PWM output is enabled on this channel. This is local bookkeeping
+    /// mirroring the last commanded state; use <c>IStreamingDevice.SetPwmEnabled</c> to change
+    /// the device.
+    /// </summary>
+    bool IsPwmEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last commanded PWM duty cycle for this channel, in whole percent
+    /// (0-100). Local bookkeeping; use <c>IStreamingDevice.SetPwmDutyCycle</c> to change the
+    /// device.
+    /// </summary>
+    int PwmDutyCyclePercent { get; set; }
 }

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -434,6 +434,78 @@ public class ScpiMessageProducer
     }
 
     /// <summary>
+    /// Creates a command message to enable or disable PWM output on a digital channel.
+    /// </summary>
+    /// <param name="channel">The digital channel number.</param>
+    /// <param name="enabled">True to enable PWM on the channel; false to disable it.</param>
+    /// <remarks>
+    /// Only PWM-capable channels accept an enable; the firmware leaves a channel in a broken
+    /// half-enabled state when PWM is enabled on a non-capable channel, so callers should gate
+    /// on capability first (the device-level API does).
+    /// Command: PWM:CHannel:ENable channel,enabled
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetPwmChannelEnabled(4, true)); // PWM on channel 4
+    /// </remarks>
+    public static IOutboundMessage<string> SetPwmChannelEnabled(int channel, bool enabled)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        return new ScpiMessage($"PWM:CHannel:ENable {channel},{(enabled ? 1 : 0)}");
+    }
+
+    /// <summary>
+    /// Creates a command message to set the PWM frequency.
+    /// </summary>
+    /// <param name="channel">The digital channel number the command is addressed to.</param>
+    /// <param name="frequencyHz">The PWM frequency in hertz.</param>
+    /// <remarks>
+    /// All PWM channels share one hardware timer, so the frequency applies to every PWM
+    /// channel on the device regardless of the channel this command is addressed to.
+    /// Command: PWM:CHannel:FREQuency channel,frequency
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetPwmChannelFrequency(0, 1000)); // 1 kHz for all PWM
+    /// </remarks>
+    public static IOutboundMessage<string> SetPwmChannelFrequency(int channel, int frequencyHz)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        if (frequencyHz <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(frequencyHz), frequencyHz, "Frequency must be positive.");
+        }
+
+        return new ScpiMessage($"PWM:CHannel:FREQuency {channel},{frequencyHz}");
+    }
+
+    /// <summary>
+    /// Creates a command message to set the PWM duty cycle of a digital channel.
+    /// </summary>
+    /// <param name="channel">The digital channel number.</param>
+    /// <param name="dutyCyclePercent">The duty cycle in whole percent (0-100).</param>
+    /// <remarks>
+    /// Command: PWM:CHannel:DUTY channel,duty
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetPwmChannelDutyCycle(4, 50)); // 50% on channel 4
+    /// </remarks>
+    public static IOutboundMessage<string> SetPwmChannelDutyCycle(int channel, int dutyCyclePercent)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        if (dutyCyclePercent is < 0 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dutyCyclePercent), dutyCyclePercent, "Duty cycle must be 0-100 percent.");
+        }
+
+        return new ScpiMessage($"PWM:CHannel:DUTY {channel},{dutyCyclePercent}");
+    }
+
+    /// <summary>
     /// Creates a command message to stage an analog output (DAC) voltage on a channel.
     /// </summary>
     /// <param name="channel">The analog output channel number.</param>

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1144,11 +1144,16 @@ namespace Daqifi.Core.Device
                 // the enable/direction/output state the device-level channel-management API
                 // computes its ADC mask and DIO state from. Keyed by (type, number) since the
                 // channel instances themselves are replaced.
-                var priorState = new Dictionary<(ChannelType, int), (bool IsEnabled, ChannelDirection Direction, bool OutputValue)>();
+                var priorState = new Dictionary<(ChannelType, int), (bool IsEnabled, ChannelDirection Direction, bool OutputValue, bool IsPwmEnabled, int PwmDutyCyclePercent)>();
                 foreach (var existing in _channels)
                 {
-                    var outputValue = existing is IDigitalChannel digitalExisting && digitalExisting.OutputValue;
-                    priorState[(existing.Type, existing.ChannelNumber)] = (existing.IsEnabled, existing.Direction, outputValue);
+                    var digitalExisting = existing as IDigitalChannel;
+                    priorState[(existing.Type, existing.ChannelNumber)] = (
+                        existing.IsEnabled,
+                        existing.Direction,
+                        digitalExisting?.OutputValue ?? false,
+                        digitalExisting?.IsPwmEnabled ?? false,
+                        digitalExisting?.PwmDutyCyclePercent ?? 0);
                 }
 
                 // Clear existing channels before repopulating
@@ -1180,6 +1185,8 @@ namespace Daqifi.Core.Device
                     if (channel is IDigitalChannel digitalChannel)
                     {
                         digitalChannel.OutputValue = state.OutputValue;
+                        digitalChannel.IsPwmEnabled = state.IsPwmEnabled;
+                        digitalChannel.PwmDutyCyclePercent = state.PwmDutyCyclePercent;
                     }
                 }
 
@@ -1230,6 +1237,13 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
+        /// Bitmask of digital channels whose hardware supports PWM output (bit n = channel n).
+        /// Channels 0, 3, 4, 5, 6 and 7 route to output-compare modules; the mask comes from the
+        /// firmware's board configuration and is identical across Nyquist variants.
+        /// </summary>
+        private const int PwmCapableChannelMask = 0x00F9;
+
+        /// <summary>
         /// Populates digital channels from the protobuf message.
         /// </summary>
         /// <param name="message">The protobuf message containing digital channel data.</param>
@@ -1240,7 +1254,8 @@ namespace Daqifi.Core.Device
 
             for (var i = 0; i < count; i++)
             {
-                var channel = new DigitalChannel(i)
+                var isPwmCapable = i < 32 && (PwmCapableChannelMask & (1 << i)) != 0;
+                var channel = new DigitalChannel(i, isPwmCapable)
                 {
                     Name = $"DIO{i}",
                     Direction = ChannelDirection.Input,

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -522,6 +522,9 @@ namespace Daqifi.Core.Device
                 {
                     // Disabling PWM leaves the pin high-impedance and the firmware zeroes its
                     // stored output value; mirror that so local state doesn't claim a driven level.
+                    // Direction is intentionally left as-is: the firmware keeps the channel's
+                    // stored direction and re-applies it (resuming driving) on the next state or
+                    // direction write, or on the next streaming tick — verified on hardware.
                     digitalChannel.OutputValue = false;
                 }
             }

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -469,6 +469,151 @@ namespace Daqifi.Core.Device
             Send(ScpiMessageProducer.SetDioPortState(channel.ChannelNumber, value ? 1 : 0));
         }
 
+        /// <summary>
+        /// The lowest PWM frequency the firmware reproduces correctly. Below this the firmware's
+        /// 16-bit period register silently wraps and the output runs in the kilohertz range.
+        /// </summary>
+        public const int MinPwmFrequencyHz = 6;
+
+        /// <summary>
+        /// The highest PWM frequency the device advertises (full duty resolution is retained
+        /// well past this, so the advertised cap is the binding limit).
+        /// </summary>
+        public const int MaxPwmFrequencyHz = 50_000;
+
+        /// <summary>
+        /// Gets the last commanded device-wide PWM frequency in hertz, or 0 when none has been
+        /// set this session. Local bookkeeping mirroring <see cref="SetPwmFrequency"/>.
+        /// </summary>
+        public int PwmFrequencyHz { get; private set; }
+
+        /// <inheritdoc />
+        public void SetPwmEnabled(IChannel channel, bool enabled)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+
+            if (channel.Type != ChannelType.Digital)
+            {
+                throw new ArgumentException("PWM can only be controlled on digital channels.", nameof(channel));
+            }
+
+            // Enabling PWM on a non-capable channel must be blocked here: the firmware flags the
+            // channel PWM-active before its capability check fails and never rolls that back,
+            // leaving the channel dead to digital writes. Disabling is that state's only recovery
+            // command, so it is accepted on any digital channel.
+            if (enabled && channel is not IDigitalChannel { IsPwmCapable: true })
+            {
+                throw new ArgumentException(
+                    $"Channel {channel.ChannelNumber} does not support PWM. PWM-capable channels: {PwmCapableChannelList}.",
+                    nameof(channel));
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            EnsureChannelBelongs(channel);
+
+            if (channel is IDigitalChannel digitalChannel)
+            {
+                digitalChannel.IsPwmEnabled = enabled;
+                if (!enabled)
+                {
+                    // Disabling PWM leaves the pin high-impedance and the firmware zeroes its
+                    // stored output value; mirror that so local state doesn't claim a driven level.
+                    digitalChannel.OutputValue = false;
+                }
+            }
+
+            Send(ScpiMessageProducer.SetPwmChannelEnabled(channel.ChannelNumber, enabled));
+        }
+
+        /// <inheritdoc />
+        public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+
+            if (channel.Type != ChannelType.Digital)
+            {
+                throw new ArgumentException("PWM can only be controlled on digital channels.", nameof(channel));
+            }
+
+            if (channel is not IDigitalChannel { IsPwmCapable: true })
+            {
+                throw new ArgumentException(
+                    $"Channel {channel.ChannelNumber} does not support PWM. PWM-capable channels: {PwmCapableChannelList}.",
+                    nameof(channel));
+            }
+
+            // Duty 0 is rejected rather than forwarded: the firmware stores it but never writes
+            // the compare register, so the output keeps toggling at the previous duty while the
+            // stored value claims 0. Stopping the output is SetPwmEnabled(channel, false).
+            if (dutyCyclePercent is < 1 or > 100)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(dutyCyclePercent), dutyCyclePercent,
+                    "Duty cycle must be 1-100 percent. To stop the output, use SetPwmEnabled(channel, false).");
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            EnsureChannelBelongs(channel);
+
+            if (channel is IDigitalChannel digitalChannel)
+            {
+                digitalChannel.PwmDutyCyclePercent = dutyCyclePercent;
+            }
+
+            Send(ScpiMessageProducer.SetPwmChannelDutyCycle(channel.ChannelNumber, dutyCyclePercent));
+        }
+
+        /// <inheritdoc />
+        public void SetPwmFrequency(int frequencyHz)
+        {
+            if (frequencyHz is < MinPwmFrequencyHz or > MaxPwmFrequencyHz)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(frequencyHz), frequencyHz,
+                    $"PWM frequency must be {MinPwmFrequencyHz}-{MaxPwmFrequencyHz} Hz.");
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            // The SCPI command is addressed to a channel, but the firmware drives all PWM from
+            // one shared timer and applies the frequency to every channel. Channel 0 is used as
+            // the address because it is PWM-capable on all supported hardware.
+            Send(ScpiMessageProducer.SetPwmChannelFrequency(0, frequencyHz));
+            PwmFrequencyHz = frequencyHz;
+        }
+
+        /// <summary>
+        /// Comma-separated PWM-capable channel numbers for error messages, derived from this
+        /// device's channel collection.
+        /// </summary>
+        private string PwmCapableChannelList
+        {
+            get
+            {
+                var capable = new List<int>();
+                foreach (var ch in SnapshotChannels())
+                {
+                    if (ch is IDigitalChannel { IsPwmCapable: true })
+                    {
+                        capable.Add(ch.ChannelNumber);
+                    }
+                }
+                capable.Sort();
+                return capable.Count > 0 ? string.Join(", ", capable) : "none on this device";
+            }
+        }
+
         /// <inheritdoc />
         public void SetAnalogOutput(int channelNumber, double voltage)
         {

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -81,6 +81,51 @@ namespace Daqifi.Core.Device
         void SetDioValue(IChannel channel, bool value);
 
         /// <summary>
+        /// Enables or disables PWM output on a PWM-capable digital channel.
+        /// </summary>
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.
+        /// Enabling requires <see cref="Channel.IDigitalChannel.IsPwmCapable"/>; disabling is accepted on any
+        /// digital channel.</param>
+        /// <param name="enabled"><c>true</c> to start PWM output; <c>false</c> to stop it.</param>
+        /// <remarks>
+        /// Set the duty cycle (and, once per session, the shared frequency) before enabling — see
+        /// <see cref="SetPwmDutyCycle"/> and <see cref="SetPwmFrequency"/>. While PWM is enabled the firmware
+        /// ignores digital direction/state writes for the channel at the hardware level. Disabling leaves the
+        /// pin high-impedance; re-issue <see cref="SetDioDirection"/>/<see cref="SetDioValue"/> to drive it
+        /// digitally again.
+        /// </remarks>
+        void SetPwmEnabled(IChannel channel, bool enabled);
+
+        /// <summary>
+        /// Sets the PWM duty cycle of a PWM-capable digital channel.
+        /// </summary>
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection
+        /// and be <see cref="Channel.IDigitalChannel.IsPwmCapable"/>.</param>
+        /// <param name="dutyCyclePercent">The duty cycle in whole percent, 1-100. A duty of 0 is rejected
+        /// because the firmware stores but never applies it (the old duty keeps toggling); stop the output
+        /// with <see cref="SetPwmEnabled"/> instead.</param>
+        void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent);
+
+        /// <summary>
+        /// Sets the PWM frequency, in hertz, for the whole device.
+        /// </summary>
+        /// <param name="frequencyHz">The frequency in hertz, 6-50000. Values below 6 Hz are rejected because
+        /// the firmware's 16-bit period register silently wraps for them, producing a kilohertz-range output.</param>
+        /// <remarks>
+        /// All PWM channels share one hardware timer, so this applies to every PWM channel at once — there is
+        /// no per-channel frequency. Changing it while channels are enabled takes effect live and rescales
+        /// each enabled channel's duty cycle.
+        /// </remarks>
+        void SetPwmFrequency(int frequencyHz);
+
+        /// <summary>
+        /// Gets the last PWM frequency commanded through <see cref="SetPwmFrequency"/> this
+        /// session, in hertz, or 0 when none has been set. Local bookkeeping only — a device
+        /// keeps its PWM state across host disconnects, so 0 does not prove the device is unset.
+        /// </summary>
+        int PwmFrequencyHz { get; }
+
+        /// <summary>
         /// Sets the analog output (DAC) voltage of a channel and applies it immediately.
         /// </summary>
         /// <param name="channelNumber">The analog output channel number. DAC channels are addressed by

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -91,8 +91,10 @@ namespace Daqifi.Core.Device
         /// Set the duty cycle (and, once per session, the shared frequency) before enabling — see
         /// <see cref="SetPwmDutyCycle"/> and <see cref="SetPwmFrequency"/>. While PWM is enabled the firmware
         /// ignores digital direction/state writes for the channel at the hardware level. Disabling leaves the
-        /// pin high-impedance; re-issue <see cref="SetDioDirection"/>/<see cref="SetDioValue"/> to drive it
-        /// digitally again.
+        /// pin transiently high-impedance, but the firmware keeps the channel's stored direction (mirrored by
+        /// <see cref="Channel.IChannel.Direction"/>), and any subsequent <see cref="SetDioValue"/> or
+        /// <see cref="SetDioDirection"/> write — or the per-tick refresh while streaming — re-applies it and
+        /// resumes driving, so no explicit direction resend is required first.
         /// </remarks>
         void SetPwmEnabled(IChannel channel, bool enabled);
 

--- a/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
+++ b/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
@@ -138,4 +138,28 @@ public class DaqifiAgentTests
             () => NewAgent().SetDigitalOutputAsync("serial:NOPE", 3, high: true));
         Assert.Contains("connect_device", ex.Message);
     }
+
+    [Fact]
+    public async Task SetPwmOutput_InReadOnlyMode_IsBlocked()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent(readOnly: true).SetPwmOutputAsync("x", 4, dutyCyclePercent: 50, frequencyHz: 1000));
+        Assert.Contains("read-only", ex.Message);
+    }
+
+    [Fact]
+    public async Task SetPwmOutput_UnknownDevice_ThrowsWithActionableMessage()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent().SetPwmOutputAsync("serial:NOPE", 4, dutyCyclePercent: 50, frequencyHz: 1000));
+        Assert.Contains("connect_device", ex.Message);
+    }
+
+    [Fact]
+    public async Task DisablePwm_InReadOnlyMode_IsBlocked()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent(readOnly: true).DisablePwmAsync("x", 4));
+        Assert.Contains("read-only", ex.Message);
+    }
 }

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -270,6 +270,67 @@ public sealed class DaqifiAgent
         }
     }
 
+    /// <summary>
+    /// Configures and starts PWM output on a PWM-capable digital channel: duty first, then the
+    /// shared frequency when supplied, then enable. The device's PWM frequency is global (one
+    /// hardware timer drives all PWM channels).
+    /// </summary>
+    public async Task<PwmResult> SetPwmOutputAsync(string deviceId, int channel, int dutyCyclePercent, int frequencyHz)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (device, streaming) = RequireStreaming(deviceId);
+            var ch = RequireDigitalChannel(device, channel);
+
+            if (frequencyHz == 0 && streaming.PwmFrequencyHz == 0)
+            {
+                throw new InvalidOperationException(
+                    "No PWM frequency has been set this session. Pass frequency_hz (6-50000). " +
+                    "The frequency is shared by all PWM channels.");
+            }
+
+            // Duty before frequency before enable: the firmware applies a stored duty when the
+            // frequency is (re)programmed, so this order never leaves a stale compare value.
+            streaming.SetPwmDutyCycle(ch, dutyCyclePercent);
+            if (frequencyHz != 0)
+            {
+                streaming.SetPwmFrequency(frequencyHz);
+            }
+            streaming.SetPwmEnabled(ch, true);
+
+            return PwmResult.From(deviceId, streaming, ch);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Stops PWM output on a digital channel. The pin is left high-impedance; use
+    /// set_digital_direction / set_digital_output to drive it digitally again.
+    /// </summary>
+    public async Task<PwmResult> DisablePwmAsync(string deviceId, int channel)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            RequireControl();
+            var (device, streaming) = RequireStreaming(deviceId);
+            var ch = RequireDigitalChannel(device, channel);
+
+            streaming.SetPwmEnabled(ch, false);
+
+            return PwmResult.From(deviceId, streaming, ch);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task<SampleRateResult> SetSampleRateAsync(string deviceId, int rateHz)
     {
         if (rateHz < 1)

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -80,18 +80,24 @@ public sealed record DeviceStatus(
 
 /// <summary>
 /// A single channel on a device. <see cref="OutputValue"/> is the last commanded output level
-/// for digital channels (null for analog channels).
+/// for digital channels; <see cref="PwmCapable"/>/<see cref="PwmEnabled"/> report PWM hardware
+/// support and the last commanded PWM state (all three are null for analog channels).
 /// </summary>
-public sealed record ChannelInfo(int ChannelNumber, string Type, string Name, bool Enabled, string Direction, bool? OutputValue)
+public sealed record ChannelInfo(int ChannelNumber, string Type, string Name, bool Enabled, string Direction, bool? OutputValue, bool? PwmCapable, bool? PwmEnabled)
 {
-    public static ChannelInfo From(IChannel ch) =>
-        new(
+    public static ChannelInfo From(IChannel ch)
+    {
+        var digital = ch as IDigitalChannel;
+        return new(
             ch.ChannelNumber,
             ch.Type.ToString(),
             ch.Name,
             ch.IsEnabled,
             ch.Direction.ToString(),
-            ch is IDigitalChannel digital ? digital.OutputValue : null);
+            digital?.OutputValue,
+            digital?.IsPwmCapable,
+            digital?.IsPwmEnabled);
+    }
 }
 
 /// <summary>Result of a channel-configuration change.</summary>
@@ -112,6 +118,25 @@ public sealed record DigitalPinResult(string DeviceId, int Channel, string Direc
         ch.ChannelNumber,
         ch.Direction.ToString(),
         ch is IDigitalChannel digital && digital.OutputValue);
+}
+
+/// <summary>
+/// Result of a PWM operation, reflecting the channel's state after it. <see cref="FrequencyHz"/>
+/// is the device-wide PWM frequency last commanded this session (0 when none was set; all PWM
+/// channels share one frequency).
+/// </summary>
+public sealed record PwmResult(string DeviceId, int Channel, bool Enabled, int DutyCyclePercent, int FrequencyHz)
+{
+    public static PwmResult From(string deviceId, IStreamingDevice device, IChannel ch)
+    {
+        var digital = ch as IDigitalChannel;
+        return new(
+            deviceId,
+            ch.ChannelNumber,
+            digital?.IsPwmEnabled ?? false,
+            digital?.PwmDutyCyclePercent ?? 0,
+            device.PwmFrequencyHz);
+    }
 }
 
 /// <summary>

--- a/src/Daqifi.Mcp/README.md
+++ b/src/Daqifi.Mcp/README.md
@@ -21,6 +21,8 @@ The server speaks MCP over **stdio**, so the client launches it as a subprocess.
 | `configure_digital_channels` | Enable exactly the given digital channels; disable the rest. |
 | `set_digital_direction` | Set a digital channel to `input` or `output`. |
 | `set_digital_output` | Drive a digital channel high or low (switches it to output if needed). |
+| `set_pwm_output` | Start PWM on a capable channel: duty 1-100%, shared frequency 6-50000 Hz. |
+| `disable_pwm` | Stop PWM on a channel (pin is left high-impedance). |
 | `set_sample_rate` | Set sample rate in Hz (Nyquist hardware supports up to 1000 Hz). |
 | `start_sd_logging` | Start on-device SD logging (**requires a USB/serial connection**). |
 | `stop_sd_logging` | Stop SD logging. |

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -92,6 +92,24 @@ public static class DaqifiTools
         [Description("true to drive the pin high, false to drive it low.")] bool high)
         => GuardAsync(() => agent.SetDigitalOutputAsync(deviceId, channel, high));
 
+    [McpServerTool(Name = "set_pwm_output")]
+    [Description("Start PWM output on a PWM-capable digital channel (Nyquist: channels 0, 3, 4, 5, 6, 7). Sets the duty cycle, optionally the device-wide frequency, then enables the channel. The frequency is shared by ALL PWM channels (one hardware timer). While PWM runs, digital direction/state commands for the channel are ignored by the hardware.")]
+    public static Task<PwmResult> SetPwmOutput(
+        DaqifiAgent agent,
+        [Description("The device_id to control.")] string deviceId,
+        [Description("The PWM-capable digital channel number.")] int channel,
+        [Description("Duty cycle in whole percent, 1-100. To stop the output use disable_pwm, not duty 0.")] int dutyCyclePercent,
+        [Description("PWM frequency in Hz, 6-50000, applied device-wide. Pass 0 to keep the frequency already set this session (required on first use).")] int frequencyHz = 0)
+        => GuardAsync(() => agent.SetPwmOutputAsync(deviceId, channel, dutyCyclePercent, frequencyHz));
+
+    [McpServerTool(Name = "disable_pwm")]
+    [Description("Stop PWM output on a digital channel. The pin is left high-impedance (not driven); use set_digital_direction/set_digital_output to drive it digitally again.")]
+    public static Task<PwmResult> DisablePwm(
+        DaqifiAgent agent,
+        [Description("The device_id to control.")] string deviceId,
+        [Description("The digital channel number to stop PWM on.")] int channel)
+        => GuardAsync(() => agent.DisablePwmAsync(deviceId, channel));
+
     [McpServerTool(Name = "set_sample_rate")]
     [Description("Set the device sample (streaming) rate in Hz, applied to streaming and SD-card logging. Nyquist hardware supports 1–1000 Hz; requests above 1000 Hz (or above --max-sample-rate-hz) are clamped and reported in the result.")]
     public static Task<SampleRateResult> SetSampleRate(


### PR DESCRIPTION
## Summary

Adds PWM output as a first-class, hardware-validated capability, building directly on the digital-output work in #280.

> **Stacked on #280** — base is `claude/mystifying-tereshkova-1c19ba`; GitHub will retarget this PR to `main` automatically when #280 merges. Only the PWM commit is new here.

### API shape (deliberate choices)

- `SetPwmEnabled(channel, bool)` and `SetPwmDutyCycle(channel, 1-100)` are **per channel**; `SetPwmFrequency(6-50000 Hz)` is **device-wide**, because all PWM channels share one hardware timer (Timer 3) — the SCPI command takes a channel argument but the firmware applies the frequency to every channel, so a per-channel frequency API would actively mislead. The wire command is addressed to channel 0 (PWM-capable on all supported hardware).
- `IDigitalChannel` gains `IsPwmCapable` (populated from the firmware board mask — channels **0, 3, 4, 5, 6, 7**; identical across Nyquist variants), plus `IsPwmEnabled` / `PwmDutyCyclePercent` bookkeeping that survives status-refresh repopulation.

### Client-side guardrails for firmware traps (all confirmed in firmware source @ v3.6.3 and on hardware)

| Guardrail | Firmware behavior it protects against |
|---|---|
| Enabling PWM on a non-capable channel throws (lists capable channels) | Firmware sets `IsPwmActive` *before* its capability check fails and never rolls back (`SCPIDIO.c:534-556`), freezing all digital writes on the channel. Disable is the only recovery, so `SetPwmEnabled(ch, false)` is accepted on any digital channel. |
| Duty 0 rejected (`ArgumentOutOfRangeException` pointing to `SetPwmEnabled(false)`) | Firmware stores duty 0 but never writes the compare register (`DIO.c:220-222`) — the old duty keeps toggling while readback claims 0. |
| Frequency limited to 6–50,000 Hz | Below 6 Hz the firmware's 16-bit period register silently wraps (`DIO.c:239-252`) and outputs ~3.6 kHz; 50 kHz is the advertised cap. |

### MCP

`set_pwm_output` (duty + optional device-wide frequency + enable in one call; requires a frequency on first use per session) and `disable_pwm`. `list_channels` now reports `PwmCapable` / `PwmEnabled`.

## Hardware validation (Nyquist 1, USB serial, FW 3.6.2)

PWM driven on channel 4, observed through the physically wired loopback on channel 2 — 15/15 checks passed:

- **Raw SCPI phase** (exact strings Core produces): enable/frequency/duty readbacks; polled duty fractions **0.47** and **0.89** for commanded 50% / 90%.
- **Core end-to-end phase**: `SetPwmDutyCycle` → `SetPwmFrequency(10)` → `SetPwmEnabled` through `ConnectSerialAsync`, measured from channel 2's **streamed** samples at 500 Hz: duty fraction **0.30** for commanded 30% (2,000 samples), **frequency 10.0 Hz** (exactly 40 rising edges in 4 s), live duty change to **0.80**, then disable → digital drive-low handback (constant low, zero edges). Capability guardrail verified client-side with no wire traffic.

Streaming coexists safely with PWM by firmware design (the per-tick DIO write pass skips PWM-active channels), and streamed digital bits for a PWM pin are live pad samples — which is exactly what made the loopback measurement possible.

## Tests

- 14 new device-level tests (capability mask, bookkeeping, guardrails, wire commands, refresh preservation), 4 new producer tests, 3 new MCP tests.
- Full suite: 1,322 Core + 23 MCP tests green on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)