### PR TITLE
feat(device): FeatureNotSupportedException + v3.5.0 floor + -113 backstop on GetSdCardStorageAsync

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceFirmwareSupportTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceFirmwareSupportTests.cs
@@ -1,0 +1,73 @@
+using Daqifi.Core.Device;
+using Daqifi.Core.Firmware;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class DaqifiDeviceFirmwareSupportTests
+    {
+        [Fact]
+        public void MinSupportedFirmware_IsV3_5_0()
+        {
+            Assert.Equal(new FirmwareVersion(3, 5, 0, null, 0), DaqifiDevice.MinSupportedFirmware);
+        }
+
+        [Fact]
+        public void IsFirmwareVersionSupported_WhenFirmwareVersionNotYetReported_ReturnsFalse()
+        {
+            var device = new DaqifiDevice("TestDevice");
+
+            Assert.Equal(string.Empty, device.Metadata.FirmwareVersion);
+            Assert.False(device.IsFirmwareVersionSupported);
+        }
+
+        [Theory]
+        [InlineData("not-a-version")]
+        [InlineData("")]
+        public void IsFirmwareVersionSupported_WhenFirmwareVersionUnparseable_ReturnsFalse(string firmwareVersion)
+        {
+            var device = new DaqifiDevice("TestDevice");
+            device.Metadata.FirmwareVersion = firmwareVersion;
+
+            Assert.False(device.IsFirmwareVersionSupported);
+        }
+
+        [Theory]
+        [InlineData("3.4.6b1")]
+        [InlineData("3.4.3")]
+        [InlineData("v3.0.0")]
+        public void IsFirmwareVersionSupported_WhenFirmwareBelowFloor_ReturnsFalse(string firmwareVersion)
+        {
+            var device = new DaqifiDevice("TestDevice");
+            device.Metadata.FirmwareVersion = firmwareVersion;
+
+            Assert.False(device.IsFirmwareVersionSupported);
+        }
+
+        [Theory]
+        [InlineData("3.5.0")]
+        [InlineData("v3.5.0")]
+        [InlineData("3.6.0")]
+        [InlineData("3.6.1")]
+        public void IsFirmwareVersionSupported_WhenFirmwareAtOrAboveFloor_ReturnsTrue(string firmwareVersion)
+        {
+            var device = new DaqifiDevice("TestDevice");
+            device.Metadata.FirmwareVersion = firmwareVersion;
+
+            Assert.True(device.IsFirmwareVersionSupported);
+        }
+
+        [Fact]
+        public void IsFirmwareVersionSupported_EvaluatesLiveAgainstCurrentMetadata()
+        {
+            // Guards against caching a version-derived bool: the property must reflect the
+            // firmware version most recently reported, not a value snapshotted earlier.
+            var device = new DaqifiDevice("TestDevice");
+            device.Metadata.FirmwareVersion = "3.4.3";
+            Assert.False(device.IsFirmwareVersionSupported);
+
+            device.Metadata.FirmwareVersion = "3.6.0";
+            Assert.True(device.IsFirmwareVersionSupported);
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/FeatureNotSupportedExceptionTests.cs
+++ b/src/Daqifi.Core.Tests/Device/FeatureNotSupportedExceptionTests.cs
@@ -1,0 +1,72 @@
+using Daqifi.Core.Device;
+using Daqifi.Core.Firmware;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class FeatureNotSupportedExceptionTests
+    {
+        [Fact]
+        public void Constructor_SetsAllProperties()
+        {
+            var requiredVersion = new FirmwareVersion(3, 5, 0, null, 0);
+
+            var ex = new FeatureNotSupportedException(
+                DeviceFeature.SdStorageQuery,
+                requiredVersion,
+                "3.4.3",
+                DeviceType.Nyquist1);
+
+            Assert.Equal(DeviceFeature.SdStorageQuery, ex.Feature);
+            Assert.Equal(requiredVersion, ex.RequiredVersion);
+            Assert.Equal("3.4.3", ex.ActualVersion);
+            Assert.Equal(DeviceType.Nyquist1, ex.Board);
+        }
+
+        [Fact]
+        public void Constructor_WithOnlyFeature_LeavesOptionalPropertiesNull()
+        {
+            var ex = new FeatureNotSupportedException(DeviceFeature.AnalogOutput);
+
+            Assert.Equal(DeviceFeature.AnalogOutput, ex.Feature);
+            Assert.Null(ex.RequiredVersion);
+            Assert.Null(ex.ActualVersion);
+            Assert.Null(ex.Board);
+        }
+
+        [Fact]
+        public void Message_IncludesFeatureRequiredAndActualVersion()
+        {
+            var requiredVersion = new FirmwareVersion(3, 5, 0, null, 0);
+
+            var ex = new FeatureNotSupportedException(
+                DeviceFeature.SdStorageQuery,
+                requiredVersion,
+                "3.4.3");
+
+            Assert.Contains("SdStorageQuery", ex.Message);
+            Assert.Contains("3.5.0", ex.Message);
+            Assert.Contains("3.4.3", ex.Message);
+        }
+
+        [Fact]
+        public void Message_WithUnknownActualVersion_SaysUnknown()
+        {
+            var requiredVersion = new FirmwareVersion(3, 5, 0, null, 0);
+
+            var ex = new FeatureNotSupportedException(DeviceFeature.SdStorageQuery, requiredVersion, null);
+
+            Assert.Contains("unknown", ex.Message);
+        }
+
+        [Fact]
+        public void Message_WithBoard_IncludesBoard()
+        {
+            var ex = new FeatureNotSupportedException(
+                DeviceFeature.AnalogOutput,
+                board: DeviceType.Nyquist1);
+
+            Assert.Contains("Nyquist1", ex.Message);
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -1162,6 +1162,29 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task GetSdCardStorageAsync_WithUndefinedHeaderError_ThrowsFeatureNotSupportedException()
+        {
+            // -113 "Undefined header" means the firmware doesn't recognize the storage query at
+            // all (e.g. it predates the version that introduced it) — a distinct, typed failure
+            // from a generic SdCardOperationException.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            device.Metadata.FirmwareVersion = "3.4.3";
+            device.Metadata.DeviceType = DeviceType.Nyquist1;
+            device.ResponseSequence.Enqueue(new List<string> { "**ERROR: -113, \"Undefined header\"" });
+            device.ResponseSequence.Enqueue(new List<string> { "**ERROR: -113, \"Undefined header\"" });
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<FeatureNotSupportedException>(
+                () => device.GetSdCardStorageAsync());
+
+            Assert.Equal(2, device.ExecuteTextCommandCallCount);
+            Assert.Equal(DeviceFeature.SdStorageQuery, ex.Feature);
+            Assert.Equal(DaqifiStreamingDevice.MinSupportedFirmware, ex.RequiredVersion);
+            Assert.Equal("3.4.3", ex.ActualVersion);
+            Assert.Equal(DeviceType.Nyquist1, ex.Board);
+        }
+
+        [Fact]
         public async Task GetSdCardStorageAsync_WithNoSdCardDetected_ThrowsSdCardNotPresentException()
         {
             // The "No SD Card Detected" marker is non-transient, so the method must

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -1185,6 +1185,39 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task GetSdCardStorageAsync_WithSpaceDelimitedUndefinedHeaderError_ThrowsFeatureNotSupportedException()
+        {
+            // The shared ScpiResponseClassifier treats ':', space, and tab as equally valid
+            // delimiters after the ERROR token, so the -113 code parser must recognize a
+            // space-delimited line too, not just the colon-delimited form.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            device.ResponseSequence.Enqueue(new List<string> { "**ERROR -113, \"Undefined header\"" });
+            device.ResponseSequence.Enqueue(new List<string> { "**ERROR -113, \"Undefined header\"" });
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<FeatureNotSupportedException>(
+                () => device.GetSdCardStorageAsync());
+
+            Assert.Equal(DeviceFeature.SdStorageQuery, ex.Feature);
+        }
+
+        [Fact]
+        public async Task GetSdCardStorageAsync_WithUndefinedHeaderError_AndUnknownDeviceType_LeavesBoardNull()
+        {
+            // Metadata.DeviceType defaults to Unknown until a part number has been reported;
+            // that sentinel should not be forwarded as a "known" board.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            device.ResponseSequence.Enqueue(new List<string> { "**ERROR: -113, \"Undefined header\"" });
+            device.ResponseSequence.Enqueue(new List<string> { "**ERROR: -113, \"Undefined header\"" });
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<FeatureNotSupportedException>(
+                () => device.GetSdCardStorageAsync());
+
+            Assert.Null(ex.Board);
+        }
+
+        [Fact]
         public async Task GetSdCardStorageAsync_WithNoSdCardDetected_ThrowsSdCardNotPresentException()
         {
             // The "No SD Card Detected" marker is non-transient, so the method must

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -4,6 +4,7 @@ using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device.Protocol;
+using Daqifi.Core.Firmware;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -42,6 +43,26 @@ namespace Daqifi.Core.Device
         /// Gets the device metadata containing part number, firmware version, etc.
         /// </summary>
         public DeviceMetadata Metadata { get; } = new DeviceMetadata();
+
+        /// <summary>
+        /// Minimum firmware version daqifi-core is built and tested against (ADR 0001,
+        /// docs/adr/0001-firmware-feature-gating.md). Every SCPI command daqifi-core issues today
+        /// exists on all firmware at or above this floor, so a device below it gets best-effort
+        /// behavior: an individual command may still work, but any that don't are surfaced as a
+        /// typed <see cref="FeatureNotSupportedException"/> via the wire-level <c>-113</c>
+        /// "Undefined header" backstop, rather than a guarantee up front.
+        /// </summary>
+        public static readonly FirmwareVersion MinSupportedFirmware = new(3, 5, 0, null, 0);
+
+        /// <summary>
+        /// Gets a value indicating whether the connected device's reported firmware version meets
+        /// <see cref="MinSupportedFirmware"/>. Evaluated live against <see cref="Metadata"/> on every
+        /// access — not cached — so it always reflects the most recently reported version rather than
+        /// a stale snapshot. Returns <c>false</c> if the firmware version has not yet been reported or
+        /// does not parse; callers should treat that as "unknown", not "confirmed unsupported".
+        /// </summary>
+        public bool IsFirmwareVersionSupported =>
+            FirmwareVersion.TryParse(Metadata.FirmwareVersion, out var parsed) && parsed >= MinSupportedFirmware;
 
         /// <summary>
         /// Gets the collection of channels populated from device status messages.

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1116,7 +1116,7 @@ namespace Daqifi.Core.Device
                     DeviceFeature.SdStorageQuery,
                     MinSupportedFirmware,
                     Metadata.FirmwareVersion,
-                    Metadata.DeviceType);
+                    Metadata.DeviceType == DeviceType.Unknown ? null : Metadata.DeviceType);
             }
 
             throw new SdCardOperationException(
@@ -1566,19 +1566,36 @@ namespace Daqifi.Core.Device
 
         /// <summary>
         /// Parses the numeric error code out of a SCPI error line matched by
-        /// <see cref="IsScpiErrorLine"/> — e.g. <c>**ERROR: -113, "Undefined header"</c> or
-        /// <c>ERROR: -113,"Undefined header"</c>. The code is the text between the first colon
-        /// and the following comma (if any).
+        /// <see cref="IsScpiErrorLine"/> — e.g. <c>**ERROR: -113, "Undefined header"</c>,
+        /// <c>ERROR: -113,"Undefined header"</c>, or a space/tab-delimited variant like
+        /// <c>**ERROR -113, "Undefined header"</c>. The delimiter between the <c>ERROR</c>/
+        /// <c>**ERROR</c> token and the code may be <c>:</c>, space, or tab — matching the
+        /// delimiters <see cref="ScpiResponseClassifier"/> accepts — and the code is the text
+        /// up to the following comma (if any).
         /// </summary>
         private static bool TryParseScpiErrorCode(string line, out int code)
         {
             code = 0;
-            var colonIndex = line.IndexOf(':');
-            if (colonIndex < 0) return false;
+            var trimmed = line.TrimStart();
 
-            var afterColon = line[(colonIndex + 1)..];
-            var commaIndex = afterColon.IndexOf(',');
-            var codeSpan = (commaIndex >= 0 ? afterColon[..commaIndex] : afterColon).Trim();
+            string afterToken;
+            if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
+            {
+                afterToken = trimmed[7..];
+            }
+            else if (trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
+            {
+                afterToken = trimmed[5..];
+            }
+            else
+            {
+                return false;
+            }
+
+            afterToken = afterToken.TrimStart(':', ' ', '\t');
+
+            var commaIndex = afterToken.IndexOf(',');
+            var codeSpan = (commaIndex >= 0 ? afterToken[..commaIndex] : afterToken).Trim();
             return int.TryParse(codeSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out code);
         }
 

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -45,6 +45,14 @@ namespace Daqifi.Core.Device
         /// </summary>
         private const int SD_LIST_MAX_RETRIES = 1;
 
+        /// <summary>
+        /// libscpi's <c>SCPI_ERROR_UNDEFINED_HEADER</c> — the code the firmware returns for a
+        /// command it doesn't recognize (e.g. a command that postdates the connected firmware).
+        /// This is the wire-level signal behind the <see cref="FeatureNotSupportedException"/>
+        /// backstop (ADR 0001, docs/adr/0001-firmware-feature-gating.md).
+        /// </summary>
+        private const int ScpiErrorCodeUndefinedHeader = -113;
+
         private bool _isLoggingToSdCard;
         private IReadOnlyList<SdCardFileInfo> _sdCardFiles = Array.Empty<SdCardFileInfo>();
 
@@ -1016,6 +1024,7 @@ namespace Daqifi.Core.Device
         /// <exception cref="InvalidOperationException">Thrown when the device is not connected or is currently logging to SD card.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
         /// <exception cref="SdCardNotPresentException">Thrown when no SD card is installed in the device.</exception>
+        /// <exception cref="FeatureNotSupportedException">Thrown when the device's firmware does not recognize the storage query (SCPI -113 "Undefined header"), typically because it predates <see cref="DaqifiDevice.MinSupportedFirmware"/>.</exception>
         /// <exception cref="SdCardOperationException">Thrown when the device returned a SCPI error or an unparseable response.</exception>
         public async Task<SdCardStorageInfo> GetSdCardStorageAsync(CancellationToken cancellationToken = default)
         {
@@ -1094,6 +1103,20 @@ namespace Daqifi.Core.Device
             if (ContainsNoSdCardMarker(lines))
             {
                 throw new SdCardNotPresentException(lines, lastScpiError);
+            }
+
+            // A -113 "Undefined header" reply means the firmware doesn't recognize the storage
+            // query at all — typically because it predates the version that introduced it — so
+            // it gets the typed feature-gating exception instead of a generic operation error.
+            if (lastScpiError != null
+                && TryParseScpiErrorCode(lastScpiError, out var scpiErrorCode)
+                && scpiErrorCode == ScpiErrorCodeUndefinedHeader)
+            {
+                throw new FeatureNotSupportedException(
+                    DeviceFeature.SdStorageQuery,
+                    MinSupportedFirmware,
+                    Metadata.FirmwareVersion,
+                    Metadata.DeviceType);
             }
 
             throw new SdCardOperationException(
@@ -1539,6 +1562,24 @@ namespace Daqifi.Core.Device
             var trimmed = line.TrimStart();
             return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
                 || trimmed.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Parses the numeric error code out of a SCPI error line matched by
+        /// <see cref="IsScpiErrorLine"/> — e.g. <c>**ERROR: -113, "Undefined header"</c> or
+        /// <c>ERROR: -113,"Undefined header"</c>. The code is the text between the first colon
+        /// and the following comma (if any).
+        /// </summary>
+        private static bool TryParseScpiErrorCode(string line, out int code)
+        {
+            code = 0;
+            var colonIndex = line.IndexOf(':');
+            if (colonIndex < 0) return false;
+
+            var afterColon = line[(colonIndex + 1)..];
+            var commaIndex = afterColon.IndexOf(',');
+            var codeSpan = (commaIndex >= 0 ? afterColon[..commaIndex] : afterColon).Trim();
+            return int.TryParse(codeSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out code);
         }
 
         // Permissive: any line that looks like a device error or status message,

--- a/src/Daqifi.Core/Device/DeviceFeature.cs
+++ b/src/Daqifi.Core/Device/DeviceFeature.cs
@@ -1,0 +1,29 @@
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Identifies a firmware- or hardware-gated capability that a device may or may not
+    /// support, carried by <see cref="FeatureNotSupportedException"/> (ADR 0001,
+    /// docs/adr/0001-firmware-feature-gating.md). New members are added only when
+    /// daqifi-core starts consuming a command that some supported device might lack.
+    /// </summary>
+    public enum DeviceFeature
+    {
+        /// <summary>
+        /// Analog output (<c>SOURce:VOLTage:LEVel</c> / <c>CONFigure:DAC:*</c>). Board-gated:
+        /// Nyquist3 only.
+        /// </summary>
+        AnalogOutput,
+
+        /// <summary>
+        /// SD card storage capacity query (<c>SYSTem:STORage:SD:SPACe?</c>). Firmware-gated:
+        /// requires firmware &gt;= v3.4.6b1, at or below the <see cref="DaqifiDevice.MinSupportedFirmware"/> floor.
+        /// </summary>
+        SdStorageQuery,
+
+        /// <summary>
+        /// Capability document query (<c>CONFigure:CAPabilities:JSON?</c> /
+        /// <c>:APIVersion?</c>). Firmware-gated: requires firmware &gt;= v3.5.0.
+        /// </summary>
+        CapabilityDocument
+    }
+}

--- a/src/Daqifi.Core/Device/DeviceFeature.cs
+++ b/src/Daqifi.Core/Device/DeviceFeature.cs
@@ -15,8 +15,12 @@ namespace Daqifi.Core.Device
         AnalogOutput,
 
         /// <summary>
-        /// SD card storage capacity query (<c>SYSTem:STORage:SD:SPACe?</c>). Firmware-gated:
-        /// requires firmware &gt;= v3.4.6b1, at or below the <see cref="DaqifiDevice.MinSupportedFirmware"/> floor.
+        /// SD card storage capacity query (<c>SYSTem:STORage:SD:SPACe?</c>). Introduced in
+        /// firmware v3.4.6b1 — below the <see cref="DaqifiDevice.MinSupportedFirmware"/> floor,
+        /// so every supported device already has it. The typed-exception backstop only fires
+        /// against below-floor devices, and reports <see cref="DaqifiDevice.MinSupportedFirmware"/>
+        /// (not v3.4.6b1) as the required version, since that floor — not the command's original
+        /// introduction version — is what daqifi-core actually guarantees.
         /// </summary>
         SdStorageQuery,
 

--- a/src/Daqifi.Core/Device/FeatureNotSupportedException.cs
+++ b/src/Daqifi.Core/Device/FeatureNotSupportedException.cs
@@ -1,0 +1,83 @@
+using System;
+using Daqifi.Core.Firmware;
+
+#nullable enable
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Thrown when a device does not support a requested <see cref="DeviceFeature"/> — typically
+    /// because its firmware predates the feature's minimum version, per ADR 0001
+    /// (docs/adr/0001-firmware-feature-gating.md). The firmware's <c>**ERROR: -113, "Undefined
+    /// header"</c> reply (libscpi's <c>SCPI_ERROR_UNDEFINED_HEADER</c>) is the authoritative signal
+    /// on the command path; an up-front check against <see cref="DaqifiDevice.MinSupportedFirmware"/>
+    /// or <see cref="DaqifiDevice.IsFirmwareVersionSupported"/> can pre-empt the round-trip for UI.
+    /// </summary>
+    public sealed class FeatureNotSupportedException : Exception
+    {
+        /// <summary>
+        /// Gets the feature the device does not support.
+        /// </summary>
+        public DeviceFeature Feature { get; }
+
+        /// <summary>
+        /// Gets the minimum firmware version required for <see cref="Feature"/>, if known.
+        /// </summary>
+        public FirmwareVersion? RequiredVersion { get; }
+
+        /// <summary>
+        /// Gets the device's reported firmware version string as last received. May be empty
+        /// (not yet reported) or unparseable — this is the raw value, not a parsed
+        /// <see cref="FirmwareVersion"/>, so it is preserved even when it doesn't parse.
+        /// </summary>
+        public string? ActualVersion { get; }
+
+        /// <summary>
+        /// Gets the device's board type, if known.
+        /// </summary>
+        public DeviceType? Board { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeatureNotSupportedException"/> class.
+        /// </summary>
+        /// <param name="feature">The feature the device does not support.</param>
+        /// <param name="requiredVersion">The minimum firmware version required for <paramref name="feature"/>, if known.</param>
+        /// <param name="actualVersion">The device's reported firmware version string, if known.</param>
+        /// <param name="board">The device's board type, if known.</param>
+        public FeatureNotSupportedException(
+            DeviceFeature feature,
+            FirmwareVersion? requiredVersion = null,
+            string? actualVersion = null,
+            DeviceType? board = null)
+            : base(BuildMessage(feature, requiredVersion, actualVersion, board))
+        {
+            Feature = feature;
+            RequiredVersion = requiredVersion;
+            ActualVersion = actualVersion;
+            Board = board;
+        }
+
+        private static string BuildMessage(
+            DeviceFeature feature,
+            FirmwareVersion? requiredVersion,
+            string? actualVersion,
+            DeviceType? board)
+        {
+            var message = $"The device does not support '{feature}'.";
+
+            if (requiredVersion.HasValue)
+            {
+                message += string.IsNullOrEmpty(actualVersion)
+                    ? $" Requires firmware >= {requiredVersion.Value}; the device's firmware version is unknown."
+                    : $" Requires firmware >= {requiredVersion.Value}; the device reports '{actualVersion}'.";
+            }
+
+            if (board.HasValue)
+            {
+                message += $" Board: {board.Value}.";
+            }
+
+            return message;
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -49,6 +49,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <returns>A task that represents the asynchronous operation, containing the SD card storage info.</returns>
         /// <exception cref="System.InvalidOperationException">Thrown when the device is not connected or is currently logging to SD card.</exception>
         /// <exception cref="SdCardNotPresentException">Thrown when no SD card is installed in the device.</exception>
+        /// <exception cref="Daqifi.Core.Device.FeatureNotSupportedException">Thrown when the device's firmware does not recognize the storage query (SCPI -113 "Undefined header"), typically because it predates the minimum supported firmware.</exception>
         /// <exception cref="SdCardOperationException">Thrown when the device returned an SCPI error or an unparseable response.</exception>
         Task<SdCardStorageInfo> GetSdCardStorageAsync(CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
## Summary
- Adds `DeviceFeature` enum (`AnalogOutput`, `SdStorageQuery`, `CapabilityDocument`) and a typed `FeatureNotSupportedException` (`Feature`, `RequiredVersion`, `ActualVersion`, `Board`), per ADR 0001's proposed API shape.
- Adds `DaqifiDevice.MinSupportedFirmware` (v3.5.0) constant and a live-evaluated `IsFirmwareVersionSupported` property (reads `Metadata.FirmwareVersion` fresh on every access — not cached, per the ADR's "don't cache version-derived flags" rule).
- `GetSdCardStorageAsync` now parses the numeric SCPI error code out of the existing `**ERROR: <code>, "<msg>"` line and, on `-113` ("Undefined header"), throws `FeatureNotSupportedException` instead of the generic `SdCardOperationException`. This is a deliberate behavior change flagged in the ADR: old-firmware failures on this command move from a generic exception to a distinct typed one — callers catching `SdCardOperationException` broadly will need to also catch `FeatureNotSupportedException`.
- Retry logic is untouched: a persistent `-113` still retries once (like today's `-200` case) before translating.

Implements the primary near-term deliverable from ADR 0001 (`docs/adr/0001-firmware-feature-gating.md`, #252). Closes #254.

## Testing
- `dotnet build -c Release`: 0 warnings, 0 errors (`TreatWarningsAsErrors`).
- `dotnet test` (net9.0 + net10.0): 1340 passed, 0 failed, 2 skipped (real-hardware-only tests).
- New unit tests: `FeatureNotSupportedException` construction/message, `DaqifiDevice.IsFirmwareVersionSupported` (unknown/unparseable/below-floor/at-or-above-floor/live-reevaluation), and `GetSdCardStorageAsync` throwing `FeatureNotSupportedException` on a persistent `-113` (with `Feature`/`RequiredVersion`/`ActualVersion`/`Board` populated from device metadata).
- Verified on hardware (Nyquist1, firmware v3.6.2, `/dev/cu.usbmodem1101`): connect + short stream and `GetSdCardStorageAsync()` happy paths are unaffected by this change, and `IsFirmwareVersionSupported` correctly reports `true` against the real reported firmware string. The `-113` path itself couldn't be exercised on this device since its firmware is above the v3.5.0 floor — that wire format was already empirically verified in #253.

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test` — 1340 passed, 0 failed, 2 skipped
- [x] Bench-tested against real Nyquist1 hardware (firmware v3.6.2)
- [ ] Smoke test against firmware below the v3.5.0 floor to directly exercise `FeatureNotSupportedException` (no such device on hand for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)