### PR TITLE
feat(firmware): kick LAN:APPLY once on -200 LAN-not-initialized (closes #203)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/GetLanChipInfoAsyncTests.cs
+++ b/src/Daqifi.Core.Tests/Device/GetLanChipInfoAsyncTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Daqifi.Core.Firmware;
+
+namespace Daqifi.Core.Tests.Device;
+
+public class GetLanChipInfoAsyncTests
+{
+    [Fact]
+    public async Task GetLanChipInfoAsync_WhenDisconnected_Throws()
+    {
+        var device = new TestableLanChipInfoDevice("TestDevice");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => device.GetLanChipInfoAsync());
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoAsync_WhenValidJson_ReturnsParsedInfo()
+    {
+        var device = new TestableLanChipInfoDevice("TestDevice")
+        {
+            CannedTextResponse = { "{\"ChipId\":1377184,\"FwVersion\":\"19.7.7\",\"BuildDate\":\"Mar 30 2022\"}" },
+        };
+        device.Connect();
+
+        var info = await device.GetLanChipInfoAsync();
+
+        Assert.NotNull(info);
+        Assert.Equal("19.7.7", info!.FwVersion);
+        Assert.Equal(1377184, info.ChipId);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoAsync_WhenScpiErrorNegative200_ThrowsLanNotInitialized()
+    {
+        // Closes #203: LAN:ENAbled=1 in saved settings but the WINC1500 state
+        // machine hasn't reached INITIALIZED yet makes GETChipInfo? return
+        // this specific SCPI error instead of JSON.
+        var device = new TestableLanChipInfoDevice("TestDevice")
+        {
+            CannedTextResponse = { "**ERROR: -200, \"Execution error\"" },
+        };
+        device.Connect();
+
+        await Assert.ThrowsAsync<LanNotInitializedException>(() => device.GetLanChipInfoAsync());
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoAsync_WhenUnrelatedScpiError_ReturnsNull()
+    {
+        // Only -200 gets the specific LanNotInitialized treatment; any other
+        // SCPI error still falls back to the generic "unavailable" null.
+        var device = new TestableLanChipInfoDevice("TestDevice")
+        {
+            CannedTextResponse = { "**ERROR: -113, \"Undefined header\"" },
+        };
+        device.Connect();
+
+        var info = await device.GetLanChipInfoAsync();
+
+        Assert.Null(info);
+    }
+
+    /// <summary>
+    /// A streaming device whose text-command exchange returns a canned response, so
+    /// <see cref="DaqifiStreamingDevice.GetLanChipInfoAsync"/> can be tested without a real
+    /// transport (mirrors <c>TestableDiagnosticsDevice</c>).
+    /// </summary>
+    private sealed class TestableLanChipInfoDevice : DaqifiStreamingDevice
+    {
+        public List<string> SentCommands { get; } = new();
+        public List<string> CannedTextResponse { get; } = new();
+
+        public TestableLanChipInfoDevice(string name, IPAddress? ipAddress = null)
+            : base(name, ipAddress)
+        {
+        }
+
+        public override void Send<T>(IOutboundMessage<T> message)
+        {
+            if (message is IOutboundMessage<string> stringMessage)
+            {
+                SentCommands.Add(stringMessage.Data);
+            }
+        }
+
+        protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            Action setupAction,
+            int responseTimeoutMs = 1000,
+            int completionTimeoutMs = 250,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            setupAction();
+            return Task.FromResult<IReadOnlyList<string>>(CannedTextResponse.ToList());
+        }
+
+        protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            Func<CancellationToken, Task> setupActionAsync,
+            int responseTimeoutMs = 1000,
+            int completionTimeoutMs = 250,
+            CancellationToken cancellationToken = default)
+        {
+            await setupActionAsync(cancellationToken).ConfigureAwait(false);
+            return CannedTextResponse.ToList();
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2657,6 +2657,123 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenLanNotInitialized_KicksLanApplyOnceAndRecovers()
+    {
+        // Closes #203: LAN:ENAbled=1 in saved settings but the WINC1500 state
+        // machine hasn't reached INITIALIZED yet makes GETChipInfo? return
+        // SCPI -200 instead of JSON. A single LAN:APPLY resolves it; the
+        // retry loop must send that kick exactly once and then recover.
+        var wifiRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(19, 7, 7, null, 0),
+            TagName = "19.7.7",
+            IsPreRelease = false
+        };
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM22",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1377184,
+                FwVersion = "19.7.7",
+                BuildDate = "Mar 30 2022"
+            },
+            lanNotInitializedFailuresBeforeSuccess: 2);
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5);
+        options.KickLanApplyOnNotInitialized = true;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService { LatestWifiRelease = wifiRelease },
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+        Assert.Equal(1, device.LanApplySentCount);
+        Assert.True(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.UpToDate, status.Reason);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_WhenLanNotInitializedExhaustsRetries_ReturnsLanNotInitialized()
+    {
+        // If the kick doesn't help within the retry budget, the caller should
+        // get the more specific LanNotInitialized reason instead of the
+        // generic ChipInfoUnavailable — same "proceed with flash" behavior,
+        // better diagnostics.
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM23",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1377184,
+                FwVersion = "19.7.7",
+                BuildDate = "Mar 30 2022"
+            },
+            lanNotInitializedFailuresBeforeSuccess: 99);
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5);
+        options.KickLanApplyOnNotInitialized = true;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+        Assert.Equal(1, device.LanApplySentCount);
+        Assert.False(status.IsUpToDate);
+        Assert.Equal(WifiFirmwareStatusReason.LanNotInitialized, status.Reason);
+    }
+
+    [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_KickLanApplyDisabled_DoesNotSendApplyOnNotInitialized()
+    {
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM24",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1377184,
+                FwVersion = "19.7.7",
+                BuildDate = "Mar 30 2022"
+            },
+            lanNotInitializedFailuresBeforeSuccess: 99);
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5);
+        options.KickLanApplyOnNotInitialized = false;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var status = await service.CheckWifiFirmwareStatusAsync(device);
+
+        Assert.Equal(0, device.LanApplySentCount);
+        Assert.Equal(WifiFirmwareStatusReason.LanNotInitialized, status.Reason);
+    }
+
+    [Fact]
     public async Task CheckWifiFirmwareStatusAsync_TotalTimeoutHit_ShortCircuitsToChipInfoUnavailable()
     {
         // Closes a Qodo follow-up on PR #199: per-attempt query timeouts
@@ -3062,22 +3179,28 @@ public class FirmwareUpdateServiceTests
         private readonly LanChipInfo? _chipInfo;
         private ConnectionStatus _status = ConnectionStatus.Connected;
         private int _remainingTransientFailures;
+        private int _remainingLanNotInitializedFailures;
 
         public FakeLanChipInfoStreamingDevice(
             string name,
             LanChipInfo? chipInfo,
             int transientFailuresBeforeSuccess = 0,
-            bool isConnected = true)
+            bool isConnected = true,
+            int lanNotInitializedFailuresBeforeSuccess = 0)
         {
             Name = name;
             _chipInfo = chipInfo;
             _remainingTransientFailures = transientFailuresBeforeSuccess;
+            _remainingLanNotInitializedFailures = lanNotInitializedFailuresBeforeSuccess;
             IsConnected = isConnected;
             if (!isConnected)
             {
                 _status = ConnectionStatus.Disconnected;
             }
         }
+
+        /// <summary>Number of times <c>SYSTem:COMMunicate:LAN:APPLY</c> was sent.</summary>
+        public int LanApplySentCount { get; private set; }
 
         private readonly System.Diagnostics.Stopwatch _eventStopwatch = System.Diagnostics.Stopwatch.StartNew();
 
@@ -3128,6 +3251,10 @@ public class FirmwareUpdateServiceTests
                 {
                     TurnDeviceOnSentAt = _eventStopwatch.Elapsed;
                 }
+                else if (textMessage.Data == "SYSTem:COMMunicate:LAN:APPLY")
+                {
+                    LanApplySentCount++;
+                }
             }
         }
 
@@ -3158,6 +3285,12 @@ public class FirmwareUpdateServiceTests
                 // genuinely-async exception path.
                 return Task.FromException<LanChipInfo?>(
                     new InvalidOperationException("Simulated transient post-reboot failure."));
+            }
+            if (_remainingLanNotInitializedFailures > 0)
+            {
+                _remainingLanNotInitializedFailures--;
+                return Task.FromException<LanChipInfo?>(
+                    new LanNotInitializedException("**ERROR: -200, \"Execution error\""));
             }
             return Task.FromResult(_chipInfo);
         }

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2774,6 +2774,96 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task CheckWifiFirmwareStatusAsync_CancelledDuringLanNotInitializedHandling_DoesNotSendLanApply()
+    {
+        // A cancellation race between the LanNotInitialized detection and the
+        // APPLY kick must not still send the state-changing command — mirrors
+        // the guard already required before the WINC power-on Send.
+        using var cts = new CancellationTokenSource();
+        var device = new CancelingLanChipInfoStreamingDevice("COM25", cts);
+
+        var options = CreateFastOptions();
+        options.LanChipInfoMaxAttempts = 3;
+        options.LanChipInfoRetryDelay = TimeSpan.FromMilliseconds(5);
+        options.KickLanApplyOnNotInitialized = true;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => service.CheckWifiFirmwareStatusAsync(device, cts.Token));
+
+        Assert.Equal(0, device.LanApplySentCount);
+    }
+
+    /// <summary>
+    /// Cancels the supplied <see cref="CancellationTokenSource"/> as soon as
+    /// <see cref="GetLanChipInfoAsync"/> is called, then throws
+    /// <see cref="LanNotInitializedException"/> — simulates cancellation racing
+    /// with the not-initialized detection, before the retry loop's APPLY kick.
+    /// </summary>
+    private sealed class CancelingLanChipInfoStreamingDevice : IStreamingDevice, ILanChipInfoProvider
+    {
+        private readonly CancellationTokenSource _cts;
+
+        public CancelingLanChipInfoStreamingDevice(string name, CancellationTokenSource cts)
+        {
+            Name = name;
+            _cts = cts;
+            IsConnected = true;
+        }
+
+        public int LanApplySentCount { get; private set; }
+
+        public string Name { get; }
+        public IPAddress? IpAddress => null;
+        public bool IsConnected { get; private set; }
+        public ConnectionStatus Status => ConnectionStatus.Connected;
+        public int StreamingFrequency { get; set; }
+        public bool IsStreaming { get; private set; }
+        public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
+        public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
+        public void Connect() => IsConnected = true;
+        public void Disconnect() => IsConnected = false;
+
+        public void Send<T>(IOutboundMessage<T> message)
+        {
+            if (message is IOutboundMessage<string> textMessage && textMessage.Data == "SYSTem:COMMunicate:LAN:APPLY")
+            {
+                LanApplySentCount++;
+            }
+        }
+
+        public void StartStreaming() => IsStreaming = true;
+        public void StopStreaming() => IsStreaming = false;
+        public void EnableChannel(IChannel channel) { }
+        public void EnableChannels(IEnumerable<IChannel> channels) { }
+        public void DisableChannel(IChannel channel) { }
+        public void DisableAllChannels() { }
+        public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
+        public void SetDioValue(IChannel channel, bool value) { }
+        public void SetPwmEnabled(IChannel channel, bool enabled) { }
+        public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent) { }
+        public void SetPwmFrequency(int frequencyHz) { }
+        public int PwmFrequencyHz => 0;
+        public void SetAnalogOutput(int channelNumber, double voltage) { }
+        public void Reboot() => IsConnected = false;
+
+        public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
+        {
+            _cts.Cancel();
+            return Task.FromException<LanChipInfo?>(
+                new LanNotInitializedException("**ERROR: -200, \"Execution error\""));
+        }
+    }
+
+    [Fact]
     public async Task CheckWifiFirmwareStatusAsync_TotalTimeoutHit_ShortCircuitsToChipInfoUnavailable()
     {
         // Closes a Qodo follow-up on PR #199: per-attempt query timeouts

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1749,8 +1749,24 @@ namespace Daqifi.Core.Device
                 responseTimeoutMs: 2000,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            LanChipInfoParser.TryParseLines(lines, out var info);
-            return info;
+            if (LanChipInfoParser.TryParseLines(lines, out var info))
+            {
+                return info;
+            }
+
+            // Closes #203: LAN:ENAbled=1 in saved settings but the WINC1500 state
+            // machine hasn't reached INITIALIZED yet (steady-state, not the
+            // post-reboot transient #144 already retries for) makes GETChipInfo?
+            // return this specific SCPI error instead of JSON. Surface it distinctly
+            // so the caller's retry loop can react (kick LAN:APPLY) instead of just
+            // waiting out a blind delay.
+            var errorLine = lines.LastOrDefault(IsScpiErrorLine);
+            if (errorLine != null && TryParseScpiErrorCode(errorLine, out var errorCode) && errorCode == -200)
+            {
+                throw new LanNotInitializedException(errorLine.Trim());
+            }
+
+            return null;
         }
 
         // -----------------------------------------------------------------

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -1004,13 +1004,20 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
                 if (_options.KickLanApplyOnNotInitialized && !hasSentLanApply && device.IsConnected)
                 {
+                    // Observe cancellation before this state-changing Send, mirroring
+                    // the WINC power-on guard above: a cancelled probe must not still
+                    // kick APPLY on the device. Uses the caller's token (not the
+                    // linked timeout token) so a total-timeout expiry alone doesn't
+                    // suppress a kick the caller never actually asked to cancel.
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     hasSentLanApply = true;
                     try
                     {
                         device.Send(ScpiMessageProducer.ApplyNetworkLan);
                         _logger.LogDebug("Sent LAN:APPLY to initialize the WINC state machine after a not-initialized chip-info response.");
                     }
-                    catch (Exception sendEx)
+                    catch (Exception sendEx) when (sendEx is not OperationCanceledException)
                     {
                         // Best-effort: falling through to the normal retry delay/loop
                         // below still gives the device a chance to recover on its own.

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -791,8 +791,8 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
 
             default:
                 // DeviceDoesNotSupportLanQuery, ChipInfoUnavailable,
-                // LatestReleaseUnavailable, VersionUnparseable — proceed
-                // with the flash conservatively.
+                // LanNotInitialized, LatestReleaseUnavailable,
+                // VersionUnparseable — proceed with the flash conservatively.
                 return false;
         }
     }
@@ -851,13 +851,16 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         // multi-minute reflash of already-current WiFi firmware. The
         // retry budget is bounded (LanChipInfoMaxAttempts × RetryDelay)
         // and observes cancellation between attempts.
-        var chipInfo = await TryGetLanChipInfoWithRetryAsync(lanChipInfoProvider, cancellationToken).ConfigureAwait(false);
+        var (chipInfo, wasLanNotInitialized) = await TryGetLanChipInfoWithRetryAsync(
+            device, lanChipInfoProvider, cancellationToken).ConfigureAwait(false);
         if (chipInfo == null)
         {
             return new WifiFirmwareStatus
             {
                 IsUpToDate = false,
-                Reason = WifiFirmwareStatusReason.ChipInfoUnavailable,
+                Reason = wasLanNotInitialized
+                    ? WifiFirmwareStatusReason.LanNotInitialized
+                    : WifiFirmwareStatusReason.ChipInfoUnavailable,
             };
         }
 
@@ -914,13 +917,25 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         };
     }
 
-    private async Task<LanChipInfo?> TryGetLanChipInfoWithRetryAsync(
+    private async Task<(LanChipInfo? ChipInfo, bool WasLanNotInitialized)> TryGetLanChipInfoWithRetryAsync(
+        IStreamingDevice device,
         ILanChipInfoProvider lanChipInfoProvider,
         CancellationToken cancellationToken)
     {
         var maxAttempts = Math.Max(1, _options.LanChipInfoMaxAttempts);
         var retryDelay = _options.LanChipInfoRetryDelay;
         var totalTimeout = _options.LanChipInfoTotalTimeout;
+
+        // Tracks the most recent failure's classification (reset on any
+        // non-LanNotInitialized outcome) so the caller can report the
+        // specific WifiFirmwareStatusReason.LanNotInitialized only when
+        // that was genuinely the terminal condition, not stale from an
+        // earlier attempt. Sent at most once per probe (closes #203) —
+        // repeatedly kicking APPLY would tear down and re-init the WINC
+        // on every failed attempt, risking disruption of an already-
+        // associated WiFi link for no additional benefit.
+        var lastFailureWasLanNotInitialized = false;
+        var hasSentLanApply = false;
 
         // Wall-clock budget guards against the pathological case where
         // attempt-count × per-attempt-timeout + retry-delay sum vastly
@@ -946,7 +961,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                     totalTimeout,
                     attempt,
                     maxAttempts);
-                return null;
+                return (null, lastFailureWasLanNotInitialized);
             }
 
             try
@@ -961,8 +976,9 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                             attempt,
                             maxAttempts);
                     }
-                    return chipInfo;
+                    return (chipInfo, false);
                 }
+                lastFailureWasLanNotInitialized = false;
                 _logger.LogDebug(
                     "LAN chip-info query returned null on attempt {Attempt}/{Max}.",
                     attempt,
@@ -975,10 +991,36 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                     totalTimeout,
                     attempt,
                     maxAttempts);
-                return null;
+                return (null, lastFailureWasLanNotInitialized);
+            }
+            catch (LanNotInitializedException ex)
+            {
+                lastFailureWasLanNotInitialized = true;
+                _logger.LogDebug(
+                    ex,
+                    "LAN chip-info query on attempt {Attempt}/{Max} reported the WINC state machine is not initialized.",
+                    attempt,
+                    maxAttempts);
+
+                if (_options.KickLanApplyOnNotInitialized && !hasSentLanApply && device.IsConnected)
+                {
+                    hasSentLanApply = true;
+                    try
+                    {
+                        device.Send(ScpiMessageProducer.ApplyNetworkLan);
+                        _logger.LogDebug("Sent LAN:APPLY to initialize the WINC state machine after a not-initialized chip-info response.");
+                    }
+                    catch (Exception sendEx)
+                    {
+                        // Best-effort: falling through to the normal retry delay/loop
+                        // below still gives the device a chance to recover on its own.
+                        _logger.LogDebug(sendEx, "Failed to send LAN:APPLY after a not-initialized chip-info response; continuing retry loop without it.");
+                    }
+                }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                lastFailureWasLanNotInitialized = false;
                 _logger.LogDebug(
                     ex,
                     "LAN chip-info query failed on attempt {Attempt}/{Max}.",
@@ -999,15 +1041,16 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
                         totalTimeout,
                         attempt,
                         maxAttempts);
-                    return null;
+                    return (null, lastFailureWasLanNotInitialized);
                 }
             }
         }
 
         _logger.LogDebug(
-            "LAN chip-info query exhausted {Max} attempts; reporting status as ChipInfoUnavailable.",
-            maxAttempts);
-        return null;
+            "LAN chip-info query exhausted {Max} attempts; reporting status as {Reason}.",
+            maxAttempts,
+            lastFailureWasLanNotInitialized ? WifiFirmwareStatusReason.LanNotInitialized : WifiFirmwareStatusReason.ChipInfoUnavailable);
+        return (null, lastFailureWasLanNotInitialized);
     }
 
     private ExternalProcessRequest BuildWifiProcessRequest(

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -285,6 +285,21 @@ public sealed class FirmwareUpdateServiceOptions
     public TimeSpan PowerOnWifiModuleSettleDelay { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
+    /// When true, the LAN chip-info retry loop sends
+    /// <see cref="Communication.Producers.ScpiMessageProducer.ApplyNetworkLan"/> once, the
+    /// first time a <c>GETChipInfo?</c> probe reports SCPI <c>-200</c> (the WINC1500 state
+    /// machine is not yet initialized even though <c>LAN:ENAbled? = 1</c>), then continues
+    /// retrying within the existing budget. Without this, that steady-state condition (as
+    /// opposed to the post-reboot transient #144 already retries for) exhausts the retry
+    /// budget and reports <see cref="WifiFirmwareStatusReason.LanNotInitialized"/>, sending
+    /// callers into a needless multi-minute reflash of already-current WiFi firmware
+    /// (closes #203). Sent at most once per probe to avoid repeatedly tearing down and
+    /// re-initializing an already-associated WiFi link. Defaults to <c>true</c>; set to
+    /// <c>false</c> to restore the legacy behavior of retrying without ever sending APPLY.
+    /// </summary>
+    public bool KickLanApplyOnNotInitialized { get; set; } = true;
+
+    /// <summary>
     /// Gets the configured timeout for a given firmware update state.
     /// </summary>
     /// <param name="state">The target state.</param>

--- a/src/Daqifi.Core/Firmware/ILanChipInfoProvider.cs
+++ b/src/Daqifi.Core/Firmware/ILanChipInfoProvider.cs
@@ -15,5 +15,9 @@ public interface ILanChipInfoProvider
     /// The parsed <see cref="LanChipInfo"/>, or <see langword="null"/> if the device
     /// did not return a recognizable response.
     /// </returns>
+    /// <exception cref="LanNotInitializedException">
+    /// The device reported SCPI <c>-200</c> ("Execution error") — its WiFi module is
+    /// enabled in saved settings but its state machine has not been initialized yet.
+    /// </exception>
     Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Daqifi.Core/Firmware/LanNotInitializedException.cs
+++ b/src/Daqifi.Core/Firmware/LanNotInitializedException.cs
@@ -1,0 +1,22 @@
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// Thrown by <see cref="ILanChipInfoProvider.GetLanChipInfoAsync"/> when the device
+/// responds to <c>SYSTem:COMMunicate:LAN:GETChipInfo?</c> with a SCPI <c>-200</c>
+/// ("Execution error") instead of JSON. This is distinct from a generic unparseable
+/// response: it means the WiFi module's saved settings report enabled
+/// (<c>LAN:ENAbled? = 1</c>) but the WINC1500 state machine has not reached
+/// <c>INITIALIZED</c> yet — a steady-state condition, not the transient post-reboot
+/// startup window already covered by bounded retry (closes #144). A single
+/// <c>SYSTem:COMMunicate:LAN:APPLY</c> resolves it within a couple of seconds (#203).
+/// </summary>
+public sealed class LanNotInitializedException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="LanNotInitializedException"/>.
+    /// </summary>
+    /// <param name="message">The raw SCPI error line reported by the device.</param>
+    public LanNotInitializedException(string message) : base(message)
+    {
+    }
+}

--- a/src/Daqifi.Core/Firmware/WifiFirmwareStatus.cs
+++ b/src/Daqifi.Core/Firmware/WifiFirmwareStatus.cs
@@ -59,6 +59,15 @@ public enum WifiFirmwareStatusReason
     /// <summary>Querying the device for chip info failed.</summary>
     ChipInfoUnavailable,
 
+    /// <summary>
+    /// The WiFi module's saved settings report enabled (<c>LAN:ENAbled? = 1</c>) but
+    /// its state machine was still not initialized (SCPI <c>-200</c>) even after a
+    /// single <c>LAN:APPLY</c> kick and exhausting the retry budget. Distinct from
+    /// <see cref="ChipInfoUnavailable"/> so callers can tell "known not-yet-ready
+    /// state, already nudged" apart from a genuinely unresponsive device.
+    /// </summary>
+    LanNotInitialized,
+
     /// <summary>Looking up the latest release on GitHub failed.</summary>
     LatestReleaseUnavailable,
 

--- a/src/Daqifi.Core/Firmware/WifiFirmwareStatus.cs
+++ b/src/Daqifi.Core/Firmware/WifiFirmwareStatus.cs
@@ -61,10 +61,13 @@ public enum WifiFirmwareStatusReason
 
     /// <summary>
     /// The WiFi module's saved settings report enabled (<c>LAN:ENAbled? = 1</c>) but
-    /// its state machine was still not initialized (SCPI <c>-200</c>) even after a
-    /// single <c>LAN:APPLY</c> kick and exhausting the retry budget. Distinct from
+    /// its state machine was still not initialized (SCPI <c>-200</c>) after exhausting
+    /// the retry budget. When <see cref="FirmwareUpdateServiceOptions.KickLanApplyOnNotInitialized"/>
+    /// is enabled and the device was connected, Core also attempted a one-shot
+    /// <c>LAN:APPLY</c> kick before giving up — but this reason is reported either way,
+    /// so it does not by itself confirm a kick was sent. Distinct from
     /// <see cref="ChipInfoUnavailable"/> so callers can tell "known not-yet-ready
-    /// state, already nudged" apart from a genuinely unresponsive device.
+    /// state" apart from a genuinely unresponsive device.
     /// </summary>
     LanNotInitialized,
 


### PR DESCRIPTION
## Summary

- `CheckWifiFirmwareStatusAsync`'s bounded chip-info retry (added in #198 for #144) only covers the *transient* post-PIC32-reboot window. A distinct steady-state failure — `LAN:ENAbled? = 1` in saved settings but the WINC1500 state machine not yet `INITIALIZED` — makes `GETChipInfo?` return SCPI `-200` instead of JSON, exhausting the retry budget and forcing a needless multi-minute WiFi reflash even when firmware is already current.
- `DaqifiStreamingDevice.GetLanChipInfoAsync` now throws a new `LanNotInitializedException` when it detects that specific `-200` line (reusing the existing `IsScpiErrorLine`/`TryParseScpiErrorCode` helpers), instead of silently returning `null` like any other unparseable response.
- `FirmwareUpdateService`'s retry loop catches that exception distinctly, sends `SYSTem:COMMunicate:LAN:APPLY` **once** per probe (new `KickLanApplyOnNotInitialized` option, default `true`, mirroring the `PowerOnWifiModuleBeforeProbe` pattern from #320), and keeps retrying within the existing budget.
- If retries still exhaust, `WifiFirmwareStatus.Reason` reports the new `WifiFirmwareStatusReason.LanNotInitialized` instead of the generic `ChipInfoUnavailable` — same conservative "proceed with flash" behavior for callers, better diagnostics.

This implements options 1+3 from the issue (the issue's own text notes they "pair naturally" — option 3 alone wouldn't have fixed the actual reflash bug, and option 2 pushes the fix onto callers who'd have to remember to call it).

## Test plan

- [x] `dotnet test` — full suite passes (1495/1497, 2 pre-existing skips unrelated to this change)
- [x] New unit tests: `-200` detection at the `DaqifiStreamingDevice.GetLanChipInfoAsync` layer (`GetLanChipInfoAsyncTests.cs`), and end-to-end retry/kick/reason behavior at the `FirmwareUpdateService` layer (kick sent exactly once, recovers to `UpToDate`, reports `LanNotInitialized` on exhaustion, respects the new option flag)
- [x] Verified against the real bench Nq1 (same hardware referenced in the issue, SN with ChipId 1377184 / FW 19.7.7) — `GetLanChipInfoAsync` still succeeds normally post-fix, confirming no regression on the healthy path. Attempted to reproduce the exact `-200` steady-state via a fresh power cycle; it did not reproduce this run (the condition is timing-dependent per the issue itself), so the recovery path itself is validated by the deterministic unit tests above rather than live on hardware this session.

Closes #203.