### PR TITLE
fix(docs): pattern-match to IStreamingDevice/IDeviceDiagnostics instead of calling members factory can't guarantee

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,17 +167,23 @@ using var customFinder = new WiFiDeviceFinder(discoveryPort: 12345);
 Digital channels default to inputs. Flip one to output and drive it — the level is applied
 immediately, and flipping back to input releases the pin to high-impedance.
 
+`DaqifiDeviceFactory` returns the base `DaqifiDevice` type, so pattern-match to `IStreamingDevice`
+to reach these members — the same way as `INetworkConfigurable` below.
+
 ```csharp
 using Daqifi.Core.Channel;
 
-var channels = device.GetChannelsSnapshot();
-var dio3 = channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 3);
+if (device is IStreamingDevice streamingDevice)
+{
+    var channels = device.GetChannelsSnapshot();
+    var dio3 = channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 3);
 
-device.SetDioDirection(dio3, ChannelDirection.Output);
-device.SetDioValue(dio3, true);   // drive high
-device.SetDioValue(dio3, false);  // drive low
+    streamingDevice.SetDioDirection(dio3, ChannelDirection.Output);
+    streamingDevice.SetDioValue(dio3, true);   // drive high
+    streamingDevice.SetDioValue(dio3, false);  // drive low
 
-device.SetDioDirection(dio3, ChannelDirection.Input); // back to a streamed input
+    streamingDevice.SetDioDirection(dio3, ChannelDirection.Input); // back to a streamed input
+}
 ```
 
 ### PWM output
@@ -189,17 +195,20 @@ one hardware timer drives them all.
 ```csharp
 using Daqifi.Core.Channel;
 
-var pwm = device.GetChannelsSnapshot()
-    .OfType<IDigitalChannel>()
-    .First(c => c.IsPwmCapable);
+if (device is IStreamingDevice streamingDevice)
+{
+    var pwm = device.GetChannelsSnapshot()
+        .OfType<IDigitalChannel>()
+        .First(c => c.IsPwmCapable);
 
-device.SetPwmDutyCycle(pwm, 25);  // 1-100 percent
-device.SetPwmFrequency(1000);     // 6-50000 Hz, applies to every PWM channel
-device.SetPwmEnabled(pwm, true);  // start
+    streamingDevice.SetPwmDutyCycle(pwm, 25);  // 1-100 percent
+    streamingDevice.SetPwmFrequency(1000);     // 6-50000 Hz, applies to every PWM channel
+    streamingDevice.SetPwmEnabled(pwm, true);  // start
 
-device.SetPwmDutyCycle(pwm, 75);  // duty changes take effect live
+    streamingDevice.SetPwmDutyCycle(pwm, 75);  // duty changes take effect live
 
-device.SetPwmEnabled(pwm, false); // stop — the pin is left high-impedance
+    streamingDevice.SetPwmEnabled(pwm, false); // stop — the pin is left high-impedance
+}
 ```
 
 ### Network configuration

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -284,39 +284,46 @@ Console.WriteLine($"Received {sampleCount} samples");
 or disabling analog channels recomputes the full `ENAble:VOLTage:DC` bitmask internally; digital
 channels are toggled via the global DIO enable.
 
+`DaqifiDeviceFactory` returns the base `DaqifiDevice` type, so pattern-match to `IStreamingDevice`
+to reach these members — the same way as `INetworkConfigurable` below.
+
 ```csharp
 using Daqifi.Core.Channel;
 
-// Channels are populated after a status message is received from the device.
-var ai0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
-var ai2 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 2);
+if (device is IStreamingDevice streamingDevice)
+{
+    // Channels are populated after a status message is received from the device.
+    // Channels itself lives on the DaqifiDevice base class, so it's read from `device`.
+    var ai0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+    var ai2 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 2);
 
-// Enable analog input channels (the device receives the combined bitmask, e.g. "5").
-device.EnableChannels(new[] { ai0, ai2 });
+    // Enable analog input channels (the device receives the combined bitmask, e.g. "5").
+    streamingDevice.EnableChannels(new[] { ai0, ai2 });
 
-// Disable a single channel — the recomputed mask reflects the remaining enabled channels.
-device.DisableChannel(ai0);
+    // Disable a single channel — the recomputed mask reflects the remaining enabled channels.
+    streamingDevice.DisableChannel(ai0);
 
-// Turn everything off.
-device.DisableAllChannels();
+    // Turn everything off.
+    streamingDevice.DisableAllChannels();
 
-// Digital I/O: set direction and drive an output.
-var dio1 = device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
-device.SetDioDirection(dio1, ChannelDirection.Output);
-device.SetDioValue(dio1, true); // drive high
+    // Digital I/O: set direction and drive an output.
+    var dio1 = device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
+    streamingDevice.SetDioDirection(dio1, ChannelDirection.Output);
+    streamingDevice.SetDioValue(dio1, true); // drive high
 
-// PWM on a capable channel (IDigitalChannel.IsPwmCapable). Duty is per channel; the
-// frequency is device-wide because one hardware timer drives every PWM channel.
-var pwm = device.Channels.OfType<IDigitalChannel>().First(c => c.IsPwmCapable);
-device.SetPwmDutyCycle(pwm, 25);  // 1-100 %
-device.SetPwmFrequency(1000);     // 6-50000 Hz, shared by all PWM channels
-device.SetPwmEnabled(pwm, true);  // start; SetPwmEnabled(pwm, false) stops (pin goes high-impedance)
+    // PWM on a capable channel (IDigitalChannel.IsPwmCapable). Duty is per channel; the
+    // frequency is device-wide because one hardware timer drives every PWM channel.
+    var pwm = device.Channels.OfType<IDigitalChannel>().First(c => c.IsPwmCapable);
+    streamingDevice.SetPwmDutyCycle(pwm, 25);  // 1-100 %
+    streamingDevice.SetPwmFrequency(1000);     // 6-50000 Hz, shared by all PWM channels
+    streamingDevice.SetPwmEnabled(pwm, true);  // start; SetPwmEnabled(pwm, false) stops (pin goes high-impedance)
 
-// Analog output (NQ3 only) — addressed by channel number; staged value is applied immediately.
-device.SetAnalogOutput(0, 2.5); // DAC channel 0 to 2.5 V
+    // Analog output (NQ3 only) — addressed by channel number; staged value is applied immediately.
+    streamingDevice.SetAnalogOutput(0, 2.5); // DAC channel 0 to 2.5 V
 
-// Reboot the device (also disconnects, since the device drops its link while restarting).
-device.Reboot();
+    // Reboot the device (also disconnects, since the device drops its link while restarting).
+    streamingDevice.Reboot();
+}
 ```
 
 > Channel objects passed to the enable/disable and DIO methods must belong to the device's
@@ -350,33 +357,39 @@ logging and diagnostics SCPI surface — the system log, runtime log levels, SCP
 error-queue depth, and streaming/memory performance counters. These values originate **on the
 device**; this is not a client-side instrumentation framework.
 
+`DaqifiDeviceFactory` returns the base `DaqifiDevice` type, so pattern-match to `IDeviceDiagnostics`
+to reach these members — the same way as `INetworkConfigurable` below.
+
 ```csharp
 using Daqifi.Core.Device.Diagnostics;
 
 using var device = await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
 
-// System log (reading the log also clears the device buffer).
-IReadOnlyList<SystemLogEntry> log = await device.GetSystemLogAsync();
-foreach (var entry in log) Console.WriteLine(entry.Message);
-await device.ClearSystemLogAsync();
+if (device is IDeviceDiagnostics diagnostics)
+{
+    // System log (reading the log also clears the device buffer).
+    IReadOnlyList<SystemLogEntry> log = await diagnostics.GetSystemLogAsync();
+    foreach (var entry in log) Console.WriteLine(entry.Message);
+    await diagnostics.ClearSystemLogAsync();
 
-// Runtime log levels (0 = None, 1 = Error, 2 = Info, 3 = Debug). The returned
-// setting reflects the level actually applied, which a module's ceiling may cap.
-LogLevelSetting applied = await device.SetLogLevelAsync("STREAM", 2);
-Console.WriteLine($"{applied.Module}: {applied.Level} (ceiling {applied.Ceiling})");
+    // Runtime log levels (0 = None, 1 = Error, 2 = Info, 3 = Debug). The returned
+    // setting reflects the level actually applied, which a module's ceiling may cap.
+    LogLevelSetting applied = await diagnostics.SetLogLevelAsync("STREAM", 2);
+    Console.WriteLine($"{applied.Module}: {applied.Level} (ceiling {applied.Ceiling})");
 
-// SCPI command history (newest first) and error-queue depth (non-destructive).
-IReadOnlyList<string> history = await device.GetCommandHistoryAsync();
-int queuedErrors = await device.GetSystemErrorCountAsync();
+    // SCPI command history (newest first) and error-queue depth (non-destructive).
+    IReadOnlyList<string> history = await diagnostics.GetCommandHistoryAsync();
+    int queuedErrors = await diagnostics.GetSystemErrorCountAsync();
 
-// Performance counters. Headline fields are typed (nullable when the running
-// firmware doesn't emit them); the full set is available via Values.
-StreamStats stream = await device.GetStreamStatsAsync();
-Console.WriteLine($"Samples: {stream.TotalSamplesStreamed}, dropped: {stream.QueueDroppedSamples}");
+    // Performance counters. Headline fields are typed (nullable when the running
+    // firmware doesn't emit them); the full set is available via Values.
+    StreamStats stream = await diagnostics.GetStreamStatsAsync();
+    Console.WriteLine($"Samples: {stream.TotalSamplesStreamed}, dropped: {stream.QueueDroppedSamples}");
 
-MemoryDiagnostics mem = await device.GetMemoryDiagnosticsAsync();
-Console.WriteLine($"Heap free: {mem.HeapFree}/{mem.HeapTotal}");
-foreach (var (key, value) in mem.Values) Console.WriteLine($"{key} = {value}");
+    MemoryDiagnostics mem = await diagnostics.GetMemoryDiagnosticsAsync();
+    Console.WriteLine($"Heap free: {mem.HeapFree}/{mem.HeapTotal}");
+    foreach (var (key, value) in mem.Values) Console.WriteLine($"{key} = {value}");
+}
 ```
 
 Notes:

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -28,11 +28,11 @@ public static class DaqifiDeviceFactory
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when host is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when port is not between 1 and 65535.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiDevice> ConnectTcpAsync(
+    public static async Task<DaqifiStreamingDevice> ConnectTcpAsync(
         string host,
         int port,
         DeviceConnectionOptions? options = null,
@@ -61,11 +61,11 @@ public static class DaqifiDeviceFactory
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when ipAddress is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when port is not between 1 and 65535.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiDevice> ConnectTcpAsync(
+    public static async Task<DaqifiStreamingDevice> ConnectTcpAsync(
         IPAddress ipAddress,
         int port,
         DeviceConnectionOptions? options = null,
@@ -93,9 +93,9 @@ public static class DaqifiDeviceFactory
     /// <param name="host">The hostname or IP address string to connect to.</param>
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when host is null or empty.</exception>
-    public static DaqifiDevice ConnectTcp(
+    public static DaqifiStreamingDevice ConnectTcp(
         string host,
         int port,
         DeviceConnectionOptions? options = null)
@@ -109,9 +109,9 @@ public static class DaqifiDeviceFactory
     /// <param name="ipAddress">The IP address to connect to.</param>
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when ipAddress is null.</exception>
-    public static DaqifiDevice ConnectTcp(
+    public static DaqifiStreamingDevice ConnectTcp(
         IPAddress ipAddress,
         int port,
         DeviceConnectionOptions? options = null)
@@ -125,10 +125,10 @@ public static class DaqifiDeviceFactory
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static Task<DaqifiDevice> ConnectSerialAsync(
+    public static Task<DaqifiStreamingDevice> ConnectSerialAsync(
         string portName,
         DeviceConnectionOptions? options = null,
         CancellationToken cancellationToken = default)
@@ -143,11 +143,11 @@ public static class DaqifiDeviceFactory
     /// <param name="baudRate">The baud rate for the serial connection.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when baudRate is less than or equal to zero.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiDevice> ConnectSerialAsync(
+    public static async Task<DaqifiStreamingDevice> ConnectSerialAsync(
         string portName,
         int baudRate,
         DeviceConnectionOptions? options = null,
@@ -182,9 +182,9 @@ public static class DaqifiDeviceFactory
     /// </summary>
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
-    public static DaqifiDevice ConnectSerial(
+    public static DaqifiStreamingDevice ConnectSerial(
         string portName,
         DeviceConnectionOptions? options = null)
     {
@@ -197,10 +197,10 @@ public static class DaqifiDeviceFactory
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="baudRate">The baud rate for the serial connection.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when baudRate is less than or equal to zero.</exception>
-    public static DaqifiDevice ConnectSerial(
+    public static DaqifiStreamingDevice ConnectSerial(
         string portName,
         int baudRate,
         DeviceConnectionOptions? options = null)
@@ -214,12 +214,12 @@ public static class DaqifiDeviceFactory
     /// <param name="deviceInfo">The device information from discovery.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when deviceInfo is null.</exception>
     /// <exception cref="ArgumentException">Thrown when deviceInfo is missing required fields (IPAddress or Port for WiFi connections).</exception>
     /// <exception cref="NotSupportedException">Thrown when the connection type is not supported (e.g., Serial, HID).</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiDevice> ConnectFromDeviceInfoAsync(
+    public static async Task<DaqifiStreamingDevice> ConnectFromDeviceInfoAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options = null,
         CancellationToken cancellationToken = default)
@@ -258,11 +258,11 @@ public static class DaqifiDeviceFactory
     /// </summary>
     /// <param name="deviceInfo">The device information from discovery.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when deviceInfo is null.</exception>
     /// <exception cref="ArgumentException">Thrown when deviceInfo is missing required fields (IPAddress or Port for WiFi connections).</exception>
     /// <exception cref="NotSupportedException">Thrown when the connection type is not supported (e.g., Serial, HID).</exception>
-    public static DaqifiDevice ConnectFromDeviceInfo(
+    public static DaqifiStreamingDevice ConnectFromDeviceInfo(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options = null)
     {
@@ -272,7 +272,7 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Connects to a WiFi device using the provided device info.
     /// </summary>
-    private static async Task<DaqifiDevice> ConnectWiFiDeviceAsync(
+    private static async Task<DaqifiStreamingDevice> ConnectWiFiDeviceAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options,
         CancellationToken cancellationToken)
@@ -323,7 +323,7 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Connects to a serial device using the provided device info.
     /// </summary>
-    private static async Task<DaqifiDevice> ConnectSerialDeviceAsync(
+    private static async Task<DaqifiStreamingDevice> ConnectSerialDeviceAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options,
         CancellationToken cancellationToken)
@@ -373,12 +373,12 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Internal method that handles the actual connection logic with a transport.
     /// </summary>
-    private static async Task<DaqifiDevice> ConnectWithTransportAsync(
+    private static async Task<DaqifiStreamingDevice> ConnectWithTransportAsync(
         IStreamTransport transport,
         DeviceConnectionOptions options,
         CancellationToken cancellationToken)
     {
-        DaqifiDevice? device = null;
+        DaqifiStreamingDevice? device = null;
 
         try
         {

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -28,11 +28,11 @@ public static class DaqifiDeviceFactory
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when host is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when port is not between 1 and 65535.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiStreamingDevice> ConnectTcpAsync(
+    public static async Task<DaqifiDevice> ConnectTcpAsync(
         string host,
         int port,
         DeviceConnectionOptions? options = null,
@@ -61,11 +61,11 @@ public static class DaqifiDeviceFactory
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when ipAddress is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when port is not between 1 and 65535.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiStreamingDevice> ConnectTcpAsync(
+    public static async Task<DaqifiDevice> ConnectTcpAsync(
         IPAddress ipAddress,
         int port,
         DeviceConnectionOptions? options = null,
@@ -93,9 +93,9 @@ public static class DaqifiDeviceFactory
     /// <param name="host">The hostname or IP address string to connect to.</param>
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when host is null or empty.</exception>
-    public static DaqifiStreamingDevice ConnectTcp(
+    public static DaqifiDevice ConnectTcp(
         string host,
         int port,
         DeviceConnectionOptions? options = null)
@@ -109,9 +109,9 @@ public static class DaqifiDeviceFactory
     /// <param name="ipAddress">The IP address to connect to.</param>
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when ipAddress is null.</exception>
-    public static DaqifiStreamingDevice ConnectTcp(
+    public static DaqifiDevice ConnectTcp(
         IPAddress ipAddress,
         int port,
         DeviceConnectionOptions? options = null)
@@ -125,10 +125,10 @@ public static class DaqifiDeviceFactory
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static Task<DaqifiStreamingDevice> ConnectSerialAsync(
+    public static Task<DaqifiDevice> ConnectSerialAsync(
         string portName,
         DeviceConnectionOptions? options = null,
         CancellationToken cancellationToken = default)
@@ -143,11 +143,11 @@ public static class DaqifiDeviceFactory
     /// <param name="baudRate">The baud rate for the serial connection.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when baudRate is less than or equal to zero.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiStreamingDevice> ConnectSerialAsync(
+    public static async Task<DaqifiDevice> ConnectSerialAsync(
         string portName,
         int baudRate,
         DeviceConnectionOptions? options = null,
@@ -182,9 +182,9 @@ public static class DaqifiDeviceFactory
     /// </summary>
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
-    public static DaqifiStreamingDevice ConnectSerial(
+    public static DaqifiDevice ConnectSerial(
         string portName,
         DeviceConnectionOptions? options = null)
     {
@@ -197,10 +197,10 @@ public static class DaqifiDeviceFactory
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="baudRate">The baud rate for the serial connection.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when baudRate is less than or equal to zero.</exception>
-    public static DaqifiStreamingDevice ConnectSerial(
+    public static DaqifiDevice ConnectSerial(
         string portName,
         int baudRate,
         DeviceConnectionOptions? options = null)
@@ -214,12 +214,12 @@ public static class DaqifiDeviceFactory
     /// <param name="deviceInfo">The device information from discovery.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when deviceInfo is null.</exception>
     /// <exception cref="ArgumentException">Thrown when deviceInfo is missing required fields (IPAddress or Port for WiFi connections).</exception>
     /// <exception cref="NotSupportedException">Thrown when the connection type is not supported (e.g., Serial, HID).</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiStreamingDevice> ConnectFromDeviceInfoAsync(
+    public static async Task<DaqifiDevice> ConnectFromDeviceInfoAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options = null,
         CancellationToken cancellationToken = default)
@@ -258,11 +258,11 @@ public static class DaqifiDeviceFactory
     /// </summary>
     /// <param name="deviceInfo">The device information from discovery.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when deviceInfo is null.</exception>
     /// <exception cref="ArgumentException">Thrown when deviceInfo is missing required fields (IPAddress or Port for WiFi connections).</exception>
     /// <exception cref="NotSupportedException">Thrown when the connection type is not supported (e.g., Serial, HID).</exception>
-    public static DaqifiStreamingDevice ConnectFromDeviceInfo(
+    public static DaqifiDevice ConnectFromDeviceInfo(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options = null)
     {
@@ -272,7 +272,7 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Connects to a WiFi device using the provided device info.
     /// </summary>
-    private static async Task<DaqifiStreamingDevice> ConnectWiFiDeviceAsync(
+    private static async Task<DaqifiDevice> ConnectWiFiDeviceAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options,
         CancellationToken cancellationToken)
@@ -323,7 +323,7 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Connects to a serial device using the provided device info.
     /// </summary>
-    private static async Task<DaqifiStreamingDevice> ConnectSerialDeviceAsync(
+    private static async Task<DaqifiDevice> ConnectSerialDeviceAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options,
         CancellationToken cancellationToken)
@@ -373,12 +373,12 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Internal method that handles the actual connection logic with a transport.
     /// </summary>
-    private static async Task<DaqifiStreamingDevice> ConnectWithTransportAsync(
+    private static async Task<DaqifiDevice> ConnectWithTransportAsync(
         IStreamTransport transport,
         DeviceConnectionOptions options,
         CancellationToken cancellationToken)
     {
-        DaqifiStreamingDevice? device = null;
+        DaqifiDevice? device = null;
 
         try
         {


### PR DESCRIPTION
## Summary
- `DaqifiDeviceFactory`'s `Connect*` methods return `DaqifiDevice`, which only implements `IDevice, IDisposable` — but `docs/DEVICE_INTERFACES.md` ("Channel Management", "Device Diagnostics") and `README.md` ("Digital output", "PWM output") called `EnableChannels`, `SetDioDirection`, `SetPwmDutyCycle`, `Reboot()`, `GetSystemLogAsync()`, etc. directly on the factory's result with no cast. Those members live on `IStreamingDevice`/`IDeviceDiagnostics`, so the examples didn't compile as written.
- **Original approach (reverted):** widen the factory's return type to `DaqifiStreamingDevice`, since that's the only type it ever constructs. Qodo correctly flagged this as a breaking API change — `Daqifi.Core` shipped v1.0.0 four days ago, and this would be binary-incompatible (and a narrow source break) for existing consumers, including `daqifi-desktop`'s in-progress migration onto Core.
- **Current approach:** keep the factory's return type as `DaqifiDevice` (no public API change) and fix the doc examples instead, pattern-matching to `IStreamingDevice` / `IDeviceDiagnostics` — the same style the existing "Network configuration" example already uses for `INetworkConfigurable`.

## Test plan
- [x] Compiled the revised `Channel Management`, `Device Diagnostics`, `Digital output`, and `PWM output` doc snippets in a standalone console project referencing `Daqifi.Core` — 0 errors, 0 warnings.
- [x] `dotnet build Daqifi.Core.sln` — succeeds, no warnings.
- [x] `dotnet test Daqifi.Core.sln` — 1387 passing, 0 failing, 2 skipped (pre-existing real-hardware tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)