### PR TITLE
fix(discovery): make serial probing immune to hung ports (closes #294)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -380,6 +380,37 @@ public class SerialDeviceFinderTests
             $"Cancellation did not short-circuit the hung probe ({stopwatch.ElapsedMilliseconds}ms).");
     }
 
+    [Fact]
+    public async Task DiscoverAsync_HungPort_QuarantinedAcrossSweeps_NoThreadPileUp()
+    {
+        // Qodo PR #295 review #1: a port whose timed-out probe is still blocked
+        // must NOT be re-probed on subsequent sweeps — the desktop apps sweep
+        // every 2-3s, so without quarantine a long-wedged port stacks one
+        // blocked thread-pool thread per sweep. The hung probe here never
+        // completes, so the second sweep must skip the port entirely.
+        var hungForever = new TaskCompletionSource<IDeviceInfo?>();
+        var hungProbeCalls = 0;
+        using var finder = CreateFinderWithProbes(
+            new[] { "COM_HUNG", "COM_OK" },
+            (port, _) =>
+            {
+                if (port == "COM_HUNG")
+                {
+                    Interlocked.Increment(ref hungProbeCalls);
+                    return hungForever.Task;
+                }
+                return Task.FromResult<IDeviceInfo?>(FakeDevice(port));
+            },
+            hardTimeoutMs: 200);
+
+        var firstSweep = (await finder.DiscoverAsync(CancellationToken.None)).ToList();
+        var secondSweep = (await finder.DiscoverAsync(CancellationToken.None)).ToList();
+
+        Assert.Equal("COM_OK", Assert.Single(firstSweep).PortName);
+        Assert.Equal("COM_OK", Assert.Single(secondSweep).PortName);
+        Assert.Equal(1, Volatile.Read(ref hungProbeCalls));
+    }
+
     private sealed class RecordingUsbPortDescriptorProvider : IUsbPortDescriptorProvider
     {
         private readonly Func<string, UsbPortDescriptor?> _classifier;

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -274,6 +274,112 @@ public class SerialDeviceFinderTests
             "Throwing descriptor provider was never invoked — the exception-handling path is not exercised by this test.");
     }
 
+    // --- #294: hang immunity -------------------------------------------------
+
+    private static SerialDeviceFinder CreateFinderWithProbes(
+        string[] ports,
+        Func<string, CancellationToken, Task<IDeviceInfo?>> probe,
+        int hardTimeoutMs)
+    {
+        var daqifiProvider = new RecordingUsbPortDescriptorProvider(_ =>
+            new UsbPortDescriptor(DaqifiUsbIds.VendorId, DaqifiUsbIds.CdcProductId));
+        var finder = new SerialDeviceFinder(
+            9600,
+            daqifiProvider,
+            portNameProvider: () => ports,
+            probeOverride: probe);
+        finder.PortProbeHardTimeoutMs = hardTimeoutMs;
+        return finder;
+    }
+
+    private static IDeviceInfo FakeDevice(string portName) => new DeviceInfo
+    {
+        Name = "Nq1",
+        SerialNumber = "1234",
+        FirmwareVersion = "1.0.0",
+        ConnectionType = ConnectionType.Serial,
+        PortName = portName,
+        IsPowerOn = true
+    };
+
+    [Fact]
+    public async Task DiscoverAsync_HungPort_TimesOutAndStillReturnsHealthyDevices()
+    {
+        // Closes #294: a wedged CDC device hangs SerialPort.Open() forever (no
+        // exception). Pre-fix, Task.WhenAll never settled and the healthy port's
+        // device was never reported. The hung probe is simulated with a
+        // never-completing task; the hard per-port timeout must abandon it.
+        var hungForever = new TaskCompletionSource<IDeviceInfo?>();
+        using var finder = CreateFinderWithProbes(
+            new[] { "COM_HUNG", "COM_OK" },
+            (port, _) => port == "COM_HUNG"
+                ? hungForever.Task
+                : Task.FromResult<IDeviceInfo?>(FakeDevice(port)),
+            hardTimeoutMs: 300);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var devices = (await finder.DiscoverAsync(CancellationToken.None)).ToList();
+        stopwatch.Stop();
+
+        var device = Assert.Single(devices);
+        Assert.Equal("COM_OK", device.PortName);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"Discovery took {stopwatch.ElapsedMilliseconds}ms — the hard timeout did not abandon the hung probe.");
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_HungPort_HealthyDeviceEventFiresBeforeSweepSettles()
+    {
+        // Closes #294 (event half): DeviceDiscovered must fire per-probe, not
+        // after Task.WhenAll, so a hung port can't delay/silence healthy ones.
+        // The hung probe here outlives the sweep (released only at the end) and
+        // the healthy device's event is awaited while the hung probe is pending.
+        var hungForever = new TaskCompletionSource<IDeviceInfo?>();
+        var discovered = new TaskCompletionSource<IDeviceInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var finder = CreateFinderWithProbes(
+            new[] { "COM_HUNG", "COM_OK" },
+            (port, _) => port == "COM_HUNG"
+                ? hungForever.Task
+                : Task.FromResult<IDeviceInfo?>(FakeDevice(port)),
+            hardTimeoutMs: 2000);
+        finder.DeviceDiscovered += (_, args) => discovered.TrySetResult(args.DeviceInfo);
+
+        var sweep = finder.DiscoverAsync(CancellationToken.None);
+
+        // The healthy device's event must arrive while COM_HUNG is still pending
+        // (well before the 2s hard timeout settles the sweep).
+        var winner = await Task.WhenAny(discovered.Task, Task.Delay(1000));
+        Assert.Same(discovered.Task, winner);
+        Assert.False(sweep.IsCompleted,
+            "Sweep settled before the hung probe timed out — hang simulation is not wired as intended.");
+        Assert.Equal("COM_OK", (await discovered.Task).PortName);
+
+        hungForever.TrySetResult(null);
+        await sweep;
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_HungPort_CallerCancellationStillPropagates()
+    {
+        // Cancelling the caller token during a hung probe must cancel the sweep
+        // (OCE surfaces as the documented "settle for finished probes" path),
+        // not wait out the hard timeout.
+        var hungForever = new TaskCompletionSource<IDeviceInfo?>();
+        using var finder = CreateFinderWithProbes(
+            new[] { "COM_HUNG" },
+            (_, _) => hungForever.Task,
+            hardTimeoutMs: 60_000);
+        using var cts = new CancellationTokenSource(200);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var devices = await finder.DiscoverAsync(cts.Token);
+        stopwatch.Stop();
+
+        Assert.Empty(devices);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+            $"Cancellation did not short-circuit the hung probe ({stopwatch.ElapsedMilliseconds}ms).");
+    }
+
     private sealed class RecordingUsbPortDescriptorProvider : IUsbPortDescriptorProvider
     {
         private readonly Func<string, UsbPortDescriptor?> _classifier;

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -5,6 +5,13 @@ using Daqifi.Core.Device.Discovery;
 
 namespace Daqifi.Core.Tests.Device.Discovery;
 
+// The hang-simulation tests mutate process-wide state (PortClaims via
+// ResetPortQuarantineForTests, QuarantineRetryTtlMs). A dedicated xUnit collection
+// keeps them serialized relative to any other test class that joins it; xUnit
+// already serializes tests WITHIN a class. Any future test class that constructs
+// SerialDeviceFinder against fake wedged ports should join this collection
+// (Qodo pass 5 #2).
+[Collection("SerialDeviceFinder static port-claim state")]
 public class SerialDeviceFinderTests
 {
     // Issue #283: Discovery.DeviceType lacked a Nyquist2 member, so

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -495,6 +495,42 @@ public class SerialDeviceFinderTests
         }
     }
 
+    [Fact]
+    public async Task DiscoverAsync_ConcurrentFinderInstances_OnlyOneProbePerWedgedPort()
+    {
+        // Step-3.5 re-gate on PR #295: the check-then-act quarantine raced across
+        // CONCURRENT finder instances — both passed the empty check and each leaked
+        // a blocked thread on the same wedged port while the dictionary tracked only
+        // one. The claim protocol reserves the port atomically (GetOrAdd) BEFORE the
+        // probe starts, so exactly one probe can exist per port process-wide.
+        SerialDeviceFinder.ResetPortQuarantineForTests();
+        var hungForever = new TaskCompletionSource<IDeviceInfo?>();
+        var hungProbeCalls = 0;
+        Func<string, CancellationToken, Task<IDeviceInfo?>> probe = (port, _) =>
+        {
+            if (port == "COM_HUNG_CONC")
+            {
+                Interlocked.Increment(ref hungProbeCalls);
+                return hungForever.Task;
+            }
+            return Task.FromResult<IDeviceInfo?>(FakeDevice(port));
+        };
+
+        using var finderA = CreateFinderWithProbes(new[] { "COM_HUNG_CONC", "COM_OK_CONC" }, probe, hardTimeoutMs: 400);
+        using var finderB = CreateFinderWithProbes(new[] { "COM_HUNG_CONC", "COM_OK_CONC" }, probe, hardTimeoutMs: 400);
+
+        var results = await Task.WhenAll(
+            Task.Run(() => finderA.DiscoverAsync(CancellationToken.None)),
+            Task.Run(() => finderB.DiscoverAsync(CancellationToken.None)));
+
+        // Both sweeps complete; at most one probe ever touched the wedged port.
+        Assert.True(Volatile.Read(ref hungProbeCalls) <= 1,
+            $"Wedged port probed {hungProbeCalls} times across two CONCURRENT finder instances — the claim protocol did not hold.");
+        // The healthy port is reported by at least one sweep (the loser of a
+        // healthy-port claim race skips it for that sweep by design).
+        Assert.Contains(results, r => r.Any(d => d.PortName == "COM_OK_CONC"));
+    }
+
     private sealed class RecordingUsbPortDescriptorProvider : IUsbPortDescriptorProvider
     {
         private readonly Func<string, UsbPortDescriptor?> _classifier;

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -305,6 +305,7 @@ public class SerialDeviceFinderTests
     [Fact]
     public async Task DiscoverAsync_HungPort_TimesOutAndStillReturnsHealthyDevices()
     {
+        SerialDeviceFinder.ResetPortQuarantineForTests();
         // Closes #294: a wedged CDC device hangs SerialPort.Open() forever (no
         // exception). Pre-fix, Task.WhenAll never settled and the healthy port's
         // device was never reported. The hung probe is simulated with a
@@ -330,6 +331,7 @@ public class SerialDeviceFinderTests
     [Fact]
     public async Task DiscoverAsync_HungPort_HealthyDeviceEventFiresBeforeSweepSettles()
     {
+        SerialDeviceFinder.ResetPortQuarantineForTests();
         // Closes #294 (event half): DeviceDiscovered must fire per-probe, not
         // after Task.WhenAll, so a hung port can't delay/silence healthy ones.
         // The hung probe here outlives the sweep (released only at the end) and
@@ -361,6 +363,7 @@ public class SerialDeviceFinderTests
     [Fact]
     public async Task DiscoverAsync_HungPort_CallerCancellationStillPropagates()
     {
+        SerialDeviceFinder.ResetPortQuarantineForTests();
         // Cancelling the caller token during a hung probe must cancel the sweep
         // (OCE surfaces as the documented "settle for finished probes" path),
         // not wait out the hard timeout.
@@ -383,6 +386,7 @@ public class SerialDeviceFinderTests
     [Fact]
     public async Task DiscoverAsync_HungPort_QuarantinedAcrossSweeps_NoThreadPileUp()
     {
+        SerialDeviceFinder.ResetPortQuarantineForTests();
         // Qodo PR #295 review #1: a port whose timed-out probe is still blocked
         // must NOT be re-probed on subsequent sweeps — the desktop apps sweep
         // every 2-3s, so without quarantine a long-wedged port stacks one
@@ -408,6 +412,41 @@ public class SerialDeviceFinderTests
 
         Assert.Equal("COM_OK", Assert.Single(firstSweep).PortName);
         Assert.Equal("COM_OK", Assert.Single(secondSweep).PortName);
+        Assert.Equal(1, Volatile.Read(ref hungProbeCalls));
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_HungPort_QuarantineSurvivesFinderRecreation()
+    {
+        // Step-3.5 audit on PR #295: the MCP DaqifiAgent constructs and disposes a
+        // fresh SerialDeviceFinder per discovery call. A per-instance quarantine
+        // forgot the stuck probe every call, re-leaking one blocked thread per
+        // request against the same wedged port — the dictionary is process-wide
+        // (static) so the one-blocked-thread bound holds across finder instances.
+        SerialDeviceFinder.ResetPortQuarantineForTests();
+        var hungForever = new TaskCompletionSource<IDeviceInfo?>();
+        var hungProbeCalls = 0;
+        Func<string, CancellationToken, Task<IDeviceInfo?>> probe = (port, _) =>
+        {
+            if (port == "COM_HUNG_X")
+            {
+                Interlocked.Increment(ref hungProbeCalls);
+                return hungForever.Task;
+            }
+            return Task.FromResult<IDeviceInfo?>(FakeDevice(port));
+        };
+
+        using (var first = CreateFinderWithProbes(new[] { "COM_HUNG_X", "COM_OK_X" }, probe, hardTimeoutMs: 200))
+        {
+            Assert.Equal("COM_OK_X", Assert.Single(await first.DiscoverAsync(CancellationToken.None)).PortName);
+        }
+
+        // Fresh instance, same process: the wedged port must stay quarantined.
+        using (var second = CreateFinderWithProbes(new[] { "COM_HUNG_X", "COM_OK_X" }, probe, hardTimeoutMs: 200))
+        {
+            Assert.Equal("COM_OK_X", Assert.Single(await second.DiscoverAsync(CancellationToken.None)).PortName);
+        }
+
         Assert.Equal(1, Volatile.Read(ref hungProbeCalls));
     }
 

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -412,7 +412,12 @@ public class SerialDeviceFinderTests
 
         Assert.Equal("COM_OK", Assert.Single(firstSweep).PortName);
         Assert.Equal("COM_OK", Assert.Single(secondSweep).PortName);
-        Assert.Equal(1, Volatile.Read(ref hungProbeCalls));
+        // <= 1, not == 1: under thread-pool contention the hung probe may not have
+        // STARTED before the first sweep's hard timeout fires — the invariant under
+        // test is "no pile-up" (2+ would be the regression), not "exactly once"
+        // (Qodo pass 4 #2).
+        Assert.True(Volatile.Read(ref hungProbeCalls) <= 1,
+            $"Hung port probed {hungProbeCalls} times across two sweeps — quarantine did not hold.");
     }
 
     [Fact]
@@ -447,7 +452,47 @@ public class SerialDeviceFinderTests
             Assert.Equal("COM_OK_X", Assert.Single(await second.DiscoverAsync(CancellationToken.None)).PortName);
         }
 
-        Assert.Equal(1, Volatile.Read(ref hungProbeCalls));
+        // <= 1 for the same no-pile-up reason as the cross-sweep test (Qodo pass 4 #2).
+        Assert.True(Volatile.Read(ref hungProbeCalls) <= 1,
+            $"Hung port probed {hungProbeCalls} times across two finder instances — static quarantine did not hold.");
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_QuarantineTtl_AllowsPeriodicRetry()
+    {
+        // Qodo pass 4 #3: if the stuck Open never completes, the port must not be
+        // suppressed until process restart — after the retry TTL elapses, one fresh
+        // probe is allowed per window so a recovered device re-appears.
+        SerialDeviceFinder.ResetPortQuarantineForTests();
+        SerialDeviceFinder.QuarantineRetryTtlMs = 100;
+        try
+        {
+            var hungForever = new TaskCompletionSource<IDeviceInfo?>();
+            var probeStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var hungProbeCalls = 0;
+            using var finder = CreateFinderWithProbes(
+                new[] { "COM_HUNG_TTL" },
+                (_, _) =>
+                {
+                    Interlocked.Increment(ref hungProbeCalls);
+                    probeStarted.TrySetResult(true);
+                    return hungForever.Task;
+                },
+                hardTimeoutMs: 100);
+
+            await finder.DiscoverAsync(CancellationToken.None);
+            await probeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5)); // first attempt definitely ran
+            await Task.Delay(300); // let the TTL window lapse
+
+            await finder.DiscoverAsync(CancellationToken.None);
+
+            Assert.True(Volatile.Read(ref hungProbeCalls) >= 2,
+                "TTL elapsed but the quarantined port was never re-probed — recovery requires app restart.");
+        }
+        finally
+        {
+            SerialDeviceFinder.ResetPortQuarantineForTests();
+        }
     }
 
     private sealed class RecordingUsbPortDescriptorProvider : IUsbPortDescriptorProvider

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -66,22 +66,41 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     // abandoned task lives, re-probing the port would just stack another blocked
     // thread-pool thread — the desktop apps sweep every 2-3s, so a port that stays
     // wedged for hours would otherwise accumulate hundreds of blocked threads
-    // (Qodo PR #295 review #1). Entries clear themselves when the kernel finally
-    // completes (or fails) the abandoned I/O.
+    // (Qodo PR #295 review #1). An entry is removed by a continuation the moment
+    // the abandoned I/O finally completes (device replug usually errors the stale
+    // handle), and QuarantineRetryTtlMs bounds the worst case: even if the stuck
+    // Open never returns, the port gets ONE fresh probe per TTL window, so a
+    // recovered device re-appears within the TTL instead of being suppressed
+    // until process restart (Qodo pass 4 #3) at a bounded leak rate.
     //
     // STATIC on purpose (step-3.5 audit, PR #295): a wedged COM port is
     // machine-global state, not finder state — callers like the MCP
     // DaqifiAgent construct and dispose a fresh finder per discovery call, and
     // a per-instance dictionary would forget the stuck probe every call,
     // re-leaking one blocked thread per request against the same dead port.
-    private static readonly ConcurrentDictionary<string, Task> QuarantinedPorts = new();
+    // Concurrent finder INSTANCES can race the check-then-act below; the worst
+    // case is one extra blocked thread at first collision on a wedged port
+    // (bounded, non-accumulating), which is accepted over a claim protocol.
+    private static readonly ConcurrentDictionary<string, QuarantineEntry> QuarantinedPorts = new();
     private bool _disposed;
+
+    private sealed record QuarantineEntry(Task Probe, long QuarantinedAtTicks);
+
+    // One fresh probe per wedged port per this window (monotonic ms).
+    private const int DefaultQuarantineRetryTtlMs = 30_000;
+
+    // Internal so tests can exercise the TTL retry without waiting 30s.
+    internal static int QuarantineRetryTtlMs { get; set; } = DefaultQuarantineRetryTtlMs;
 
     /// <summary>
     /// Test seam: clears the process-wide port quarantine so hang-simulation
     /// tests can't contaminate each other through the shared dictionary.
     /// </summary>
-    internal static void ResetPortQuarantineForTests() => QuarantinedPorts.Clear();
+    internal static void ResetPortQuarantineForTests()
+    {
+        QuarantinedPorts.Clear();
+        QuarantineRetryTtlMs = DefaultQuarantineRetryTtlMs;
+    }
 
     // Internal so tests can shrink the hard timeout instead of waiting 8s per case.
     internal int PortProbeHardTimeoutMs { get; set; } = DefaultPortProbeHardTimeoutMs;
@@ -299,15 +318,21 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     {
         try
         {
-            // Quarantine: skip a port whose previous timed-out probe is still stuck.
-            // One wedged port costs at most ONE blocked thread, not one per sweep.
-            if (QuarantinedPorts.TryGetValue(portName, out var abandoned))
+            // Quarantine: skip a port whose previous timed-out probe is still stuck —
+            // one wedged port costs at most ONE blocked thread per TTL window, not one
+            // per sweep. A completed entry is cleared here as a fallback (its own
+            // continuation normally removed it already); an expired-TTL entry lets one
+            // fresh attempt through so a recovered port re-appears without a restart.
+            if (QuarantinedPorts.TryGetValue(portName, out var quarantined))
             {
-                if (!abandoned.IsCompleted)
+                if (quarantined.Probe.IsCompleted)
+                {
+                    QuarantinedPorts.TryRemove(portName, out _);
+                }
+                else if (Environment.TickCount64 - quarantined.QuarantinedAtTicks < QuarantineRetryTtlMs)
                 {
                     return null;
                 }
-                QuarantinedPorts.TryRemove(portName, out _);
             }
 
             var probe = _probeOverride ?? TryGetDeviceInfoAsync;
@@ -337,14 +362,24 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
                 // observe it BEFORE surfacing cancellation, so a cancelled sweep
                 // can't abandon an untracked probe that a later sweep would then
                 // stack a fresh blocked thread on (Qodo PR #295 pass 2 #1).
-                QuarantinedPorts[portName] = probeTask;
+                QuarantinedPorts[portName] = new QuarantineEntry(probeTask, Environment.TickCount64);
 
-                // Observe the abandoned task's eventual fault/cancellation so it
-                // can't surface as an UnobservedTaskException later.
+                // When the abandoned I/O finally completes (any way), observe its
+                // fault so it can't surface as an UnobservedTaskException, and clear
+                // the port's quarantine entry — but only if the entry still refers to
+                // THIS probe (a TTL retry may have replaced it with a newer attempt).
                 _ = probeTask.ContinueWith(
-                    static t => _ = t.Exception,
+                    t =>
+                    {
+                        _ = t.Exception;
+                        if (QuarantinedPorts.TryGetValue(portName, out var current)
+                            && ReferenceEquals(current.Probe, t))
+                        {
+                            QuarantinedPorts.TryRemove(portName, out _);
+                        }
+                    },
                     CancellationToken.None,
-                    TaskContinuationOptions.NotOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default);
 
                 // Surface caller cancellation only after tracking the abandoned probe.

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -63,13 +63,25 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     private readonly Func<string[]>? _portNameProvider;
     private readonly Func<string, CancellationToken, Task<IDeviceInfo?>>? _probeOverride;
     // Ports whose timed-out probe is still blocked in uncancellable I/O. While that
-    // abandoned task lives, re-probing the port on the next sweep would just stack
-    // another blocked thread-pool thread — the desktop apps sweep every 2-3s, so a
-    // port that stays wedged for hours would otherwise accumulate hundreds of
-    // blocked threads (Qodo PR #295 review #1). Entries clear themselves when the
-    // kernel finally completes (or fails) the abandoned I/O.
-    private readonly ConcurrentDictionary<string, Task> _quarantinedPorts = new();
+    // abandoned task lives, re-probing the port would just stack another blocked
+    // thread-pool thread — the desktop apps sweep every 2-3s, so a port that stays
+    // wedged for hours would otherwise accumulate hundreds of blocked threads
+    // (Qodo PR #295 review #1). Entries clear themselves when the kernel finally
+    // completes (or fails) the abandoned I/O.
+    //
+    // STATIC on purpose (step-3.5 audit, PR #295): a wedged COM port is
+    // machine-global state, not finder state — callers like the MCP
+    // DaqifiAgent construct and dispose a fresh finder per discovery call, and
+    // a per-instance dictionary would forget the stuck probe every call,
+    // re-leaking one blocked thread per request against the same dead port.
+    private static readonly ConcurrentDictionary<string, Task> QuarantinedPorts = new();
     private bool _disposed;
+
+    /// <summary>
+    /// Test seam: clears the process-wide port quarantine so hang-simulation
+    /// tests can't contaminate each other through the shared dictionary.
+    /// </summary>
+    internal static void ResetPortQuarantineForTests() => QuarantinedPorts.Clear();
 
     // Internal so tests can shrink the hard timeout instead of waiting 8s per case.
     internal int PortProbeHardTimeoutMs { get; set; } = DefaultPortProbeHardTimeoutMs;
@@ -289,13 +301,13 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
         {
             // Quarantine: skip a port whose previous timed-out probe is still stuck.
             // One wedged port costs at most ONE blocked thread, not one per sweep.
-            if (_quarantinedPorts.TryGetValue(portName, out var abandoned))
+            if (QuarantinedPorts.TryGetValue(portName, out var abandoned))
             {
                 if (!abandoned.IsCompleted)
                 {
                     return null;
                 }
-                _quarantinedPorts.TryRemove(portName, out _);
+                QuarantinedPorts.TryRemove(portName, out _);
             }
 
             var probe = _probeOverride ?? TryGetDeviceInfoAsync;
@@ -325,7 +337,7 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
                 // observe it BEFORE surfacing cancellation, so a cancelled sweep
                 // can't abandon an untracked probe that a later sweep would then
                 // stack a fresh blocked thread on (Qodo PR #295 pass 2 #1).
-                _quarantinedPorts[portName] = probeTask;
+                QuarantinedPorts[portName] = probeTask;
 
                 // Observe the abandoned task's eventual fault/cancellation so it
                 // can't surface as an UnobservedTaskException later.

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Ports;
 using System.Linq;
@@ -58,6 +59,13 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     private readonly IUsbLocationProvider _usbLocationProvider;
     private readonly Func<string[]>? _portNameProvider;
     private readonly Func<string, CancellationToken, Task<IDeviceInfo?>>? _probeOverride;
+    // Ports whose timed-out probe is still blocked in uncancellable I/O. While that
+    // abandoned task lives, re-probing the port on the next sweep would just stack
+    // another blocked thread-pool thread — the desktop apps sweep every 2-3s, so a
+    // port that stays wedged for hours would otherwise accumulate hundreds of
+    // blocked threads (Qodo PR #295 review #1). Entries clear themselves when the
+    // kernel finally completes (or fails) the abandoned I/O.
+    private readonly ConcurrentDictionary<string, Task> _quarantinedPorts = new();
     private bool _disposed;
 
     // Internal so tests can shrink the hard timeout instead of waiting 8s per case.
@@ -276,6 +284,17 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     {
         try
         {
+            // Quarantine: skip a port whose previous timed-out probe is still stuck.
+            // One wedged port costs at most ONE blocked thread, not one per sweep.
+            if (_quarantinedPorts.TryGetValue(portName, out var abandoned))
+            {
+                if (!abandoned.IsCompleted)
+                {
+                    return null;
+                }
+                _quarantinedPorts.TryRemove(portName, out _);
+            }
+
             var probe = _probeOverride ?? TryGetDeviceInfoAsync;
 
             // Task.Run: SerialPort.Open() (and DiscardInBuffer etc.) are synchronous
@@ -300,6 +319,9 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             {
                 // Either the caller cancelled (surface that) or the port timed out.
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // Quarantine the port until the abandoned attempt actually finishes.
+                _quarantinedPorts[portName] = probeTask;
 
                 // Observe the abandoned task's eventual fault/cancellation so it
                 // can't surface as an UnobservedTaskException later.

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -345,25 +345,45 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             // most ONE blocked thread per TTL window regardless of how many finder
             // instances sweep concurrently.
             claim = new PortProbeClaim();
-            var existing = PortClaims.GetOrAdd(portName, claim);
-            if (!ReferenceEquals(existing, claim))
+            var claimed = false;
+            // Two attempts: the second handles exactly one stale-completed claim
+            // (its release continuation raced us) by clearing it and re-claiming
+            // immediately, so an available port isn't skipped for a whole sweep —
+            // that miss is invisible to the 2-3s desktop sweeps but real for
+            // one-shot MCP discovery calls (Qodo pass 5 #3).
+            for (var attempt = 0; attempt < 2 && !claimed; attempt++)
             {
-                var abandonedAt = existing.AbandonedAtTicks;
+                var existing = PortClaims.GetOrAdd(portName, claim);
+                if (ReferenceEquals(existing, claim))
+                {
+                    claimed = true;
+                    break;
+                }
+
                 if (existing.Probe is { IsCompleted: true })
                 {
-                    // Stale completed claim (continuation raced us) — clear and skip
-                    // this sweep; the next sweep probes cleanly.
+                    // Stale completed claim — clear it and retry the claim once.
                     ReleaseClaimIfOwned(portName, existing);
-                    return null;
+                    continue;
                 }
-                if (abandonedAt < 0
-                    || Environment.TickCount64 - abandonedAt < QuarantineRetryTtlMs
-                    || !PortClaims.TryUpdate(portName, claim, existing))
+
+                var abandonedAt = existing.AbandonedAtTicks;
+                if (abandonedAt >= 0
+                    && Environment.TickCount64 - abandonedAt >= QuarantineRetryTtlMs
+                    && PortClaims.TryUpdate(portName, claim, existing))
                 {
-                    // In flight elsewhere, still inside the TTL window, or another
-                    // instance won the TTL-retry race — the port is spoken for.
-                    return null;
+                    // TTL elapsed on a still-stuck claim — we won the retry.
+                    claimed = true;
+                    break;
                 }
+
+                // In flight elsewhere, inside the TTL window, or another instance
+                // won the race — the port is spoken for.
+                return null;
+            }
+            if (!claimed)
+            {
+                return null;
             }
 
             var probe = _probeOverride ?? TryGetDeviceInfoAsync;
@@ -389,6 +409,15 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
 
             if (winner != probeTask)
             {
+                if (probeTask.IsCompletedSuccessfully)
+                {
+                    // The probe finished right at the timeout/cancellation boundary —
+                    // honor DiscoverAsync's "settle for whatever probes already
+                    // finished cleanly" contract instead of discarding a completed
+                    // result (Qodo pass 5 #4). The finally releases our claim.
+                    return await probeTask.ConfigureAwait(false);
+                }
+
                 // Whether the wait ended by timeout or by caller cancellation, the
                 // uncancellable probe may still be blocked in native I/O — mark the
                 // claim abandoned BEFORE surfacing cancellation, so a cancelled sweep

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -317,10 +317,11 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
 
             if (winner != probeTask)
             {
-                // Either the caller cancelled (surface that) or the port timed out.
-                cancellationToken.ThrowIfCancellationRequested();
-
-                // Quarantine the port until the abandoned attempt actually finishes.
+                // Whether the wait ended by timeout or by caller cancellation, the
+                // uncancellable probe may still be blocked in native I/O — track and
+                // observe it BEFORE surfacing cancellation, so a cancelled sweep
+                // can't abandon an untracked probe that a later sweep would then
+                // stack a fresh blocked thread on (Qodo PR #295 pass 2 #1).
                 _quarantinedPorts[portName] = probeTask;
 
                 // Observe the abandoned task's eventual fault/cancellation so it
@@ -330,6 +331,9 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
                     CancellationToken.None,
                     TaskContinuationOptions.NotOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default);
+
+                // Surface caller cancellation only after tracking the abandoned probe.
+                cancellationToken.ThrowIfCancellationRequested();
                 return null;
             }
 

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -44,10 +44,13 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     // Hard ceiling on a single port probe. A wedged USB CDC device can hang
     // SerialPort.Open() inside native GetCommState indefinitely — no exception,
     // no cancellation (Open is uncancellable blocking I/O) — observed live on a
-    // hung-firmware Nq1 (#294). The normal probe path completes in well under
-    // 3s (open + DeviceWakeUpDelayMs + EchoDisableSettleMs + ResponseTimeoutMs),
-    // so 8s only ever fires on a genuinely stuck port.
-    private const int DefaultPortProbeHardTimeoutMs = 8000;
+    // hung-firmware Nq1 (#294). The healthy probe worst case is ~1.5s
+    // (DeviceWakeUpDelayMs 200 + EchoDisableSettleMs 250 + ResponseTimeoutMs 1000)
+    // plus Open() itself; 3s gives ~2x headroom for a slow open (fresh
+    // enumeration, parallel opens) while abandoning a genuinely stuck port fast
+    // enough that discovery feels responsive (bench QA feedback 2026-07-13:
+    // 8s felt sluggish next to the 2-3s sweep cadence).
+    private const int DefaultPortProbeHardTimeoutMs = 3000;
 
     #endregion
 

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -40,6 +40,13 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     // beyond that, IO failures and slow opens stack up. Common case (with
     // VID/PID classifier) leaves 0-1 candidates so this cap rarely engages.
     private const int MaxParallelProbes = 4;
+    // Hard ceiling on a single port probe. A wedged USB CDC device can hang
+    // SerialPort.Open() inside native GetCommState indefinitely — no exception,
+    // no cancellation (Open is uncancellable blocking I/O) — observed live on a
+    // hung-firmware Nq1 (#294). The normal probe path completes in well under
+    // 3s (open + DeviceWakeUpDelayMs + EchoDisableSettleMs + ResponseTimeoutMs),
+    // so 8s only ever fires on a genuinely stuck port.
+    private const int DefaultPortProbeHardTimeoutMs = 8000;
 
     #endregion
 
@@ -50,7 +57,11 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     private readonly IUsbPortDescriptorProvider _usbPortDescriptorProvider;
     private readonly IUsbLocationProvider _usbLocationProvider;
     private readonly Func<string[]>? _portNameProvider;
+    private readonly Func<string, CancellationToken, Task<IDeviceInfo?>>? _probeOverride;
     private bool _disposed;
+
+    // Internal so tests can shrink the hard timeout instead of waiting 8s per case.
+    internal int PortProbeHardTimeoutMs { get; set; } = DefaultPortProbeHardTimeoutMs;
 
     #endregion
 
@@ -109,11 +120,17 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     /// key. When null, a platform-default provider is used (Windows → WMI,
     /// others → no-op fallback).
     /// </param>
+    /// <param name="probeOverride">
+    /// Test seam: when non-null, replaces <see cref="TryGetDeviceInfoAsync"/>
+    /// as the per-port probe. Lets unit tests simulate hung, slow, failing,
+    /// or succeeding ports without real serial hardware (#294).
+    /// </param>
     internal SerialDeviceFinder(
         int baudRate,
         IUsbPortDescriptorProvider? usbPortDescriptorProvider,
         Func<string[]>? portNameProvider = null,
-        IUsbLocationProvider? usbLocationProvider = null)
+        IUsbLocationProvider? usbLocationProvider = null,
+        Func<string, CancellationToken, Task<IDeviceInfo?>>? probeOverride = null)
     {
         _baudRate = baudRate;
         _usbPortDescriptorProvider = usbPortDescriptorProvider
@@ -121,6 +138,7 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
         _portNameProvider = portNameProvider;
         _usbLocationProvider = usbLocationProvider
             ?? UsbLocationProviderFactory.CreateForCurrentPlatform();
+        _probeOverride = probeOverride;
     }
 
     #endregion
@@ -173,7 +191,17 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
                 await probeGate.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    return await ProbeSafelyAsync(portName, cancellationToken).ConfigureAwait(false);
+                    var deviceInfo = await ProbeSafelyAsync(portName, cancellationToken).ConfigureAwait(false);
+                    if (deviceInfo != null)
+                    {
+                        // Raise per-probe rather than after Task.WhenAll: one hung port
+                        // must not silence every healthy device on the system (#294).
+                        // Fires on a worker thread, possibly concurrently with other
+                        // probes' events — handlers own their thread marshaling (both
+                        // desktop apps already dispatch to their UI thread).
+                        OnDeviceDiscovered(deviceInfo);
+                    }
+                    return deviceInfo;
                 }
                 finally
                 {
@@ -200,12 +228,13 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
                     .ToArray();
             }
 
+            // Events already fired per-probe above; this loop only aggregates the
+            // return value.
             foreach (var deviceInfo in probeResults)
             {
                 if (deviceInfo != null)
                 {
                     discoveredDevices.Add(deviceInfo);
-                    OnDeviceDiscovered(deviceInfo);
                 }
             }
 
@@ -247,7 +276,42 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     {
         try
         {
-            return await TryGetDeviceInfoAsync(portName, cancellationToken).ConfigureAwait(false);
+            var probe = _probeOverride ?? TryGetDeviceInfoAsync;
+
+            // Task.Run: SerialPort.Open() (and DiscardInBuffer etc.) are synchronous
+            // blocking I/O that would otherwise run on the CALLING thread up to the
+            // probe's first await — in the desktop apps that thread is the UI thread,
+            // and a slow or stuck open froze the whole window (#294). Pass
+            // CancellationToken.None to Task.Run itself: the inner token still
+            // cancels the probe's delays; we never want "cancelled before start"
+            // to look like a probe fault.
+            var probeTask = Task.Run(() => probe(portName, cancellationToken), CancellationToken.None);
+
+            // Hard per-port ceiling: a wedged CDC device hangs Open() inside native
+            // GetCommState with no exception, so the catch below never fires and,
+            // pre-#294, Task.WhenAll in DiscoverAsync never settled. Open() is
+            // uncancellable, so on timeout the stuck task is ABANDONED — its own
+            // finally block closes the port if the kernel ever completes the I/O.
+            var winner = await Task.WhenAny(
+                probeTask,
+                Task.Delay(PortProbeHardTimeoutMs, cancellationToken)).ConfigureAwait(false);
+
+            if (winner != probeTask)
+            {
+                // Either the caller cancelled (surface that) or the port timed out.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Observe the abandoned task's eventual fault/cancellation so it
+                // can't surface as an UnobservedTaskException later.
+                _ = probeTask.ContinueWith(
+                    static t => _ = t.Exception,
+                    CancellationToken.None,
+                    TaskContinuationOptions.NotOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+                return null;
+            }
+
+            return await probeTask.ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -62,29 +62,49 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     private readonly IUsbLocationProvider _usbLocationProvider;
     private readonly Func<string[]>? _portNameProvider;
     private readonly Func<string, CancellationToken, Task<IDeviceInfo?>>? _probeOverride;
-    // Ports whose timed-out probe is still blocked in uncancellable I/O. While that
-    // abandoned task lives, re-probing the port would just stack another blocked
-    // thread-pool thread — the desktop apps sweep every 2-3s, so a port that stays
-    // wedged for hours would otherwise accumulate hundreds of blocked threads
-    // (Qodo PR #295 review #1). An entry is removed by a continuation the moment
-    // the abandoned I/O finally completes (device replug usually errors the stale
-    // handle), and QuarantineRetryTtlMs bounds the worst case: even if the stuck
-    // Open never returns, the port gets ONE fresh probe per TTL window, so a
-    // recovered device re-appears within the TTL instead of being suppressed
-    // until process restart (Qodo pass 4 #3) at a bounded leak rate.
+    // Process-wide per-port probe claims. A port is CLAIMED (atomically, via
+    // GetOrAdd) before its probe starts and released when the probe completes,
+    // so at most one probe can ever be in flight or abandoned per port across
+    // ALL finder instances — the desktop apps sweep every 2-3s and the MCP
+    // DaqifiAgent constructs a fresh finder per call, so without this a port
+    // whose SerialPort.Open() wedges in uncancellable native I/O would leak one
+    // blocked thread-pool thread per sweep/call (Qodo PR #295 review #1;
+    // step-3.5 audit x2: per-instance state lost the bound for per-call finders,
+    // and a non-atomic check-then-act lost it for concurrent instances).
     //
-    // STATIC on purpose (step-3.5 audit, PR #295): a wedged COM port is
-    // machine-global state, not finder state — callers like the MCP
-    // DaqifiAgent construct and dispose a fresh finder per discovery call, and
-    // a per-instance dictionary would forget the stuck probe every call,
-    // re-leaking one blocked thread per request against the same dead port.
-    // Concurrent finder INSTANCES can race the check-then-act below; the worst
-    // case is one extra blocked thread at first collision on a wedged port
-    // (bounded, non-accumulating), which is accepted over a claim protocol.
-    private static readonly ConcurrentDictionary<string, QuarantineEntry> QuarantinedPorts = new();
+    // Lifecycle: claim -> probe -> (completes: released by owner) or (times out:
+    // claim marked abandoned; a continuation releases it the moment the stuck
+    // I/O finally completes — device replug usually errors the stale handle —
+    // and QuarantineRetryTtlMs bounds the worst case by letting ONE fresh
+    // attempt replace a still-stuck claim per TTL window, so a recovered port
+    // re-appears without a process restart at a bounded leak rate).
+    //
+    // STATIC on purpose: a wedged COM port is machine-global state, not finder
+    // state.
+    private static readonly ConcurrentDictionary<string, PortProbeClaim> PortClaims = new();
     private bool _disposed;
 
-    private sealed record QuarantineEntry(Task Probe, long QuarantinedAtTicks);
+    private sealed class PortProbeClaim
+    {
+        /// <summary>Set right after Task.Run; null means claimed-but-starting.</summary>
+        public volatile Task<IDeviceInfo?>? Probe;
+
+        // -1 = in flight; >= 0 = abandoned at this Environment.TickCount64.
+        private long _abandonedAtTicks = -1;
+        public long AbandonedAtTicks
+        {
+            get => Interlocked.Read(ref _abandonedAtTicks);
+            set => Interlocked.Exchange(ref _abandonedAtTicks, value);
+        }
+    }
+
+    private static void ReleaseClaimIfOwned(string portName, PortProbeClaim claim)
+    {
+        // Atomic remove-only-if-same-claim: a TTL retry may have replaced the
+        // entry with a newer claim that must survive this release.
+        ((ICollection<KeyValuePair<string, PortProbeClaim>>)PortClaims)
+            .Remove(new KeyValuePair<string, PortProbeClaim>(portName, claim));
+    }
 
     // One fresh probe per wedged port per this window (monotonic ms).
     private const int DefaultQuarantineRetryTtlMs = 30_000;
@@ -98,7 +118,7 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     /// </summary>
     internal static void ResetPortQuarantineForTests()
     {
-        QuarantinedPorts.Clear();
+        PortClaims.Clear();
         QuarantineRetryTtlMs = DefaultQuarantineRetryTtlMs;
     }
 
@@ -316,21 +336,32 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     /// short-circuits when the caller's token is canceled.</returns>
     private async Task<IDeviceInfo?> ProbeSafelyAsync(string portName, CancellationToken cancellationToken)
     {
+        PortProbeClaim? claim = null;
+        var claimHandedToContinuation = false;
         try
         {
-            // Quarantine: skip a port whose previous timed-out probe is still stuck —
-            // one wedged port costs at most ONE blocked thread per TTL window, not one
-            // per sweep. A completed entry is cleared here as a fallback (its own
-            // continuation normally removed it already); an expired-TTL entry lets one
-            // fresh attempt through so a recovered port re-appears without a restart.
-            if (QuarantinedPorts.TryGetValue(portName, out var quarantined))
+            // Claim the port BEFORE probing (atomic): at most one probe may be in
+            // flight or abandoned per port process-wide, so one wedged port costs at
+            // most ONE blocked thread per TTL window regardless of how many finder
+            // instances sweep concurrently.
+            claim = new PortProbeClaim();
+            var existing = PortClaims.GetOrAdd(portName, claim);
+            if (!ReferenceEquals(existing, claim))
             {
-                if (quarantined.Probe.IsCompleted)
+                var abandonedAt = existing.AbandonedAtTicks;
+                if (existing.Probe is { IsCompleted: true })
                 {
-                    QuarantinedPorts.TryRemove(portName, out _);
+                    // Stale completed claim (continuation raced us) — clear and skip
+                    // this sweep; the next sweep probes cleanly.
+                    ReleaseClaimIfOwned(portName, existing);
+                    return null;
                 }
-                else if (Environment.TickCount64 - quarantined.QuarantinedAtTicks < QuarantineRetryTtlMs)
+                if (abandonedAt < 0
+                    || Environment.TickCount64 - abandonedAt < QuarantineRetryTtlMs
+                    || !PortClaims.TryUpdate(portName, claim, existing))
                 {
+                    // In flight elsewhere, still inside the TTL window, or another
+                    // instance won the TTL-retry race — the port is spoken for.
                     return null;
                 }
             }
@@ -345,6 +376,7 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             // cancels the probe's delays; we never want "cancelled before start"
             // to look like a probe fault.
             var probeTask = Task.Run(() => probe(portName, cancellationToken), CancellationToken.None);
+            claim.Probe = probeTask;
 
             // Hard per-port ceiling: a wedged CDC device hangs Open() inside native
             // GetCommState with no exception, so the catch below never fires and,
@@ -358,25 +390,22 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             if (winner != probeTask)
             {
                 // Whether the wait ended by timeout or by caller cancellation, the
-                // uncancellable probe may still be blocked in native I/O — track and
-                // observe it BEFORE surfacing cancellation, so a cancelled sweep
-                // can't abandon an untracked probe that a later sweep would then
-                // stack a fresh blocked thread on (Qodo PR #295 pass 2 #1).
-                QuarantinedPorts[portName] = new QuarantineEntry(probeTask, Environment.TickCount64);
+                // uncancellable probe may still be blocked in native I/O — mark the
+                // claim abandoned BEFORE surfacing cancellation, so a cancelled sweep
+                // can't walk away from an untracked probe (Qodo PR #295 pass 2 #1).
+                claim.AbandonedAtTicks = Environment.TickCount64;
+                claimHandedToContinuation = true;
 
                 // When the abandoned I/O finally completes (any way), observe its
-                // fault so it can't surface as an UnobservedTaskException, and clear
-                // the port's quarantine entry — but only if the entry still refers to
-                // THIS probe (a TTL retry may have replaced it with a newer attempt).
+                // fault so it can't surface as an UnobservedTaskException, and release
+                // the claim — atomically only if it's still ours (a TTL retry may have
+                // replaced it with a newer attempt that must survive).
+                var abandonedClaim = claim;
                 _ = probeTask.ContinueWith(
                     t =>
                     {
                         _ = t.Exception;
-                        if (QuarantinedPorts.TryGetValue(portName, out var current)
-                            && ReferenceEquals(current.Probe, t))
-                        {
-                            QuarantinedPorts.TryRemove(portName, out _);
-                        }
+                        ReleaseClaimIfOwned(portName, abandonedClaim);
                     },
                     CancellationToken.None,
                     TaskContinuationOptions.ExecuteSynchronously,
@@ -401,6 +430,17 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             // expected for non-DAQiFi serial devices — keep the rest of the
             // concurrent probe set going and return no device for this port.
             return null;
+        }
+        finally
+        {
+            // Release our claim unless the abandonment continuation now owns it
+            // (it releases when the stuck I/O eventually completes). Claims we
+            // never won (ReferenceEquals miss) were never inserted under our
+            // identity, so ReleaseClaimIfOwned is a no-op for them.
+            if (claim != null && !claimHandedToContinuation)
+            {
+                ReleaseClaimIfOwned(portName, claim);
+            }
         }
     }
 


### PR DESCRIPTION
Closes #294.

## The incident (2026-07-13, live on the bench)

A hung-firmware Nq1 kept its USB CDC interface enumerated but blocked `SerialPort.Open()` inside native `GetCommState` — no exception, no cancellation possible. One such device:

1. **Froze the desktop app's UI** — `TryGetDeviceInfoAsync` runs `Open()` synchronously before its first await, i.e. on the calling thread; both desktop apps awaited `DiscoverAsync` from a UI context (daqifi-desktop#685).
2. **Silenced every healthy device** — the stuck probe never completed and never threw, so `ProbeSafelyAsync`'s catch never fired, `Task.WhenAll` never settled, and `DeviceDiscovered` (raised only after `WhenAll`) never fired for the healthy ports either.

## The fix — one change per defect

- **`Task.Run` around the probe** in `ProbeSafelyAsync`: blocking serial I/O always runs on the thread pool now, regardless of caller context.
- **Hard per-port ceiling (8s, `Task.WhenAny`)**: `Open()` is uncancellable, so a timed-out probe is *abandoned* — its own `finally` closes the port if the kernel ever completes the I/O, and a `ContinueWith` observes any eventual fault so it can't become an `UnobservedTaskException`. Caller cancellation still short-circuits ahead of the ceiling.
- **Per-probe event raising**: `DeviceDiscovered` fires as each port succeeds (worker thread, possibly concurrent — handlers own marshaling; both desktop apps already dispatch to their UI threads). The post-`WhenAll` loop only aggregates the return list.

## Tests

New internal ctor seam `probeOverride` (mirrors the existing `portNameProvider` pattern) lets tests simulate hung/healthy ports without hardware; `PortProbeHardTimeoutMs` is internally overridable so tests don't wait 8s. Three new tests:

- hung port times out, healthy device still returned, sweep bounded;
- healthy device's event fires **while** the hung probe is still pending;
- caller cancellation propagates past a hung probe.

`dotnet test`: 1388 passed / 0 failed (net9.0 + net10.0). Rebased onto current main (co-resolved the ctor with #290's `usbLocationProvider`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)