### PR TITLE
feat(firmware): attempt JMP_TO_APP soft-reset recovery on failed bootloader health check

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -872,6 +872,138 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateFirmwareAsync_WhenBootloaderHealthCheckFails_SoftResetsAndCompletes()
+    {
+        // #298: a dirty HID bootloader handle (left behind by another program)
+        // makes the initial version health check fail even though the device is
+        // physically present. One JMP_TO_APP soft reset forces a clean
+        // re-enumeration; the retried health check then succeeds and the update
+        // proceeds normally.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0xEE]);       // initial version check -> "Error" (dirty handle)
+        hidTransport.EnqueueRead([0x01, 0x10]); // version check after soft reset -> healthy
+        hidTransport.EnqueueRead([0x01, 0x02]); // erase ack
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 1
+        hidTransport.EnqueueRead([0x01, 0x03]); // program ack 2
+        hidTransport.EnqueueRead([0x01, 0x10]); // verify version (no CRC regions configured)
+
+        var bootloaderDevice = new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader");
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [bootloaderDevice],
+            [bootloaderDevice] // re-enumeration after the JMP_TO_APP soft reset
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions());
+
+        var stateTransitions = new List<FirmwareUpdateState>();
+        service.StateChanged += (_, args) => stateTransitions.Add(args.CurrentState);
+
+        var hexPath = CreateTempFile();
+        try
+        {
+            await service.UpdateFirmwareAsync(device, hexPath);
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(
+            [
+                FirmwareUpdateState.PreparingDevice,
+                FirmwareUpdateState.WaitingForBootloader,
+                FirmwareUpdateState.Connecting,
+                FirmwareUpdateState.ErasingFlash,
+                FirmwareUpdateState.Programming,
+                FirmwareUpdateState.Verifying,
+                FirmwareUpdateState.JumpingToApp,
+                FirmwareUpdateState.Complete
+            ],
+            stateTransitions);
+
+        // The JMP_TO_APP soft-reset message was written exactly once, before the
+        // successful jump-to-application write at the end of the update.
+        Assert.Equal(2, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x55));
+        // The version request was sent twice: the failed initial check and the
+        // successful retry after the soft reset.
+        Assert.Equal(3, hidTransport.Writes.Count(w => w.Length > 0 && w[0] == 0x11));
+    }
+
+    [Fact]
+    public async Task UpdateFirmwareAsync_WhenSoftResetRecoveryAlsoFails_FallsThroughToFailedWithGuidance()
+    {
+        // #298: when the JMP_TO_APP soft-reset recovery does not restore a
+        // healthy bootloader session (health check fails again after the
+        // reset), the update must fall through to today's Connecting-state
+        // failure/guidance behavior rather than throwing an unrelated error.
+        var device = new FakeStreamingDevice("COM3");
+        var hidTransport = new FakeHidTransport();
+        hidTransport.EnqueueRead([0xEE]); // initial version check -> "Error"
+        hidTransport.EnqueueRead([0xEE]); // version check after soft reset -> still "Error"
+
+        var bootloaderDevice = new HidDeviceInfo(0x04D8, 0x003C, "path-1", "SN-1", "DAQiFi Bootloader");
+        var enumerator = new FakeHidDeviceEnumerator([
+            Array.Empty<HidDeviceInfo>(),
+            [bootloaderDevice],
+            [bootloaderDevice] // re-enumeration after the JMP_TO_APP soft reset
+        ]);
+
+        var bootloaderProtocol = new FakeBootloaderProtocol([[0xA1, 0x01], [0xA1, 0x02]]);
+
+        var service = new FirmwareUpdateService(
+            hidTransport,
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            bootloaderProtocol,
+            enumerator,
+            CreateFastOptions());
+
+        var stateTransitions = new List<FirmwareUpdateState>();
+        service.StateChanged += (_, args) => stateTransitions.Add(args.CurrentState);
+
+        var hexPath = CreateTempFile();
+        FirmwareUpdateException exception;
+        try
+        {
+            exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateFirmwareAsync(device, hexPath));
+        }
+        finally
+        {
+            File.Delete(hexPath);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Connecting, exception.FailedState);
+        Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+        Assert.DoesNotContain(FirmwareUpdateState.CleaningUp, stateTransitions);
+        Assert.DoesNotContain(FirmwareUpdateState.Recovered, stateTransitions);
+
+        // The original (pre-recovery) failure surfaces to the caller, not a new
+        // exception type introduced by the recovery attempt.
+        var inner = Assert.IsType<InvalidDataException>(exception.InnerException);
+        Assert.Contains("invalid version response", inner.Message);
+
+        // The soft reset was still attempted before giving up.
+        Assert.Contains(hidTransport.Writes, w => w.Length > 0 && w[0] == 0x55);
+
+        Assert.NotNull(exception.RecoveryGuidance);
+        Assert.Contains("Bootloader was found but HID connection failed", exception.RecoveryGuidance);
+    }
+
+    [Fact]
     public async Task UpdateFirmwareAsync_WhenCanceled_ThrowsOperationCanceledExceptionAndTransitionsToFailed()
     {
         // Cancellation BEFORE flash is touched (here during WaitingForBootloader)

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Daqifi.Core.Communication.Producers;
@@ -1454,7 +1455,11 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             _logger.LogWarning(
                 ex,
                 "JMP_TO_APP soft-reset write failed; the bootloader handle is likely already unusable.");
-            throw originalFailure;
+            // Rethrow via ExceptionDispatchInfo (not `throw originalFailure;`) so the
+            // original exception's stack trace still points at the actual
+            // connect/health-check failure site, not this recovery method.
+            ExceptionDispatchInfo.Capture(originalFailure).Throw();
+            throw; // unreachable; satisfies flow analysis
         }
         finally
         {
@@ -1489,7 +1494,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             _logger.LogWarning(
                 ex,
                 "Bootloader is still unhealthy after the JMP_TO_APP soft-reset recovery attempt.");
-            throw originalFailure;
+            ExceptionDispatchInfo.Capture(originalFailure).Throw();
+            throw; // unreachable; satisfies flow analysis
         }
     }
 

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -399,17 +399,35 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             TransitionToState(FirmwareUpdateState.Connecting, "Connecting to HID bootloader.");
             ReportProgress(progress, FirmwareUpdateState.Connecting, 10, _currentOperation, 0, totalBytes);
 
-            await ExecuteWithStateTimeoutAsync(
-                FirmwareUpdateState.Connecting,
-                "connect HID transport",
-                ct => ConnectToBootloaderWithRetryAsync(hidDevice, targetDevicePath, targetLocationKey, ct),
-                cancellationToken).ConfigureAwait(false);
+            string version;
+            try
+            {
+                await ExecuteWithStateTimeoutAsync(
+                    FirmwareUpdateState.Connecting,
+                    "connect HID transport",
+                    ct => ConnectToBootloaderWithRetryAsync(hidDevice, targetDevicePath, targetLocationKey, ct),
+                    cancellationToken).ConfigureAwait(false);
 
-            var version = await ExecuteWithStateTimeoutAsync(
-                FirmwareUpdateState.Connecting,
-                "request bootloader version",
-                RequestBootloaderVersionAsync,
-                cancellationToken).ConfigureAwait(false);
+                version = await ExecuteWithStateTimeoutAsync(
+                    FirmwareUpdateState.Connecting,
+                    "request bootloader version",
+                    RequestBootloaderVersionAsync,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // #298: a dirty HID bootloader handle left behind by another
+                // program (or a previous run) can make the connect or the
+                // version health check fail even though the device is
+                // physically present. Nothing has been erased yet, so it's
+                // safe to attempt one JMP_TO_APP soft reset to force a clean
+                // re-enumeration before giving up.
+                version = await RecoverBootloaderHealthWithSoftResetAsync(
+                    ex,
+                    targetDevicePath,
+                    targetLocationKey,
+                    cancellationToken).ConfigureAwait(false);
+            }
 
             _logger.LogInformation("Bootloader version response: {BootloaderVersion}", version);
 
@@ -1397,6 +1415,82 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             },
             ex => ex is IOException or TimeoutException or InvalidOperationException,
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Recovers from a failed <see cref="FirmwareUpdateState.Connecting"/> health
+    /// check (bad connect or a garbage version response) by issuing one
+    /// <c>JMP_TO_APP</c> soft reset, waiting for the bootloader to re-enumerate,
+    /// and retrying the connect + version check exactly once. See #298: the
+    /// observed failure is a dirty HID bootloader handle left behind by another
+    /// program, which a clean reset clears without touching flash.
+    /// </summary>
+    private async Task<string> RecoverBootloaderHealthWithSoftResetAsync(
+        Exception originalFailure,
+        string? targetDevicePath,
+        string? targetLocationKey,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogWarning(
+            originalFailure,
+            "Bootloader connect/health-check failed in {State}; attempting a JMP_TO_APP soft-reset recovery before giving up.",
+            FirmwareUpdateState.Connecting);
+
+        try
+        {
+            // Best-effort: the handle may already be unusable (that's often why
+            // the health check failed in the first place), so a write failure
+            // here just falls through to the original failure below rather than
+            // surfacing a new unhandled exception.
+            if (_hidTransport.IsConnected)
+            {
+                await _hidTransport
+                    .WriteAsync(_bootloaderProtocol.CreateJumpToApplicationMessage(), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "JMP_TO_APP soft-reset write failed; the bootloader handle is likely already unusable.");
+            throw originalFailure;
+        }
+        finally
+        {
+            await SafeDisconnectHidAsync().ConfigureAwait(false);
+        }
+
+        try
+        {
+            var recoveredDevice = await ExecuteWithStateTimeoutAsync(
+                FirmwareUpdateState.WaitingForBootloader,
+                "wait for HID bootloader re-enumeration after soft reset",
+                ct => WaitForBootloaderDeviceAsync(targetDevicePath, targetLocationKey, ct),
+                cancellationToken).ConfigureAwait(false);
+
+            await ExecuteWithStateTimeoutAsync(
+                FirmwareUpdateState.Connecting,
+                "reconnect HID transport after soft reset",
+                ct => ConnectToBootloaderWithRetryAsync(recoveredDevice, targetDevicePath, targetLocationKey, ct),
+                cancellationToken).ConfigureAwait(false);
+
+            var version = await ExecuteWithStateTimeoutAsync(
+                FirmwareUpdateState.Connecting,
+                "request bootloader version after soft reset",
+                RequestBootloaderVersionAsync,
+                cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation("Bootloader health restored after JMP_TO_APP soft reset.");
+            return version;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Bootloader is still unhealthy after the JMP_TO_APP soft-reset recovery attempt.");
+            throw originalFailure;
+        }
     }
 
     private async Task<string> RequestBootloaderVersionAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

On a PIC32 firmware-update failure during `Connecting` (the HID bootloader connect + `RequestBootloaderVersionAsync` health check), `FirmwareUpdateService.RunPic32UpdateAsync` previously only retried the disconnect/reconnect loop before giving up. It never attempted a `JMP_TO_APP` soft reset to recover an unhealthy/dirty bootloader session, even though `Pic32BootloaderProtocol.CreateJumpToApplicationMessage()` already exists and Core already uses it on the success path (`JumpToApplicationAndReconnectAsync`).

The observed real-world failure mode (daqifi-desktop#630) is a dirty HID bootloader handle left behind by another program (Microchip's HID bootloader PC tool, or historically desktop's own HID device finder). Once dirty, `RequestBootloaderVersionAsync` fails or returns garbage even though the physical device is present and enumerated.

Closes #298

## Changes

- `RunPic32UpdateAsync`: the initial connect + version health check in `Connecting` is now wrapped in a try/catch. On failure (bad connect or a garbage/`Error` version response), it calls a new `RecoverBootloaderHealthWithSoftResetAsync` before giving up.
- `RecoverBootloaderHealthWithSoftResetAsync`:
  1. Writes `CreateJumpToApplicationMessage()` to the current HID handle, best-effort (guarded by `IsConnected`; a write failure falls through to the original failure rather than throwing a new unhandled exception).
  2. Disconnects and waits for HID re-enumeration, reusing `WaitForBootloaderDeviceAsync` (bounded by the existing `WaitingForBootloaderTimeout`).
  3. Reconnects (`ConnectToBootloaderWithRetryAsync`) and retries the version health check exactly once.
  4. If still unhealthy, rethrows the **original** pre-recovery exception, so the existing `Connecting`-state failure/guidance path and cleanup-eligibility logic (`Connecting` stays `NotEligible` — nothing has been erased yet) are completely unchanged.
- No changes to the erase-eligible failure paths (`ErasingFlash`/`Programming`/`Verifying`).

## Test plan

- [x] `dotnet build Daqifi.Core.sln -c Release` — 0 warnings/errors
- [x] `dotnet test Daqifi.Core.sln -c Release` — 1394/1396 passed, 2 skipped (real-hardware-only tests); no new failures. (`ContinuousDeviceFinderTests.Start_DiscoversDevice_RaisesDeviceDiscoveredAndPopulatesDevices` is a known pre-existing intermittent flake, reproduces identically on `main` without this change.)
- [x] New unit tests in `FirmwareUpdateServiceTests`:
  - `UpdateFirmwareAsync_WhenBootloaderHealthCheckFails_SoftResetsAndCompletes` — health check fails → soft reset issued → re-check succeeds → update proceeds through to `Complete`.
  - `UpdateFirmwareAsync_WhenSoftResetRecoveryAlsoFails_FallsThroughToFailedWithGuidance` — health check fails → soft reset recovery also fails → falls through to today's `Failed` behavior, original exception and `Connecting` recovery guidance preserved, no `CleaningUp`/`Recovered` detour.
- [x] **Bench-validated on real hardware**: built the [daqifi-core-example-app](https://github.com/daqifi/daqifi-core-example-app) CLI against this branch (`DaqifiCoreProjectPath`) and ran a full `--fw-update-latest` PIC32 update against a real Nyquist (COM3, FW 3.7.2). State trace `PreparingDevice → WaitingForBootloader → Connecting → ErasingFlash → Programming (43,207 records) → Verifying (3 CRC regions) → JumpingToApp → Complete`; the device re-enumerated healthy afterward at the same firmware version. The HID handle was clean going in, so this confirms the modified `Connecting` step introduces **no regression** on the normal path (the new soft-reset branch is skipped entirely when the first health check succeeds) — it does not exercise the soft-reset recovery branch itself, which is covered deterministically by the two unit tests above instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
