### PR TITLE
feat(device): add device friendly-name support (SCPI setter, validation, DeviceMetadata.FriendlyName)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -744,7 +744,7 @@ public class ScpiMessageProducerTests
     [InlineData("has a \ncontrol char")]
     public void SetDeviceName_WithInvalidName_Throws(string? name)
     {
-        Assert.Throws<ArgumentException>(() => ScpiMessageProducer.SetDeviceName(name!));
+        Assert.Throws<ArgumentException>(() => ScpiMessageProducer.SetDeviceName(name));
     }
 
     [Fact]
@@ -785,7 +785,7 @@ public class ScpiMessageProducerTests
     [InlineData("has a \ncontrol char")]
     public void IsFriendlyNameValid_WithInvalidName_ReturnsFalse(string? name)
     {
-        Assert.False(ScpiMessageProducer.IsFriendlyNameValid(name!));
+        Assert.False(ScpiMessageProducer.IsFriendlyNameValid(name));
     }
 
     private static void AssertMessageFormat(IOutboundMessage<string> message)

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -720,6 +720,74 @@ public class ScpiMessageProducerTests
         Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetLogLevel("STREAM", level));
     }
 
+    [Fact]
+    public void SetDeviceName_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetDeviceName("My Device");
+        Assert.Equal("SYSTem:DEVice:NAME \"My Device\"", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SaveDeviceName_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SaveDeviceName;
+        Assert.Equal("SYSTem:DEVice:NAME:SAVE", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("has a \"quote")]
+    [InlineData("has a \\backslash")]
+    [InlineData("has a \ncontrol char")]
+    public void SetDeviceName_WithInvalidName_Throws(string? name)
+    {
+        Assert.Throws<ArgumentException>(() => ScpiMessageProducer.SetDeviceName(name!));
+    }
+
+    [Fact]
+    public void SetDeviceName_TooLong_Throws()
+    {
+        var name = new string('a', ScpiMessageProducer.MaxFriendlyNameLength + 1);
+        Assert.Throws<ArgumentException>(() => ScpiMessageProducer.SetDeviceName(name));
+    }
+
+    [Theory]
+    [InlineData("A")]
+    [InlineData("My Device")]
+    [InlineData("~!@#$%^&*()_+-=[]{}|;:,.<>/?")]
+    public void IsFriendlyNameValid_WithValidName_ReturnsTrue(string name)
+    {
+        Assert.True(ScpiMessageProducer.IsFriendlyNameValid(name));
+    }
+
+    [Fact]
+    public void IsFriendlyNameValid_AtMaxLength_ReturnsTrue()
+    {
+        var name = new string('a', ScpiMessageProducer.MaxFriendlyNameLength);
+        Assert.True(ScpiMessageProducer.IsFriendlyNameValid(name));
+    }
+
+    [Fact]
+    public void IsFriendlyNameValid_OverMaxLength_ReturnsFalse()
+    {
+        var name = new string('a', ScpiMessageProducer.MaxFriendlyNameLength + 1);
+        Assert.False(ScpiMessageProducer.IsFriendlyNameValid(name));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("has a \"quote")]
+    [InlineData("has a \\backslash")]
+    [InlineData("has a \ncontrol char")]
+    public void IsFriendlyNameValid_WithInvalidName_ReturnsFalse(string? name)
+    {
+        Assert.False(ScpiMessageProducer.IsFriendlyNameValid(name!));
+    }
+
     private static void AssertMessageFormat(IOutboundMessage<string> message)
     {
         var bytes = message.GetBytes();

--- a/src/Daqifi.Core.Tests/Device/DeviceMetadataTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceMetadataTests.cs
@@ -26,6 +26,7 @@ public class DeviceMetadataTests
         Assert.Equal(string.Empty, metadata.MacAddress);
         Assert.Equal(string.Empty, metadata.Ssid);
         Assert.Equal(string.Empty, metadata.HostName);
+        Assert.Equal(string.Empty, metadata.FriendlyName);
         Assert.Equal(0, metadata.DevicePort);
     }
 
@@ -190,5 +191,39 @@ public class DeviceMetadataTests
         Assert.Equal(string.Empty, metadata.Ssid);
         Assert.Equal(string.Empty, metadata.HostName);
         Assert.Equal(0, metadata.DevicePort);
+    }
+
+    [Fact]
+    public void UpdateFromProtobuf_UpdatesFriendlyName()
+    {
+        // Arrange
+        var metadata = new DeviceMetadata();
+        var message = new DaqifiOutMessage
+        {
+            FriendlyDeviceName = "My Device"
+        };
+
+        // Act
+        metadata.UpdateFromProtobuf(message);
+
+        // Assert
+        Assert.Equal("My Device", metadata.FriendlyName);
+    }
+
+    [Fact]
+    public void UpdateFromProtobuf_WithEmptyFriendlyName_LeavesFriendlyNameUnchanged()
+    {
+        // Arrange
+        var metadata = new DeviceMetadata { FriendlyName = "Previous Name" };
+        var message = new DaqifiOutMessage
+        {
+            FriendlyDeviceName = ""
+        };
+
+        // Act
+        metadata.UpdateFromProtobuf(message);
+
+        // Assert
+        Assert.Equal("Previous Name", metadata.FriendlyName);
     }
 }

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -22,6 +22,75 @@ namespace Daqifi.Core.Communication.Producers;
 public class ScpiMessageProducer
 {
     /// <summary>
+    /// Maximum length, in characters, of a device friendly name accepted by firmware.
+    /// </summary>
+    public const int MaxFriendlyNameLength = 31;
+
+    /// <summary>
+    /// Validates a candidate device friendly name against firmware's acceptance rule.
+    /// </summary>
+    /// <param name="name">The candidate name.</param>
+    /// <remarks>
+    /// Mirrors firmware's <c>daqifi_settings_FriendlyNameIsValid</c> exactly: 1-<see cref="MaxFriendlyNameLength"/>
+    /// printable ASCII characters (0x20-0x7E), excluding <c>"</c> and <c>\</c> (which would break the
+    /// SCPI string literal and the JSON info-message encoding).
+    /// </remarks>
+    /// <returns><c>true</c> if <paramref name="name"/> would be accepted by the device; otherwise <c>false</c>.</returns>
+    public static bool IsFriendlyNameValid(string name)
+    {
+        if (name is null || name.Length is 0 or > MaxFriendlyNameLength)
+        {
+            return false;
+        }
+
+        foreach (var c in name)
+        {
+            if (c is < (char)0x20 or > (char)0x7E or '"' or '\\')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Creates a command message to set the device's friendly name.
+    /// </summary>
+    /// <param name="name">
+    /// 1-<see cref="MaxFriendlyNameLength"/> printable ASCII characters (0x20-0x7E); cannot contain
+    /// <c>"</c> or <c>\</c>. See <see cref="IsFriendlyNameValid"/>.
+    /// </param>
+    /// <remarks>
+    /// The new name is staged into the device's runtime settings and takes effect immediately, but
+    /// is not persisted across reboots until <see cref="SaveDeviceName"/> is also sent.
+    /// Command: SYSTem:DEVice:NAME "name"
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetDeviceName("My Device"));
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> fails validation.</exception>
+    public static IOutboundMessage<string> SetDeviceName(string name)
+    {
+        if (!IsFriendlyNameValid(name))
+        {
+            throw new ArgumentException(
+                $"Device name must be 1-{MaxFriendlyNameLength} printable ASCII characters and cannot contain '\"' or '\\'.",
+                nameof(name));
+        }
+
+        return new ScpiMessage($"SYSTem:DEVice:NAME \"{name}\"");
+    }
+
+    /// <summary>
+    /// Creates a command message to persist the device's friendly name to NVM.
+    /// </summary>
+    /// <remarks>
+    /// Send after <see cref="SetDeviceName"/> so the staged name survives a reboot.
+    /// Command: SYSTem:DEVice:NAME:SAVE
+    /// Example: messageProducer.Send(ScpiMessageProducer.SaveDeviceName);
+    /// </remarks>
+    public static IOutboundMessage<string> SaveDeviceName => new ScpiMessage("SYSTem:DEVice:NAME:SAVE");
+
+    /// <summary>
     /// Creates a command message to reboot the device.
     /// </summary>
     /// <remarks>

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -29,14 +29,14 @@ public class ScpiMessageProducer
     /// <summary>
     /// Validates a candidate device friendly name against firmware's acceptance rule.
     /// </summary>
-    /// <param name="name">The candidate name.</param>
+    /// <param name="name">The candidate name. <c>null</c> is always invalid.</param>
     /// <remarks>
     /// Mirrors firmware's <c>daqifi_settings_FriendlyNameIsValid</c> exactly: 1-<see cref="MaxFriendlyNameLength"/>
     /// printable ASCII characters (0x20-0x7E), excluding <c>"</c> and <c>\</c> (which would break the
     /// SCPI string literal and the JSON info-message encoding).
     /// </remarks>
     /// <returns><c>true</c> if <paramref name="name"/> would be accepted by the device; otherwise <c>false</c>.</returns>
-    public static bool IsFriendlyNameValid(string name)
+    public static bool IsFriendlyNameValid(string? name)
     {
         if (name is null || name.Length is 0 or > MaxFriendlyNameLength)
         {
@@ -59,7 +59,7 @@ public class ScpiMessageProducer
     /// </summary>
     /// <param name="name">
     /// 1-<see cref="MaxFriendlyNameLength"/> printable ASCII characters (0x20-0x7E); cannot contain
-    /// <c>"</c> or <c>\</c>. See <see cref="IsFriendlyNameValid"/>.
+    /// <c>"</c> or <c>\</c>. See <see cref="IsFriendlyNameValid"/>. <c>null</c> is always invalid.
     /// </param>
     /// <remarks>
     /// The new name is staged into the device's runtime settings and takes effect immediately, but
@@ -68,7 +68,7 @@ public class ScpiMessageProducer
     /// Example: messageProducer.Send(ScpiMessageProducer.SetDeviceName("My Device"));
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> fails validation.</exception>
-    public static IOutboundMessage<string> SetDeviceName(string name)
+    public static IOutboundMessage<string> SetDeviceName(string? name)
     {
         if (!IsFriendlyNameValid(name))
         {

--- a/src/Daqifi.Core/Device/DeviceMetadata.cs
+++ b/src/Daqifi.Core/Device/DeviceMetadata.cs
@@ -58,6 +58,11 @@ public class DeviceMetadata
     public string HostName { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the user-defined friendly name of the device.
+    /// </summary>
+    public string FriendlyName { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the TCP port for device communication.
     /// </summary>
     public int DevicePort { get; set; }
@@ -108,6 +113,11 @@ public class DeviceMetadata
         if (!string.IsNullOrWhiteSpace(message.HostName))
         {
             HostName = message.HostName;
+        }
+
+        if (!string.IsNullOrEmpty(message.FriendlyDeviceName))
+        {
+            FriendlyName = message.FriendlyDeviceName;
         }
 
         if (message.DevicePort != 0)


### PR DESCRIPTION
## Summary

Core had no device-name support anywhere in its surface, forcing daqifi-desktop to hand-build the wire strings and reimplement firmware's own name-validation rules.

- `ScpiMessageProducer.SetDeviceName(string)` / `ScpiMessageProducer.SaveDeviceName` — build `SYSTem:DEVice:NAME "..."` and `SYSTem:DEVice:NAME:SAVE`.
- `ScpiMessageProducer.IsFriendlyNameValid(string)` (+ `MaxFriendlyNameLength = 31`) — mirrors firmware's `daqifi_settings_FriendlyNameIsValid` exactly: 1-31 printable ASCII (0x20-0x7E), excluding `"` and `\`. `SetDeviceName` throws `ArgumentException` for a name that fails this check.
- `DeviceMetadata.FriendlyName`, populated by `UpdateFromProtobuf` from the status message's `friendly_device_name` field.

Closes #302

## Test plan

- [x] `dotnet test` — full Core suite passes (1414 passed, 2 skipped, 0 failed)
- [x] New unit tests for `SetDeviceName`/`SaveDeviceName`/`IsFriendlyNameValid` (valid/invalid/boundary-length cases) and `DeviceMetadata.FriendlyName` (populated from protobuf, unchanged on empty)
- [x] Bench-tested against a physical DAQiFi Nyquist (Nq1, FW 3.7.2) on COM3: validation rejects the same inputs firmware would reject, and a `SetDeviceName` → `SaveDeviceName` → `GetDeviceInfo` round-trip confirms the device echoes the new name back via `friendly_device_name`, correctly populating `DeviceMetadata.FriendlyName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)