### PR TITLE
feat(device): add DeviceMetadata.CopyFrom and DeviceCapabilities.Clone

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DeviceCapabilitiesTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceCapabilitiesTests.cs
@@ -77,4 +77,62 @@ public class DeviceCapabilitiesTests
         Assert.Equal(16, capabilities.DigitalChannels);
         Assert.Equal(2000, capabilities.MaxSamplingRate);
     }
+
+    [Fact]
+    public void Clone_CopiesAllFieldValues()
+    {
+        // Arrange
+        var capabilities = new DeviceCapabilities
+        {
+            SupportsStreaming = false,
+            HasSdCard = true,
+            HasWiFi = true,
+            HasUsb = true,
+            AnalogInputChannels = 8,
+            AnalogOutputChannels = 2,
+            DigitalChannels = 16,
+            MaxSamplingRate = 5000
+        };
+
+        // Act
+        var clone = capabilities.Clone();
+
+        // Assert
+        Assert.Equal(capabilities.SupportsStreaming, clone.SupportsStreaming);
+        Assert.Equal(capabilities.HasSdCard, clone.HasSdCard);
+        Assert.Equal(capabilities.HasWiFi, clone.HasWiFi);
+        Assert.Equal(capabilities.HasUsb, clone.HasUsb);
+        Assert.Equal(capabilities.AnalogInputChannels, clone.AnalogInputChannels);
+        Assert.Equal(capabilities.AnalogOutputChannels, clone.AnalogOutputChannels);
+        Assert.Equal(capabilities.DigitalChannels, clone.DigitalChannels);
+        Assert.Equal(capabilities.MaxSamplingRate, clone.MaxSamplingRate);
+    }
+
+    [Fact]
+    public void Clone_ReturnsDistinctInstance()
+    {
+        // Arrange
+        var capabilities = new DeviceCapabilities();
+
+        // Act
+        var clone = capabilities.Clone();
+
+        // Assert
+        Assert.NotSame(capabilities, clone);
+    }
+
+    [Fact]
+    public void Clone_MutatingCloneDoesNotAffectOriginal()
+    {
+        // Arrange
+        var capabilities = new DeviceCapabilities { AnalogInputChannels = 8 };
+        var clone = capabilities.Clone();
+
+        // Act
+        clone.AnalogInputChannels = 16;
+
+        // Assert
+        Assert.Equal(8, capabilities.AnalogInputChannels);
+        Assert.Equal(16, clone.AnalogInputChannels);
+    }
 }

--- a/src/Daqifi.Core.Tests/Device/DeviceMetadataTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceMetadataTests.cs
@@ -226,4 +226,95 @@ public class DeviceMetadataTests
         // Assert
         Assert.Equal("Previous Name", metadata.FriendlyName);
     }
+
+    [Fact]
+    public void CopyFrom_CopiesAllFieldValues()
+    {
+        // Arrange
+        var source = new DeviceMetadata
+        {
+            PartNumber = "Nq3",
+            SerialNumber = "12345",
+            FirmwareVersion = "1.2.3",
+            HardwareRevision = "2.0",
+            DeviceType = DeviceType.Nyquist3,
+            Capabilities = new DeviceCapabilities
+            {
+                SupportsStreaming = true,
+                HasSdCard = true,
+                HasWiFi = true,
+                HasUsb = true,
+                AnalogInputChannels = 8,
+                AnalogOutputChannels = 2,
+                DigitalChannels = 16,
+                MaxSamplingRate = 5000
+            },
+            IpAddress = "192.168.1.100",
+            MacAddress = "AA-BB-CC-DD-EE-FF",
+            Ssid = "TestNetwork",
+            HostName = "daqifi-001",
+            FriendlyName = "My Device",
+            DevicePort = 9760,
+            WifiSecurityMode = 3,
+            WifiInfrastructureMode = 1
+        };
+        var target = new DeviceMetadata();
+
+        // Act
+        target.CopyFrom(source);
+
+        // Assert
+        Assert.Equal(source.PartNumber, target.PartNumber);
+        Assert.Equal(source.SerialNumber, target.SerialNumber);
+        Assert.Equal(source.FirmwareVersion, target.FirmwareVersion);
+        Assert.Equal(source.HardwareRevision, target.HardwareRevision);
+        Assert.Equal(source.DeviceType, target.DeviceType);
+        Assert.Equal(source.IpAddress, target.IpAddress);
+        Assert.Equal(source.MacAddress, target.MacAddress);
+        Assert.Equal(source.Ssid, target.Ssid);
+        Assert.Equal(source.HostName, target.HostName);
+        Assert.Equal(source.FriendlyName, target.FriendlyName);
+        Assert.Equal(source.DevicePort, target.DevicePort);
+        Assert.Equal(source.WifiSecurityMode, target.WifiSecurityMode);
+        Assert.Equal(source.WifiInfrastructureMode, target.WifiInfrastructureMode);
+        Assert.Equal(source.Capabilities.AnalogInputChannels, target.Capabilities.AnalogInputChannels);
+        Assert.Equal(source.Capabilities.AnalogOutputChannels, target.Capabilities.AnalogOutputChannels);
+        Assert.Equal(source.Capabilities.DigitalChannels, target.Capabilities.DigitalChannels);
+        Assert.Equal(source.Capabilities.MaxSamplingRate, target.Capabilities.MaxSamplingRate);
+        Assert.Equal(source.Capabilities.HasSdCard, target.Capabilities.HasSdCard);
+        Assert.Equal(source.Capabilities.HasWiFi, target.Capabilities.HasWiFi);
+        Assert.Equal(source.Capabilities.HasUsb, target.Capabilities.HasUsb);
+        Assert.Equal(source.Capabilities.SupportsStreaming, target.Capabilities.SupportsStreaming);
+    }
+
+    [Fact]
+    public void CopyFrom_CapabilitiesAreDeepCopiedNotShared()
+    {
+        // Arrange
+        var source = new DeviceMetadata();
+        var target = new DeviceMetadata();
+
+        // Act
+        target.CopyFrom(source);
+
+        // Assert
+        Assert.NotSame(source.Capabilities, target.Capabilities);
+    }
+
+    [Fact]
+    public void CopyFrom_MutatingSourceAfterCopyDoesNotAffectTarget()
+    {
+        // Arrange
+        var source = new DeviceMetadata { PartNumber = "Nq3" };
+        var target = new DeviceMetadata();
+        target.CopyFrom(source);
+
+        // Act
+        source.PartNumber = "Nq1";
+        source.Capabilities.AnalogInputChannels = 8;
+
+        // Assert
+        Assert.Equal("Nq3", target.PartNumber);
+        Assert.Equal(0, target.Capabilities.AnalogInputChannels);
+    }
 }

--- a/src/Daqifi.Core.Tests/Device/DeviceMetadataTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceMetadataTests.cs
@@ -317,4 +317,28 @@ public class DeviceMetadataTests
         Assert.Equal("Nq3", target.PartNumber);
         Assert.Equal(0, target.Capabilities.AnalogInputChannels);
     }
+
+    [Fact]
+    public void CopyFrom_NullSource_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var target = new DeviceMetadata();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => target.CopyFrom(null!));
+    }
+
+    [Fact]
+    public void CopyFrom_SourceWithNullCapabilities_DefaultsToNewCapabilities()
+    {
+        // Arrange
+        var source = new DeviceMetadata { Capabilities = null! };
+        var target = new DeviceMetadata();
+
+        // Act
+        target.CopyFrom(source);
+
+        // Assert
+        Assert.NotNull(target.Capabilities);
+    }
 }

--- a/src/Daqifi.Core/Device/DeviceCapabilities.cs
+++ b/src/Daqifi.Core/Device/DeviceCapabilities.cs
@@ -96,4 +96,23 @@ public class DeviceCapabilities
             _ => new DeviceCapabilities()
         };
     }
+
+    /// <summary>
+    /// Creates a deep copy of this <see cref="DeviceCapabilities"/> instance.
+    /// </summary>
+    /// <returns>A new <see cref="DeviceCapabilities"/> instance with the same field values.</returns>
+    public DeviceCapabilities Clone()
+    {
+        return new DeviceCapabilities
+        {
+            SupportsStreaming = SupportsStreaming,
+            HasSdCard = HasSdCard,
+            HasWiFi = HasWiFi,
+            HasUsb = HasUsb,
+            AnalogInputChannels = AnalogInputChannels,
+            AnalogOutputChannels = AnalogOutputChannels,
+            DigitalChannels = DigitalChannels,
+            MaxSamplingRate = MaxSamplingRate
+        };
+    }
 }

--- a/src/Daqifi.Core/Device/DeviceMetadata.cs
+++ b/src/Daqifi.Core/Device/DeviceMetadata.cs
@@ -81,14 +81,17 @@ public class DeviceMetadata
     /// Copies all field values from another <see cref="DeviceMetadata"/> instance into this one.
     /// </summary>
     /// <param name="source">The instance to copy field values from.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
     public void CopyFrom(DeviceMetadata source)
     {
+        ArgumentNullException.ThrowIfNull(source);
+
         PartNumber = source.PartNumber;
         SerialNumber = source.SerialNumber;
         FirmwareVersion = source.FirmwareVersion;
         HardwareRevision = source.HardwareRevision;
         DeviceType = source.DeviceType;
-        Capabilities = source.Capabilities.Clone();
+        Capabilities = source.Capabilities?.Clone() ?? new DeviceCapabilities();
         IpAddress = source.IpAddress;
         MacAddress = source.MacAddress;
         Ssid = source.Ssid;

--- a/src/Daqifi.Core/Device/DeviceMetadata.cs
+++ b/src/Daqifi.Core/Device/DeviceMetadata.cs
@@ -78,6 +78,28 @@ public class DeviceMetadata
     public uint WifiInfrastructureMode { get; set; }
 
     /// <summary>
+    /// Copies all field values from another <see cref="DeviceMetadata"/> instance into this one.
+    /// </summary>
+    /// <param name="source">The instance to copy field values from.</param>
+    public void CopyFrom(DeviceMetadata source)
+    {
+        PartNumber = source.PartNumber;
+        SerialNumber = source.SerialNumber;
+        FirmwareVersion = source.FirmwareVersion;
+        HardwareRevision = source.HardwareRevision;
+        DeviceType = source.DeviceType;
+        Capabilities = source.Capabilities.Clone();
+        IpAddress = source.IpAddress;
+        MacAddress = source.MacAddress;
+        Ssid = source.Ssid;
+        HostName = source.HostName;
+        FriendlyName = source.FriendlyName;
+        DevicePort = source.DevicePort;
+        WifiSecurityMode = source.WifiSecurityMode;
+        WifiInfrastructureMode = source.WifiInfrastructureMode;
+    }
+
+    /// <summary>
     /// Updates the device metadata from a protobuf message.
     /// </summary>
     /// <param name="message">The protobuf message containing device information.</param>


### PR DESCRIPTION
## Summary
- Add `DeviceCapabilities.Clone()`, sitting next to the existing `FromDeviceType` factory
- Add `DeviceMetadata.CopyFrom(source)`, which copies all 13 scalar fields plus a deep-cloned `Capabilities`
- Both methods copy every field explicitly so adding a new field to either type without updating the copy method is a visible diff, not a silent drop

## Why
Consumers (e.g. daqifi-desktop's `AbstractStreamingDevice.HydrateDeviceMetadata`/`CloneCapabilities`) were hand-copying fields one at a time. Any new field added to `DeviceMetadata`/`DeviceCapabilities` in Core would silently not get copied in every consumer doing this, with no compiler error.

Closes #305

## Test plan
- [x] `dotnet test` for `DeviceMetadataTests` / `DeviceCapabilitiesTests` — 23/23 passing, including new `Clone`/`CopyFrom` tests covering full field coverage, deep-copy independence (mutating source/clone after copy doesn't affect the other), and distinct-instance checks
- [x] Full `Daqifi.Core.Tests` suite run — 1461/1462 passing; the one failure (`ContinuousDeviceFinderTests.Start_DiscoversDevice_...`) is a pre-existing timing-based discovery flake unrelated to this change (no discovery code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)