### PR TITLE
feat(device): expose classified StatusMessageReceived/StreamMessageReceived events

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
@@ -1,3 +1,4 @@
+using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
 using System.Collections.Generic;
 using System.Net;
@@ -78,5 +79,50 @@ namespace Daqifi.Core.Tests.Device
             // Act & Assert
             Assert.Throws<System.InvalidOperationException>(() => device.Send(new Daqifi.Core.Communication.Messages.ScpiMessage("")));
         }
+
+        [Fact]
+        public void OnStatusMessageReceived_RaisesClassifiedStatusMessageReceived()
+        {
+            // Arrange
+            var device = new TestableDaqifiDevice("TestDevice");
+            DaqifiOutMessage? classified = null;
+            device.StatusMessageReceived += m => classified = m;
+
+            var status = new DaqifiOutMessage { AnalogInPortNum = 1 };
+
+            // Act
+            device.InvokeStatusMessage(status);
+
+            // Assert
+            Assert.Same(status, classified);
+        }
+
+        [Fact]
+        public void OnStreamMessageReceived_RaisesClassifiedStreamMessageReceived()
+        {
+            // Arrange
+            var device = new TestableDaqifiDevice("TestDevice");
+            DaqifiOutMessage? classified = null;
+            device.StreamMessageReceived += m => classified = m;
+
+            var stream = new DaqifiOutMessage { MsgTimeStamp = 1 };
+
+            // Act
+            device.InvokeStreamMessage(stream);
+
+            // Assert
+            Assert.Same(stream, classified);
+        }
+
+        private sealed class TestableDaqifiDevice : DaqifiDevice
+        {
+            public TestableDaqifiDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)
+            {
+            }
+
+            public void InvokeStatusMessage(DaqifiOutMessage message) => OnStatusMessageReceived(message);
+
+            public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+        }
     }
-} 
+}

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
@@ -114,6 +114,44 @@ namespace Daqifi.Core.Tests.Device
             Assert.Same(stream, classified);
         }
 
+        [Fact]
+        public void OnStatusMessageReceived_SubscriberException_StillRaisesMessageReceived()
+        {
+            // A misbehaving StatusMessageReceived subscriber must not prevent the
+            // undifferentiated MessageReceived event from firing for the same frame.
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.StatusMessageReceived += _ => throw new InvalidOperationException("boom");
+
+            Daqifi.Core.Device.MessageReceivedEventArgs? raised = null;
+            device.MessageReceived += (_, e) => raised = e;
+
+            var status = new DaqifiOutMessage { AnalogInPortNum = 1 };
+
+            var ex = Record.Exception(() => device.InvokeStatusMessage(status));
+
+            Assert.Null(ex);
+            Assert.NotNull(raised);
+        }
+
+        [Fact]
+        public void OnStreamMessageReceived_SubscriberException_StillRaisesMessageReceived()
+        {
+            // A misbehaving StreamMessageReceived subscriber must not prevent the
+            // undifferentiated MessageReceived event from firing for the same frame.
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.StreamMessageReceived += _ => throw new InvalidOperationException("boom");
+
+            Daqifi.Core.Device.MessageReceivedEventArgs? raised = null;
+            device.MessageReceived += (_, e) => raised = e;
+
+            var stream = new DaqifiOutMessage { MsgTimeStamp = 1 };
+
+            var ex = Record.Exception(() => device.InvokeStreamMessage(stream));
+
+            Assert.Null(ex);
+            Assert.NotNull(raised);
+        }
+
         private sealed class TestableDaqifiDevice : DaqifiDevice
         {
             public TestableDaqifiDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
@@ -298,6 +298,25 @@ public class DaqifiStreamingDeviceDecodeTests
     }
 
     [Fact]
+    public void Decode_RaisesClassifiedStreamMessageReceived()
+    {
+        // Classified event should fire in addition to the undifferentiated MessageReceived.
+        var device = CreateStreamingDevice(analogCount: 1);
+        AnalogChannel(device, 0).IsEnabled = true;
+        device.StartStreaming();
+
+        DaqifiOutMessage? classified = null;
+        device.StreamMessageReceived += m => classified = m;
+
+        var frame = new DaqifiOutMessage { MsgTimeStamp = 1 };
+        frame.AnalogInDataFloat.Add(1f);
+
+        device.InvokeStreamMessage(frame);
+
+        Assert.Same(frame, classified);
+    }
+
+    [Fact]
     public void Decode_MoreValuesThanChannels_MapsAvailableWithoutThrowing()
     {
         var device = CreateStreamingDevice(analogCount: 1);

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
@@ -2,6 +2,7 @@ using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
 using Google.Protobuf;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -314,6 +315,28 @@ public class DaqifiStreamingDeviceDecodeTests
         device.InvokeStreamMessage(frame);
 
         Assert.Same(frame, classified);
+    }
+
+    [Fact]
+    public void Decode_SubscriberExceptionInStreamMessageReceived_StillDecodesSample()
+    {
+        // A misbehaving StreamMessageReceived subscriber runs inside the base
+        // OnStreamMessageReceived call, before DecodeStreamFrame — it must not prevent
+        // the sample decode below from running.
+        var device = CreateStreamingDevice(analogCount: 1);
+        var ai0 = AnalogChannel(device, 0);
+        ai0.IsEnabled = true;
+        device.StartStreaming();
+
+        device.StreamMessageReceived += _ => throw new InvalidOperationException("boom");
+
+        var frame = new DaqifiOutMessage { MsgTimeStamp = 1 };
+        frame.AnalogInDataFloat.Add(1f);
+
+        var ex = Record.Exception(() => device.InvokeStreamMessage(frame));
+
+        Assert.Null(ex);
+        Assert.Equal(1.0, ai0.ActiveSample!.Value);
     }
 
     [Fact]

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1178,12 +1178,44 @@ namespace Daqifi.Core.Device
             PopulateChannelsFromStatus(message);
 
             // Raise the classified event first so consumers that only care about status
-            // messages can react before the undifferentiated MessageReceived below.
-            StatusMessageReceived?.Invoke(message);
+            // messages can react before the undifferentiated MessageReceived below. A
+            // misbehaving subscriber must not prevent MessageReceived from firing for this
+            // frame — the consumer loop that calls in here does not retry a failed frame,
+            // so an uncaught exception here would silently drop it for every other consumer.
+            RaiseClassifiedEvent(StatusMessageReceived, message, nameof(StatusMessageReceived));
 
             // Raise event for external consumers
             var inboundMessage = new ProtobufMessage(message);
             OnMessageReceived(inboundMessage);
+        }
+
+        /// <summary>
+        /// Invokes a classified message event, isolating the caller from a subscriber exception.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="OnStatusMessageReceived"/> and <see cref="OnStreamMessageReceived"/> still have
+        /// work to do after raising their classified event (the undifferentiated <see cref="MessageReceived"/>
+        /// event, and for <see cref="DaqifiStreamingDevice"/> the per-channel sample decode) — an exception
+        /// escaping a classified-event subscriber must not skip that remaining work for the frame.
+        /// </remarks>
+        /// <param name="handler">The event delegate to invoke, or <c>null</c> if unsubscribed.</param>
+        /// <param name="message">The message to pass to subscribers.</param>
+        /// <param name="eventName">The event name, for the trace log if a subscriber throws.</param>
+        private static void RaiseClassifiedEvent(Action<DaqifiOutMessage>? handler, DaqifiOutMessage message, string eventName)
+        {
+            if (handler == null)
+            {
+                return;
+            }
+
+            try
+            {
+                handler(message);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[{eventName}] Subscriber threw: {ex}");
+            }
         }
 
         /// <summary>
@@ -1378,8 +1410,10 @@ namespace Daqifi.Core.Device
         protected virtual void OnStreamMessageReceived(DaqifiOutMessage message)
         {
             // Raise the classified event first so consumers that only care about streaming
-            // frames can react before the undifferentiated MessageReceived below.
-            StreamMessageReceived?.Invoke(message);
+            // frames can react before the undifferentiated MessageReceived below. See
+            // RaiseClassifiedEvent for why a subscriber exception must not skip that (or, for
+            // DaqifiStreamingDevice, the per-channel decode that runs after this base call).
+            RaiseClassifiedEvent(StreamMessageReceived, message, nameof(StreamMessageReceived));
 
             // Raise event for external consumers
             var inboundMessage = new ProtobufMessage(message);

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -204,6 +204,24 @@ namespace Daqifi.Core.Device
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived;
 
         /// <summary>
+        /// Occurs when an inbound protobuf message is classified as a status message by the
+        /// internal <see cref="ProtobufProtocolHandler"/>. Raised in addition to the
+        /// undifferentiated <see cref="MessageReceived"/> event, so consumers that only need
+        /// the status/stream classification don't have to re-run <c>CanHandle</c> /
+        /// <c>DetectMessageType</c> over the same frame themselves.
+        /// </summary>
+        public event Action<DaqifiOutMessage>? StatusMessageReceived;
+
+        /// <summary>
+        /// Occurs when an inbound protobuf message is classified as a streaming data message by
+        /// the internal <see cref="ProtobufProtocolHandler"/>. Raised in addition to the
+        /// undifferentiated <see cref="MessageReceived"/> event, so consumers that only need
+        /// the status/stream classification don't have to re-run <c>CanHandle</c> /
+        /// <c>DetectMessageType</c> over the same frame themselves.
+        /// </summary>
+        public event Action<DaqifiOutMessage>? StreamMessageReceived;
+
+        /// <summary>
         /// Occurs when channels have been populated from a device status message.
         /// </summary>
         public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated;
@@ -1159,6 +1177,10 @@ namespace Daqifi.Core.Device
             // Populate channels from the status message
             PopulateChannelsFromStatus(message);
 
+            // Raise the classified event first so consumers that only care about status
+            // messages can react before the undifferentiated MessageReceived below.
+            StatusMessageReceived?.Invoke(message);
+
             // Raise event for external consumers
             var inboundMessage = new ProtobufMessage(message);
             OnMessageReceived(inboundMessage);
@@ -1355,6 +1377,10 @@ namespace Daqifi.Core.Device
         /// <param name="message">The streaming message from the device.</param>
         protected virtual void OnStreamMessageReceived(DaqifiOutMessage message)
         {
+            // Raise the classified event first so consumers that only care about streaming
+            // frames can react before the undifferentiated MessageReceived below.
+            StreamMessageReceived?.Invoke(message);
+
             // Raise event for external consumers
             var inboundMessage = new ProtobufMessage(message);
             OnMessageReceived(inboundMessage);


### PR DESCRIPTION
## Summary
- `DaqifiDevice` already classifies inbound protobuf frames into status vs. stream messages internally via `ProtobufProtocolHandler`, but only surfaced the undifferentiated `MessageReceived` event.
- Adds `event Action<DaqifiOutMessage> StatusMessageReceived` and `event Action<DaqifiOutMessage> StreamMessageReceived`, raised from `OnStatusMessageReceived` / `OnStreamMessageReceived` alongside the existing `MessageReceived` event.
- Consumers (e.g. daqifi-desktop) can now use Core's already-computed classification instead of constructing a second `ProtobufProtocolHandler` and re-running `CanHandle`/`DetectMessageType` over the same frame stream.

Closes #308

## Test plan
- [x] `dotnet test src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj` — full suite passes (1485 passed, 2 skipped)
- [x] Added unit tests: `DaqifiDeviceTests.OnStatusMessageReceived_RaisesClassifiedStatusMessageReceived`, `OnStreamMessageReceived_RaisesClassifiedStreamMessageReceived`, `DaqifiStreamingDeviceDecodeTests.Decode_RaisesClassifiedStreamMessageReceived`
- [x] Verified on the physical bench Nyquist device (COM3, FW 3.7.2): connected via `DaqifiDeviceFactory.ConnectSerialAsync`, subscribed to both new events, confirmed `StatusMessageReceived` fired once for the device-info response and `StreamMessageReceived` fired once per streaming frame, with counts matching the undifferentiated `MessageReceived` total exactly (23 = 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)