### PR TITLE
fix(device): retry transient SCPI errors during InitializeAsync, throw typed exception

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -111,6 +111,26 @@ namespace Daqifi.Core.Tests.Device
             Assert.Equal(2, device.TextCommandAttemptCount);
         }
 
+        [Theory]
+        [InlineData("ERROR -200,\"Execution error\"\r\n")]
+        [InlineData("ERROR\t-200,\"Execution error\"\r\n")]
+        [InlineData("ERROR: -200,\"Execution error\"\r\n")]
+        public async Task InitializeAsync_WhenDeviceReturnsBareErrorWithNonColonDelimiter_ThrowsTypedException(string errorLine)
+        {
+            // Arrange — a bare "ERROR" token (no "**" prefix) using a space/tab/colon delimiter
+            // rather than "**ERROR" must still be recognized as a real SCPI error.
+            var device = new TestableDaqifiDevice("TestDevice",
+                textCommandResponse: new[] { errorLine });
+            device.Connect();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<ScpiInitializationErrorException>(
+                () => device.InitializeAsync());
+
+            Assert.Contains("-200", ex.Message);
+            Assert.Equal(DeviceState.Error, device.State);
+        }
+
         [Fact]
         public async Task InitializeAsync_WhenDeviceReturnsScpiError_SetsStateToError()
         {

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -93,19 +93,22 @@ namespace Daqifi.Core.Tests.Device
         }
 
         [Fact]
-        public async Task InitializeAsync_WhenDeviceReturnsScpiError_Throws()
+        public async Task InitializeAsync_WhenDeviceReturnsScpiError_ThrowsTypedExceptionAfterRetry()
         {
-            // Arrange — device returns a -200 error line during init
+            // Arrange — device returns a -200 error line on every attempt (persistent, not transient)
             var device = new TestableDaqifiDevice("TestDevice",
                 textCommandResponse: new[] { "**ERROR: -200, \"Execution error\"\r\n" });
             device.Connect();
 
             // Act & Assert
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            var ex = await Assert.ThrowsAsync<ScpiInitializationErrorException>(
                 () => device.InitializeAsync());
 
             Assert.Contains("-200", ex.Message);
+            Assert.Equal("**ERROR: -200, \"Execution error\"", ex.LastScpiError);
             Assert.Equal(DeviceState.Error, device.State);
+            // One initial attempt plus one retry.
+            Assert.Equal(2, device.TextCommandAttemptCount);
         }
 
         [Fact]
@@ -117,10 +120,28 @@ namespace Daqifi.Core.Tests.Device
             device.Connect();
 
             // Act
-            try { await device.InitializeAsync(); } catch (InvalidOperationException) { }
+            try { await device.InitializeAsync(); } catch (ScpiInitializationErrorException) { }
 
             // Assert
             Assert.Equal(DeviceState.Error, device.State);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenDeviceReturnsTransientScpiError_RetriesAndSucceeds()
+        {
+            // Arrange — the first attempt returns a SCPI error, the retry succeeds, simulating
+            // the narrow timing race described in issue #310.
+            var device = new TestableDaqifiDevice("TestDevice",
+                textCommandResponse: Array.Empty<string>(),
+                failFirstAttempt: true);
+            device.Connect();
+
+            // Act
+            await device.InitializeAsync();
+
+            // Assert
+            Assert.Equal(DeviceState.Ready, device.State);
+            Assert.Equal(2, device.TextCommandAttemptCount);
         }
 
         [Fact]
@@ -236,13 +257,33 @@ namespace Daqifi.Core.Tests.Device
         [Fact]
         public async Task InitializeAsync_StreamingUsb_WhenUsbStepReturnsScpiError_SetsErrorNotReady()
         {
-            // Arrange — the USB SetStreamInterface step fails after base init populated channels
+            // Arrange — the USB SetStreamInterface step fails on every attempt (persistent, not
+            // transient) after base init populated channels
             var device = new TestableStreamingDevice("TestDevice", UsbStepBehavior.ScpiError);
             device.Connect();
 
-            // Act & Assert — failure in the override must not leave the device falsely Ready
-            await Assert.ThrowsAsync<InvalidOperationException>(() => device.InitializeAsync());
+            // Act & Assert — failure in the override must not leave the device falsely Ready,
+            // and surfaces as the typed exception rather than a bare InvalidOperationException
+            var ex = await Assert.ThrowsAsync<ScpiInitializationErrorException>(() => device.InitializeAsync());
             Assert.Equal(DeviceState.Error, device.State);
+            Assert.Equal(2, device.UsbStepAttemptCount);
+            Assert.NotNull(ex.LastScpiError);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_StreamingUsb_WhenUsbStepReturnsTransientScpiError_RetriesAndSucceeds()
+        {
+            // Arrange — the USB SetStreamInterface step fails once, then succeeds on retry,
+            // simulating the narrow timing race described in issue #310.
+            var device = new TestableStreamingDevice("TestDevice", UsbStepBehavior.ScpiErrorThenSucceed);
+            device.Connect();
+
+            // Act
+            await device.InitializeAsync();
+
+            // Assert
+            Assert.Equal(DeviceState.Ready, device.State);
+            Assert.Equal(2, device.UsbStepAttemptCount);
         }
 
         [Fact]
@@ -283,6 +324,7 @@ namespace Daqifi.Core.Tests.Device
         private class TestableDaqifiDevice : DaqifiDevice
         {
             private readonly IReadOnlyList<string> _textCommandResponse;
+            private readonly bool _failFirstAttempt;
 
             /// <summary>
             /// All messages sent via direct Send() calls.
@@ -293,6 +335,11 @@ namespace Daqifi.Core.Tests.Device
             /// Number of GetDeviceInfo (SYSInfoPB?) requests observed.
             /// </summary>
             public int DeviceInfoRequestCount { get; private set; }
+
+            /// <summary>
+            /// Number of times the init SCPI setup sequence's ExecuteTextCommandAsync was invoked.
+            /// </summary>
+            public int TextCommandAttemptCount { get; private set; }
 
             /// <summary>
             /// When true, a GetDeviceInfo request synchronously populates channels (simulating
@@ -313,11 +360,13 @@ namespace Daqifi.Core.Tests.Device
                 string name,
                 IPAddress? ipAddress = null,
                 IReadOnlyList<string>? textCommandResponse = null,
-                bool populateChannelsOnDeviceInfo = true)
+                bool populateChannelsOnDeviceInfo = true,
+                bool failFirstAttempt = false)
                 : base(name, ipAddress)
             {
                 _textCommandResponse = textCommandResponse ?? Array.Empty<string>();
                 PopulateChannelsOnDeviceInfo = populateChannelsOnDeviceInfo;
+                _failFirstAttempt = failFirstAttempt;
             }
 
             public override void Send<T>(IOutboundMessage<T> message)
@@ -367,6 +416,14 @@ namespace Daqifi.Core.Tests.Device
             {
                 // Run the setup action so that Send() calls inside it are captured
                 setupAction();
+                TextCommandAttemptCount++;
+
+                if (_failFirstAttempt && TextCommandAttemptCount == 1)
+                {
+                    return Task.FromResult<IReadOnlyList<string>>(
+                        new[] { "**ERROR: -200, \"Execution error\"\r\n" });
+                }
+
                 return Task.FromResult(_textCommandResponse);
             }
         }
@@ -379,6 +436,7 @@ namespace Daqifi.Core.Tests.Device
         {
             Succeed,
             ScpiError,
+            ScpiErrorThenSucceed,
             Cancel
         }
 
@@ -393,6 +451,11 @@ namespace Daqifi.Core.Tests.Device
             private readonly List<string> _sent = new();
 
             public IReadOnlyList<string> SentData => _sent;
+
+            /// <summary>
+            /// Number of times the USB SetStreamInterface step's ExecuteTextCommandAsync was invoked.
+            /// </summary>
+            public int UsbStepAttemptCount { get; private set; }
 
             public override bool IsUsbConnection => true;
 
@@ -431,11 +494,20 @@ namespace Daqifi.Core.Tests.Device
 
                 if (isUsbStep)
                 {
+                    UsbStepAttemptCount++;
+
                     switch (_usbStepBehavior)
                     {
                         case UsbStepBehavior.ScpiError:
                             return Task.FromResult<IReadOnlyList<string>>(
                                 new[] { "**ERROR: -200, \"Execution error\"\r\n" });
+                        case UsbStepBehavior.ScpiErrorThenSucceed:
+                            if (UsbStepAttemptCount == 1)
+                            {
+                                return Task.FromResult<IReadOnlyList<string>>(
+                                    new[] { "**ERROR: -200, \"Execution error\"\r\n" });
+                            }
+                            break;
                         case UsbStepBehavior.Cancel:
                             throw new OperationCanceledException();
                     }

--- a/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
@@ -1,0 +1,33 @@
+using Daqifi.Core.Device;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class ScpiResponseClassifierTests
+    {
+        [Theory]
+        [InlineData("**ERROR: -200, \"Execution error\"")]
+        [InlineData("**ERROR -200, \"Execution error\"")]
+        [InlineData("**ERROR\t-200, \"Execution error\"")]
+        [InlineData("ERROR: -200, \"Execution error\"")]
+        [InlineData("ERROR -200, \"Execution error\"")]
+        [InlineData("ERROR\t-200, \"Execution error\"")]
+        [InlineData("  ERROR: -200, \"Execution error\"  \r\n")]
+        public void IsScpiErrorLine_MatchesAllDelimiterVariants(string line)
+        {
+            Assert.True(ScpiResponseClassifier.IsScpiErrorLine(line));
+        }
+
+        [Theory]
+        [InlineData("Error !! No SD Card Detected")]
+        [InlineData("Error!! No SD Card Detected")]
+        [InlineData("error_log.bin")]
+        [InlineData("Errors.txt")]
+        [InlineData("OK")]
+        [InlineData("")]
+        public void IsScpiErrorLine_DoesNotMatchNonScpiText(string line)
+        {
+            Assert.False(ScpiResponseClassifier.IsScpiErrorLine(line));
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -145,6 +145,20 @@ namespace Daqifi.Core.Device
         /// </summary>
         private static readonly TimeSpan ChannelPopulationPollInterval = TimeSpan.FromSeconds(1);
 
+        /// <summary>
+        /// Maximum number of retry attempts for the <see cref="InitializeAsync"/> SCPI setup
+        /// sequence when the device returns a transient SCPI error (e.g. -200 "Execution error").
+        /// A common trigger is the firmware rejecting a command tied to a persisted prior-session
+        /// state (e.g. stream interface) within the tight response window right after connect.
+        /// </summary>
+        private const int InitScpiErrorMaxRetries = 1;
+
+        /// <summary>
+        /// Delay in milliseconds before retrying the <see cref="InitializeAsync"/> SCPI setup
+        /// sequence after a transient SCPI error.
+        /// </summary>
+        private const int InitScpiErrorRetryDelayMs = 150;
+
         // Serializes ExecuteTextCommandAsync calls device-wide (closes #186).
         // Multiple callers — e.g. concurrent GetSdCardFilesAsync /
         // DrainErrorQueueAsync / GetSystemInfoAsync — would otherwise race the
@@ -879,7 +893,8 @@ namespace Daqifi.Core.Device
         /// surfaces a <see cref="TimeoutException"/>).
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="channelPopulationTimeout"/> is not positive.</exception>
-        /// <exception cref="InvalidOperationException">Thrown when the device is not connected, or the device returns a SCPI error during initialization.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the device is not connected.</exception>
+        /// <exception cref="ScpiInitializationErrorException">Thrown when the device returns a SCPI error during initialization that persists after an internal retry.</exception>
         /// <exception cref="TimeoutException">Thrown when the device does not report its channel configuration within <paramref name="channelPopulationTimeout"/>.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
         public virtual async Task InitializeAsync(
@@ -935,28 +950,52 @@ namespace Daqifi.Core.Device
                 // by the protobuf consumer.  The protobuf consumer is stopped for the duration
                 // of this call and restarted afterward, leaving the device in protobuf mode
                 // and ready to receive the SYSInfoPB? response.
-                var initLines = await ExecuteTextCommandAsync(() =>
+                //
+                // A SCPI error here is often transient — e.g. the firmware rejecting a command
+                // tied to a persisted prior-session state within the tight response window right
+                // after connect — so retry the whole sequence with a settle delay before treating
+                // it as a hard failure (mirrors the retry already used for SD card operations).
+                IReadOnlyList<string> initLines = Array.Empty<string>();
+                string? errorLine = null;
+                for (var attempt = 0; attempt <= InitScpiErrorMaxRetries; attempt++)
                 {
-                    Send(ScpiMessageProducer.DisableDeviceEcho);
-                    Thread.Sleep(100);
+                    if (attempt > 0)
+                    {
+                        await Task.Delay(InitScpiErrorRetryDelayMs, cancellationToken).ConfigureAwait(false);
+                    }
 
-                    Send(ScpiMessageProducer.StopStreaming);
-                    Thread.Sleep(100);
+                    initLines = await ExecuteTextCommandAsync(() =>
+                    {
+                        Send(ScpiMessageProducer.DisableDeviceEcho);
+                        Thread.Sleep(100);
 
-                    Send(ScpiMessageProducer.TurnDeviceOn);
-                    Thread.Sleep(100);
+                        Send(ScpiMessageProducer.StopStreaming);
+                        Thread.Sleep(100);
 
-                    Send(ScpiMessageProducer.SetProtobufStreamFormat);
-                }, responseTimeoutMs: 1000, cancellationToken: cancellationToken).ConfigureAwait(false);
+                        Send(ScpiMessageProducer.TurnDeviceOn);
+                        Thread.Sleep(100);
 
-                // Surface any SCPI error that occurred during initialization so callers
-                // know the device is not in the expected state.
-                var errorLine = initLines.FirstOrDefault(
-                    l => l.TrimStart().StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase));
+                        Send(ScpiMessageProducer.SetProtobufStreamFormat);
+                    }, responseTimeoutMs: 1000, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    errorLine = initLines.FirstOrDefault(
+                        l => l.TrimStart().StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase));
+                    if (errorLine == null)
+                    {
+                        break;
+                    }
+                }
+
+                // Surface any SCPI error that survived the retry so callers know the device
+                // is not in the expected state, via a typed exception so it can be classified
+                // without matching on the message.
                 if (errorLine != null)
                 {
-                    throw new InvalidOperationException(
-                        $"Device returned a SCPI error during initialization: {errorLine.Trim()}");
+                    var trimmedErrorLine = errorLine.Trim();
+                    throw new ScpiInitializationErrorException(
+                        $"Device returned a SCPI error during initialization: {trimmedErrorLine}",
+                        initLines,
+                        trimmedErrorLine);
                 }
 
                 // Query device info and block until the device reports its channel

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -978,8 +978,11 @@ namespace Daqifi.Core.Device
                         Send(ScpiMessageProducer.SetProtobufStreamFormat);
                     }, responseTimeoutMs: 1000, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                    errorLine = initLines.FirstOrDefault(
-                        l => l.TrimStart().StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase));
+                    // Shared with DaqifiStreamingDevice's SCPI error detection so both sites
+                    // recognize the same set of delimiter-separated error formats — a bare
+                    // "**ERROR"-prefix check would miss "ERROR: ..." and space/tab-delimited
+                    // variants like "ERROR -200,..." or "ERROR\t-200,...".
+                    errorLine = initLines.FirstOrDefault(ScpiResponseClassifier.IsScpiErrorLine);
                     if (errorLine == null)
                     {
                         break;

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -46,6 +46,19 @@ namespace Daqifi.Core.Device
         private const int SD_LIST_MAX_RETRIES = 1;
 
         /// <summary>
+        /// Maximum number of retry attempts for the USB stream-interface command sent during
+        /// <see cref="OnDeviceInitializingAsync"/> when the device returns a transient SCPI error
+        /// (e.g. because the firmware still has the interface set from a prior WiFi session).
+        /// </summary>
+        private const int UsbStreamInterfaceMaxRetries = 1;
+
+        /// <summary>
+        /// Delay in milliseconds before retrying the USB stream-interface command after a
+        /// transient SCPI error.
+        /// </summary>
+        private const int UsbStreamInterfaceRetryDelayMs = 150;
+
+        /// <summary>
         /// libscpi's <c>SCPI_ERROR_UNDEFINED_HEADER</c> — the code the firmware returns for a
         /// command it doesn't recognize (e.g. a command that postdates the connected firmware).
         /// This is the wire-level signal behind the <see cref="FeatureNotSupportedException"/>
@@ -146,6 +159,12 @@ namespace Daqifi.Core.Device
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to observe while initializing.</param>
         /// <returns>A task representing the asynchronous initialization operation.</returns>
+        /// <exception cref="ScpiInitializationErrorException">
+        /// Thrown when the device returns a SCPI error while setting the stream interface to USB
+        /// that persists after an internal retry. A common trigger is the firmware rejecting the
+        /// command because it still has the interface set from a prior WiFi-streaming session,
+        /// within the tight response window right after connect.
+        /// </exception>
         protected override async Task OnDeviceInitializingAsync(CancellationToken cancellationToken)
         {
             if (!IsUsbConnection)
@@ -156,16 +175,34 @@ namespace Daqifi.Core.Device
             // Direct streaming to the USB interface. Uses ExecuteTextCommandAsync so the
             // command is sent in text mode (protobuf consumer temporarily stopped) and any
             // SCPI error response is captured rather than garbling the protobuf stream.
-            var lines = await ExecuteTextCommandAsync(
-                () => Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.Usb)),
-                responseTimeoutMs: 500,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            if (ContainsScpiError(lines))
+            //
+            // The firmware persists the last-used stream interface across sessions, so this can
+            // transiently reject with a -200 "Execution error" right after connect. Retry with a
+            // settle delay before treating it as a hard failure (mirrors the SD card retry).
+            IReadOnlyList<string> lines = Array.Empty<string>();
+            for (var attempt = 0; attempt <= UsbStreamInterfaceMaxRetries; attempt++)
             {
-                throw new InvalidOperationException(
-                    "Device returned a SCPI error while setting stream interface to USB.");
+                if (attempt > 0)
+                {
+                    await Task.Delay(UsbStreamInterfaceRetryDelayMs, cancellationToken).ConfigureAwait(false);
+                }
+
+                lines = await ExecuteTextCommandAsync(
+                    () => Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.Usb)),
+                    responseTimeoutMs: 500,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                if (!ContainsScpiError(lines))
+                {
+                    return;
+                }
             }
+
+            var lastScpiError = lines.LastOrDefault(IsScpiErrorLine)?.Trim();
+            throw new ScpiInitializationErrorException(
+                "Device returned a SCPI error while setting stream interface to USB.",
+                lines,
+                lastScpiError);
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1590,15 +1590,16 @@ namespace Daqifi.Core.Device
             return lines.Any(IsScpiErrorLine);
         }
 
-        // Strict SCPI error format: "**ERROR..." or "ERROR: ...". The colon (or **
-        // prefix) distinguishes a true SCPI error from firmware status text like
-        // "Error !! No SD Card Detected", which should not be surfaced as
-        // SdCardOperationException.LastScpiError.
+        // Strict SCPI error format: "**ERROR" or bare "ERROR" followed by a SCPI delimiter
+        // (":", space, tab, or end-of-line). Distinguishes a true SCPI error from firmware
+        // status text like "Error !! No SD Card Detected", which should not be surfaced as
+        // SdCardOperationException.LastScpiError. Shared with ScpiInitializationErrorException
+        // classification in DaqifiDevice.InitializeAsync so both sites recognize the same set
+        // of delimiter-separated error formats (closes a gap where "ERROR -200,..." or
+        // "ERROR\t-200,..." without a colon went undetected).
         private static bool IsScpiErrorLine(string line)
         {
-            var trimmed = line.TrimStart();
-            return trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase)
-                || trimmed.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase);
+            return ScpiResponseClassifier.IsScpiErrorLine(line);
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/ScpiInitializationErrorException.cs
+++ b/src/Daqifi.Core/Device/ScpiInitializationErrorException.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Represents a SCPI error returned by the device during <see cref="DaqifiDevice.InitializeAsync"/>
+    /// (including the streaming-device USB stream-interface step). Thrown after the init sequence's
+    /// built-in retry has been exhausted, so consumers can classify this specific, often-transient
+    /// failure by type instead of matching on the exception message.
+    /// </summary>
+    /// <remarks>
+    /// A common trigger is the firmware persisting the last-used stream interface across sessions:
+    /// a device previously left streaming over WiFi can reject <c>SYSTem:STReam:INTerface 0</c>
+    /// (or another init-sequence command) on the very next USB connect, within the tight
+    /// response window. See issue #310.
+    /// </remarks>
+    public class ScpiInitializationErrorException : Exception
+    {
+        /// <summary>
+        /// Gets the raw response lines that were captured from the device when the error
+        /// was classified. Useful for diagnostics and for surfacing actionable detail in
+        /// higher-level UIs.
+        /// </summary>
+        public IReadOnlyList<string> RawDeviceResponse { get; }
+
+        /// <summary>
+        /// Gets the last SCPI error line observed in the response (e.g.
+        /// <c>**ERROR: -200, "Execution error"</c>), or <c>null</c> if none was present.
+        /// </summary>
+        public string? LastScpiError { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScpiInitializationErrorException"/> class.
+        /// </summary>
+        public ScpiInitializationErrorException(
+            string message,
+            IReadOnlyList<string> rawDeviceResponse,
+            string? lastScpiError = null,
+            Exception? innerException = null)
+            : base(message, innerException)
+        {
+            RawDeviceResponse = rawDeviceResponse ?? Array.Empty<string>();
+            LastScpiError = lastScpiError;
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -32,6 +32,24 @@ namespace Daqifi.Core.Device
                    || MatchesErrorPrefix(trimmed, "ERROR");
         }
 
+        /// <summary>
+        /// Returns true if the line is a genuine SCPI-formatted error line: the canonical
+        /// <c>**ERROR</c> marker, or a bare <c>ERROR</c> token, in either case followed by
+        /// <c>:</c>, end-of-line, or a space/tab that in turn precedes an error code (a digit
+        /// or <c>-</c>) — e.g. <c>**ERROR: -200,...</c>, <c>ERROR -200,...</c>, or
+        /// <c>ERROR\t-200,...</c>. Unlike <see cref="IsErrorResponseLine"/>, this deliberately
+        /// excludes the firmware <c>Error !! ...</c> status-text form (space followed by
+        /// non-numeric text), so callers that need to surface only a real SCPI error (e.g. as a
+        /// typed exception's error-code field) don't pick up non-SCPI status text. Trims both
+        /// ends so a bare <c>"ERROR\r"</c> from CRLF line endings still classifies.
+        /// </summary>
+        internal static bool IsScpiErrorLine(string line)
+        {
+            var trimmed = line.Trim();
+            return MatchesStrictScpiErrorPrefix(trimmed, "**ERROR")
+                   || MatchesStrictScpiErrorPrefix(trimmed, "ERROR");
+        }
+
         private static bool MatchesErrorPrefix(string trimmed, string prefix)
         {
             if (trimmed.Length < prefix.Length
@@ -48,6 +66,28 @@ namespace Daqifi.Core.Device
             return next == '!'
                 && trimmed.Length > prefix.Length + 1
                 && trimmed[prefix.Length + 1] == '!';
+        }
+
+        private static bool MatchesStrictScpiErrorPrefix(string trimmed, string prefix)
+        {
+            if (trimmed.Length < prefix.Length
+                || !trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (trimmed.Length == prefix.Length)
+                return true;
+
+            var next = trimmed[prefix.Length];
+            if (next == ':')
+                return true;
+            if (next != ' ' && next != '\t')
+                return false;
+
+            // A space/tab delimiter alone is ambiguous — firmware status text like
+            // "Error !! No SD Card Detected" also uses a space after "Error". Only
+            // treat it as a real SCPI error when what follows looks like an error
+            // code (digit or leading '-').
+            var rest = trimmed[(prefix.Length + 1)..].TrimStart(' ', '\t');
+            return rest.Length > 0 && (char.IsDigit(rest[0]) || rest[0] == '-');
         }
     }
 }


### PR DESCRIPTION
## Summary
- `DaqifiDevice.InitializeAsync()`'s SCPI setup sequence and `DaqifiStreamingDevice`'s USB `SetStreamInterface` step now retry once after a settle delay when the device returns a transient SCPI error (e.g. `-200 "Execution error"`), instead of failing the whole connection attempt on the first occurrence — mirroring the retry pattern already used for SD card operations.
- A SCPI error that survives the retry now throws a new typed `ScpiInitializationErrorException` (carrying `RawDeviceResponse` and `LastScpiError`) instead of a bare `InvalidOperationException`, so consumers (e.g. daqifi-desktop) can classify it by type instead of matching on the message substring `"SCPI error"`.

## Why
A device previously left streaming over WiFi can reject `SYSTem:STReam:INTerface 0` on the next USB connect because the firmware persists the last-used stream interface across sessions — within the tight response window this aborted the whole connection attempt. See daqifi-desktop issue [#589](https://github.com/daqifi/daqifi-desktop/issues/589).

## Test plan
- [x] `dotnet test` — full suite passes (one pre-existing, unrelated flaky discovery test confirmed to fail identically on `main`).
- [x] New unit tests cover: persistent SCPI error → `ScpiInitializationErrorException` after retry exhausted; transient SCPI error → retry succeeds; USB stream-interface step same two cases.
- [x] Built the local example CLI app against this branch's `Daqifi.Core.csproj` (via `DaqifiCoreProjectPath`) and ran `--discover-serial` and a live `--serial COM3 --channels 1` stream against a physical Nyquist device — connects, initializes (including the USB stream-interface step), and streams normally with no regression.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)