### PR TITLE
ci: migrate NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,10 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
     - uses: actions/checkout@v7
     
@@ -44,11 +47,17 @@ jobs:
     - name: Pack
       run: dotnet pack src/Daqifi.Core/Daqifi.Core.csproj --configuration Release --no-build -p:PackageVersion=${VERSION} --output nupkgs
 
+    - name: NuGet login (OIDC -> temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: tylerkron
+
     - name: Push to NuGet
-      run: dotnet nuget push nupkgs/Daqifi.Core.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push nupkgs/Daqifi.Core.*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Pack MCP server (dotnet tool)
       run: dotnet pack src/Daqifi.Mcp/Daqifi.Mcp.csproj --configuration Release --no-build -p:PackageVersion=${VERSION} --output nupkgs
 
     - name: Push MCP server to NuGet
-      run: dotnet nuget push nupkgs/Daqifi.Mcp.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push nupkgs/Daqifi.Mcp.*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary
- Migrates `release.yml`'s `publish` job from the long-lived `NUGET_API_KEY` secret to [Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) (OIDC).
- Adds `permissions: { id-token: write, contents: read }` to the job.
- Adds a `NuGet/login@v1` step before the push steps to exchange the GitHub OIDC token for a short-lived NuGet API key.
- Both push steps (`Daqifi.Core` and `Daqifi.Mcp`) now use `${{ steps.login.outputs.NUGET_API_KEY }}` instead of `${{ secrets.NUGET_API_KEY }}`.

The nuget.org Trusted Publishing policy (Policy Owner: DAQiFi, Repository: daqifi/daqifi-core, Workflow File: `release.yml`) has already been created per the first task in #278.

Closes #278 (remaining tasks: verify a real release publishes both packages via TP, then delete the `NUGET_API_KEY` repo secret).

## Test plan
- [x] YAML syntax validated (`ruby -ryaml -e "YAML.load_file(...)"`)
- [ ] Cut a real release (e.g. next patch/minor tag) and confirm `Daqifi.Core` and `Daqifi.Mcp` both publish successfully via Trusted Publishing (no `NUGET_API_KEY` secret used)
- [ ] After a successful TP publish, delete the `NUGET_API_KEY` repo secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)