### PR TITLE
fix(discovery): add Nyquist2 to Discovery.DeviceType and map it through

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -7,6 +7,22 @@ namespace Daqifi.Core.Tests.Device.Discovery;
 
 public class SerialDeviceFinderTests
 {
+    // Issue #283: Discovery.DeviceType lacked a Nyquist2 member, so
+    // ConvertDeviceType silently downgraded a correctly-detected Nyquist2 to
+    // Unknown.
+    [Theory]
+    [InlineData(Daqifi.Core.Device.DeviceType.Unknown, DeviceType.Unknown)]
+    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist1, DeviceType.Nyquist1)]
+    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist2, DeviceType.Nyquist2)]
+    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist3, DeviceType.Nyquist3)]
+    public void ConvertDeviceType_MapsToMatchingDiscoveryType(
+        Daqifi.Core.Device.DeviceType deviceType, DeviceType expected)
+    {
+        var result = SerialDeviceFinder.ConvertDeviceType(deviceType);
+
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
     public async Task DiscoverAsync_WithCancellationToken_ReturnsDevices()
     {

--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -25,7 +25,7 @@ public class WiFiDeviceFinderTests
     [InlineData(null, DeviceType.Unknown)]
     public void GetDeviceType_PartNumber_ReturnsCorrectType(string? partNumber, DeviceType expected)
     {
-        var result = WiFiDeviceFinder.GetDeviceType(partNumber!);
+        var result = WiFiDeviceFinder.GetDeviceType(partNumber);
 
         Assert.Equal(expected, result);
     }

--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -10,6 +10,26 @@ namespace Daqifi.Core.Tests.Device.Discovery;
 
 public class WiFiDeviceFinderTests
 {
+    // Issue #283: GetDeviceType had no "nq2" case, so a Nyquist2's part
+    // number was silently reported as Unknown, same class of bug as
+    // SerialDeviceFinder.ConvertDeviceType.
+    [Theory]
+    [InlineData("nq1", DeviceType.Nyquist1)]
+    [InlineData("Nq1", DeviceType.Nyquist1)]
+    [InlineData("nq2", DeviceType.Nyquist2)]
+    [InlineData("Nq2", DeviceType.Nyquist2)]
+    [InlineData("nq3", DeviceType.Nyquist3)]
+    [InlineData("Nq3", DeviceType.Nyquist3)]
+    [InlineData("nq4", DeviceType.Unknown)]
+    [InlineData("", DeviceType.Unknown)]
+    [InlineData(null, DeviceType.Unknown)]
+    public void GetDeviceType_PartNumber_ReturnsCorrectType(string? partNumber, DeviceType expected)
+    {
+        var result = WiFiDeviceFinder.GetDeviceType(partNumber!);
+
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
     public async Task DiscoverAsync_WithTimeout_CompletesWithinTimeout()
     {

--- a/src/Daqifi.Core/Device/Discovery/IDeviceInfo.cs
+++ b/src/Daqifi.Core/Device/Discovery/IDeviceInfo.cs
@@ -79,22 +79,22 @@ public enum DeviceType
     /// <summary>
     /// Unknown device type.
     /// </summary>
-    Unknown,
+    Unknown = 0,
 
     /// <summary>
     /// Nyquist 1 device.
     /// </summary>
-    Nyquist1,
+    Nyquist1 = 1,
 
     /// <summary>
     /// Nyquist 2 device.
     /// </summary>
-    Nyquist2,
+    Nyquist2 = 2,
 
     /// <summary>
     /// Nyquist 3 device.
     /// </summary>
-    Nyquist3
+    Nyquist3 = 3
 }
 
 /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/IDeviceInfo.cs
+++ b/src/Daqifi.Core/Device/Discovery/IDeviceInfo.cs
@@ -87,6 +87,11 @@ public enum DeviceType
     Nyquist1,
 
     /// <summary>
+    /// Nyquist 2 device.
+    /// </summary>
+    Nyquist2,
+
+    /// <summary>
     /// Nyquist 3 device.
     /// </summary>
     Nyquist3

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -513,11 +513,12 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     /// </summary>
     /// <param name="deviceType">The Device namespace DeviceType.</param>
     /// <returns>The Discovery namespace DeviceType.</returns>
-    private static DeviceType ConvertDeviceType(Device.DeviceType deviceType)
+    internal static DeviceType ConvertDeviceType(Device.DeviceType deviceType)
     {
         return deviceType switch
         {
             Device.DeviceType.Nyquist1 => DeviceType.Nyquist1,
+            Device.DeviceType.Nyquist2 => DeviceType.Nyquist2,
             Device.DeviceType.Nyquist3 => DeviceType.Nyquist3,
             _ => DeviceType.Unknown
         };

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -344,7 +344,7 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
     /// <summary>
     /// Determines device type from part number.
     /// </summary>
-    private static DeviceType GetDeviceType(string partNumber)
+    internal static DeviceType GetDeviceType(string partNumber)
     {
         if (string.IsNullOrWhiteSpace(partNumber))
             return DeviceType.Unknown;
@@ -352,6 +352,7 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         return partNumber.ToLowerInvariant() switch
         {
             "nq1" => DeviceType.Nyquist1,
+            "nq2" => DeviceType.Nyquist2,
             "nq3" => DeviceType.Nyquist3,
             _ => DeviceType.Unknown
         };

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -344,7 +344,7 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
     /// <summary>
     /// Determines device type from part number.
     /// </summary>
-    internal static DeviceType GetDeviceType(string partNumber)
+    internal static DeviceType GetDeviceType(string? partNumber)
     {
         if (string.IsNullOrWhiteSpace(partNumber))
             return DeviceType.Unknown;


### PR DESCRIPTION
## Summary
- `Daqifi.Core.Device.Discovery.DeviceType` was missing `Nyquist2` (only had `Unknown`/`Nyquist1`/`Nyquist3`), so both `SerialDeviceFinder.ConvertDeviceType` and `WiFiDeviceFinder.GetDeviceType` silently downgraded a correctly-detected Nyquist 2 device to `Unknown`.
- Added `Nyquist2` to the Discovery enum and wired it through both finders' mapping switches (the WiFi finder had the identical `"nq2"`-missing bug, same root cause).
- Made both mapping methods `internal static` (matching the existing pattern used elsewhere in `WiFiDeviceFinder`) so they're directly unit-testable via `InternalsVisibleTo`.

This enum reorder shifts `Nyquist3`'s underlying int value (2→3), but that's safe here: the enum is only ever constructed via these switch expressions and read through `IDeviceInfo.Type`/`ToString()` (the MCP DTO layer serializes it as a string) — never cast to `int`, JSON-number-serialized, or persisted, in either this repo or daqifi-desktop.

Fixes #283

## Test plan
- [x] Added theory tests for `SerialDeviceFinder.ConvertDeviceType` covering all four `Device.DeviceType` values
- [x] Added theory tests for `WiFiDeviceFinder.GetDeviceType` covering nq1/nq2/nq3/unknown/empty/null part numbers
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test src/Daqifi.Core.Tests` — 1355 passed, 2 skipped (pre-existing, hardware-only), 0 failed, both net9.0/net10.0
- [x] `dotnet format --verify-no-changes` — no formatting issues in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)