### PR TITLE
feat(sdcard): add SdCardLogEntry.HasDeviceTimestamp

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
@@ -715,6 +715,56 @@ public sealed class SdCardCsvFileParserTests
     }
 
     // -------------------------------------------------------------------------
+    // HasDeviceTimestamp
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseAsync_WithTimestampTickRate_MarksHasDeviceTimestampTrue()
+    {
+        // Arrange
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nyquist 1", "SN123", 100u,
+            (1000u, new[] { 1.5, 2.5 }),
+            (1100u, new[] { 3.5, 4.5 })
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal(2, samples.Count);
+        Assert.All(samples, s => Assert.True(s.HasDeviceTimestamp));
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithoutTimestampTickRate_MarksHasDeviceTimestampFalse()
+    {
+        // Arrange — no "Timestamp Tick Rate" comment and no fallback frequency, so ticks
+        // can't be converted to elapsed time and entries fall back to the session base time.
+        const string content =
+            "# Device: Nyquist 1\n" +
+            "# Serial Number: SN123\n" +
+            "ain0_ts,ain0_val\n" +
+            "1000,1.5\n" +
+            "1100,3.5\n";
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions { FallbackTimestampFrequency = 0 };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.csv", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal(2, samples.Count);
+        Assert.All(samples, s => Assert.False(s.HasDeviceTimestamp));
+    }
+
+    // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------
 

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserTests.cs
@@ -852,6 +852,81 @@ public class SdCardFileParserTests
 
     #endregion
 
+    #region HasDeviceTimestamp
+
+    [Fact]
+    public async Task ParseAsync_WithRealTimestamps_MarksHasDeviceTimestampTrue()
+    {
+        // Arrange
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 50_000_000))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 100_000_000,
+                analogFloatValues: new[] { 1.0f }))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 150_000_000,
+                analogFloatValues: new[] { 2.0f }));
+
+        using var stream = builder.Build();
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "real_ts.bin");
+
+        // Assert
+        var samples = await ToListAsync(session.Samples);
+        Assert.Equal(2, samples.Count);
+        Assert.All(samples, s => Assert.True(s.HasDeviceTimestamp));
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithZeroMsgTimeStamp_MarksHasDeviceTimestampFalse()
+    {
+        // Arrange — a message with MsgTimeStamp == 0 has no usable device timestamp,
+        // so the entry falls back to the session base time.
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 50_000_000))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 0,
+                analogFloatValues: new[] { 1.0f }));
+
+        using var stream = builder.Build();
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "zero_ts.bin");
+
+        // Assert
+        var samples = await ToListAsync(session.Samples);
+        Assert.Single(samples);
+        Assert.False(samples[0].HasDeviceTimestamp);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithNoTimestampFrequency_MarksHasDeviceTimestampFalse()
+    {
+        // Arrange — no TimestampFreq means ticks can't be converted to elapsed time,
+        // so every entry is substituted with the base time.
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 1000,
+                analogFloatValues: new[] { 1.0f }))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 2000,
+                analogFloatValues: new[] { 2.0f }));
+
+        using var stream = builder.Build();
+        var options = new SdCardParseOptions { FallbackTimestampFrequency = 0 };
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "no_freq.bin", options);
+
+        // Assert
+        var samples = await ToListAsync(session.Samples);
+        Assert.Equal(2, samples.Count);
+        Assert.All(samples, s => Assert.False(s.HasDeviceTimestamp));
+    }
+
+    #endregion
+
     #region Helpers
 
     private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
@@ -408,6 +408,49 @@ public sealed class SdCardJsonFileParserTests
         Assert.Equal(16.0, samples[0].AnalogValues[1], precision: 5);
     }
 
+    [Fact]
+    public async Task ParseAsync_WithTimestampFrequency_MarksHasDeviceTimestampTrue()
+    {
+        // Arrange
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0 }, ""),
+            (200u, new[] { 2.0 }, "")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions { FallbackTimestampFrequency = 100 };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal(2, samples.Count);
+        Assert.All(samples, s => Assert.True(s.HasDeviceTimestamp));
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithoutTimestampFrequency_MarksHasDeviceTimestampFalse()
+    {
+        // Arrange — no timestamp frequency available, so ticks can't be converted
+        // and every entry falls back to the session base time.
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (100u, new[] { 1.0 }, ""),
+            (200u, new[] { 2.0 }, "")
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions { FallbackTimestampFrequency = 0 };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert
+        Assert.Equal(2, samples.Count);
+        Assert.All(samples, s => Assert.False(s.HasDeviceTimestamp));
+    }
+
     private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
     {
         var list = new List<T>();

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -307,7 +307,10 @@ public sealed class SdCardCsvFileParser
                 absoluteTime = baseTime.AddSeconds(elapsedSeconds);
             }
 
-            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, perChannelTimestamps, hasDeviceTimestamp);
+            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, perChannelTimestamps)
+            {
+                HasDeviceTimestamp = hasDeviceTimestamp
+            };
 
             // Report progress every 100 lines for efficiency
             if (linesProcessed % 100 == 0 && progress != null)

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -290,7 +290,8 @@ public sealed class SdCardCsvFileParser
 
             // Reconstruct absolute timestamp using first channel timestamp
             var absoluteTime = baseTime;
-            if (tickPeriod > 0)
+            var hasDeviceTimestamp = tickPeriod > 0;
+            if (hasDeviceTimestamp)
             {
                 if (previousTimestamp == null)
                 {
@@ -306,7 +307,7 @@ public sealed class SdCardCsvFileParser
                 absoluteTime = baseTime.AddSeconds(elapsedSeconds);
             }
 
-            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, perChannelTimestamps);
+            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, perChannelTimestamps, hasDeviceTimestamp);
 
             // Report progress every 100 lines for efficiency
             if (linesProcessed % 100 == 0 && progress != null)

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -278,7 +278,8 @@ public sealed class SdCardFileParser
 
             // Reconstruct timestamp
             var timestamp = baseTime;
-            if (msg.MsgTimeStamp != 0 && tickPeriod > 0)
+            var hasDeviceTimestamp = msg.MsgTimeStamp != 0 && tickPeriod > 0;
+            if (hasDeviceTimestamp)
             {
                 if (previousTimestamp == null)
                 {
@@ -326,7 +327,7 @@ public sealed class SdCardFileParser
                 ? msg.AnalogInDataTs.ToArray()
                 : null;
 
-            yield return new SdCardLogEntry(timestamp, analogValues, digitalData, analogTimestamps);
+            yield return new SdCardLogEntry(timestamp, analogValues, digitalData, analogTimestamps, hasDeviceTimestamp);
         }
     }
 #pragma warning restore CS1998

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -327,7 +327,10 @@ public sealed class SdCardFileParser
                 ? msg.AnalogInDataTs.ToArray()
                 : null;
 
-            yield return new SdCardLogEntry(timestamp, analogValues, digitalData, analogTimestamps, hasDeviceTimestamp);
+            yield return new SdCardLogEntry(timestamp, analogValues, digitalData, analogTimestamps)
+            {
+                HasDeviceTimestamp = hasDeviceTimestamp
+            };
         }
     }
 #pragma warning restore CS1998

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -136,7 +136,8 @@ public sealed class SdCardJsonFileParser
 
             // Reconstruct absolute timestamp
             var absoluteTime = baseTime;
-            if (tickPeriod > 0)
+            var hasDeviceTimestamp = tickPeriod > 0;
+            if (hasDeviceTimestamp)
             {
                 if (previousTimestamp == null)
                 {
@@ -152,7 +153,7 @@ public sealed class SdCardJsonFileParser
                 absoluteTime = baseTime.AddSeconds(elapsedSeconds);
             }
 
-            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, null);
+            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, null, hasDeviceTimestamp);
 
             // Report progress every 100 lines for efficiency
             if (linesProcessed % 100 == 0 && progress != null)

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -153,7 +153,10 @@ public sealed class SdCardJsonFileParser
                 absoluteTime = baseTime.AddSeconds(elapsedSeconds);
             }
 
-            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, null, hasDeviceTimestamp);
+            yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, null)
+            {
+                HasDeviceTimestamp = hasDeviceTimestamp
+            };
 
             // Report progress every 100 lines for efficiency
             if (linesProcessed % 100 == 0 && progress != null)

--- a/src/Daqifi.Core/Device/SdCard/SdCardLogEntry.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardLogEntry.cs
@@ -10,8 +10,15 @@ namespace Daqifi.Core.Device.SdCard;
 /// <param name="AnalogValues">Analog channel readings.</param>
 /// <param name="DigitalData">Digital port state.</param>
 /// <param name="AnalogTimestamps">Per-channel timestamps if available.</param>
+/// <param name="HasDeviceTimestamp">
+/// <c>true</c> when <see cref="Timestamp"/> was reconstructed from a real device tick for this
+/// entry; <c>false</c> when no usable device timestamp was available (e.g. a zero message
+/// timestamp, a missing CSV timestamp column, or an unknown tick rate) and the session's base
+/// time was substituted instead.
+/// </param>
 public sealed record SdCardLogEntry(
     DateTime Timestamp,
     IReadOnlyList<double> AnalogValues,
     uint DigitalData,
-    IReadOnlyList<uint>? AnalogTimestamps);
+    IReadOnlyList<uint>? AnalogTimestamps,
+    bool HasDeviceTimestamp = true);

--- a/src/Daqifi.Core/Device/SdCard/SdCardLogEntry.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardLogEntry.cs
@@ -10,15 +10,21 @@ namespace Daqifi.Core.Device.SdCard;
 /// <param name="AnalogValues">Analog channel readings.</param>
 /// <param name="DigitalData">Digital port state.</param>
 /// <param name="AnalogTimestamps">Per-channel timestamps if available.</param>
-/// <param name="HasDeviceTimestamp">
-/// <c>true</c> when <see cref="Timestamp"/> was reconstructed from a real device tick for this
-/// entry; <c>false</c> when no usable device timestamp was available (e.g. a zero message
-/// timestamp, a missing CSV timestamp column, or an unknown tick rate) and the session's base
-/// time was substituted instead.
-/// </param>
 public sealed record SdCardLogEntry(
     DateTime Timestamp,
     IReadOnlyList<double> AnalogValues,
     uint DigitalData,
-    IReadOnlyList<uint>? AnalogTimestamps,
-    bool HasDeviceTimestamp = true);
+    IReadOnlyList<uint>? AnalogTimestamps)
+{
+    /// <summary>
+    /// <c>true</c> when <see cref="Timestamp"/> was reconstructed from a real device tick for this
+    /// entry; <c>false</c> when no usable device timestamp was available (e.g. a zero message
+    /// timestamp or an unknown tick rate) and the session's base time was substituted instead.
+    /// </summary>
+    /// <remarks>
+    /// Declared as an <c>init</c> property (not a primary-constructor parameter) so the record's
+    /// generated constructor and <see cref="Deconstruct"/> signatures stay binary-compatible with
+    /// consumers compiled before this property was added.
+    /// </remarks>
+    public bool HasDeviceTimestamp { get; init; } = true;
+}


### PR DESCRIPTION
## Summary
- Add `SdCardLogEntry.HasDeviceTimestamp` (default `true`), reporting per-entry whether `Timestamp` was reconstructed from a real device tick or substituted with the session base time
- Wire it through all three parsers:
  - `SdCardFileParser` (protobuf): `false` when `MsgTimeStamp == 0` or the tick rate is unknown
  - `SdCardJsonFileParser`: `false` when the tick rate is unknown
  - `SdCardCsvFileParser`: `false` when the tick rate is unknown

## Why
Core already knows, exactly and per-entry, whether a timestamp was real or substituted, but previously threw that away — only the resulting (possibly-substituted) tick was exposed. daqifi-desktop needs this distinction to warn users about a flat time axis on import, so it reverse-engineers it statistically in `ImportTimestampQuality.cs` by counting how many ticks equal the first tick past a 20% threshold. That heuristic misclassifies any legitimately high-rate file whose first ≥20% of samples happen to share a tick. Exposing the real per-entry flag lets desktop drop the heuristic (and the ~60 lines of `Observe`/`CollapsedFraction`/`HasFlatTimeAxis` state it requires) in favor of an exact answer.

Closes #303

## Test plan
- [x] New unit tests in `SdCardFileParserTests`, `SdCardJsonFileParserTests`, `SdCardCsvFileParserTests` covering `HasDeviceTimestamp` true/false cases (zero message timestamp, unknown tick rate) for all three parsers
- [x] Full `dotnet test` suite: 1475/1475 passing (net9.0 and net10.0)
- [x] Verified on physical hardware: built the `daqifi-core-example-app` CLI against this branch (`DaqifiCoreProjectPath`), downloaded a real SD card log from a Nyquist device on COM3, and confirmed parsed entries report `HasDeviceTimestamp=true` with correctly reconstructed, monotonically increasing timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)