### PR TITLE
feat(firmware): add WifiBridgeActivator.Deactivate to own the transparent-mode exit

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
@@ -27,4 +27,28 @@ public class WifiBridgeActivatorTests
     {
         Assert.ThrowsAny<Exception>(() => WifiBridgeActivator.Activate("COM999"));
     }
+
+    [Fact]
+    public void Deactivate_NullPortName_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => WifiBridgeActivator.Deactivate(null!));
+    }
+
+    [Fact]
+    public void Deactivate_AlreadyCancelled_ThrowsBeforeOpeningPort()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Use a bogus port name; if cancellation isn't honored up-front the test would
+        // surface a port-open failure instead of OperationCanceledException.
+        Assert.Throws<OperationCanceledException>(
+            () => WifiBridgeActivator.Deactivate("COM999", cts.Token));
+    }
+
+    [Fact]
+    public void Deactivate_InvalidPort_Throws()
+    {
+        Assert.ThrowsAny<Exception>(() => WifiBridgeActivator.Deactivate("COM999"));
+    }
 }

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -57,6 +57,37 @@ public static class WifiBridgeActivator
         WaitOrCancel(ApplySettleDelay, cancellationToken);
     }
 
+    /// <summary>
+    /// Briefly opens <paramref name="portName"/>, sends the SCPI sequence that
+    /// takes the device's WiFi module back out of bridge mode after a firmware
+    /// update, then closes the port.
+    /// </summary>
+    /// <param name="portName">The serial port name (e.g. <c>COM5</c>, <c>/dev/cu.usbmodem1</c>).</param>
+    /// <param name="cancellationToken">Cancellation token observed between port-open, each command write, and each inter-command delay.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="portName"/> is null.</exception>
+    /// <exception cref="OperationCanceledException">Cancellation was requested.</exception>
+    public static void Deactivate(string portName, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(portName);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var transport = new SerialStreamTransport(portName);
+        transport.Connect();
+
+        // Allow firmware to recognise DTR before sending commands.
+        WaitOrCancel(DtrSettleDelay, cancellationToken);
+
+        // Turn off transparent mode so the port goes back to the SCPI console.
+        WriteCommand(transport, ScpiMessageProducer.SetUsbTransparencyMode(0));
+        WaitOrCancel(InterCommandDelay, cancellationToken);
+
+        // Trigger the WiFi manager REINIT out of bridge-mode state machine.
+        WriteCommand(transport, ScpiMessageProducer.ApplyNetworkLan);
+
+        // Give firmware time to enqueue APPLY before the port closes.
+        WaitOrCancel(ApplySettleDelay, cancellationToken);
+    }
+
     private static void WriteCommand(SerialStreamTransport transport, IOutboundMessage<string> message)
     {
         var bytes = message.GetBytes();

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -47,11 +47,11 @@ public static class WifiBridgeActivator
         WaitOrCancel(DtrSettleDelay, cancellationToken);
 
         // Re-assert the FW-update-requested flag (idempotent with the earlier handshake).
-        WriteCommand(transport, ScpiMessageProducer.SetLanFirmwareUpdateMode);
+        WriteCommand(transport, ScpiMessageProducer.SetLanFirmwareUpdateMode, cancellationToken);
         WaitOrCancel(InterCommandDelay, cancellationToken);
 
         // Trigger the WiFi manager REINIT to bridge-mode state machine.
-        WriteCommand(transport, ScpiMessageProducer.ApplyNetworkLan);
+        WriteCommand(transport, ScpiMessageProducer.ApplyNetworkLan, cancellationToken);
 
         // Give firmware time to enqueue APPLY before the port closes.
         WaitOrCancel(ApplySettleDelay, cancellationToken);
@@ -78,18 +78,20 @@ public static class WifiBridgeActivator
         WaitOrCancel(DtrSettleDelay, cancellationToken);
 
         // Turn off transparent mode so the port goes back to the SCPI console.
-        WriteCommand(transport, ScpiMessageProducer.SetUsbTransparencyMode(0));
+        WriteCommand(transport, ScpiMessageProducer.SetUsbTransparencyMode(0), cancellationToken);
         WaitOrCancel(InterCommandDelay, cancellationToken);
 
         // Trigger the WiFi manager REINIT out of bridge-mode state machine.
-        WriteCommand(transport, ScpiMessageProducer.ApplyNetworkLan);
+        WriteCommand(transport, ScpiMessageProducer.ApplyNetworkLan, cancellationToken);
 
         // Give firmware time to enqueue APPLY before the port closes.
         WaitOrCancel(ApplySettleDelay, cancellationToken);
     }
 
-    private static void WriteCommand(SerialStreamTransport transport, IOutboundMessage<string> message)
+    private static void WriteCommand(SerialStreamTransport transport, IOutboundMessage<string> message, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var bytes = message.GetBytes();
         var stream = transport.Stream;
         stream.Write(bytes, 0, bytes.Length);


### PR DESCRIPTION
## Summary

- Adds `WifiBridgeActivator.Deactivate(portName, ct)`, the mirror image of the existing `Activate`, so Core owns both halves of WINC bridge mode.
- Uses the same transient raw-`SerialPort` pattern as `Activate` (DTR settle delay, timed SCPI writes, close), sending `ScpiMessageProducer.SetUsbTransparencyMode(0)` followed by `ScpiMessageProducer.ApplyNetworkLan` with the same inter-command timing the firmware expects.
- This removes the need for consumers (e.g. daqifi-desktop's `FirmwareUpdateCoordinator.ExitWifiTransparentModeRaw`) to hand-roll the raw SCPI wire string and timing themselves.

Closes #304

## Test plan

- [x] `dotnet test` for `Daqifi.Core.Tests.Firmware.WifiBridgeActivatorTests` — 6/6 passing (3 new `Deactivate_*` tests mirroring the existing `Activate_*` coverage: null port name, already-cancelled token, invalid port).
- [x] Full solution build succeeds with 0 warnings/errors.
- [x] Full test suite run — only pre-existing, unrelated flake (`ContinuousDeviceFinderTests.Start_DiscoversDevice_...`, a timing-sensitive discovery test untouched by this change) failed; all else passes.
- Not exercised against physical hardware — no bench/device attached in this environment. The implementation is a structural mirror of the already-hardware-validated `Activate` method, but the actual WINC bridge-mode exit sequence timing on real firmware hasn't been verified end-to-end here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)