### PR TITLE
fix(discovery): resolve USB location via parent node for HID devices

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/UsbLocationProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/UsbLocationProviderTests.cs
@@ -89,4 +89,109 @@ public class UsbLocationProviderTests
 
         Assert.Null(result);
     }
+
+    // LocationParentWalker: a HID collection's own PnP node never carries
+    // DEVPKEY_Device_LocationInfo directly (confirmed on real bootloader hardware) — only its
+    // parent USB device node does. These tests drive the walk with a fake query function so the
+    // hop/normalization/termination logic is verified without any WMI/hardware dependency.
+
+    [Fact]
+    public void LocationParentWalker_Resolve_LocationOnFirstNode_ReturnsImmediately()
+    {
+        var result = LocationParentWalker.Resolve(
+            "USB\\VID_04D8&PID_003C\\5&2C705BFE&0&1",
+            _ => ("Port_#0001.Hub_#0001", null));
+
+        Assert.Equal("Port_#0001.Hub_#0001", result);
+    }
+
+    [Fact]
+    public void LocationParentWalker_Resolve_LocationOnParent_WalksUpOneHop()
+    {
+        const string hidChild = "HID\\VID_04D8&PID_003C\\6&353A92F2&0&0000";
+        const string usbParent = "USB\\VID_04D8&PID_003C\\5&2C705BFE&0&1";
+
+        var result = LocationParentWalker.Resolve(hidChild, id => id switch
+        {
+            hidChild => (null, usbParent),
+            usbParent => ("Port_#0001.Hub_#0001", null),
+            _ => (null, null)
+        });
+
+        Assert.Equal("Port_#0001.Hub_#0001", result);
+    }
+
+    [Fact]
+    public void LocationParentWalker_Resolve_ParentIdLowercase_IsNormalizedBeforeRequery()
+    {
+        // Real WMI DEVPKEY_Device_Parent values come back with lowercase hex segments (e.g.
+        // "5&2c705bfe&0&1"), which fails InstanceIdRegex (uppercase-only) unless normalized
+        // before the next hop's query — this is the exact bug this walker was introduced to fix.
+        const string hidChild = "HID\\VID_04D8&PID_003C\\6&353A92F2&0&0000";
+        const string lowercaseParent = "USB\\VID_04D8&PID_003C\\5&2c705bfe&0&1";
+        const string normalizedParent = "USB\\VID_04D8&PID_003C\\5&2C705BFE&0&1";
+
+        var queriedIds = new List<string>();
+        var result = LocationParentWalker.Resolve(hidChild, id =>
+        {
+            queriedIds.Add(id);
+            return id == hidChild ? (null, lowercaseParent) : ("Port_#0001.Hub_#0001", null);
+        });
+
+        Assert.Equal("Port_#0001.Hub_#0001", result);
+        Assert.Equal([hidChild, normalizedParent], queriedIds);
+    }
+
+    [Fact]
+    public void LocationParentWalker_Resolve_EmptyStringLocation_IsTreatedAsNotFound()
+    {
+        // WMI can return an empty string (not null) for a property that exists on the node but
+        // resolves to no value — must not be mistaken for a found location.
+        var result = LocationParentWalker.Resolve(
+            "HID\\VID_04D8&PID_003C\\6&353A92F2&0&0000",
+            _ => (string.Empty, null));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void LocationParentWalker_Resolve_NoParent_ReturnsNull()
+    {
+        var result = LocationParentWalker.Resolve(
+            "HID\\VID_04D8&PID_003C\\6&353A92F2&0&0000",
+            _ => (null, null));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void LocationParentWalker_Resolve_MalformedParentId_StopsWalk()
+    {
+        var queriedIds = new List<string>();
+        var result = LocationParentWalker.Resolve("HID\\VID_04D8&PID_003C\\6&353A92F2&0&0000", id =>
+        {
+            queriedIds.Add(id);
+            return (null, "not a valid instance id");
+        });
+
+        Assert.Null(result);
+        Assert.Single(queriedIds);
+    }
+
+    [Fact]
+    public void LocationParentWalker_Resolve_CyclicParentChain_StopsAtMaxHops()
+    {
+        // Defensive: a self-referential or cyclic parent chain must not spin forever.
+        const string id = "HID\\VID_04D8&PID_003C\\6&353A92F2&0&0000";
+        var callCount = 0;
+
+        var result = LocationParentWalker.Resolve(id, _ =>
+        {
+            callCount++;
+            return (null, id);
+        });
+
+        Assert.Null(result);
+        Assert.Equal(LocationParentWalker.MaxParentHops + 1, callCount);
+    }
 }

--- a/src/Daqifi.Core/Device/Discovery/LocationParentWalker.cs
+++ b/src/Daqifi.Core/Device/Discovery/LocationParentWalker.cs
@@ -1,0 +1,66 @@
+using System.Text.RegularExpressions;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Walks a PnP device's parent chain looking for a resolved USB physical-location value. Kept
+/// separate from <see cref="WindowsUsbLocationProvider"/> (which is Windows-only because it calls
+/// into <see cref="System.Management"/>) so this pure decision logic — when to stop, how deep to
+/// go, and how to normalize a parent instance ID before re-querying it — can be unit tested on any
+/// platform with a fake query function, without WMI/hardware access.
+/// </summary>
+internal static class LocationParentWalker
+{
+    // A HID collection's own PnP node never carries DEVPKEY_Device_LocationInfo — only the
+    // physical USB device node one level up in the device tree does (confirmed on real hardware:
+    // a bootloader's HID node returns no LocationInfo property at all, while its
+    // DEVPKEY_Device_Parent node returns the same value the same physical port reports in
+    // serial/CDC mode). Bounded so a pathological/cyclic parent chain can't spin forever; the
+    // real device tree is 1 hop away.
+    internal const int MaxParentHops = 4;
+
+    // A parsed PnP instance ID is composed of hex/word segments separated by backslashes
+    // (e.g. "HID\VID_04D8&PID_003C\7&1A2B3C4D&0&0000"). Validated before a caller interpolates
+    // it into a WQL query string so a malformed/unexpected value can never inject WQL syntax.
+    internal static readonly Regex InstanceIdRegex = new(
+        @"^[A-Z0-9_&]+(\\[A-Z0-9_&]+)+$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Repeatedly calls <paramref name="query"/> for <paramref name="instanceId"/> and then each
+    /// resolved parent, returning the first non-empty location found, or null if none is found
+    /// within <see cref="MaxParentHops"/> hops, the chain ends, or a parent ID doesn't look like a
+    /// valid PnP instance ID.
+    /// </summary>
+    /// <param name="instanceId">Starting PnP instance ID; must already match <see cref="InstanceIdRegex"/>.</param>
+    /// <param name="query">
+    /// Resolves a PnP instance ID to its location (or null/empty if unresolved) and its parent's
+    /// instance ID (or null if it has none / couldn't be resolved).
+    /// </param>
+    internal static string? Resolve(string instanceId, Func<string, (string? Location, string? ParentId)> query)
+    {
+        var currentId = instanceId;
+        for (var hop = 0; hop <= MaxParentHops; hop++)
+        {
+            var (location, parentId) = query(currentId);
+            if (!string.IsNullOrEmpty(location))
+            {
+                return location;
+            }
+
+            // WMI's DEVPKEY_Device_Parent value case doesn't match the uppercase convention this
+            // module normalizes instance IDs to — normalize before validating/re-querying, or a
+            // real parent chain segment with lowercase hex fails the regex and the walk stops one
+            // hop too early.
+            var normalizedParentId = parentId?.ToUpperInvariant();
+            if (normalizedParentId == null || !InstanceIdRegex.IsMatch(normalizedParentId))
+            {
+                return null;
+            }
+
+            currentId = normalizedParentId;
+        }
+
+        return null;
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/WindowsUsbLocationProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsUsbLocationProvider.cs
@@ -60,12 +60,17 @@ internal sealed class WindowsUsbLocationProvider : IUsbLocationProvider
         // same query shape as WindowsUsbPortDescriptorProvider.
         using var searcher = new System.Management.ManagementObjectSearcher(
             $"SELECT DeviceID FROM Win32_PnPEntity WHERE PNPClass = 'Ports' AND Caption LIKE '%({portName})%'");
-        var deviceId = FindDeviceId(searcher);
-        return deviceId != null ? LocationParentWalker.Resolve(deviceId, QueryLocationAndParent) : null;
+        var deviceId = FindDeviceId(searcher)?.ToUpperInvariant();
+        return deviceId != null ? QueryLocationByDeviceId(deviceId) : null;
     }
 
     private static string? QueryLocationByDeviceId(string instanceId)
     {
+        // Both this and LocationParentWalker.Resolve validate: the walker enforces the contract
+        // on every hop it re-queries internally, but the FIRST id comes from two different
+        // sources here (a caller-supplied HID path vs. whatever WMI's Caption match returns for
+        // a COM port) — validating it before the walker ever sees it is what stops an unexpected
+        // DeviceID shape from reaching the WQL interpolation in QueryLocationAndParent at all.
         return LocationParentWalker.InstanceIdRegex.IsMatch(instanceId)
             ? LocationParentWalker.Resolve(instanceId, QueryLocationAndParent)
             : null;
@@ -73,8 +78,13 @@ internal sealed class WindowsUsbLocationProvider : IUsbLocationProvider
 
     private static (string? Location, string? ParentId) QueryLocationAndParent(string instanceId)
     {
-        // WQL requires backslashes in string literals to be escaped as "\\".
-        var escaped = instanceId.Replace(@"\", @"\\", StringComparison.Ordinal);
+        // WQL requires backslashes in string literals escaped as "\\" and embedded single quotes
+        // escaped as "''"; the caller already validates instanceId against InstanceIdRegex (which
+        // permits neither a literal quote nor other WQL metacharacters), but escaping quotes here
+        // too is defense-in-depth against a future caller that skips that validation.
+        var escaped = instanceId
+            .Replace(@"\", @"\\", StringComparison.Ordinal)
+            .Replace("'", "''", StringComparison.Ordinal);
         using var searcher = new System.Management.ManagementObjectSearcher(
             $"SELECT DeviceID FROM Win32_PnPEntity WHERE DeviceID = '{escaped}'");
         using var results = searcher.Get();

--- a/src/Daqifi.Core/Device/Discovery/WindowsUsbLocationProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsUsbLocationProvider.cs
@@ -15,19 +15,13 @@ namespace Daqifi.Core.Device.Discovery;
 internal sealed class WindowsUsbLocationProvider : IUsbLocationProvider
 {
     private const string LocationInfoKeyName = "DEVPKEY_Device_LocationInfo";
+    private const string ParentKeyName = "DEVPKEY_Device_Parent";
 
     // SerialPort.GetPortNames() returns "COM<n>" on Windows; validated before
     // interpolation into the WQL query string below.
     private static readonly Regex PortNameRegex = new(
         @"^COM\d+$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-    // A parsed PnP instance ID is composed of hex/word segments separated by backslashes
-    // (e.g. "HID\VID_04D8&PID_003C\7&1A2B3C4D&0&0000"). Validated before interpolation into
-    // a WQL query string so a malformed device path can never inject WQL syntax.
-    private static readonly Regex InstanceIdRegex = new(
-        @"^[A-Z0-9_&]+(\\[A-Z0-9_&]+)+$",
-        RegexOptions.Compiled);
 
     public string? GetLocationKey(string portNameOrDevicePath)
     {
@@ -66,25 +60,23 @@ internal sealed class WindowsUsbLocationProvider : IUsbLocationProvider
         // same query shape as WindowsUsbPortDescriptorProvider.
         using var searcher = new System.Management.ManagementObjectSearcher(
             $"SELECT DeviceID FROM Win32_PnPEntity WHERE PNPClass = 'Ports' AND Caption LIKE '%({portName})%'");
-        return FindLocationInfo(searcher);
+        var deviceId = FindDeviceId(searcher);
+        return deviceId != null ? LocationParentWalker.Resolve(deviceId, QueryLocationAndParent) : null;
     }
 
     private static string? QueryLocationByDeviceId(string instanceId)
     {
-        if (!InstanceIdRegex.IsMatch(instanceId))
-        {
-            return null;
-        }
+        return LocationParentWalker.InstanceIdRegex.IsMatch(instanceId)
+            ? LocationParentWalker.Resolve(instanceId, QueryLocationAndParent)
+            : null;
+    }
 
+    private static (string? Location, string? ParentId) QueryLocationAndParent(string instanceId)
+    {
         // WQL requires backslashes in string literals to be escaped as "\\".
         var escaped = instanceId.Replace(@"\", @"\\", StringComparison.Ordinal);
         using var searcher = new System.Management.ManagementObjectSearcher(
             $"SELECT DeviceID FROM Win32_PnPEntity WHERE DeviceID = '{escaped}'");
-        return FindLocationInfo(searcher);
-    }
-
-    private static string? FindLocationInfo(System.Management.ManagementObjectSearcher searcher)
-    {
         using var results = searcher.Get();
         foreach (var entity in results)
         {
@@ -92,43 +84,79 @@ internal sealed class WindowsUsbLocationProvider : IUsbLocationProvider
             {
                 if (entity is System.Management.ManagementObject managementObject)
                 {
-                    var location = GetLocationInfoProperty(managementObject);
-                    if (location != null)
-                    {
-                        return location;
-                    }
+                    return GetDeviceProperties(managementObject);
                 }
+            }
+        }
+
+        return (null, null);
+    }
+
+    private static string? FindDeviceId(System.Management.ManagementObjectSearcher searcher)
+    {
+        using var results = searcher.Get();
+        foreach (var entity in results)
+        {
+            using (entity)
+            {
+                return entity["DeviceID"] as string;
             }
         }
 
         return null;
     }
 
-    private static string? GetLocationInfoProperty(System.Management.ManagementObject entity)
+    private static (string? Location, string? ParentId) GetDeviceProperties(System.Management.ManagementObject entity)
     {
         using var inParams = entity.GetMethodParameters("GetDeviceProperties");
-        inParams["devicePropertyKeys"] = new[] { LocationInfoKeyName };
+        inParams["devicePropertyKeys"] = new[] { LocationInfoKeyName, ParentKeyName };
 
         using var outParams = entity.InvokeMethod("GetDeviceProperties", inParams, null);
         if (outParams?["deviceProperties"] is not System.Management.ManagementBaseObject[] deviceProperties)
         {
-            return null;
+            return (null, null);
         }
 
+        string? location = null;
+        string? parentId = null;
         foreach (var property in deviceProperties)
         {
             using (property)
             {
-                var keyName = property["KeyName"] as string;
-                if (!string.Equals(keyName, LocationInfoKeyName, StringComparison.Ordinal))
+                // A key WMI couldn't resolve on this node comes back as a property object whose
+                // "Type"/"KeyName"/"Data" members throw ManagementException("Not found") on access
+                // instead of yielding null — requesting the LocationInfo and Parent keys together
+                // means one can legitimately be absent (a HID collection's own node never has
+                // LocationInfo) while the other resolves, so each read must tolerate that per-entry.
+                var keyName = TryGetStringProperty(property, "KeyName");
+                if (keyName == null)
                 {
                     continue;
                 }
 
-                return property["Data"] as string;
+                if (string.Equals(keyName, LocationInfoKeyName, StringComparison.Ordinal))
+                {
+                    location = TryGetStringProperty(property, "Data");
+                }
+                else if (string.Equals(keyName, ParentKeyName, StringComparison.Ordinal))
+                {
+                    parentId = TryGetStringProperty(property, "Data");
+                }
             }
         }
 
-        return null;
+        return (location, parentId);
+    }
+
+    private static string? TryGetStringProperty(System.Management.ManagementBaseObject obj, string propertyName)
+    {
+        try
+        {
+            return obj[propertyName] as string;
+        }
+        catch (System.Management.ManagementException)
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary

`WindowsUsbLocationProvider` (added in #290) queries `DEVPKEY_Device_LocationInfo` directly on the PnP node `HidDevicePathParser` resolves a HID device interface path to — but that node (the HID collection's own PnP node) never carries the property. Only the physical USB device node one level up in the device tree does.

**Confirmed on real bootloader hardware** (a DAQiFi device forced into PIC32 HID bootloader mode): the bootloader's HID node returns no `LocationInfo` at all via WMI (not an exception — the property is simply absent), while querying its `DEVPKEY_Device_Parent` node returns the exact same value (`Port_#0001.Hub_#0001`) the same physical port reports in serial/CDC mode.

This silently broke location-key resolution for **every** real HID device — always `null`, no exception, no visible failure — which defeats the entire point of the cross-mode correlation [daqifi-desktop#655](https://github.com/daqifi/daqifi-desktop/issues/655) depends on (PR 692 there is the consumer). #290's own test plan explicitly flagged this exact case as unverified on real Windows hardware; this PR closes that gap.

## Changes

- New `LocationParentWalker`: pure, WMI-independent walk-up logic (bounded to 4 hops to guard against a pathological/cyclic parent chain), unit tested with a fake query function — following the same "extract the pure logic" pattern `HidDevicePathParser` already uses.
- `WindowsUsbLocationProvider` now walks to `DEVPKEY_Device_Parent` and retries when the direct lookup on a node comes back empty.
- Two more bugs found and fixed while building/testing this against real hardware:
  - WMI's `GetDeviceProperties` throws `ManagementException("Not found")` when reading a property key it couldn't resolve on a given node — only surfaced once two keys (`LocationInfo` + `Parent`) were requested in the same call. Property reads are now defensive per-entry (`TryGetStringProperty`).
  - `DEVPKEY_Device_Parent` values come back from WMI with lowercase hex segments (e.g. `5&2c705bfe&0&1`), which fails `InstanceIdRegex` (uppercase-only, by design, to safely interpolate into WQL) unless normalized before the next hop's query — without this the walk silently stopped one hop too early even with the parent-walk fix in place.

## Test plan

- [x] `dotnet build Daqifi.Core.sln -c Release` — 0 warnings/errors
- [x] `dotnet test Daqifi.Core.sln -c Release` — 1391/1392 passed (1 pre-existing unrelated flake in `ContinuousDeviceFinderTests`, reproduces identically on `main` without this change)
- [x] New `LocationParentWalker` unit tests (7 cases: immediate resolution, one-hop walk, lowercase-parent normalization, empty-string-treated-as-not-found, no-parent termination, malformed-parent termination, cyclic-chain bounded termination)
- [x] **Bench-validated on real hardware**: built this branch's `Daqifi.Core.dll`, loaded it via reflection against the real `WindowsUsbLocationProvider` type, and confirmed the same physical DAQiFi device's location key resolves to the identical `Port_#0001.Hub_#0001` in both serial mode (`GetLocationKey("COM3")`) and HID bootloader mode (`GetLocationKey(rawHidDevicePath)`) — before this fix, the HID-mode call always returned `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)