### PR TITLE
feat(discovery): surface a stable USB physical-location identifier

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -151,6 +151,14 @@ await firmwareUpdateService.UpdateFirmwareAsync(
 `LocationKey` is resolved via `IUsbLocationProvider` and is Windows-only in v1 (Linux/macOS
 resolve to `null`, same as `IUsbPortDescriptorProvider`'s cross-platform fallback pattern).
 
+> **Verification status:** the serial ⇄ HID-bootloader stability claim above is this feature's
+> core design assumption ([#285](https://github.com/daqifi/daqifi-core/issues/285)), but it has
+> **not yet been empirically confirmed on Windows hardware** in this repo — the environment this
+> was built in has no Windows machine. `WindowsUsbLocationProvider`'s WMI query path is likewise
+> unverified against a real device (CI runs `ubuntu-latest` only, so only the platform-independent
+> parsing/fallback logic has automated coverage). Confirm both on a Windows bench with real
+> hardware before relying on this for anything safety-critical.
+
 ### Continuous Discovery (Live Device Set)
 
 `IDeviceFinder.DiscoverAsync` is a single pass. For a UI that shows a live, self-updating

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -125,6 +125,32 @@ if (devices.Any())
 }
 ```
 
+### USB Physical-Location Correlation
+
+`IDeviceInfo.LocationKey` is a stable, topology-derived identifier for the physical USB port a
+device is plugged into (e.g. `Port_#0001.Hub_#0001` on Windows). Unlike `PortName`, `DevicePath`,
+and `SerialNumber` — which are transport-scoped and don't survive a device switching identities —
+`LocationKey` stays the same for the same physical port across a device's transitions between
+serial (app) mode and HID bootloader mode, and across re-enumerations. Use it to correlate the
+same physical unit across a firmware update's mode switch, or to disambiguate multiple identical
+HID bootloaders (same VID/PID, no serial number) plugged into different ports:
+
+```csharp
+using var serialFinder = new SerialDeviceFinder();
+var device = (await serialFinder.DiscoverAsync()).First();
+var targetLocation = device.LocationKey; // resolved while still in serial/app mode
+
+// ...device reboots into bootloader mode via ForceBootloader...
+
+// Target the bootloader that came from the SAME physical port, even though its
+// HID device path didn't exist until after the reboot.
+await firmwareUpdateService.UpdateFirmwareAsync(
+    device, hexFilePath, progress: null, targetDevicePath: null, targetLocationKey: targetLocation);
+```
+
+`LocationKey` is resolved via `IUsbLocationProvider` and is Windows-only in v1 (Linux/macOS
+resolve to `null`, same as `IUsbPortDescriptorProvider`'s cross-platform fallback pattern).
+
 ### Continuous Discovery (Live Device Set)
 
 `IDeviceFinder.DiscoverAsync` is a single pass. For a UI that shows a live, self-updating

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
@@ -573,7 +573,9 @@ public class DaqifiDeviceFactoryTests
         public ConnectionType ConnectionType { get; set; } = ConnectionType.Unknown;
         public string? PortName { get; set; }
         public string? DevicePath { get; set; }
-        public string? LocationKey { get; set; }
+        // LocationKey deliberately NOT implemented here: it's a default interface property on
+        // IDeviceInfo (defaults to null), so this pre-existing implementer compiles and works
+        // unmodified — proving the default-interface-method approach avoids a breaking change.
     }
 
     #endregion

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
@@ -573,6 +573,7 @@ public class DaqifiDeviceFactoryTests
         public ConnectionType ConnectionType { get; set; } = ConnectionType.Unknown;
         public string? PortName { get; set; }
         public string? DevicePath { get; set; }
+        public string? LocationKey { get; set; }
     }
 
     #endregion

--- a/src/Daqifi.Core.Tests/Device/Discovery/DeviceInfoTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/DeviceInfoTests.cs
@@ -83,6 +83,24 @@ public class DeviceInfoTests
         Assert.Equal(ConnectionType.Unknown, deviceInfo.ConnectionType);
         Assert.True(deviceInfo.IsPowerOn); // Default should be true
         Assert.Null(deviceInfo.LocalInterfaceAddress); // Default should be null
+        Assert.Null(deviceInfo.LocationKey); // Default should be null
+    }
+
+    [Fact]
+    public void DeviceInfo_LocationKey_CanBeSetAndRetrieved()
+    {
+        // Arrange
+        var deviceInfo = new DeviceInfo
+        {
+            Name = "DAQiFi",
+            SerialNumber = "67890",
+            PortName = "COM3",
+            ConnectionType = ConnectionType.Serial,
+            LocationKey = "Port_#0001.Hub_#0001"
+        };
+
+        // Act & Assert
+        Assert.Equal("Port_#0001.Hub_#0001", deviceInfo.LocationKey);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/Discovery/HidDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/HidDeviceFinderTests.cs
@@ -111,6 +111,28 @@ public class HidDeviceFinderTests
     }
 
     [Fact]
+    public async Task DiscoverAsync_WithThrowingLocationProvider_DoesNotAbortDiscovery()
+    {
+        // A misbehaving custom IUsbLocationProvider must never take down the whole enumeration —
+        // location is enrichment metadata, not identification. Mirrors
+        // SerialDeviceFinder's DiscoverAsync_WithThrowingDescriptorProvider_DoesNotAbortDiscovery.
+        var enumerator = new FakeHidDeviceEnumerator([
+            new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN1", "Bootloader A"),
+            new HidDeviceInfo(0x04D8, 0x003C, "path-2", "SN2", "Bootloader B")
+        ]);
+        var throwingProvider = new RecordingUsbLocationProvider(
+            path => path == "path-1" ? throw new InvalidOperationException("simulated provider failure") : "loc-2");
+
+        using var finder = new HidDeviceFinder(enumerator, throwingProvider);
+
+        var devices = (await finder.DiscoverAsync()).ToList();
+
+        Assert.Equal(2, devices.Count);
+        Assert.Null(devices[0].LocationKey);
+        Assert.Equal("loc-2", devices[1].LocationKey);
+    }
+
+    [Fact]
     public void HidDeviceFinder_Dispose_DoesNotThrow()
     {
         var enumerator = new FakeHidDeviceEnumerator();

--- a/src/Daqifi.Core.Tests/Device/Discovery/HidDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/HidDeviceFinderTests.cs
@@ -76,6 +76,41 @@ public class HidDeviceFinderTests
     }
 
     [Fact]
+    public async Task DiscoverAsync_PopulatesLocationKey_FromInjectedProvider()
+    {
+        var enumerator = new FakeHidDeviceEnumerator([
+            new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN1", "DAQiFi Bootloader")
+        ]);
+        var locationProvider = new RecordingUsbLocationProvider(
+            path => path == "path-1" ? "Port_#0001.Hub_#0001" : null);
+
+        using var finder = new HidDeviceFinder(enumerator, locationProvider);
+
+        var devices = (await finder.DiscoverAsync()).ToList();
+
+        var device = Assert.IsType<DeviceInfo>(devices[0]);
+        Assert.Equal("Port_#0001.Hub_#0001", device.LocationKey);
+        Assert.Contains("path-1", locationProvider.Requests);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_WithUnresolvableDevicePath_LocationKeyIsNull()
+    {
+        // The default (no explicit provider) constructor resolves the platform provider, which
+        // on any platform returns null for a path this malformed — proving discovery never
+        // throws when location resolution can't classify the device.
+        var enumerator = new FakeHidDeviceEnumerator([
+            new HidDeviceInfo(0x04D8, 0x003C, "not-a-real-device-interface-path", "SN1", "DAQiFi Bootloader")
+        ]);
+
+        using var finder = new HidDeviceFinder(enumerator);
+
+        var devices = (await finder.DiscoverAsync()).ToList();
+
+        Assert.Null(devices[0].LocationKey);
+    }
+
+    [Fact]
     public void HidDeviceFinder_Dispose_DoesNotThrow()
     {
         var enumerator = new FakeHidDeviceEnumerator();
@@ -116,6 +151,21 @@ public class HidDeviceFinderTests
             LastVendorId = vendorId;
             LastProductId = productId;
             return Task.FromResult(_devices);
+        }
+    }
+
+    private sealed class RecordingUsbLocationProvider : IUsbLocationProvider
+    {
+        private readonly Func<string, string?> _resolver;
+
+        public RecordingUsbLocationProvider(Func<string, string?> resolver) => _resolver = resolver;
+
+        public List<string> Requests { get; } = [];
+
+        public string? GetLocationKey(string portNameOrDevicePath)
+        {
+            Requests.Add(portNameOrDevicePath);
+            return _resolver(portNameOrDevicePath);
         }
     }
 }

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -112,6 +112,22 @@ public class SerialDeviceFinderTests
     }
 
     [Fact]
+    public void SerialDeviceFinder_CustomUsbLocationProvider_AcceptsProvider()
+    {
+        // DeviceInfo.LocationKey is only populated after a real status-message probe succeeds
+        // (see TryGetDeviceInfoAsync), which this suite has no fake serial transport to
+        // simulate — the same limitation that already applies to every other field mapped
+        // from statusMessage there (SerialNumber, FirmwareVersion, etc.). This test locks in
+        // the constructor wiring; end-to-end LocationKey population is exercised on real
+        // hardware, not here.
+        var fakeProvider = new RecordingUsbLocationProvider(_ => "Port_#0001.Hub_#0001");
+
+        using var finder = new SerialDeviceFinder(9600, usbPortDescriptorProvider: null, usbLocationProvider: fakeProvider);
+
+        Assert.NotNull(finder);
+    }
+
+    [Fact]
     public async Task DiscoverAsync_WithNonDaqifiVidPid_DoesNotProbePort()
     {
         // Closes #157: ports whose USB descriptor is NOT a known DAQiFi
@@ -230,5 +246,12 @@ public class SerialDeviceFinderTests
             Interlocked.Increment(ref _callCount);
             return _classifier(portName);
         }
+    }
+
+    private sealed class RecordingUsbLocationProvider : IUsbLocationProvider
+    {
+        private readonly Func<string, string?> _resolver;
+        public RecordingUsbLocationProvider(Func<string, string?> resolver) => _resolver = resolver;
+        public string? GetLocationKey(string portNameOrDevicePath) => _resolver(portNameOrDevicePath);
     }
 }

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -114,17 +114,57 @@ public class SerialDeviceFinderTests
     [Fact]
     public void SerialDeviceFinder_CustomUsbLocationProvider_AcceptsProvider()
     {
-        // DeviceInfo.LocationKey is only populated after a real status-message probe succeeds
-        // (see TryGetDeviceInfoAsync), which this suite has no fake serial transport to
-        // simulate — the same limitation that already applies to every other field mapped
-        // from statusMessage there (SerialNumber, FirmwareVersion, etc.). This test locks in
-        // the constructor wiring; end-to-end LocationKey population is exercised on real
-        // hardware, not here.
         var fakeProvider = new RecordingUsbLocationProvider(_ => "Port_#0001.Hub_#0001");
 
         using var finder = new SerialDeviceFinder(9600, usbPortDescriptorProvider: null, usbLocationProvider: fakeProvider);
 
         Assert.NotNull(finder);
+    }
+
+    [Fact]
+    public void BuildDeviceInfo_MapsStatusMessageAndLocationKey()
+    {
+        // BuildDeviceInfo is the pure mapping logic TryGetDeviceInfoAsync delegates to after a
+        // real probe succeeds — split out specifically so this mapping (including the new
+        // LocationKey field) is unit-testable with a hand-constructed status message, without
+        // needing a fake serial transport (which this suite has none of).
+        var statusMessage = new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceSn = 12345,
+            DeviceFwRev = "3.7.1"
+        };
+
+        var deviceInfo = SerialDeviceFinder.BuildDeviceInfo(statusMessage, "COM3", "Port_#0001.Hub_#0001");
+
+        Assert.Equal("Nq1", deviceInfo.Name);
+        Assert.Equal("12345", deviceInfo.SerialNumber);
+        Assert.Equal("3.7.1", deviceInfo.FirmwareVersion);
+        Assert.Equal(ConnectionType.Serial, deviceInfo.ConnectionType);
+        Assert.Equal("COM3", deviceInfo.PortName);
+        Assert.Equal("Port_#0001.Hub_#0001", deviceInfo.LocationKey);
+    }
+
+    [Fact]
+    public void BuildDeviceInfo_WithNullLocationKey_LeavesLocationKeyNull()
+    {
+        // Covers the "location provider returned null / threw and the caller passed null"
+        // path — e.g. macOS/Linux's NullUsbLocationProvider fallback.
+        var statusMessage = new DaqifiOutMessage { DevicePn = "Nq1", DeviceSn = 1, DeviceFwRev = "3.7.1" };
+
+        var deviceInfo = SerialDeviceFinder.BuildDeviceInfo(statusMessage, "COM3", null);
+
+        Assert.Null(deviceInfo.LocationKey);
+    }
+
+    [Fact]
+    public void BuildDeviceInfo_WithBlankDevicePn_FallsBackToPortNameAsName()
+    {
+        var statusMessage = new DaqifiOutMessage { DevicePn = "", DeviceSn = 1, DeviceFwRev = "3.7.1" };
+
+        var deviceInfo = SerialDeviceFinder.BuildDeviceInfo(statusMessage, "COM3", null);
+
+        Assert.Equal("COM3", deviceInfo.Name);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/Discovery/UsbLocationProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/UsbLocationProviderTests.cs
@@ -1,0 +1,92 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+public class UsbLocationProviderTests
+{
+    [Fact]
+    public void NullUsbLocationProvider_AlwaysReturnsNull()
+    {
+        var provider = NullUsbLocationProvider.Instance;
+        Assert.Null(provider.GetLocationKey("COM9"));
+        Assert.Null(provider.GetLocationKey(@"\\?\hid#vid_04d8&pid_003c#7&1a2b3c4d&0&0000#{4d1e55b2-f46c-11d0-894f-00a0c90c8b6e}"));
+        Assert.Null(provider.GetLocationKey(""));
+    }
+
+    [Fact]
+    public void HidDevicePathParser_ParseInstanceId_TypicalHidPath_ReturnsExpectedInstanceId()
+    {
+        const string devicePath =
+            @"\\?\hid#vid_04d8&pid_003c#7&1a2b3c4d&0&0000#{4d1e55b2-f46c-11d0-894f-00a0c90c8b6e}";
+
+        var result = HidDevicePathParser.ParseInstanceId(devicePath);
+
+        Assert.Equal(@"HID\VID_04D8&PID_003C\7&1A2B3C4D&0&0000", result);
+    }
+
+    [Fact]
+    public void HidDevicePathParser_ParseInstanceId_LowercaseInput_IsUppercased()
+    {
+        const string devicePath =
+            @"\\?\hid#vid_04d8&pid_003c#7&1a2b3c4d&0&0000#{4d1e55b2-f46c-11d0-894f-00a0c90c8b6e}";
+
+        var result = HidDevicePathParser.ParseInstanceId(devicePath);
+
+        Assert.Equal(result, result?.ToUpperInvariant());
+    }
+
+    [Fact]
+    public void HidDevicePathParser_ParseInstanceId_WithoutLeadingPrefix_StillParses()
+    {
+        // Defensive: some libraries surface the path without the "\\?\" prefix.
+        const string devicePath =
+            @"hid#vid_04d8&pid_003c#7&1a2b3c4d&0&0000#{4d1e55b2-f46c-11d0-894f-00a0c90c8b6e}";
+
+        var result = HidDevicePathParser.ParseInstanceId(devicePath);
+
+        Assert.Equal(@"HID\VID_04D8&PID_003C\7&1A2B3C4D&0&0000", result);
+    }
+
+    [Fact]
+    public void HidDevicePathParser_ParseInstanceId_MissingGuidSegment_ReturnsNull()
+    {
+        const string devicePath = @"\\?\hid#vid_04d8&pid_003c#7&1a2b3c4d&0&0000";
+
+        var result = HidDevicePathParser.ParseInstanceId(devicePath);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HidDevicePathParser_ParseInstanceId_NoHashSeparators_ReturnsNull()
+    {
+        // e.g. a plain COM port name reaching the HID-path parser by mistake.
+        var result = HidDevicePathParser.ParseInstanceId("COM9");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HidDevicePathParser_ParseInstanceId_EmptyInput_ReturnsNull()
+    {
+        Assert.Null(HidDevicePathParser.ParseInstanceId(string.Empty));
+    }
+
+    [Fact]
+    public void HidDevicePathParser_ParseInstanceId_NullInput_ReturnsNull()
+    {
+        Assert.Null(HidDevicePathParser.ParseInstanceId(null!));
+    }
+
+    [Fact]
+    public void HidDevicePathParser_ParseInstanceId_GuidSegmentNotBraced_ReturnsNull()
+    {
+        // Trailing segment must look like "{guid}"; anything else means this isn't a device
+        // interface path in the expected shape.
+        const string devicePath = @"\\?\hid#vid_04d8&pid_003c#7&1a2b3c4d&0&0000#not-a-guid";
+
+        var result = HidDevicePathParser.ParseInstanceId(devicePath);
+
+        Assert.Null(result);
+    }
+}

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -4,6 +4,7 @@ using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
+using Daqifi.Core.Device.Discovery;
 using Daqifi.Core.Firmware;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -181,6 +182,155 @@ public class FirmwareUpdateServiceTests
         Assert.Equal("path-2", hidTransport.LastConnectByPath);
         Assert.Equal(1, hidTransport.ConnectByPathAttempts);
         Assert.Equal(0, hidTransport.ConnectAttempts); // did NOT fall back to VID/PID first-match
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WithTargetLocationKey_FlashesThatExactBootloaderByLocation()
+    {
+        // Same multi-device scenario as the targetDevicePath test above, but the caller only
+        // knows the target's USB physical-location key (resolved before the reboot into
+        // bootloader mode, when the device was still enumerable by its old identity) — not its
+        // future bootloader device path. WaitForBootloaderDeviceAsync must resolve each
+        // candidate's location via the injected provider and match on that.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0xCD, 0xAB]); // READ_CRC response → 0xABCD (match)
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            [
+                new HidDeviceInfo(0x04D8, 0x003C, "path-1", null, "DAQiFi Bootloader"),
+                new HidDeviceInfo(0x04D8, 0x003C, "path-2", null, "DAQiFi Bootloader")
+            ]
+        ]);
+
+        var locationProvider = new FakeUsbLocationProvider(new Dictionary<string, string>
+        {
+            ["path-1"] = "Port_#0001.Hub_#0001",
+            ["path-2"] = "Port_#0002.Hub_#0001"
+        });
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions(),
+            locationProvider);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(
+                device, hexPath, progress: null, targetDevicePath: null, targetLocationKey: "Port_#0002.Hub_#0001");
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal("path-2", hidTransport.LastConnectByPath);
+        Assert.Equal(1, hidTransport.ConnectByPathAttempts);
+        Assert.Equal(0, hidTransport.ConnectAttempts); // did NOT fall back to VID/PID first-match
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WithTargetDevicePathAndTargetLocationKey_DevicePathTakesPriority()
+    {
+        // When both are supplied, targetDevicePath must win — it's an exact identifier while
+        // targetLocationKey depends on a resolvable provider.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0xCD, 0xAB]); // READ_CRC response → 0xABCD (match)
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            [
+                new HidDeviceInfo(0x04D8, 0x003C, "path-1", null, "DAQiFi Bootloader"),
+                new HidDeviceInfo(0x04D8, 0x003C, "path-2", null, "DAQiFi Bootloader")
+            ]
+        ]);
+
+        // Deliberately mismatched: the location key would resolve to path-2, but the explicit
+        // device path (path-1) must win.
+        var locationProvider = new FakeUsbLocationProvider(new Dictionary<string, string>
+        {
+            ["path-1"] = "Port_#0001.Hub_#0001",
+            ["path-2"] = "Port_#0002.Hub_#0001"
+        });
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions(),
+            locationProvider);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(
+                device,
+                hexPath,
+                progress: null,
+                targetDevicePath: "path-1",
+                targetLocationKey: "Port_#0002.Hub_#0001");
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal("path-1", hidTransport.LastConnectByPath);
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WithWhitespaceTargetLocationKey_ThrowsArgumentException()
+    {
+        // Same fast-fail contract as targetDevicePath: whitespace can never match a resolved
+        // location key, so fail before polling until the WaitingForBootloader timeout.
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0xA1, 0x01]]),
+            new FakeHidDeviceEnumerator([]),
+            CreateFastOptions());
+
+        var device = new FakeStreamingDevice("COM3");
+        var hexPath = CreateTempFile();
+        try
+        {
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => service.UpdateFirmwareAsync(
+                    device, hexPath, progress: null, targetDevicePath: null, targetLocationKey: "   "));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
     }
 
     [Fact]
@@ -2831,6 +2981,19 @@ public class FirmwareUpdateServiceTests
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromException<IReadOnlyList<HidDeviceInfo>>(_exception);
         }
+    }
+
+    private sealed class FakeUsbLocationProvider : IUsbLocationProvider
+    {
+        private readonly IReadOnlyDictionary<string, string> _locationsByDevicePath;
+
+        public FakeUsbLocationProvider(IReadOnlyDictionary<string, string> locationsByDevicePath)
+        {
+            _locationsByDevicePath = locationsByDevicePath;
+        }
+
+        public string? GetLocationKey(string portNameOrDevicePath)
+            => _locationsByDevicePath.TryGetValue(portNameOrDevicePath, out var location) ? location : null;
     }
 
     private sealed class FakeBootloaderProtocol : IBootloaderProtocol

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -306,6 +306,69 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateFirmwareAsync_WithTargetLocationKey_ResolvesEachDevicePathAtMostOncePerPoll()
+    {
+        // Regression test: WaitForBootloaderDeviceAsync used to call GetLocationKey(...) inside
+        // its FirstOrDefault predicate on every poll iteration, re-resolving the SAME device
+        // path's (WMI, on the real Windows provider) location repeatedly while polling. A device
+        // path's physical location can't change while it stays enumerated, so a per-call cache
+        // should mean each unique path is resolved at most once across the whole wait, no matter
+        // how many poll iterations it takes to see a match. path-1 is enumerated on BOTH polls
+        // below; path-2 (the match) only appears on the second.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0x01, 0x10]); // version
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0xCD, 0xAB]); // READ_CRC response → 0xABCD (match)
+
+        var enumerator = new FakeHidDeviceEnumerator([
+            [new HidDeviceInfo(0x04D8, 0x003C, "path-1", null, "DAQiFi Bootloader")],
+            [
+                new HidDeviceInfo(0x04D8, 0x003C, "path-1", null, "DAQiFi Bootloader"),
+                new HidDeviceInfo(0x04D8, 0x003C, "path-2", null, "DAQiFi Bootloader")
+            ]
+        ]);
+
+        var locationProvider = new FakeUsbLocationProvider(new Dictionary<string, string>
+        {
+            ["path-1"] = "Port_#0001.Hub_#0001",
+            ["path-2"] = "Port_#0002.Hub_#0001"
+        });
+
+        var bootloaderProtocol = new FakeBootloaderProtocol(
+            [[0xA1, 0x01], [0xA1, 0x02]],
+            crcRegions: [new FlashCrcRegion(0x9D000000, 256, 0xABCD)]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions(),
+            locationProvider);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(
+                device, hexPath, progress: null, targetDevicePath: null, targetLocationKey: "Port_#0002.Hub_#0001");
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal("path-2", hidTransport.LastConnectByPath);
+        Assert.Equal(1, locationProvider.Requests.Count(p => p == "path-1"));
+        Assert.Equal(1, locationProvider.Requests.Count(p => p == "path-2"));
+    }
+
+    [Fact]
     public async Task UpdateFirmwareAsync_WithWhitespaceTargetLocationKey_ThrowsArgumentException()
     {
         // Same fast-fail contract as targetDevicePath: whitespace can never match a resolved
@@ -2992,8 +3055,13 @@ public class FirmwareUpdateServiceTests
             _locationsByDevicePath = locationsByDevicePath;
         }
 
+        public List<string> Requests { get; } = [];
+
         public string? GetLocationKey(string portNameOrDevicePath)
-            => _locationsByDevicePath.TryGetValue(portNameOrDevicePath, out var location) ? location : null;
+        {
+            Requests.Add(portNameOrDevicePath);
+            return _locationsByDevicePath.TryGetValue(portNameOrDevicePath, out var location) ? location : null;
+        }
     }
 
     private sealed class FakeBootloaderProtocol : IBootloaderProtocol

--- a/src/Daqifi.Core/Device/Discovery/DeviceInfo.cs
+++ b/src/Daqifi.Core/Device/Discovery/DeviceInfo.cs
@@ -71,6 +71,12 @@ public class DeviceInfo : IDeviceInfo
     public string? DevicePath { get; set; }
 
     /// <summary>
+    /// Gets or sets the USB physical-location key (e.g. <c>Port_#0001.Hub_#0001</c>), or null
+    /// if it could not be resolved. See <see cref="IDeviceInfo.LocationKey"/>.
+    /// </summary>
+    public string? LocationKey { get; set; }
+
+    /// <summary>
     /// Returns a string representation of the device info.
     /// </summary>
     /// <returns>A string describing the device.</returns>

--- a/src/Daqifi.Core/Device/Discovery/HidDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/HidDeviceFinder.cs
@@ -18,6 +18,7 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
     public const int DefaultProductId = 0x003C;
 
     private readonly IHidDeviceEnumerator _hidDeviceEnumerator;
+    private readonly IUsbLocationProvider _usbLocationProvider;
     private readonly SemaphoreSlim _discoverySemaphore = new(1, 1);
     private bool _disposed;
 
@@ -30,9 +31,27 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
     }
 
     internal HidDeviceFinder(IHidDeviceEnumerator hidDeviceEnumerator)
+        : this(hidDeviceEnumerator, usbLocationProvider: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the HidDeviceFinder class with an
+    /// explicit USB location provider — primarily for tests that mock the
+    /// platform-specific WMI lookup.
+    /// </summary>
+    /// <param name="hidDeviceEnumerator">Enumerator used to list HID devices.</param>
+    /// <param name="usbLocationProvider">
+    /// Provider used to resolve a discovered device's USB physical-location
+    /// key. When null, a platform-default provider is used (Windows → WMI,
+    /// others → no-op fallback).
+    /// </param>
+    internal HidDeviceFinder(IHidDeviceEnumerator hidDeviceEnumerator, IUsbLocationProvider? usbLocationProvider)
     {
         _hidDeviceEnumerator = hidDeviceEnumerator
             ?? throw new ArgumentNullException(nameof(hidDeviceEnumerator));
+        _usbLocationProvider = usbLocationProvider
+            ?? UsbLocationProviderFactory.CreateForCurrentPlatform();
 
         VendorIdFilter = DefaultVendorId;
         ProductIdFilter = DefaultProductId;
@@ -94,7 +113,8 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
                     FirmwareVersion = string.Empty,
                     ConnectionType = ConnectionType.Hid,
                     Type = DeviceType.Unknown,
-                    DevicePath = hidDevice.DevicePath
+                    DevicePath = hidDevice.DevicePath,
+                    LocationKey = _usbLocationProvider.GetLocationKey(hidDevice.DevicePath)
                 };
 
                 discoveredDevices.Add(deviceInfo);

--- a/src/Daqifi.Core/Device/Discovery/HidDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/HidDeviceFinder.cs
@@ -104,6 +104,19 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
 
             foreach (var hidDevice in hidDevices)
             {
+                string? locationKey;
+                try
+                {
+                    locationKey = _usbLocationProvider.GetLocationKey(hidDevice.DevicePath);
+                }
+                catch
+                {
+                    // A misbehaving custom IUsbLocationProvider must never abort the whole
+                    // enumeration — location is enrichment metadata, not identification.
+                    // Mirrors SerialDeviceFinder's handling of a throwing provider.
+                    locationKey = null;
+                }
+
                 var deviceInfo = new DeviceInfo
                 {
                     Name = string.IsNullOrWhiteSpace(hidDevice.ProductName)
@@ -114,7 +127,7 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
                     ConnectionType = ConnectionType.Hid,
                     Type = DeviceType.Unknown,
                     DevicePath = hidDevice.DevicePath,
-                    LocationKey = _usbLocationProvider.GetLocationKey(hidDevice.DevicePath)
+                    LocationKey = locationKey
                 };
 
                 discoveredDevices.Add(deviceInfo);

--- a/src/Daqifi.Core/Device/Discovery/HidDevicePathParser.cs
+++ b/src/Daqifi.Core/Device/Discovery/HidDevicePathParser.cs
@@ -1,0 +1,52 @@
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Parses the PnP device instance ID embedded in a Windows HID device interface path. Kept
+/// separate from <see cref="WindowsUsbLocationProvider"/> (which is Windows-only because it
+/// calls into <see cref="System.Management"/>) so this pure string-manipulation logic can be
+/// unit tested on any platform without WMI/hardware access.
+/// </summary>
+internal static class HidDevicePathParser
+{
+    private const string DevicePathPrefix = @"\\?\";
+
+    /// <summary>
+    /// Extracts the PnP device instance ID embedded in a HID device interface path (e.g.
+    /// <c>\\?\hid#vid_04d8&amp;pid_003c#7&amp;1a2b3c4d&amp;0&amp;0000#{4d1e55b2-f46c-11d0-894f-00a0c90c8b6e}</c>
+    /// → <c>HID\VID_04D8&amp;PID_003C\7&amp;1A2B3C4D&amp;0&amp;0000</c>), or null if
+    /// <paramref name="devicePath"/> doesn't match the expected shape. A device interface path
+    /// encodes the instance ID with '#' in place of '\', followed by a trailing
+    /// '#{device-interface-class-guid}' segment that must be stripped first.
+    /// </summary>
+    internal static string? ParseInstanceId(string devicePath)
+    {
+        if (string.IsNullOrWhiteSpace(devicePath))
+        {
+            return null;
+        }
+
+        var path = devicePath.StartsWith(DevicePathPrefix, StringComparison.OrdinalIgnoreCase)
+            ? devicePath[DevicePathPrefix.Length..]
+            : devicePath;
+
+        var lastHash = path.LastIndexOf('#');
+        if (lastHash < 0)
+        {
+            return null;
+        }
+
+        var guidSegment = path[(lastHash + 1)..];
+        if (guidSegment.Length < 2 || guidSegment[0] != '{' || guidSegment[^1] != '}')
+        {
+            return null;
+        }
+
+        var instanceSegments = path[..lastHash];
+        if (instanceSegments.Length == 0)
+        {
+            return null;
+        }
+
+        return instanceSegments.Replace('#', '\\').ToUpperInvariant();
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/IDeviceInfo.cs
+++ b/src/Daqifi.Core/Device/Discovery/IDeviceInfo.cs
@@ -69,6 +69,16 @@ public interface IDeviceInfo
     /// Gets the device path (for HID devices).
     /// </summary>
     string? DevicePath { get; }
+
+    /// <summary>
+    /// Gets the USB physical-location key (e.g. <c>Port_#0001.Hub_#0001</c>), or null if it
+    /// could not be resolved. Stable for a given physical USB port across a device's
+    /// transitions between transports (e.g. serial app mode ⇄ HID bootloader mode) and
+    /// re-enumerations, so it can be used to correlate the same physical unit and disambiguate
+    /// multiple identical devices (same VID/PID, no serial number). Resolved via
+    /// <see cref="IUsbLocationProvider"/>; Windows-only in v1, always null elsewhere.
+    /// </summary>
+    string? LocationKey { get; }
 }
 
 /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/IDeviceInfo.cs
+++ b/src/Daqifi.Core/Device/Discovery/IDeviceInfo.cs
@@ -78,7 +78,15 @@ public interface IDeviceInfo
     /// multiple identical devices (same VID/PID, no serial number). Resolved via
     /// <see cref="IUsbLocationProvider"/>; Windows-only in v1, always null elsewhere.
     /// </summary>
-    string? LocationKey { get; }
+    /// <remarks>
+    /// Implemented as a default interface property (so adding it does not break existing
+    /// implementers — the same technique used by
+    /// <see cref="Daqifi.Core.Firmware.IFirmwareUpdateService"/>'s targeted-update overloads):
+    /// an external <c>IDeviceInfo</c> implementation compiled before this member existed
+    /// inherits this default (null, meaning "not resolved") without recompiling.
+    /// <see cref="DeviceInfo"/> overrides it with a real stored value.
+    /// </remarks>
+    string? LocationKey => null;
 }
 
 /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/IUsbLocationProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/IUsbLocationProvider.cs
@@ -1,0 +1,28 @@
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Resolves a stable USB physical-location key for a serial port name (e.g.
+/// <c>COM9</c>) or a HID device interface path. Unlike <see cref="IUsbPortDescriptorProvider"/>
+/// (which identifies WHAT is plugged in) this identifies WHERE it is plugged in — a
+/// topology-derived key that stays the same for the same physical USB port across a
+/// device's transitions between transports (e.g. serial app mode ⇄ HID bootloader mode)
+/// and re-enumerations, letting callers correlate the same physical unit and disambiguate
+/// multiple identical devices (same VID/PID, no serial number) plugged into different ports.
+/// </summary>
+/// <remarks>
+/// Implementations are platform-specific: Windows resolves the key via
+/// <c>DEVPKEY_Device_LocationInfo</c>. Platforms without an implementation fall back to
+/// <see cref="NullUsbLocationProvider"/>, which returns null for every input.
+/// </remarks>
+public interface IUsbLocationProvider
+{
+    /// <summary>
+    /// Returns the USB physical-location key for <paramref name="portNameOrDevicePath"/>,
+    /// or <c>null</c> if it can't be resolved.
+    /// </summary>
+    /// <param name="portNameOrDevicePath">
+    /// A serial port name (e.g. <c>COM9</c>) or a HID device interface path
+    /// (e.g. <c>HidDeviceInfo.DevicePath</c>).
+    /// </param>
+    string? GetLocationKey(string portNameOrDevicePath);
+}

--- a/src/Daqifi.Core/Device/Discovery/NullUsbLocationProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/NullUsbLocationProvider.cs
@@ -1,0 +1,15 @@
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// No-op location provider that returns null for every input. Used as the fallback on
+/// platforms where USB physical-location resolution isn't implemented (Linux, macOS,
+/// and any other non-Windows platform in v1).
+/// </summary>
+internal sealed class NullUsbLocationProvider : IUsbLocationProvider
+{
+    public static readonly NullUsbLocationProvider Instance = new();
+
+    private NullUsbLocationProvider() { }
+
+    public string? GetLocationKey(string portNameOrDevicePath) => null;
+}

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -48,6 +48,7 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     private readonly int _baudRate;
     private readonly SemaphoreSlim _discoverySemaphore = new(1, 1);
     private readonly IUsbPortDescriptorProvider _usbPortDescriptorProvider;
+    private readonly IUsbLocationProvider _usbLocationProvider;
     private readonly Func<string[]>? _portNameProvider;
     private bool _disposed;
 
@@ -103,15 +104,23 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     /// Lets unit tests deterministically exercise the descriptor / probe
     /// path on hosts (CI containers) that have no real serial ports.
     /// </param>
+    /// <param name="usbLocationProvider">
+    /// Provider used to resolve a discovered device's USB physical-location
+    /// key. When null, a platform-default provider is used (Windows → WMI,
+    /// others → no-op fallback).
+    /// </param>
     internal SerialDeviceFinder(
         int baudRate,
         IUsbPortDescriptorProvider? usbPortDescriptorProvider,
-        Func<string[]>? portNameProvider = null)
+        Func<string[]>? portNameProvider = null,
+        IUsbLocationProvider? usbLocationProvider = null)
     {
         _baudRate = baudRate;
         _usbPortDescriptorProvider = usbPortDescriptorProvider
             ?? UsbPortDescriptorProviderFactory.CreateForCurrentPlatform();
         _portNameProvider = portNameProvider;
+        _usbLocationProvider = usbLocationProvider
+            ?? UsbLocationProviderFactory.CreateForCurrentPlatform();
     }
 
     #endregion
@@ -356,7 +365,8 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
                 ConnectionType = ConnectionType.Serial,
                 PortName = portName,
                 Type = ConvertDeviceType(DeviceTypeDetector.DetectFromPartNumber(statusMessage.DevicePn)),
-                IsPowerOn = true
+                IsPowerOn = true,
+                LocationKey = _usbLocationProvider.GetLocationKey(portName)
             };
 
             return deviceInfo;

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -354,22 +354,22 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
                 return null; // Not a DAQiFi device or device not responding
             }
 
-            // Extract device information from the status message
-            var deviceInfo = new DeviceInfo
+            string? locationKey;
+            try
             {
-                Name = !string.IsNullOrWhiteSpace(statusMessage.DevicePn)
-                    ? statusMessage.DevicePn
-                    : portName,
-                SerialNumber = statusMessage.DeviceSn.ToString(),
-                FirmwareVersion = statusMessage.DeviceFwRev ?? "Unknown",
-                ConnectionType = ConnectionType.Serial,
-                PortName = portName,
-                Type = ConvertDeviceType(DeviceTypeDetector.DetectFromPartNumber(statusMessage.DevicePn)),
-                IsPowerOn = true,
-                LocationKey = _usbLocationProvider.GetLocationKey(portName)
-            };
+                locationKey = _usbLocationProvider.GetLocationKey(portName);
+            }
+            catch
+            {
+                // Location resolution is enrichment metadata, not identification — a
+                // misbehaving custom IUsbLocationProvider must never discard an otherwise
+                // successfully-probed device by throwing into the broad catch below.
+                // Mirrors FilterByUsbDescriptor's handling of a throwing
+                // IUsbPortDescriptorProvider.
+                locationKey = null;
+            }
 
-            return deviceInfo;
+            return BuildDeviceInfo(statusMessage, portName, locationKey);
         }
         catch (UnauthorizedAccessException)
         {
@@ -531,6 +531,32 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             Device.DeviceType.Nyquist2 => DeviceType.Nyquist2,
             Device.DeviceType.Nyquist3 => DeviceType.Nyquist3,
             _ => DeviceType.Unknown
+        };
+    }
+
+    /// <summary>
+    /// Maps a device's status message to <see cref="DeviceInfo"/>. Pure mapping logic split out
+    /// from <see cref="TryGetDeviceInfoAsync"/> (which owns the SerialPort probe and any
+    /// IUsbLocationProvider error handling) so it can be unit tested directly with a
+    /// hand-constructed <see cref="DaqifiOutMessage"/> — no real serial port required.
+    /// </summary>
+    /// <param name="statusMessage">The device's SYSInfo status response.</param>
+    /// <param name="portName">The serial port name the device was probed on.</param>
+    /// <param name="locationKey">The already-resolved USB physical-location key, or null.</param>
+    internal static DeviceInfo BuildDeviceInfo(DaqifiOutMessage statusMessage, string portName, string? locationKey)
+    {
+        return new DeviceInfo
+        {
+            Name = !string.IsNullOrWhiteSpace(statusMessage.DevicePn)
+                ? statusMessage.DevicePn
+                : portName,
+            SerialNumber = statusMessage.DeviceSn.ToString(),
+            FirmwareVersion = statusMessage.DeviceFwRev ?? "Unknown",
+            ConnectionType = ConnectionType.Serial,
+            PortName = portName,
+            Type = ConvertDeviceType(DeviceTypeDetector.DetectFromPartNumber(statusMessage.DevicePn)),
+            IsPowerOn = true,
+            LocationKey = locationKey
         };
     }
 

--- a/src/Daqifi.Core/Device/Discovery/UsbLocationProviderFactory.cs
+++ b/src/Daqifi.Core/Device/Discovery/UsbLocationProviderFactory.cs
@@ -1,0 +1,26 @@
+using System.Runtime.InteropServices;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Picks the platform-appropriate <see cref="IUsbLocationProvider"/>: Windows → WMI-resolved
+/// <c>DEVPKEY_Device_LocationInfo</c>, others → null fallback (location correlation is
+/// unavailable; consumers should treat every device as having no known location).
+/// </summary>
+internal static class UsbLocationProviderFactory
+{
+    public static IUsbLocationProvider CreateForCurrentPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // The WindowsUsbLocationProvider type is annotated
+            // [SupportedOSPlatform("windows")]; constructor only runs after
+            // the runtime check above, so the analyzer warning is suppressed.
+#pragma warning disable CA1416
+            return new WindowsUsbLocationProvider();
+#pragma warning restore CA1416
+        }
+
+        return NullUsbLocationProvider.Instance;
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/WindowsUsbLocationProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsUsbLocationProvider.cs
@@ -1,0 +1,134 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Resolves a USB physical-location key via WMI's <c>DEVPKEY_Device_LocationInfo</c> device
+/// property (e.g. <c>Port_#0001.Hub_#0001</c>) — a topology-derived string Windows computes
+/// from physical bus/port position, independent of which driver/class is bound to the node.
+/// Uses <see cref="System.Management"/>; returns null on non-Windows platforms so callers can
+/// fall back to a no-correlation strategy.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class WindowsUsbLocationProvider : IUsbLocationProvider
+{
+    private const string LocationInfoKeyName = "DEVPKEY_Device_LocationInfo";
+
+    // SerialPort.GetPortNames() returns "COM<n>" on Windows; validated before
+    // interpolation into the WQL query string below.
+    private static readonly Regex PortNameRegex = new(
+        @"^COM\d+$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // A parsed PnP instance ID is composed of hex/word segments separated by backslashes
+    // (e.g. "HID\VID_04D8&PID_003C\7&1A2B3C4D&0&0000"). Validated before interpolation into
+    // a WQL query string so a malformed device path can never inject WQL syntax.
+    private static readonly Regex InstanceIdRegex = new(
+        @"^[A-Z0-9_&]+(\\[A-Z0-9_&]+)+$",
+        RegexOptions.Compiled);
+
+    public string? GetLocationKey(string portNameOrDevicePath)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(portNameOrDevicePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            if (PortNameRegex.IsMatch(portNameOrDevicePath))
+            {
+                return QueryLocationByCaption(portNameOrDevicePath);
+            }
+
+            var instanceId = HidDevicePathParser.ParseInstanceId(portNameOrDevicePath);
+            return instanceId != null ? QueryLocationByDeviceId(instanceId) : null;
+        }
+        catch
+        {
+            // Any WMI/interop error → behave like the no-op provider for this input.
+            // The caller falls through to "no known location", which is correct for
+            // any input we can't resolve.
+            return null;
+        }
+    }
+
+    private static string? QueryLocationByCaption(string portName)
+    {
+        // Match COM-port entities by Caption suffix, e.g. "USB Serial Device (COM9)",
+        // same query shape as WindowsUsbPortDescriptorProvider.
+        using var searcher = new System.Management.ManagementObjectSearcher(
+            $"SELECT DeviceID FROM Win32_PnPEntity WHERE PNPClass = 'Ports' AND Caption LIKE '%({portName})%'");
+        return FindLocationInfo(searcher);
+    }
+
+    private static string? QueryLocationByDeviceId(string instanceId)
+    {
+        if (!InstanceIdRegex.IsMatch(instanceId))
+        {
+            return null;
+        }
+
+        // WQL requires backslashes in string literals to be escaped as "\\".
+        var escaped = instanceId.Replace(@"\", @"\\", StringComparison.Ordinal);
+        using var searcher = new System.Management.ManagementObjectSearcher(
+            $"SELECT DeviceID FROM Win32_PnPEntity WHERE DeviceID = '{escaped}'");
+        return FindLocationInfo(searcher);
+    }
+
+    private static string? FindLocationInfo(System.Management.ManagementObjectSearcher searcher)
+    {
+        using var results = searcher.Get();
+        foreach (var entity in results)
+        {
+            using (entity)
+            {
+                if (entity is System.Management.ManagementObject managementObject)
+                {
+                    var location = GetLocationInfoProperty(managementObject);
+                    if (location != null)
+                    {
+                        return location;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetLocationInfoProperty(System.Management.ManagementObject entity)
+    {
+        using var inParams = entity.GetMethodParameters("GetDeviceProperties");
+        inParams["devicePropertyKeys"] = new[] { LocationInfoKeyName };
+
+        using var outParams = entity.InvokeMethod("GetDeviceProperties", inParams, null);
+        if (outParams?["deviceProperties"] is not System.Management.ManagementBaseObject[] deviceProperties)
+        {
+            return null;
+        }
+
+        foreach (var property in deviceProperties)
+        {
+            using (property)
+            {
+                var keyName = property["KeyName"] as string;
+                if (!string.Equals(keyName, LocationInfoKeyName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return property["Data"] as string;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -1290,6 +1290,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         string? targetLocationKey,
         CancellationToken cancellationToken)
     {
+        // A device path's physical location can't change while it stays enumerated, so caching
+        // per call (across poll iterations, not across separate update runs) avoids re-issuing a
+        // WMI query for the same candidate on every poll while targeting by location.
+        var locationCache = new Dictionary<string, string?>(StringComparer.Ordinal);
+
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -1329,7 +1334,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                 : targetLocationKey != null
                     ? devices.FirstOrDefault(d =>
                         string.Equals(
-                            _usbLocationProvider.GetLocationKey(d.DevicePath),
+                            ResolveLocationCached(d.DevicePath, locationCache),
                             targetLocationKey,
                             StringComparison.Ordinal))
                     : devices.FirstOrDefault();
@@ -1340,6 +1345,18 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
             await Task.Delay(_options.PollInterval, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private string? ResolveLocationCached(string devicePath, Dictionary<string, string?> cache)
+    {
+        if (cache.TryGetValue(devicePath, out var cached))
+        {
+            return cached;
+        }
+
+        var resolved = _usbLocationProvider.GetLocationKey(devicePath);
+        cache[devicePath] = resolved;
+        return resolved;
     }
 
     private async Task ConnectToBootloaderWithRetryAsync(

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
+using Daqifi.Core.Device.Discovery;
 using Microsoft.Extensions.Logging;
 
 namespace Daqifi.Core.Firmware;
@@ -129,6 +130,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     private readonly ILogger<FirmwareUpdateService> _logger;
     private readonly IBootloaderProtocol _bootloaderProtocol;
     private readonly IHidDeviceEnumerator _hidDeviceEnumerator;
+    private readonly IUsbLocationProvider _usbLocationProvider;
     private readonly FirmwareUpdateServiceOptions _options;
 
     private string _currentOperation = "Idle";
@@ -136,10 +138,14 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     private int _bootloaderPollAttempts;
     private Exception? _lastBootloaderEnumerationError;
     private string? _targetBootloaderDevicePath;
+    private string? _targetBootloaderLocationKey;
     private bool _disposed;
 
     /// <summary>
-    /// Initializes a new firmware update service.
+    /// Initializes a new firmware update service. <paramref name="usbLocationProvider"/> resolves
+    /// an enumerated bootloader's USB physical-location key when targeting by
+    /// <c>targetLocationKey</c>; when null, a platform-default provider is used (Windows → WMI,
+    /// others → no-op fallback, which makes location-key targeting a no-op).
     /// </summary>
     public FirmwareUpdateService(
         IHidTransport hidTransport,
@@ -148,7 +154,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         ILogger<FirmwareUpdateService> logger,
         IBootloaderProtocol? bootloaderProtocol = null,
         IHidDeviceEnumerator? hidDeviceEnumerator = null,
-        FirmwareUpdateServiceOptions? options = null)
+        FirmwareUpdateServiceOptions? options = null,
+        IUsbLocationProvider? usbLocationProvider = null)
     {
         _hidTransport = hidTransport ?? throw new ArgumentNullException(nameof(hidTransport));
         FirmwareDownloadService = firmwareDownloadService ?? throw new ArgumentNullException(nameof(firmwareDownloadService));
@@ -158,6 +165,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         _hidDeviceEnumerator = hidDeviceEnumerator ?? new HidLibraryDeviceEnumerator();
         _options = options ?? new FirmwareUpdateServiceOptions();
         _options.Validate();
+        _usbLocationProvider = usbLocationProvider ?? UsbLocationProviderFactory.CreateForCurrentPlatform();
     }
 
     /// <summary>
@@ -181,11 +189,21 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         => UpdateFirmwareAsync(device, hexFilePath, progress, null, cancellationToken);
 
     /// <inheritdoc />
+    public Task UpdateFirmwareAsync(
+        IStreamingDevice device,
+        string hexFilePath,
+        IProgress<FirmwareUpdateProgress>? progress,
+        string? targetDevicePath,
+        CancellationToken cancellationToken = default)
+        => UpdateFirmwareAsync(device, hexFilePath, progress, targetDevicePath, null, cancellationToken);
+
+    /// <inheritdoc />
     public async Task UpdateFirmwareAsync(
         IStreamingDevice device,
         string hexFilePath,
         IProgress<FirmwareUpdateProgress>? progress,
         string? targetDevicePath,
+        string? targetLocationKey,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(device);
@@ -200,6 +218,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         if (targetDevicePath != null && string.IsNullOrWhiteSpace(targetDevicePath))
         {
             throw new ArgumentException("Target device path cannot be whitespace.", nameof(targetDevicePath));
+        }
+
+        if (targetLocationKey != null && string.IsNullOrWhiteSpace(targetLocationKey))
+        {
+            throw new ArgumentException("Target location key cannot be whitespace.", nameof(targetLocationKey));
         }
 
         if (!File.Exists(hexFilePath))
@@ -221,7 +244,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         var crcRegions = _bootloaderProtocol.ComputeCrcRegions(hexLines);
 
         await RunExclusiveAsync(
-            ct => RunPic32UpdateAsync(device, hexRecords, crcRegions, totalBytes, progress, targetDevicePath, ct),
+            ct => RunPic32UpdateAsync(
+                device, hexRecords, crcRegions, totalBytes, progress, targetDevicePath, targetLocationKey, ct),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -316,6 +340,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             _bootloaderPollAttempts = 0;
             _lastBootloaderEnumerationError = null;
             _targetBootloaderDevicePath = null;
+            _targetBootloaderLocationKey = null;
             await operation(cancellationToken).ConfigureAwait(false);
         }
         finally
@@ -332,10 +357,12 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         long totalBytes,
         IProgress<FirmwareUpdateProgress>? progress,
         string? targetDevicePath,
+        string? targetLocationKey,
         CancellationToken cancellationToken)
     {
-        // Recorded so a WaitingForBootloader timeout can name the requested path in its message.
+        // Recorded so a WaitingForBootloader timeout can name the requested path/location in its message.
         _targetBootloaderDevicePath = targetDevicePath;
+        _targetBootloaderLocationKey = targetLocationKey;
 
         try
         {
@@ -366,7 +393,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             var hidDevice = await ExecuteWithStateTimeoutAsync(
                 FirmwareUpdateState.WaitingForBootloader,
                 "wait for HID bootloader enumeration",
-                ct => WaitForBootloaderDeviceAsync(targetDevicePath, ct),
+                ct => WaitForBootloaderDeviceAsync(targetDevicePath, targetLocationKey, ct),
                 cancellationToken).ConfigureAwait(false);
 
             TransitionToState(FirmwareUpdateState.Connecting, "Connecting to HID bootloader.");
@@ -375,7 +402,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             await ExecuteWithStateTimeoutAsync(
                 FirmwareUpdateState.Connecting,
                 "connect HID transport",
-                ct => ConnectToBootloaderWithRetryAsync(hidDevice, targetDevicePath, ct),
+                ct => ConnectToBootloaderWithRetryAsync(hidDevice, targetDevicePath, targetLocationKey, ct),
                 cancellationToken).ConfigureAwait(false);
 
             var version = await ExecuteWithStateTimeoutAsync(
@@ -1260,6 +1287,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
     private async Task<HidDeviceInfo> WaitForBootloaderDeviceAsync(
         string? targetDevicePath,
+        string? targetLocationKey,
         CancellationToken cancellationToken)
     {
         while (true)
@@ -1287,14 +1315,24 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             }
 
             // Multiple identical bootloaders can be enumerated at once; when a specific one was
-            // requested, match it by path (the rest stay held by the caller). Otherwise take the
-            // first match, preserving the single-device behavior.
+            // requested, match it by path (the rest stay held by the caller). Otherwise, if a
+            // location key was requested, resolve each candidate's physical-location key and match
+            // on that — this is what lets a caller target the bootloader a device rebooted INTO,
+            // before its device path exists, using the location it observed while the device was
+            // still in serial/app mode. Otherwise take the first match, preserving the
+            // single-device behavior.
             // Ordinal (case-sensitive): a device path is an OS identifier and, in this flow, comes from
             // the same in-process HID enumeration (via IHidPlatform) the caller used to obtain targetDevicePath.
-            var match = targetDevicePath == null
-                ? devices.FirstOrDefault()
-                : devices.FirstOrDefault(d =>
-                    string.Equals(d.DevicePath, targetDevicePath, StringComparison.Ordinal));
+            var match = targetDevicePath != null
+                ? devices.FirstOrDefault(d =>
+                    string.Equals(d.DevicePath, targetDevicePath, StringComparison.Ordinal))
+                : targetLocationKey != null
+                    ? devices.FirstOrDefault(d =>
+                        string.Equals(
+                            _usbLocationProvider.GetLocationKey(d.DevicePath),
+                            targetLocationKey,
+                            StringComparison.Ordinal))
+                    : devices.FirstOrDefault();
             if (match != null)
             {
                 return match;
@@ -1307,6 +1345,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     private async Task ConnectToBootloaderWithRetryAsync(
         HidDeviceInfo bootloaderDevice,
         string? targetDevicePath,
+        string? targetLocationKey,
         CancellationToken cancellationToken)
     {
         await ExecuteWithRetryAsync(
@@ -1320,10 +1359,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                     await _hidTransport.DisconnectAsync().ConfigureAwait(false);
                 }
 
-                // When a specific device was requested (several identical bootloaders present), connect to
-                // that exact device by path — bootloaderDevice was matched on the same path. Otherwise fall
-                // back to VID/PID(+serial) first-match for the single-device case.
-                if (targetDevicePath != null)
+                // When a specific device was requested (by path or by location, several identical
+                // bootloaders present), connect to that exact device by path — bootloaderDevice was
+                // already matched on the requested criterion in WaitForBootloaderDeviceAsync.
+                // Otherwise fall back to VID/PID(+serial) first-match for the single-device case.
+                if (targetDevicePath != null || targetLocationKey != null)
                 {
                     await _hidTransport
                         .ConnectByPathAsync(bootloaderDevice.DevicePath, ct)
@@ -1843,6 +1883,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         if (_targetBootloaderDevicePath != null)
         {
             details += $" Target device path requested: {_targetBootloaderDevicePath}.";
+        }
+
+        if (_targetBootloaderLocationKey != null)
+        {
+            details += $" Target location key requested: {_targetBootloaderLocationKey}.";
         }
 
         if (_lastBootloaderEnumerationError == null)

--- a/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/IFirmwareUpdateService.cs
@@ -70,6 +70,40 @@ public interface IFirmwareUpdateService
             "This IFirmwareUpdateService implementation does not support targeted (device-path) firmware updates.");
 
     /// <summary>
+    /// Executes a PIC32 firmware update targeting one specific bootloader by USB physical-location
+    /// key, for callers that know the target device's location (e.g. from <c>IDeviceInfo.LocationKey</c>
+    /// in serial/app mode) but not its future bootloader device path — the path only exists once the
+    /// device has already rebooted into bootloader mode. Added as a default interface method so
+    /// existing implementers and callers of the untargeted/path-targeted overloads above are
+    /// unaffected; implementations that support location-key targeting (the production
+    /// <c>FirmwareUpdateService</c>) override it. The default throws <see cref="NotSupportedException"/>.
+    /// </summary>
+    /// <param name="device">The connected streaming device to update.</param>
+    /// <param name="hexFilePath">Path to an Intel HEX firmware file.</param>
+    /// <param name="progress">Progress reporter (may be null).</param>
+    /// <param name="targetDevicePath">
+    /// HID device path identifying which bootloader to flash (from discovery's
+    /// <c>HidDeviceInfo.DevicePath</c>). Null behaves like the untargeted overload. Takes priority
+    /// over <paramref name="targetLocationKey"/> when both are supplied.
+    /// </param>
+    /// <param name="targetLocationKey">
+    /// USB physical-location key identifying which bootloader to flash (from discovery's
+    /// <c>IDeviceInfo.LocationKey</c>, resolved before the device rebooted into bootloader mode).
+    /// Ignored when <paramref name="targetDevicePath"/> is non-null. Null behaves like the
+    /// untargeted overload.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpdateFirmwareAsync(
+        IStreamingDevice device,
+        string hexFilePath,
+        IProgress<FirmwareUpdateProgress>? progress,
+        string? targetDevicePath,
+        string? targetLocationKey,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(
+            "This IFirmwareUpdateService implementation does not support targeted (location-key) firmware updates.");
+
+    /// <summary>
     /// Executes a WiFi module update using an external flashing tool.
     /// </summary>
     /// <param name="device">The connected streaming device to update.</param>


### PR DESCRIPTION
## Summary

Closes #285. Adds `IUsbLocationProvider` — a stable USB physical-location key (Windows: WMI `DEVPKEY_Device_LocationInfo`, other platforms: no-op fallback) — and wires `IDeviceInfo.LocationKey` through `SerialDeviceFinder` and `HidDeviceFinder`, so the same physical device can be correlated across serial ⇄ HID-bootloader mode transitions and multiple identical bootloaders (same VID/PID, no serial number) can be disambiguated.

- `IUsbLocationProvider` / `WindowsUsbLocationProvider` / `NullUsbLocationProvider` / `UsbLocationProviderFactory` — mirrors the existing `IUsbPortDescriptorProvider` pattern. The Windows implementation resolves a COM port name or HID device interface path to `DEVPKEY_Device_LocationInfo` via WMI's `GetDeviceProperties` method call, matching the issue's verified reference (`Get-PnpDeviceProperty ... DEVPKEY_Device_LocationInfo`).
- `HidDevicePathParser.ParseInstanceId` — extracts a PnP instance ID from a HID device interface path via documented string manipulation (no new `SetupDi`/`Cfgmgr32` P/Invoke surface), kept in its own untagged type so the pure logic is unit-testable without a Windows-only WMI dependency.
- `IDeviceInfo`/`DeviceInfo.LocationKey`, populated by both finders via an injectable provider (constructor param, same shape as the existing descriptor-provider seam).
- `FirmwareUpdateService`/`IFirmwareUpdateService` gain a `targetLocationKey` parameter alongside `targetDevicePath` (path wins if both are given). `WaitForBootloaderDeviceAsync` resolves each candidate bootloader's location and matches on it, letting a caller target the bootloader a device reboots *into* using the location it observed *before* the reboot — closing the first-match auto-update limitation documented in daqifi-desktop's `FirmwareUpdateCoordinator.cs`.

## What's verified vs. not

- Unit tests cover the platform-independent logic (`NullUsbLocationProvider`, `HidDevicePathParser` parsing edge cases) and the discovery/firmware-service wiring via hand-written fakes, following this repo's existing no-mocking-library convention.
- Ran the example CLI against this branch's `Daqifi.Core` on real hardware (macOS bench rig): `--discover-serial` and a connect+stream smoke test both succeeded, confirming the new `LocationKey` code path in `SerialDeviceFinder` doesn't regress discovery (resolves to `null` via the macOS no-op fallback, as expected).
- **Not verified**: the real Windows WMI calls (`GetDeviceProperties`) — no Windows machine in this environment, and CI is `ubuntu-latest` only, so only the pure parsing/fallback logic has real test coverage (same limitation the pre-existing `WindowsUsbPortDescriptorProvider` has).
- **Not verified**: the acceptance criterion that the location key is identical for the same physical device in serial vs. HID mode — needs a Windows bench test with real hardware.

## Test plan

- [x] `dotnet build Daqifi.Core.sln` — clean, 0 warnings/errors (repo has `TreatWarningsAsErrors`)
- [x] `dotnet test Daqifi.Core.sln` — 1403 passed, 2 pre-existing hardware-only skips, 0 failed
- [x] Real-hardware serial discovery + connect/stream smoke test (see above)
- [ ] Manual Windows bench verification of `WindowsUsbLocationProvider` and the serial↔HID location-key stability assumption (follow-up, not done in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)