### PR TITLE
docs: add CONTRIBUTING.md with attachment security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to DAQiFi Core
+
+Thanks for taking the time to contribute!
+
+## Reporting bugs & requesting features
+
+[Open an issue](https://github.com/daqifi/daqifi-core/issues) with as much detail as you can:
+repro steps, expected vs. actual behavior, device model/firmware version, and OS/.NET version.
+
+## Submitting code changes
+
+All code changes go through a pull request:
+
+1. Fork the repo (or branch, if you have write access) — `feature/short-description`,
+   `fix/short-description`, or `docs/short-description`.
+2. Make your changes and add/update tests.
+3. Open a PR against `main` describing the change and linking any related issue.
+4. CI must pass and the PR needs review before merge.
+
+## Security: how we do and don't accept code
+
+**We only ever accept code changes as pull requests against this repository.** A PR gives
+reviewers a real diff, runs CI against the change, and ties it to an accountable GitHub identity.
+
+We do **not** accept patches, "fixes," or libraries attached as `.zip`/binary files in issue or
+PR comments — regardless of how convincing or on-topic the surrounding message is. If you see a
+comment offering a downloadable file as a fix, please don't run or extract it, and flag it to a
+maintainer (or use GitHub's "Report content" option on the comment) so it can be reviewed and
+removed.
+
+If you've found a genuine security vulnerability, please report it privately to the maintainers
+via [daqifi.com](https://daqifi.com) rather than filing a public issue.


### PR DESCRIPTION
## Summary
- Adds a CONTRIBUTING.md covering the standard bug-report/PR workflow
- States explicitly that code changes are only ever accepted as PRs — never as files attached to issue/PR comments

## Context
A brand-new (`author_association: NONE`) account posted a zip attachment on [#285](https://github.com/daqifi/daqifi-core/issues/285#issuecomment-4907618358), disguised as a "patched core lib" fixing a real bootloader/re-enumeration pain point, as a social-engineering lure. That comment has been minimized as spam and the account blocked from the org; a 6-month "existing users only" interaction limit is now active on the repo. This PR documents the policy so future readers of the issue thread (and future would-be victims) see the expectation clearly.

## Test plan
- [x] N/A — documentation only