### PR TITLE
feat(sdcard): add SdCardFileParserFactory.TryDetectFormat and SupportedExtensions

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserFactoryTests.cs
@@ -46,6 +46,54 @@ public sealed class SdCardFileParserFactoryTests
             global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.DetectFormat(null!));
     }
 
+    [Theory]
+    [InlineData("log.bin", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf)]
+    [InlineData("log.BIN", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf)]
+    [InlineData("log.json", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Json)]
+    [InlineData("log.csv", global::Daqifi.Core.Device.SdCard.SdCardLogFormat.Csv)]
+    public void TryDetectFormat_ValidExtensions_ReturnsTrueAndCorrectFormat(string fileName, global::Daqifi.Core.Device.SdCard.SdCardLogFormat expectedFormat)
+    {
+        // Act
+        var result = global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.TryDetectFormat(fileName, out var format);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(expectedFormat, format);
+    }
+
+    [Theory]
+    [InlineData("log.txt")]
+    [InlineData("log.dat")]
+    [InlineData("log")]
+    [InlineData("log.")]
+    public void TryDetectFormat_UnsupportedExtension_ReturnsFalse(string fileName)
+    {
+        // Act
+        var result = global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.TryDetectFormat(fileName, out var format);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(default, format);
+    }
+
+    [Fact]
+    public void TryDetectFormat_NullFileName_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.TryDetectFormat(null!, out _));
+    }
+
+    [Fact]
+    public void SupportedExtensions_ContainsExpectedExtensions()
+    {
+        // Act
+        var extensions = global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.SupportedExtensions;
+
+        // Assert
+        Assert.Equal(new[] { ".bin", ".json", ".csv" }, extensions);
+    }
+
     [Fact]
     public async Task ParseAsync_JsonFile_RoutesToJsonParser()
     {

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserFactoryTests.cs
@@ -39,6 +39,16 @@ public sealed class SdCardFileParserFactoryTests
     }
 
     [Fact]
+    public void DetectFormat_UnsupportedExtension_MessageIsLowercased()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentException>(() =>
+            global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.DetectFormat("log.TXT"));
+
+        Assert.Contains(".txt", exception.Message);
+    }
+
+    [Fact]
     public void DetectFormat_NullFileName_ThrowsArgumentNullException()
     {
         // Act & Assert
@@ -92,6 +102,17 @@ public sealed class SdCardFileParserFactoryTests
 
         // Assert
         Assert.Equal(new[] { ".bin", ".json", ".csv" }, extensions);
+    }
+
+    [Fact]
+    public void SupportedExtensions_IsNotMutableViaDowncast()
+    {
+        // Act
+        var extensions = global::Daqifi.Core.Device.SdCard.SdCardFileParserFactory.SupportedExtensions;
+
+        // Assert
+        Assert.False(extensions is string[], "SupportedExtensions should not be backed by a directly mutable array.");
+        Assert.Throws<NotSupportedException>(() => ((IList<string>)extensions)[0] = ".mutated");
     }
 
     [Fact]

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
@@ -12,10 +12,12 @@ namespace Daqifi.Core.Device.SdCard;
 /// </summary>
 public static class SdCardFileParserFactory
 {
+    private static readonly string[] _supportedExtensions = { ".bin", ".json", ".csv" };
+
     /// <summary>
     /// The file extensions supported for format auto-detection, in the order they are checked.
     /// </summary>
-    public static IReadOnlyList<string> SupportedExtensions { get; } = new[] { ".bin", ".json", ".csv" };
+    public static IReadOnlyList<string> SupportedExtensions { get; } = Array.AsReadOnly(_supportedExtensions);
 
     /// <summary>
     /// Parses an SD card log file with format auto-detection from file extension.
@@ -101,7 +103,7 @@ public static class SdCardFileParserFactory
 
         if (!TryDetectFormat(fileName, out var format))
         {
-            var ext = Path.GetExtension(fileName);
+            var ext = Path.GetExtension(fileName).ToLowerInvariant();
             throw new ArgumentException($"Unsupported file extension: {ext}. Supported extensions are .bin, .json, .csv", nameof(fileName));
         }
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +12,11 @@ namespace Daqifi.Core.Device.SdCard;
 /// </summary>
 public static class SdCardFileParserFactory
 {
+    /// <summary>
+    /// The file extensions supported for format auto-detection, in the order they are checked.
+    /// </summary>
+    public static IReadOnlyList<string> SupportedExtensions { get; } = new[] { ".bin", ".json", ".csv" };
+
     /// <summary>
     /// Parses an SD card log file with format auto-detection from file extension.
     /// </summary>
@@ -93,12 +99,39 @@ public static class SdCardFileParserFactory
     {
         ArgumentNullException.ThrowIfNull(fileName);
 
-        return Path.GetExtension(fileName).ToLowerInvariant() switch
+        if (!TryDetectFormat(fileName, out var format))
         {
-            ".bin" => SdCardLogFormat.Protobuf,
-            ".json" => SdCardLogFormat.Json,
-            ".csv" => SdCardLogFormat.Csv,
-            var ext => throw new ArgumentException($"Unsupported file extension: {ext}. Supported extensions are .bin, .json, .csv", nameof(fileName))
-        };
+            var ext = Path.GetExtension(fileName);
+            throw new ArgumentException($"Unsupported file extension: {ext}. Supported extensions are .bin, .json, .csv", nameof(fileName));
+        }
+
+        return format;
+    }
+
+    /// <summary>
+    /// Attempts to detect the SD card log file format from the file extension.
+    /// </summary>
+    /// <param name="fileName">The file name or path.</param>
+    /// <param name="format">The detected <see cref="SdCardLogFormat"/>, if the extension is supported.</param>
+    /// <returns><c>true</c> if the extension was recognized; otherwise <c>false</c>.</returns>
+    public static bool TryDetectFormat(string fileName, out SdCardLogFormat format)
+    {
+        ArgumentNullException.ThrowIfNull(fileName);
+
+        switch (Path.GetExtension(fileName).ToLowerInvariant())
+        {
+            case ".bin":
+                format = SdCardLogFormat.Protobuf;
+                return true;
+            case ".json":
+                format = SdCardLogFormat.Json;
+                return true;
+            case ".csv":
+                format = SdCardLogFormat.Csv;
+                return true;
+            default:
+                format = default;
+                return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `SdCardFileParserFactory.TryDetectFormat(string, out SdCardLogFormat)` as a non-throwing predicate for format detection, so consumers can check an extension without a try/catch around `DetectFormat`.
- Add `SdCardFileParserFactory.SupportedExtensions` (`.bin`, `.json`, `.csv`) as the single source of truth for the supported-extension list, so downstream consumers (e.g. daqifi-desktop's file allowlist and OpenFileDialog filter) can derive from it instead of hand-rolling the list.
- `DetectFormat` now delegates to `TryDetectFormat` internally; its throwing behavior and exception message are unchanged.

Closes #307

## Test plan
- [x] `dotnet test src/Daqifi.Core.Tests` — full suite passes (one pre-existing, unrelated flaky failure in `ContinuousDeviceFinderTests`, a UDP discovery test not touched by this change)
- [x] Added unit tests for `TryDetectFormat` (valid/invalid extensions, null argument) and `SupportedExtensions`
- [x] Bench-verified against the live Nq1 device on COM3: built the example CLI app against this branch's `Daqifi.Core` via `DaqifiCoreProjectPath`, ran `--sd-list` against the device, and confirmed real on-device filenames (`log_*.bin`) still resolve correctly through the refactored `DetectFormat` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)