### PR TITLE
fix(device): keep IChannel instances stable across PopulateChannelsFromStatus

### DIFF
--- a/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
@@ -76,9 +76,9 @@ public class ChannelPopulationTests
     [Fact]
     public void PopulateChannelsFromStatus_PreservesEnableDirectionAndOutputAcrossRepopulation()
     {
-        // A later status refresh (e.g. reconnect / metadata re-query) recreates channel
-        // instances; previously-applied configuration must survive, keyed by (type, number),
-        // so the device-level channel API does not silently lose enable/direction/output state.
+        // A later status refresh (e.g. reconnect / metadata re-query) updates channel instances
+        // whose identity (type, number) is unchanged in place, so previously-applied
+        // configuration — and the IChannel reference itself — survives untouched.
         var device = new DaqifiDevice("TestDevice");
         var message = new DaqifiOutMessage { AnalogInPortNum = 2, AnalogInRes = 65535, DigitalPortNum = 2 };
         device.PopulateChannelsFromStatus(message);
@@ -90,13 +90,15 @@ public class ChannelPopulationTests
         digital1.Direction = ChannelDirection.Output;
         digital1.OutputValue = true;
 
-        // Repopulate with the same shape — produces a fresh generation of channel instances.
+        // Repopulate with the same shape — identity is unchanged, so instances are reused.
         device.PopulateChannelsFromStatus(message);
 
         var newAnalog0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+        Assert.Same(analog0, newAnalog0);
         Assert.True(newAnalog0.IsEnabled);
 
         var newDigital1 = (IDigitalChannel)device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
+        Assert.Same(digital1, newDigital1);
         Assert.True(newDigital1.IsEnabled);
         Assert.Equal(ChannelDirection.Output, newDigital1.Direction);
         Assert.True(newDigital1.OutputValue);
@@ -500,6 +502,43 @@ public class ChannelPopulationTests
         Assert.Equal(12, device.Channels.Count);
         Assert.Equal(4, device.Channels.Count(c => c.Type == ChannelType.Analog));
         Assert.Equal(8, device.Channels.Count(c => c.Type == ChannelType.Digital));
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_ReusesExistingChannelInstancesWhenIdentityUnchanged()
+    {
+        // Arrange
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage { AnalogInPortNum = 4, AnalogInRes = 65535, DigitalPortNum = 4 };
+        device.PopulateChannelsFromStatus(message);
+        var originalChannels = device.Channels.ToList();
+
+        // Act - repopulate with the same channel shape (identity unchanged)
+        device.PopulateChannelsFromStatus(message);
+
+        // Assert - every channel instance is reused, not replaced
+        var refreshedChannels = device.Channels;
+        Assert.Equal(originalChannels.Count, refreshedChannels.Count);
+        for (var i = 0; i < originalChannels.Count; i++)
+        {
+            Assert.Same(originalChannels[i], refreshedChannels[i]);
+        }
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_DropsChannelsNoLongerPresent()
+    {
+        // Arrange
+        var device = new DaqifiDevice("TestDevice");
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage { AnalogInPortNum = 4, AnalogInRes = 65535 });
+        var analog2 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 2);
+
+        // Act - a subsequent status report fewer channels
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage { AnalogInPortNum = 2, AnalogInRes = 65535 });
+
+        // Assert - the dropped channel is no longer part of the collection
+        Assert.Equal(2, device.Channels.Count);
+        Assert.DoesNotContain(device.Channels, c => ReferenceEquals(c, analog2));
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
@@ -563,7 +563,9 @@ namespace Daqifi.Core.Tests.Device
             });
 
             var refreshed = (IDigitalChannel)DigitalChannelAt(device, 4);
-            Assert.NotSame(channel, refreshed);
+            // Channel identity (type, number) is unchanged across the refresh, so the same
+            // instance is updated in place rather than replaced.
+            Assert.Same(channel, refreshed);
             Assert.True(refreshed.IsPwmEnabled);
             Assert.Equal(42, refreshed.PwmDutyCyclePercent);
         }

--- a/src/Daqifi.Core/Channel/AnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogChannel.cs
@@ -16,6 +16,7 @@ public class AnalogChannel : IAnalogChannel
     private double _calibrationB;
     private double _internalScaleM;
     private double _portRange;
+    private uint _resolution;
 
     /// <summary>
     /// Gets the channel number/index.
@@ -89,7 +90,16 @@ public class AnalogChannel : IAnalogChannel
     /// <summary>
     /// Gets the resolution of the ADC (e.g., 65535 for 16-bit).
     /// </summary>
-    public uint Resolution { get; }
+    /// <remarks>
+    /// The setter is internal so that <see cref="Device.DaqifiDevice.PopulateChannelsFromStatus"/>
+    /// can refresh this value in place on a status re-population without recreating the channel
+    /// instance, keeping <see cref="IChannel"/> references stable for consumers.
+    /// </remarks>
+    public uint Resolution
+    {
+        get { lock (_lock) { return _resolution; } }
+        internal set { lock (_lock) { _resolution = value; } }
+    }
 
     /// <summary>
     /// Gets or sets the calibration slope (M in the scaling formula).
@@ -146,7 +156,7 @@ public class AnalogChannel : IAnalogChannel
             throw new ArgumentOutOfRangeException(nameof(resolution), "Resolution must be greater than zero.");
 
         ChannelNumber = channelNumber;
-        Resolution = resolution;
+        _resolution = resolution;
         _name = $"Analog Channel {channelNumber}";
         _isEnabled = false;
         _direction = ChannelDirection.Input;

--- a/src/Daqifi.Core/Channel/AnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogChannel.cs
@@ -91,14 +91,14 @@ public class AnalogChannel : IAnalogChannel
     /// Gets the resolution of the ADC (e.g., 65535 for 16-bit).
     /// </summary>
     /// <remarks>
-    /// The setter is internal so that <see cref="Device.DaqifiDevice.PopulateChannelsFromStatus"/>
-    /// can refresh this value in place on a status re-population without recreating the channel
-    /// instance, keeping <see cref="IChannel"/> references stable for consumers.
+    /// Updated only via <see cref="UpdateScalingFromStatus"/>, which
+    /// <see cref="Device.DaqifiDevice.PopulateChannelsFromStatus"/> uses to refresh this value in
+    /// place on a status re-population without recreating the channel instance, keeping
+    /// <see cref="IChannel"/> references stable for consumers.
     /// </remarks>
     public uint Resolution
     {
         get { lock (_lock) { return _resolution; } }
-        internal set { lock (_lock) { _resolution = value; } }
     }
 
     /// <summary>
@@ -166,6 +166,27 @@ public class AnalogChannel : IAnalogChannel
         _calibrationB = 0.0;
         _internalScaleM = 1.0;
         _portRange = 1.0;
+    }
+
+    /// <summary>
+    /// Atomically updates the resolution and calibration/scaling metadata under a single lock.
+    /// </summary>
+    /// <remarks>
+    /// Used by <see cref="Device.DaqifiDevice.PopulateChannelsFromStatus"/> when refreshing a
+    /// reused channel instance in place, so a concurrent reader (e.g. via
+    /// <see cref="Device.DaqifiDevice.GetChannelsSnapshot"/> on another thread) can never observe
+    /// a torn mix of old and new scaling values from <see cref="GetScaledValue"/>.
+    /// </remarks>
+    internal void UpdateScalingFromStatus(uint resolution, double calibrationB, double calibrationM, double internalScaleM, double portRange)
+    {
+        lock (_lock)
+        {
+            _resolution = resolution;
+            _calibrationB = calibrationB;
+            _calibrationM = calibrationM;
+            _internalScaleM = internalScaleM;
+            _portRange = portRange;
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Channel/DigitalChannel.cs
+++ b/src/Daqifi.Core/Channel/DigitalChannel.cs
@@ -13,6 +13,7 @@ public class DigitalChannel : IDigitalChannel
     private bool _outputValue;
     private bool _isPwmEnabled;
     private int _pwmDutyCyclePercent;
+    private bool _isPwmCapable;
 
     /// <summary>
     /// Gets the channel number/index.
@@ -99,7 +100,16 @@ public class DigitalChannel : IDigitalChannel
     /// <summary>
     /// Gets whether this channel's hardware supports PWM output.
     /// </summary>
-    public bool IsPwmCapable { get; }
+    /// <remarks>
+    /// The setter is internal so that <see cref="Device.DaqifiDevice.PopulateChannelsFromStatus"/>
+    /// can refresh this value in place on a status re-population without recreating the channel
+    /// instance, keeping <see cref="IChannel"/> references stable for consumers.
+    /// </remarks>
+    public bool IsPwmCapable
+    {
+        get { lock (_lock) { return _isPwmCapable; } }
+        internal set { lock (_lock) { _isPwmCapable = value; } }
+    }
 
     /// <summary>
     /// Gets or sets whether PWM output is enabled on this channel (local bookkeeping mirroring
@@ -137,7 +147,7 @@ public class DigitalChannel : IDigitalChannel
             throw new ArgumentOutOfRangeException(nameof(channelNumber), "Channel number must be non-negative.");
 
         ChannelNumber = channelNumber;
-        IsPwmCapable = isPwmCapable;
+        _isPwmCapable = isPwmCapable;
         _name = $"Digital Channel {channelNumber}";
         _isEnabled = false;
         _direction = ChannelDirection.Input;

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1226,11 +1226,7 @@ namespace Daqifi.Core.Device
 
                 if (existingByKey.TryGetValue((ChannelType.Analog, i), out var existing) && existing is AnalogChannel existingAnalog)
                 {
-                    existingAnalog.Resolution = resolution;
-                    existingAnalog.CalibrationB = calibrationB;
-                    existingAnalog.CalibrationM = calibrationM;
-                    existingAnalog.InternalScaleM = internalScaleM;
-                    existingAnalog.PortRange = portRange;
+                    existingAnalog.UpdateScalingFromStatus(resolution, calibrationB, calibrationM, internalScaleM, portRange);
                     destination.Add(existingAnalog);
                     continue;
                 }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1159,57 +1159,32 @@ namespace Daqifi.Core.Device
             // half-cleared or torn list.
             lock (_channelsLock)
             {
-                // Capture the prior per-channel configuration before recreating instances.
-                // A status refresh (e.g. a later GetDeviceInfo on reconnect / metadata refresh)
-                // would otherwise reset every channel to IsEnabled=false, silently discarding
-                // the enable/direction/output state the device-level channel-management API
-                // computes its ADC mask and DIO state from. Keyed by (type, number) since the
-                // channel instances themselves are replaced.
-                var priorState = new Dictionary<(ChannelType, int), (bool IsEnabled, ChannelDirection Direction, bool OutputValue, bool IsPwmEnabled, int PwmDutyCyclePercent)>();
+                // Index existing channels by identity (type, number). Channels whose identity
+                // is unchanged are updated in place rather than replaced below, so consumer-held
+                // IChannel references — and the configuration on them (enable/direction/output/
+                // PWM state) — survive a routine status re-population untouched.
+                var existingByKey = new Dictionary<(ChannelType, int), IChannel>();
                 foreach (var existing in _channels)
                 {
-                    var digitalExisting = existing as IDigitalChannel;
-                    priorState[(existing.Type, existing.ChannelNumber)] = (
-                        existing.IsEnabled,
-                        existing.Direction,
-                        digitalExisting?.OutputValue ?? false,
-                        digitalExisting?.IsPwmEnabled ?? false,
-                        digitalExisting?.PwmDutyCyclePercent ?? 0);
+                    existingByKey[(existing.Type, existing.ChannelNumber)] = existing;
                 }
 
-                // Clear existing channels before repopulating
-                _channels.Clear();
+                var updatedChannels = new List<IChannel>();
 
                 // Populate analog input channels
                 if (message.AnalogInPortNum > 0)
                 {
-                    analogCount = PopulateAnalogChannels(message);
+                    analogCount = PopulateAnalogChannels(message, existingByKey, updatedChannels);
                 }
 
                 // Populate digital channels
                 if (message.DigitalPortNum > 0)
                 {
-                    digitalCount = PopulateDigitalChannels(message);
+                    digitalCount = PopulateDigitalChannels(message, existingByKey, updatedChannels);
                 }
 
-                // Reapply the captured state to the freshly created channels so configuration
-                // survives the refresh. Channels with no prior entry keep their defaults.
-                foreach (var channel in _channels)
-                {
-                    if (!priorState.TryGetValue((channel.Type, channel.ChannelNumber), out var state))
-                    {
-                        continue;
-                    }
-
-                    channel.IsEnabled = state.IsEnabled;
-                    channel.Direction = state.Direction;
-                    if (channel is IDigitalChannel digitalChannel)
-                    {
-                        digitalChannel.OutputValue = state.OutputValue;
-                        digitalChannel.IsPwmEnabled = state.IsPwmEnabled;
-                        digitalChannel.PwmDutyCyclePercent = state.PwmDutyCyclePercent;
-                    }
-                }
+                _channels.Clear();
+                _channels.AddRange(updatedChannels);
 
                 channelsSnapshot = _channels.ToArray();
             }
@@ -1224,11 +1199,14 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
-        /// Populates analog channels from the protobuf message.
+        /// Populates analog channels from the protobuf message, updating existing channel
+        /// instances in place where their identity (type, number) is unchanged.
         /// </summary>
         /// <param name="message">The protobuf message containing analog channel data.</param>
-        /// <returns>The number of analog channels created.</returns>
-        private int PopulateAnalogChannels(DaqifiOutMessage message)
+        /// <param name="existingByKey">Existing channels from the prior population, keyed by (type, number).</param>
+        /// <param name="destination">The list to append the resulting channel instances to, in order.</param>
+        /// <returns>The number of analog channels populated.</returns>
+        private int PopulateAnalogChannels(DaqifiOutMessage message, Dictionary<(ChannelType, int), IChannel> existingByKey, List<IChannel> destination)
         {
             var analogInPortRanges = message.AnalogInPortRange;
             var analogInCalibrationBValues = message.AnalogInCalB;
@@ -1237,21 +1215,38 @@ namespace Daqifi.Core.Device
             var analogInResolution = message.AnalogInRes;
 
             var count = (int)message.AnalogInPortNum;
+            var resolution = analogInResolution > 0 ? analogInResolution : 65535;
 
             for (var i = 0; i < count; i++)
             {
-                var channel = new AnalogChannel(i, analogInResolution > 0 ? analogInResolution : 65535)
+                var calibrationB = GetWithDefault(analogInCalibrationBValues, i, 0.0f);
+                var calibrationM = GetWithDefault(analogInCalibrationMValues, i, 1.0f);
+                var internalScaleM = GetWithDefault(analogInInternalScaleMValues, i, 1.0f);
+                var portRange = GetWithDefault(analogInPortRanges, i, 1.0f);
+
+                if (existingByKey.TryGetValue((ChannelType.Analog, i), out var existing) && existing is AnalogChannel existingAnalog)
+                {
+                    existingAnalog.Resolution = resolution;
+                    existingAnalog.CalibrationB = calibrationB;
+                    existingAnalog.CalibrationM = calibrationM;
+                    existingAnalog.InternalScaleM = internalScaleM;
+                    existingAnalog.PortRange = portRange;
+                    destination.Add(existingAnalog);
+                    continue;
+                }
+
+                var channel = new AnalogChannel(i, resolution)
                 {
                     Name = $"AI{i}",
                     Direction = ChannelDirection.Input,
                     IsEnabled = false,
-                    CalibrationB = GetWithDefault(analogInCalibrationBValues, i, 0.0f),
-                    CalibrationM = GetWithDefault(analogInCalibrationMValues, i, 1.0f),
-                    InternalScaleM = GetWithDefault(analogInInternalScaleMValues, i, 1.0f),
-                    PortRange = GetWithDefault(analogInPortRanges, i, 1.0f)
+                    CalibrationB = calibrationB,
+                    CalibrationM = calibrationM,
+                    InternalScaleM = internalScaleM,
+                    PortRange = portRange
                 };
 
-                _channels.Add(channel);
+                destination.Add(channel);
             }
 
             return count;
@@ -1265,17 +1260,28 @@ namespace Daqifi.Core.Device
         private const int PwmCapableChannelMask = 0x00F9;
 
         /// <summary>
-        /// Populates digital channels from the protobuf message.
+        /// Populates digital channels from the protobuf message, updating existing channel
+        /// instances in place where their identity (type, number) is unchanged.
         /// </summary>
         /// <param name="message">The protobuf message containing digital channel data.</param>
-        /// <returns>The number of digital channels created.</returns>
-        private int PopulateDigitalChannels(DaqifiOutMessage message)
+        /// <param name="existingByKey">Existing channels from the prior population, keyed by (type, number).</param>
+        /// <param name="destination">The list to append the resulting channel instances to, in order.</param>
+        /// <returns>The number of digital channels populated.</returns>
+        private int PopulateDigitalChannels(DaqifiOutMessage message, Dictionary<(ChannelType, int), IChannel> existingByKey, List<IChannel> destination)
         {
             var count = (int)message.DigitalPortNum;
 
             for (var i = 0; i < count; i++)
             {
                 var isPwmCapable = i < 32 && (PwmCapableChannelMask & (1 << i)) != 0;
+
+                if (existingByKey.TryGetValue((ChannelType.Digital, i), out var existing) && existing is DigitalChannel existingDigital)
+                {
+                    existingDigital.IsPwmCapable = isPwmCapable;
+                    destination.Add(existingDigital);
+                    continue;
+                }
+
                 var channel = new DigitalChannel(i, isPwmCapable)
                 {
                     Name = $"DIO{i}",
@@ -1283,7 +1289,7 @@ namespace Daqifi.Core.Device
                     IsEnabled = false
                 };
 
-                _channels.Add(channel);
+                destination.Add(channel);
             }
 
             return count;


### PR DESCRIPTION
## Summary

Closes #309.

The issue's caveat asked to confirm Core's actual population semantics before acting — confirmed: `PopulateChannelsFromStatus` in [DaqifiDevice.cs](src/Daqifi.Core/Device/DaqifiDevice.cs) did construct brand-new `AnalogChannel`/`DigitalChannel` instances on every status message (`_channels.Clear()` + rebuild), with a `priorState` dictionary keyed by `(Type, ChannelNumber)` that hand-copied `IsEnabled`/`Direction`/`OutputValue`/PWM bookkeeping onto the new instances afterward purely to compensate for the identity churn.

This PR changes that: existing channels are now indexed by `(Type, ChannelNumber)`, and when a message's channel at that identity still exists, the existing `AnalogChannel`/`DigitalChannel` instance is updated in place (`Resolution`, `CalibrationB`/`CalibrationM`/`InternalScaleM`/`PortRange` for analog; `IsPwmCapable` for digital) instead of being replaced. `IChannel` references handed out via `ChannelsPopulated`/`Channels` now stay stable across a routine status refresh.

- `Resolution` (AnalogChannel) and `IsPwmCapable` (DigitalChannel) gained `internal` setters so `DaqifiDevice` can refresh them without recreating the channel; both stay read-only to external consumers.
- The `priorState` capture/reapply dance is gone — since reused instances are never touched on `IsEnabled`/`Direction`/`OutputValue`/PWM fields, that state simply survives untouched.
- Channels whose identity disappears from a new status message (e.g. channel count shrinks) are still dropped, same as before.

## Downstream (daqifi-desktop)

Since Core no longer replaces channel instances, the daqifi-desktop workarounds that exist purely to cope with churn become obsolete and can be removed as a desktop-side follow-up once this ships:
- `ReplaceCoreChannel` in `Daqifi.Desktop/Channel/AnalogChannel.cs` and `DigitalChannel.cs`
- `SyncChannelsFromCore` plus the `_channelSampleHandlers` re-subscribe dance in `Daqifi.Desktop/Device/AbstractStreamingDevice.cs`

## Test plan

- [x] `dotnet test Daqifi.Core.Tests` — 1422 passed (net9.0 and net10.0). One pre-existing unrelated flaky failure (`ContinuousDeviceFinderTests.Start_DiscoversDevice_RaisesDeviceDiscoveredAndPopulatesDevices`), confirmed to fail identically on `main` without this change.
- [x] Updated `PopulateChannelsFromStatus_PreservesPwmBookkeepingAcrossRefresh` (previously asserted `NotSame` — now asserts `Same`, since instance stability across refresh is exactly the fix)
- [x] Added `PopulateChannelsFromStatus_ReusesExistingChannelInstancesWhenIdentityUnchanged` and `PopulateChannelsFromStatus_DropsChannelsNoLongerPresent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)