### PR TITLE
feat(firmware): power on WINC before chip-info probe in CheckWifiFirmwareStatusAsync

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DeviceCapabilitiesTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceCapabilitiesTests.cs
@@ -18,6 +18,7 @@ public class DeviceCapabilitiesTests
         Assert.True(capabilities.SupportsStreaming);
         Assert.False(capabilities.HasSdCard);
         Assert.False(capabilities.HasWiFi);
+        Assert.False(capabilities.HasWincWifiModule);
         Assert.False(capabilities.HasUsb);
         Assert.Equal(0, capabilities.AnalogInputChannels);
         Assert.Equal(0, capabilities.AnalogOutputChannels);
@@ -38,6 +39,7 @@ public class DeviceCapabilitiesTests
         Assert.True(capabilities.SupportsStreaming);
         Assert.True(capabilities.HasSdCard);
         Assert.True(capabilities.HasWiFi);
+        Assert.True(capabilities.HasWincWifiModule);
         Assert.True(capabilities.HasUsb);
         Assert.Equal(1000, capabilities.MaxSamplingRate);
     }
@@ -52,6 +54,7 @@ public class DeviceCapabilitiesTests
         Assert.True(capabilities.SupportsStreaming);
         Assert.False(capabilities.HasSdCard);
         Assert.False(capabilities.HasWiFi);
+        Assert.False(capabilities.HasWincWifiModule);
         Assert.False(capabilities.HasUsb);
         Assert.Equal(0, capabilities.AnalogInputChannels);
         Assert.Equal(0, capabilities.AnalogOutputChannels);

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Net;
 using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Discovery;
@@ -2777,6 +2778,135 @@ public class FirmwareUpdateServiceTests
         Assert.Equal(1, device.GetLanChipInfoCallCount);
     }
 
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_PowerOnBeforeProbeEnabled_SendsTurnDeviceOnBeforeChipInfoProbe()
+    {
+        // Closes #301: right after a PIC32 reflash the WINC comes back powered
+        // off, so the probe must power it on before the first GETChipInfo?
+        // query, not merely rely on retrying a powered-off module.
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM18",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            });
+
+        var options = CreateFastOptions();
+        options.PowerOnWifiModuleBeforeProbe = true;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Contains("SYSTem:POWer:STATe 1", device.SentCommands);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_PowerOnBeforeProbeDisabled_DoesNotSendTurnDeviceOn()
+    {
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM19",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            });
+
+        var options = CreateFastOptions();
+        options.PowerOnWifiModuleBeforeProbe = false;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.DoesNotContain("SYSTem:POWer:STATe 1", device.SentCommands);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_DeviceNotConnected_SkipsPowerOnAndDoesNotThrow()
+    {
+        // FakeLanChipInfoStreamingDevice.Send does not itself throw when
+        // disconnected (unlike the real DaqifiDevice), so this asserts the
+        // guard on the caller side: CheckWifiFirmwareStatusAsync must not
+        // attempt to send TurnDeviceOn to a device it knows is disconnected.
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM20",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            },
+            isConnected: false);
+
+        var options = CreateFastOptions();
+        options.PowerOnWifiModuleBeforeProbe = true;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.DoesNotContain("SYSTem:POWer:STATe 1", device.SentCommands);
+        Assert.NotNull(status);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_PowerOnBeforeProbe_WaitsSettleDelayBeforeProbing()
+    {
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM21",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            });
+
+        var options = CreateFastOptions();
+        options.PowerOnWifiModuleBeforeProbe = true;
+        options.PowerOnWifiModuleSettleDelay = TimeSpan.FromMilliseconds(200);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        await service.CheckWifiFirmwareStatusAsync(device);
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(180),
+            $"Expected the probe to wait out the settle delay, but only took {stopwatch.ElapsedMilliseconds}ms.");
+    }
+
     private sealed class SyncProgress<T> : IProgress<T>
     {
         private readonly Action<T> _handler;
@@ -2812,7 +2942,11 @@ public class FirmwareUpdateServiceTests
             // Disable the macOS USB CDC stale-handle settling delay for unit
             // tests — FakeStreamingDevice doesn't reproduce the re-enum race,
             // so the dance is pure latency that would blow the fast budgets.
-            PostReconnectStaleHandleDelay = TimeSpan.Zero
+            PostReconnectStaleHandleDelay = TimeSpan.Zero,
+            // Skip the WINC power-on settle wait — fakes don't model power state,
+            // so the delay is pure latency here. Individual tests re-enable it
+            // where the power-on behavior itself is under test.
+            PowerOnWifiModuleSettleDelay = TimeSpan.Zero
         };
     }
 
@@ -2920,12 +3054,20 @@ public class FirmwareUpdateServiceTests
         private ConnectionStatus _status = ConnectionStatus.Connected;
         private int _remainingTransientFailures;
 
-        public FakeLanChipInfoStreamingDevice(string name, LanChipInfo? chipInfo, int transientFailuresBeforeSuccess = 0)
+        public FakeLanChipInfoStreamingDevice(
+            string name,
+            LanChipInfo? chipInfo,
+            int transientFailuresBeforeSuccess = 0,
+            bool isConnected = true)
         {
             Name = name;
             _chipInfo = chipInfo;
             _remainingTransientFailures = transientFailuresBeforeSuccess;
-            IsConnected = true;
+            IsConnected = isConnected;
+            if (!isConnected)
+            {
+                _status = ConnectionStatus.Disconnected;
+            }
         }
 
         public int GetLanChipInfoCallCount { get; private set; }

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2899,12 +2899,21 @@ public class FirmwareUpdateServiceTests
             new FakeHidDeviceEnumerator([]),
             options);
 
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         await service.CheckWifiFirmwareStatusAsync(device);
-        stopwatch.Stop();
 
-        Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(180),
-            $"Expected the probe to wait out the settle delay, but only took {stopwatch.ElapsedMilliseconds}ms.");
+        // Assert against the fake's own recorded event timestamps rather than
+        // the whole call's wall-clock duration — this isolates the assertion
+        // to the actual gap between the two operations under test instead of
+        // being sensitive to unrelated CI/test-framework overhead.
+        Assert.NotNull(device.TurnDeviceOnSentAt);
+        Assert.NotNull(device.FirstGetLanChipInfoCallAt);
+        Assert.True(
+            device.FirstGetLanChipInfoCallAt > device.TurnDeviceOnSentAt,
+            "Expected the chip-info probe to happen after the power-on command.");
+
+        var gap = device.FirstGetLanChipInfoCallAt!.Value - device.TurnDeviceOnSentAt!.Value;
+        Assert.True(gap >= TimeSpan.FromMilliseconds(180),
+            $"Expected the probe to wait out the settle delay between power-on and chip-info query, but the gap was only {gap.TotalMilliseconds}ms.");
     }
 
     private sealed class SyncProgress<T> : IProgress<T>
@@ -3070,6 +3079,8 @@ public class FirmwareUpdateServiceTests
             }
         }
 
+        private readonly System.Diagnostics.Stopwatch _eventStopwatch = System.Diagnostics.Stopwatch.StartNew();
+
         public int GetLanChipInfoCallCount { get; private set; }
 
         public string Name { get; }
@@ -3080,6 +3091,12 @@ public class FirmwareUpdateServiceTests
         public bool IsStreaming { get; private set; }
 
         public List<string> SentCommands { get; } = [];
+
+        /// <summary>Elapsed time (from construction) at which "SYSTem:POWer:STATe 1" was sent, if any.</summary>
+        public TimeSpan? TurnDeviceOnSentAt { get; private set; }
+
+        /// <summary>Elapsed time (from construction) at which the first <see cref="GetLanChipInfoAsync"/> call landed.</summary>
+        public TimeSpan? FirstGetLanChipInfoCallAt { get; private set; }
 
         public event EventHandler<DeviceStatusEventArgs>? StatusChanged;
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived
@@ -3107,6 +3124,10 @@ public class FirmwareUpdateServiceTests
             if (message is IOutboundMessage<string> textMessage)
             {
                 SentCommands.Add(textMessage.Data);
+                if (textMessage.Data == "SYSTem:POWer:STATe 1")
+                {
+                    TurnDeviceOnSentAt = _eventStopwatch.Elapsed;
+                }
             }
         }
 
@@ -3127,6 +3148,7 @@ public class FirmwareUpdateServiceTests
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
+            FirstGetLanChipInfoCallAt ??= _eventStopwatch.Elapsed;
             GetLanChipInfoCallCount++;
             if (_remainingTransientFailures > 0)
             {

--- a/src/Daqifi.Core/Device/DeviceCapabilities.cs
+++ b/src/Daqifi.Core/Device/DeviceCapabilities.cs
@@ -21,6 +21,16 @@ public class DeviceCapabilities
     public bool HasWiFi { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the device's WiFi connectivity is provided by a
+    /// discrete WINC1500 module (as opposed to, e.g., a future SoC-integrated WiFi part). Lets
+    /// consumers ask Core whether WINC-specific handling (power-on-before-probe, the WINC flash
+    /// tool, bridge-mode activation) applies to a device instead of pattern-matching
+    /// <see cref="DeviceType"/> themselves. Distinct from <see cref="HasWiFi"/>, which only
+    /// indicates WiFi connectivity in general.
+    /// </summary>
+    public bool HasWincWifiModule { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the device supports USB connectivity.
     /// </summary>
     public bool HasUsb { get; set; }
@@ -53,6 +63,7 @@ public class DeviceCapabilities
         SupportsStreaming = true;
         HasSdCard = false;
         HasWiFi = false;
+        HasWincWifiModule = false;
         HasUsb = false;
         AnalogInputChannels = 0;
         AnalogOutputChannels = 0;
@@ -74,6 +85,7 @@ public class DeviceCapabilities
                 SupportsStreaming = true,
                 HasSdCard = true,
                 HasWiFi = true,
+                HasWincWifiModule = true,
                 HasUsb = true,
                 MaxSamplingRate = 1000
             },
@@ -82,6 +94,7 @@ public class DeviceCapabilities
                 SupportsStreaming = true,
                 HasSdCard = true,
                 HasWiFi = true,
+                HasWincWifiModule = true,
                 HasUsb = true,
                 MaxSamplingRate = 1000
             },
@@ -90,6 +103,7 @@ public class DeviceCapabilities
                 SupportsStreaming = true,
                 HasSdCard = true,
                 HasWiFi = true,
+                HasWincWifiModule = true,
                 HasUsb = true,
                 MaxSamplingRate = 1000
             },

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -810,6 +810,22 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
             };
         }
 
+        // Closes #301: right after a PIC32 reflash the WINC module comes back
+        // powered off, so the first GETChipInfo? probe below would always fail,
+        // report ChipInfoUnavailable, and send the caller into a needless
+        // multi-minute WiFi reflash. Powering it on first (mirroring what
+        // daqifi-desktop's FirmwareUpdateCoordinator does today) closes that gap.
+        // Skipped when the device isn't connected — Send would throw, and a
+        // disconnected device will fail the chip-info probe regardless.
+        if (_options.PowerOnWifiModuleBeforeProbe && device.IsConnected)
+        {
+            device.Send(ScpiMessageProducer.TurnDeviceOn);
+            if (_options.PowerOnWifiModuleSettleDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(_options.PowerOnWifiModuleSettleDelay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         // Bounded retry for the LAN chip-info probe (closes #144). Right
         // after a PIC32 firmware update the application is up while WiFi
         // is still finishing startup, so the first chip-info query can

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -819,10 +819,27 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         // disconnected device will fail the chip-info probe regardless.
         if (_options.PowerOnWifiModuleBeforeProbe && device.IsConnected)
         {
-            device.Send(ScpiMessageProducer.TurnDeviceOn);
-            if (_options.PowerOnWifiModuleSettleDelay > TimeSpan.Zero)
+            // Observe cancellation before this state-changing Send: a
+            // pre-cancelled call must not power on the device before the
+            // cancellation is surfaced to the caller.
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
             {
-                await Task.Delay(_options.PowerOnWifiModuleSettleDelay, cancellationToken).ConfigureAwait(false);
+                device.Send(ScpiMessageProducer.TurnDeviceOn);
+                if (_options.PowerOnWifiModuleSettleDelay > TimeSpan.Zero)
+                {
+                    await Task.Delay(_options.PowerOnWifiModuleSettleDelay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Best-effort: the chip-info probe below has its own bounded
+                // retry and gracefully degrades to ChipInfoUnavailable, so a
+                // failure to send the power-on command must not abort the
+                // whole status check. Skip the settle delay too — there is
+                // nothing to settle if the send itself failed.
+                _logger.LogDebug(ex, "Failed to send WINC power-on command before chip-info probe; continuing without it.");
             }
         }
 

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -265,6 +265,26 @@ public sealed class FirmwareUpdateServiceOptions
     public TimeSpan LanChipInfoTotalTimeout { get; set; } = TimeSpan.FromSeconds(8);
 
     /// <summary>
+    /// When true, <see cref="FirmwareUpdateService.CheckWifiFirmwareStatusAsync"/> sends
+    /// <see cref="Communication.Producers.ScpiMessageProducer.TurnDeviceOn"/> and waits
+    /// <see cref="PowerOnWifiModuleSettleDelay"/> before the first chip-info probe, when the
+    /// device is connected. Right after a PIC32 reflash the WINC module comes back powered
+    /// off, so every <c>GETChipInfo?</c> query fails, the probe reports
+    /// <see cref="WifiFirmwareStatusReason.ChipInfoUnavailable"/>, and callers conservatively
+    /// default to "needs flash" — producing a needless multi-minute WiFi reflash. Powering the
+    /// module on first closes that gap. Defaults to <c>true</c>; set to <c>false</c> to restore
+    /// the legacy behavior of probing without a preceding power-on.
+    /// </summary>
+    public bool PowerOnWifiModuleBeforeProbe { get; set; } = true;
+
+    /// <summary>
+    /// Delay after sending the WINC power-on command, before the first chip-info probe.
+    /// Only consulted when <see cref="PowerOnWifiModuleBeforeProbe"/> is <c>true</c>. Gives the
+    /// module time to power up and start responding to <c>GETChipInfo?</c> queries.
+    /// </summary>
+    public TimeSpan PowerOnWifiModuleSettleDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
     /// Gets the configured timeout for a given firmware update state.
     /// </summary>
     /// <param name="state">The target state.</param>
@@ -376,6 +396,11 @@ public sealed class FirmwareUpdateServiceOptions
 
         ValidatePositive(LanChipInfoRetryDelay, nameof(LanChipInfoRetryDelay));
         ValidatePositive(LanChipInfoTotalTimeout, nameof(LanChipInfoTotalTimeout));
+
+        // Only consulted when PowerOnWifiModuleBeforeProbe is true, but validated
+        // unconditionally so a misconfiguration surfaces even if the flag is
+        // toggled on later without re-touching this value.
+        ValidateNonNegative(PowerOnWifiModuleSettleDelay, nameof(PowerOnWifiModuleSettleDelay));
 
         if (BootloaderVendorId < 0 || BootloaderVendorId > 0xFFFF)
         {


### PR DESCRIPTION
## Summary
- `CheckWifiFirmwareStatusAsync` now sends `ScpiMessageProducer.TurnDeviceOn` (`SYSTem:POWer:STATe 1`) and waits a settle delay before the first LAN chip-info probe, when the device is connected. Right after a PIC32 reflash the WINC comes back powered off, so every `GETChipInfo?` previously failed, the probe reported `ChipInfoUnavailable`, and callers defaulted to a needless multi-minute WiFi reflash.
- Added `FirmwareUpdateServiceOptions.PowerOnWifiModuleBeforeProbe` (default `true`) to gate the new behavior, and `PowerOnWifiModuleSettleDelay` (default 1s) to control the settle wait. Set the flag to `false` to restore the legacy probe-without-power-on behavior.
- Added `DeviceCapabilities.HasWincWifiModule`, populated by `FromDeviceType` for Nyquist1/2/3, so consumers can ask Core whether a device's WiFi is backed by a discrete WINC1500 module instead of pattern-matching `DeviceType` themselves (daqifi-desktop's `AbstractStreamingDevice.cs:281-288` currently hardcodes this).

Closes #301

## Test plan
- [x] `dotnet test` — full suite passes except one pre-existing, unrelated flaky failure in `ContinuousDeviceFinderTests` (a UDP discovery test not touched by this change)
- [x] Added unit tests covering: `TurnDeviceOn` sent when the option is enabled, not sent when disabled, not sent (and no throw) when the device is disconnected, and that the settle delay is actually observed
- [x] Added `HasWincWifiModule` coverage to `DeviceCapabilitiesTests`
- [ ] Not bench-verified against physical hardware in this session — no device attached in this environment; the change is a pure SCPI-send + delay ahead of the existing (already bench-tested) chip-info retry path

🤖 Generated with [Claude Code](https://claude.com/claude-code)