### PR TITLE
fix(firmware): isolate WifiBridgeActivator against uncancellable SerialPort.Open() hangs

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
@@ -51,4 +51,138 @@ public class WifiBridgeActivatorTests
     {
         Assert.ThrowsAny<Exception>(() => WifiBridgeActivator.Deactivate("COM999"));
     }
+
+    [Fact]
+    public async Task ActivateAsync_NullPortName_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => WifiBridgeActivator.ActivateAsync(null!));
+    }
+
+    [Fact]
+    public async Task ActivateAsync_AlreadyCancelled_ThrowsBeforeOpeningPort()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => WifiBridgeActivator.ActivateAsync("COM999", cts.Token));
+    }
+
+    [Fact]
+    public async Task ActivateAsync_InvalidPort_PropagatesUnderlyingException()
+    {
+        await Assert.ThrowsAnyAsync<Exception>(() => WifiBridgeActivator.ActivateAsync("COM999"));
+    }
+
+    [Fact]
+    public async Task DeactivateAsync_NullPortName_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => WifiBridgeActivator.DeactivateAsync(null!));
+    }
+
+    [Fact]
+    public async Task DeactivateAsync_AlreadyCancelled_ThrowsBeforeOpeningPort()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => WifiBridgeActivator.DeactivateAsync("COM999", cts.Token));
+    }
+
+    [Fact]
+    public async Task DeactivateAsync_InvalidPort_PropagatesUnderlyingException()
+    {
+        await Assert.ThrowsAnyAsync<Exception>(() => WifiBridgeActivator.DeactivateAsync("COM999"));
+    }
+
+    [Fact]
+    public async Task RunWithHardTimeoutAsync_OperationCompletes_Succeeds()
+    {
+        var ran = false;
+
+        await WifiBridgeActivator.RunWithHardTimeoutAsync(
+            () => ran = true,
+            "TestOp",
+            CancellationToken.None);
+
+        Assert.True(ran);
+    }
+
+    [Fact]
+    public async Task RunWithHardTimeoutAsync_OperationThrows_PropagatesException()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            WifiBridgeActivator.RunWithHardTimeoutAsync(
+                () => throw new InvalidOperationException("boom"),
+                "TestOp",
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RunWithHardTimeoutAsync_UncancellableHang_ThrowsTimeoutExceptionAndAbandonsTask()
+    {
+        var originalTimeout = WifiBridgeActivator.HardTimeoutMs;
+        WifiBridgeActivator.HardTimeoutMs = 50;
+        try
+        {
+            var released = new ManualResetEventSlim(false);
+
+            var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+                WifiBridgeActivator.RunWithHardTimeoutAsync(
+                    () =>
+                    {
+                        // Simulates SerialPort.Open()'s uncancellable native hang: this
+                        // blocking wait ignores the hard timeout entirely and only
+                        // completes when the test releases it below.
+                        released.Wait();
+                        throw new InvalidOperationException("late failure after abandonment");
+                    },
+                    "TestOp",
+                    CancellationToken.None));
+
+            Assert.Contains("TestOp", ex.Message);
+            Assert.Contains("50ms", ex.Message);
+
+            // Let the abandoned worker task finish so its continuation observes the
+            // fault; if this were left unobserved it would surface as an
+            // UnobservedTaskException on GC, which the isolation pattern must avoid.
+            released.Set();
+            await Task.Delay(50);
+        }
+        finally
+        {
+            WifiBridgeActivator.HardTimeoutMs = originalTimeout;
+        }
+    }
+
+    [Fact]
+    public async Task RunWithHardTimeoutAsync_CallerCancelledBeforeTimeout_ThrowsOperationCanceledException()
+    {
+        var originalTimeout = WifiBridgeActivator.HardTimeoutMs;
+        WifiBridgeActivator.HardTimeoutMs = 5000;
+        try
+        {
+            using var cts = new CancellationTokenSource();
+            var released = new ManualResetEventSlim(false);
+
+            var runTask = WifiBridgeActivator.RunWithHardTimeoutAsync(
+                () =>
+                {
+                    released.Wait();
+                },
+                "TestOp",
+                cts.Token);
+
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => runTask);
+
+            released.Set();
+        }
+        finally
+        {
+            WifiBridgeActivator.HardTimeoutMs = originalTimeout;
+        }
+    }
 }

--- a/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
@@ -102,7 +102,7 @@ public class WifiBridgeActivatorTests
         var ran = false;
 
         await WifiBridgeActivator.RunWithHardTimeoutAsync(
-            () => ran = true,
+            _ => ran = true,
             "TestOp",
             CancellationToken.None);
 
@@ -114,7 +114,7 @@ public class WifiBridgeActivatorTests
     {
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             WifiBridgeActivator.RunWithHardTimeoutAsync(
-                () => throw new InvalidOperationException("boom"),
+                _ => throw new InvalidOperationException("boom"),
                 "TestOp",
                 CancellationToken.None));
     }
@@ -130,7 +130,7 @@ public class WifiBridgeActivatorTests
 
             var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
                 WifiBridgeActivator.RunWithHardTimeoutAsync(
-                    () =>
+                    _ =>
                     {
                         // Simulates SerialPort.Open()'s uncancellable native hang: this
                         // blocking wait ignores the hard timeout entirely and only
@@ -167,7 +167,7 @@ public class WifiBridgeActivatorTests
             var released = new ManualResetEventSlim(false);
 
             var runTask = WifiBridgeActivator.RunWithHardTimeoutAsync(
-                () =>
+                _ =>
                 {
                     released.Wait();
                 },
@@ -179,6 +179,49 @@ public class WifiBridgeActivatorTests
             await Assert.ThrowsAsync<OperationCanceledException>(() => runTask);
 
             released.Set();
+        }
+        finally
+        {
+            WifiBridgeActivator.HardTimeoutMs = originalTimeout;
+        }
+    }
+
+    [Fact]
+    public async Task RunWithHardTimeoutAsync_HardTimeoutElapses_StopsWorkerBeforeLateStep()
+    {
+        // Qodo review #326 finding #2: once the hard timeout fires, an operation that
+        // is still running (e.g. Open() returned late) must observe cancellation via
+        // the token it was given and stop before performing a further state-changing
+        // step, rather than being left free to run to completion after the caller
+        // already received a TimeoutException.
+        var originalTimeout = WifiBridgeActivator.HardTimeoutMs;
+        WifiBridgeActivator.HardTimeoutMs = 50;
+        try
+        {
+            var lateStepRan = false;
+            var lateStepGate = new ManualResetEventSlim(false);
+
+            var runTask = WifiBridgeActivator.RunWithHardTimeoutAsync(
+                token =>
+                {
+                    // Simulates Open() blocking well past the hard timeout, then
+                    // finally returning — the operation must check the token before
+                    // doing anything further.
+                    lateStepGate.Wait();
+                    token.ThrowIfCancellationRequested();
+                    lateStepRan = true;
+                },
+                "TestOp",
+                CancellationToken.None);
+
+            await Assert.ThrowsAsync<TimeoutException>(() => runTask);
+
+            // Only now let the blocked operation proceed, well after the internal
+            // hard-timeout token should already be cancelled.
+            lateStepGate.Set();
+            await Task.Delay(50);
+
+            Assert.False(lateStepRan);
         }
         finally
         {

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -187,13 +187,21 @@ public static class WifiBridgeActivator
         var hardTimeoutCts = new CancellationTokenSource(hardTimeoutMs);
         var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, hardTimeoutCts.Token);
 
-        // Task.Run: the operation's SerialPort.Open() and blocking stream writes
-        // would otherwise run on the CALLING thread up to first await — on a UI
-        // thread that means a stuck open freezes the window. Pass
-        // CancellationToken.None to Task.Run itself: the inner token still
-        // cancels the operation's own delays; we never want "cancelled before
-        // start" to look like an operation fault.
-        var workerTask = Task.Run(() => operation(linkedCts.Token), CancellationToken.None);
+        // LongRunning (a dedicated thread, not a pooled one): the operation's
+        // SerialPort.Open() and blocking stream writes would otherwise run on the
+        // CALLING thread up to first await — on a UI thread that means a stuck open
+        // freezes the window. A plain Task.Run would occupy a thread-pool worker for
+        // the operation's full (potentially unbounded) blocking duration; under
+        // thread-pool pressure that can starve the pool queue the hardTimeoutCts
+        // timer callback also runs on, delaying the very cancellation this method
+        // exists to deliver. Pass CancellationToken.None to StartNew itself: the
+        // inner token still cancels the operation's own delays; we never want
+        // "cancelled before start" to look like an operation fault.
+        var workerTask = Task.Factory.StartNew(
+            () => operation(linkedCts.Token),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
 
         try
         {

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -129,7 +129,7 @@ public static class WifiBridgeActivator
         cancellationToken.ThrowIfCancellationRequested();
 
         return RunWithHardTimeoutAsync(
-            () => Activate(portName, cancellationToken),
+            token => Activate(portName, token),
             nameof(ActivateAsync),
             cancellationToken);
     }
@@ -151,7 +151,7 @@ public static class WifiBridgeActivator
         cancellationToken.ThrowIfCancellationRequested();
 
         return RunWithHardTimeoutAsync(
-            () => Deactivate(portName, cancellationToken),
+            token => Deactivate(portName, token),
             nameof(DeactivateAsync),
             cancellationToken);
     }
@@ -164,46 +164,91 @@ public static class WifiBridgeActivator
     /// abandonment path directly with a synthetic hang, without needing a real
     /// wedged serial port.
     /// </summary>
-    /// <param name="operation">The synchronous operation to isolate.</param>
+    /// <param name="operation">
+    /// The synchronous operation to isolate. Receives a token that is already
+    /// cancelled once the hard timeout elapses — <see cref="Activate(string, CancellationToken)"/>
+    /// / <see cref="Deactivate(string, CancellationToken)"/> observe it between
+    /// port-open and each subsequent delay/write, so a late-returning
+    /// <see cref="System.IO.Ports.SerialPort.Open"/> still stops the sequence
+    /// before it sends any SCPI command (Qodo review #326 #2: a late open must
+    /// not let an abandoned worker mutate device state after the caller already
+    /// received a <see cref="TimeoutException"/>).
+    /// </param>
     /// <param name="operationName">Used only in the <see cref="TimeoutException"/> message.</param>
     /// <param name="cancellationToken">Cancellation token observed while waiting for the worker task.</param>
-    internal static async Task RunWithHardTimeoutAsync(Action operation, string operationName, CancellationToken cancellationToken)
+    internal static async Task RunWithHardTimeoutAsync(Action<CancellationToken> operation, string operationName, CancellationToken cancellationToken)
     {
+        var hardTimeoutMs = HardTimeoutMs;
+
+        // hardTimeoutCts fires on its own timer independent of the Task.Delay race
+        // below, so it reaches the worker even if Open() only returns long after
+        // the race has already been decided. linkedCts is what the worker actually
+        // observes: caller cancellation OR the hard timeout, whichever comes first.
+        var hardTimeoutCts = new CancellationTokenSource(hardTimeoutMs);
+        var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, hardTimeoutCts.Token);
+
         // Task.Run: the operation's SerialPort.Open() and blocking stream writes
         // would otherwise run on the CALLING thread up to first await — on a UI
         // thread that means a stuck open freezes the window. Pass
         // CancellationToken.None to Task.Run itself: the inner token still
         // cancels the operation's own delays; we never want "cancelled before
         // start" to look like an operation fault.
-        var workerTask = Task.Run(operation, CancellationToken.None);
+        var workerTask = Task.Run(() => operation(linkedCts.Token), CancellationToken.None);
 
-        var winner = await Task.WhenAny(
-            workerTask,
-            Task.Delay(HardTimeoutMs, cancellationToken)).ConfigureAwait(false);
-
-        if (winner == workerTask)
+        try
         {
+            var winner = await Task.WhenAny(
+                workerTask,
+                Task.Delay(hardTimeoutMs, cancellationToken)).ConfigureAwait(false);
+
+            // Only abandon when the worker is genuinely still running. WhenAny can
+            // return the delay/cancellation task even though workerTask completed
+            // right at that same boundary — awaiting it below instead of throwing
+            // honors that result instead of discarding it (Qodo review #326 #1,
+            // same race SerialDeviceFinder guards against per #295).
+            if (winner != workerTask && !workerTask.IsCompleted)
+            {
+                // Open() is uncancellable, so on timeout/cancellation the worker task
+                // is ABANDONED rather than awaited — it may still be blocked in native
+                // I/O. Observe its eventual fault so it can't surface as an
+                // UnobservedTaskException once the stuck I/O finally completes, and
+                // dispose the token sources only once the worker is done with them
+                // (disposing early would make its still-pending WaitOrCancel/
+                // WriteCommand calls throw ObjectDisposedException instead of
+                // observing cancellation).
+                _ = workerTask.ContinueWith(
+                    t =>
+                    {
+                        _ = t.Exception;
+                        linkedCts.Dispose();
+                        hardTimeoutCts.Dispose();
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+
+                // Prefer surfacing caller cancellation over a generic timeout when
+                // both raced at once.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                throw new TimeoutException(
+                    $"{operationName} did not complete within {hardTimeoutMs}ms; the serial port open may be permanently blocked.");
+            }
+
             // Propagate success or the operation's own exception unchanged.
             await workerTask.ConfigureAwait(false);
-            return;
         }
-
-        // Open() is uncancellable, so on timeout/cancellation the worker task is
-        // ABANDONED rather than awaited — it may still be blocked in native I/O.
-        // Observe its eventual fault so it can't surface as an
-        // UnobservedTaskException once the stuck I/O finally completes.
-        _ = workerTask.ContinueWith(
-            t => { _ = t.Exception; },
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
-
-        // Prefer surfacing caller cancellation over a generic timeout when both
-        // raced at once.
-        cancellationToken.ThrowIfCancellationRequested();
-
-        throw new TimeoutException(
-            $"{operationName} did not complete within {HardTimeoutMs}ms; the serial port open may be permanently blocked.");
+        finally
+        {
+            // The abandon path above transfers disposal ownership to its own
+            // continuation instead — only dispose here when the worker already
+            // finished (the common, non-hung case).
+            if (workerTask.IsCompleted)
+            {
+                linkedCts.Dispose();
+                hardTimeoutCts.Dispose();
+            }
+        }
     }
 
     private static void WriteCommand(SerialStreamTransport transport, IOutboundMessage<string> message, CancellationToken cancellationToken)

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -17,6 +17,19 @@ namespace Daqifi.Core.Firmware;
 /// pair with the timing the firmware's WiFi-deinit/reinit state machine
 /// expects, then closes the port so it can be handed back.
 /// </remarks>
+/// <remarks>
+/// <see cref="Activate(string, CancellationToken)"/> and
+/// <see cref="Deactivate(string, CancellationToken)"/> call
+/// <see cref="SerialStreamTransport.Connect"/> synchronously, which ultimately
+/// calls <see cref="System.IO.Ports.SerialPort.Open"/>. That call can hang
+/// uncancellably in native code (see the discovery-side isolation in
+/// <c>SerialDeviceFinder</c>, #294/#295) — a stuck open blocks the calling
+/// thread indefinitely and no <see cref="CancellationToken"/> can interrupt it
+/// once the call has begun. Do not call the synchronous overloads from a UI
+/// thread; prefer <see cref="ActivateAsync(string, CancellationToken)"/> /
+/// <see cref="DeactivateAsync(string, CancellationToken)"/>, which isolate the
+/// call onto a worker task and race it against a hard timeout.
+/// </remarks>
 public static class WifiBridgeActivator
 {
     // USB CDC virtual ports ignore the baud rate, but firmware checks DTR
@@ -25,6 +38,17 @@ public static class WifiBridgeActivator
     private static readonly TimeSpan DtrSettleDelay = TimeSpan.FromMilliseconds(200);
     private static readonly TimeSpan InterCommandDelay = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan ApplySettleDelay = TimeSpan.FromMilliseconds(300);
+
+    // Hard ceiling for the async overloads' worker task. The healthy path costs
+    // ~600ms of scripted delays (DtrSettleDelay + InterCommandDelay +
+    // ApplySettleDelay) plus Open() and two near-instant writes; 5s gives
+    // generous headroom for a slow open while still abandoning a genuinely
+    // wedged port (SerialPort.Open() stuck in native GetCommState, same failure
+    // mode as #294) in bounded time instead of hanging forever.
+    private const int DefaultHardTimeoutMs = 5000;
+
+    // Internal so tests can shrink the hard timeout instead of waiting 5s per case.
+    internal static int HardTimeoutMs { get; set; } = DefaultHardTimeoutMs;
 
     /// <summary>
     /// Briefly opens <paramref name="portName"/>, sends the SCPI sequence that
@@ -86,6 +110,100 @@ public static class WifiBridgeActivator
 
         // Give firmware time to enqueue APPLY before the port closes.
         WaitOrCancel(ApplySettleDelay, cancellationToken);
+    }
+
+    /// <summary>
+    /// Async, isolated equivalent of <see cref="Activate(string, CancellationToken)"/>.
+    /// Runs the synchronous sequence on a worker task and races it against a
+    /// hard timeout, so a wedged <see cref="System.IO.Ports.SerialPort.Open"/>
+    /// cannot block the caller indefinitely.
+    /// </summary>
+    /// <param name="portName">The serial port name (e.g. <c>COM5</c>, <c>/dev/cu.usbmodem1</c>).</param>
+    /// <param name="cancellationToken">Cancellation token observed up front and while waiting for the worker task.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="portName"/> is null.</exception>
+    /// <exception cref="OperationCanceledException">Cancellation was requested.</exception>
+    /// <exception cref="TimeoutException">The worker task did not complete within the hard timeout.</exception>
+    public static Task ActivateAsync(string portName, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(portName);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return RunWithHardTimeoutAsync(
+            () => Activate(portName, cancellationToken),
+            nameof(ActivateAsync),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Async, isolated equivalent of <see cref="Deactivate(string, CancellationToken)"/>.
+    /// Runs the synchronous sequence on a worker task and races it against a
+    /// hard timeout, so a wedged <see cref="System.IO.Ports.SerialPort.Open"/>
+    /// cannot block the caller indefinitely.
+    /// </summary>
+    /// <param name="portName">The serial port name (e.g. <c>COM5</c>, <c>/dev/cu.usbmodem1</c>).</param>
+    /// <param name="cancellationToken">Cancellation token observed up front and while waiting for the worker task.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="portName"/> is null.</exception>
+    /// <exception cref="OperationCanceledException">Cancellation was requested.</exception>
+    /// <exception cref="TimeoutException">The worker task did not complete within the hard timeout.</exception>
+    public static Task DeactivateAsync(string portName, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(portName);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return RunWithHardTimeoutAsync(
+            () => Deactivate(portName, cancellationToken),
+            nameof(DeactivateAsync),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="operation"/> on a worker task and races it against
+    /// <see cref="HardTimeoutMs"/>, mirroring the isolation pattern
+    /// <c>SerialDeviceFinder</c> uses around <see cref="System.IO.Ports.SerialPort.Open"/>
+    /// (#294/#295). Internal (not private) so tests can exercise the timeout /
+    /// abandonment path directly with a synthetic hang, without needing a real
+    /// wedged serial port.
+    /// </summary>
+    /// <param name="operation">The synchronous operation to isolate.</param>
+    /// <param name="operationName">Used only in the <see cref="TimeoutException"/> message.</param>
+    /// <param name="cancellationToken">Cancellation token observed while waiting for the worker task.</param>
+    internal static async Task RunWithHardTimeoutAsync(Action operation, string operationName, CancellationToken cancellationToken)
+    {
+        // Task.Run: the operation's SerialPort.Open() and blocking stream writes
+        // would otherwise run on the CALLING thread up to first await — on a UI
+        // thread that means a stuck open freezes the window. Pass
+        // CancellationToken.None to Task.Run itself: the inner token still
+        // cancels the operation's own delays; we never want "cancelled before
+        // start" to look like an operation fault.
+        var workerTask = Task.Run(operation, CancellationToken.None);
+
+        var winner = await Task.WhenAny(
+            workerTask,
+            Task.Delay(HardTimeoutMs, cancellationToken)).ConfigureAwait(false);
+
+        if (winner == workerTask)
+        {
+            // Propagate success or the operation's own exception unchanged.
+            await workerTask.ConfigureAwait(false);
+            return;
+        }
+
+        // Open() is uncancellable, so on timeout/cancellation the worker task is
+        // ABANDONED rather than awaited — it may still be blocked in native I/O.
+        // Observe its eventual fault so it can't surface as an
+        // UnobservedTaskException once the stuck I/O finally completes.
+        _ = workerTask.ContinueWith(
+            t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        // Prefer surfacing caller cancellation over a generic timeout when both
+        // raced at once.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        throw new TimeoutException(
+            $"{operationName} did not complete within {HardTimeoutMs}ms; the serial port open may be permanently blocked.");
     }
 
     private static void WriteCommand(SerialStreamTransport transport, IOutboundMessage<string> message, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- `WifiBridgeActivator.Activate`/`Deactivate` call `SerialStreamTransport.Connect()` → `SerialPort.Open()` synchronously, which can hang uncancellably in native code — the same failure mode already documented and isolated in `SerialDeviceFinder` (#294/#295). A caller's `CancellationToken` cannot interrupt `Activate`/`Deactivate` once `Connect()` begins.
- Adds `ActivateAsync`/`DeactivateAsync` that isolate the existing synchronous sequence onto a worker task (`Task.Run`) and race it against a 5s hard timeout (`Task.WhenAny`). On timeout/cancellation the worker task is abandoned (since `Open()` is uncancellable) rather than awaited, and its eventual fault is observed via a continuation so it can't surface as an `UnobservedTaskException`.
- Existing synchronous `Activate`/`Deactivate` are unchanged; the class docs now note they must not be called from a UI thread and point callers at the async overloads.

Closes #316.

## Test plan
- [x] `dotnet test` — full suite green (1523 passed, 0 failed)
- [x] New unit tests cover null/cancelled/invalid-port paths for both async methods, plus direct exercise of the internal `RunWithHardTimeoutAsync` isolation helper (success, exception propagation, timeout+abandonment, cancellation-races-timeout)
- [x] Bench tested `ActivateAsync` → `DeactivateAsync` against a real Nyquist NQ1 device over USB serial — both completed normally (806ms / 609ms), well under the 5s timeout, confirming the isolation wrapper doesn't disturb the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)