### PR TITLE
feat(channel): validate AnalogChannel bounds + cover bipolar scaling (closes #300, #297)

### DIFF
--- a/src/Daqifi.Core.Tests/Channel/AnalogChannelTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/AnalogChannelTests.cs
@@ -276,6 +276,196 @@ public class AnalogChannelTests
         Assert.Equal(5.0, channel.PortRange);
     }
 
+    // ---------------------------------------------------------------------
+    // Bounds validation (daqifi-core#300)
+    // ---------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(254u)]        // just below the 8-bit max-count floor
+    [InlineData(16_777_217u)] // just above the 24-bit max-count ceiling
+    public void Constructor_WithOutOfRangeResolution_ThrowsException(uint resolution)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AnalogChannel(channelNumber: 0, resolution: resolution));
+    }
+
+    [Theory]
+    [InlineData(255u)]         // 8-bit max-count floor
+    [InlineData(16_777_216u)]  // 24-bit ceiling
+    public void Constructor_WithBoundaryResolution_IsAccepted(uint resolution)
+    {
+        var channel = new AnalogChannel(channelNumber: 0, resolution: resolution);
+        Assert.Equal(resolution, channel.Resolution);
+    }
+
+    [Theory]
+    [InlineData(0.0)]                        // zero range
+    [InlineData(-5.0)]                       // negative range
+    [InlineData(AnalogChannel.MaxPortRangeVolts + 0.1)] // beyond max
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void PortRange_WithInvalidValue_ThrowsException(double value)
+    {
+        var channel = new AnalogChannel(0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => channel.PortRange = value);
+    }
+
+    [Theory]
+    [InlineData(0.0)]  // zero scale factor discards the measurement
+    [InlineData(double.NaN)]
+    [InlineData(double.NegativeInfinity)]
+    [InlineData(AnalogChannel.MaxCalibrationMagnitude * 2)]
+    public void CalibrationM_WithInvalidValue_ThrowsException(double value)
+    {
+        var channel = new AnalogChannel(0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => channel.CalibrationM = value);
+    }
+
+    [Fact]
+    public void CalibrationM_WithNegativeValue_IsAccepted()
+    {
+        // A negative slope legitimately inverts the signal (e.g. reversed wiring).
+        var channel = new AnalogChannel(0) { CalibrationM = -2.5 };
+        Assert.Equal(-2.5, channel.CalibrationM);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(AnalogChannel.MaxCalibrationMagnitude * 2)]
+    public void CalibrationB_WithInvalidValue_ThrowsException(double value)
+    {
+        var channel = new AnalogChannel(0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => channel.CalibrationB = value);
+    }
+
+    [Fact]
+    public void CalibrationB_WithZero_IsAccepted()
+    {
+        // Zero is a valid offset (it's the default).
+        var channel = new AnalogChannel(0) { CalibrationB = 0.0 };
+        Assert.Equal(0.0, channel.CalibrationB);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void InternalScaleM_WithInvalidValue_ThrowsException(double value)
+    {
+        var channel = new AnalogChannel(0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => channel.InternalScaleM = value);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.NegativeInfinity)]
+    public void MinValue_WithNonFinite_ThrowsException(double value)
+    {
+        var channel = new AnalogChannel(0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => channel.MinValue = value);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void MaxValue_WithNonFinite_ThrowsException(double value)
+    {
+        var channel = new AnalogChannel(0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => channel.MaxValue = value);
+    }
+
+    [Fact]
+    public void PortRange_AtMaxBoundary_IsAccepted()
+    {
+        var channel = new AnalogChannel(0) { PortRange = AnalogChannel.MaxPortRangeVolts };
+        Assert.Equal(AnalogChannel.MaxPortRangeVolts, channel.PortRange);
+    }
+
+    // ---------------------------------------------------------------------
+    // Bipolar / signed scaling (daqifi-core#297)
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void GetScaledValue_WithNegativeRawValue_ProducesNegativeVoltage()
+    {
+        // ±10V bipolar range: signed two's-complement raw counts should map straight through
+        // to signed voltages with no unipolar-only assumption in the formula.
+        var channel = new AnalogChannel(0, 262143)
+        {
+            PortRange = 10.0,
+            CalibrationM = 1.0,
+            CalibrationB = 0.0,
+            InternalScaleM = 1.0,
+            MinValue = -10.0,
+            MaxValue = 10.0
+        };
+
+        // -full scale -> -PortRange
+        Assert.Equal(-10.0, channel.GetScaledValue(-262143), precision: 6);
+        // -half scale -> -PortRange/2
+        Assert.Equal(-5.0, channel.GetScaledValue(-131072), precision: 2);
+        // zero raw -> 0 V (no offset)
+        Assert.Equal(0.0, channel.GetScaledValue(0), precision: 6);
+    }
+
+    [Fact]
+    public void GetScaledValue_IsSymmetricAboutZeroForBipolarRange()
+    {
+        var channel = new AnalogChannel(0, 65535)
+        {
+            PortRange = 5.0,
+            CalibrationM = 1.0,
+            CalibrationB = 0.0,
+            InternalScaleM = 1.0
+        };
+
+        var positive = channel.GetScaledValue(20000);
+        var negative = channel.GetScaledValue(-20000);
+
+        Assert.Equal(-positive, negative, precision: 9);
+    }
+
+    [Fact]
+    public void GetScaledValue_WithNegativeRawAndOffset_AppliesOffsetAfterSignedGain()
+    {
+        // Formula: (raw/Res * PortRange * M + B) * InternalScaleM.
+        // At -full scale with M=1, B=1: (-1 * 10 * 1 + 1) = -9.
+        var channel = new AnalogChannel(0, 262143)
+        {
+            PortRange = 10.0,
+            CalibrationM = 1.0,
+            CalibrationB = 1.0,
+            InternalScaleM = 1.0
+        };
+
+        Assert.Equal(-9.0, channel.GetScaledValue(-262143), precision: 6);
+    }
+
+    [Fact]
+    public void GetScaledValue_WithNegativeCalibrationM_InvertsSign()
+    {
+        var channel = new AnalogChannel(0, 65535)
+        {
+            PortRange = 10.0,
+            CalibrationM = -1.0,
+            CalibrationB = 0.0,
+            InternalScaleM = 1.0
+        };
+
+        // A negative raw with an inverting slope yields a positive voltage.
+        Assert.Equal(10.0, channel.GetScaledValue(-65535), precision: 6);
+    }
+
+    [Fact]
+    public void IsBipolar_ReflectsConfiguredMinValue()
+    {
+        var bipolar = new AnalogChannel(0) { MinValue = -10.0, MaxValue = 10.0 };
+        Assert.True(bipolar.IsBipolar);
+
+        var unipolar = new AnalogChannel(0) { MinValue = 0.0, MaxValue = 10.0 };
+        Assert.False(unipolar.IsBipolar);
+    }
+
     [Fact]
     public void ToString_ReturnsChannelName()
     {

--- a/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
@@ -270,6 +270,40 @@ public class ChannelPopulationTests
         Assert.Equal(5.0, analogChannels[1].PortRange, 3);
     }
 
+    [Theory]
+    [InlineData(0u)]            // missing resolution
+    [InlineData(1u)]            // non-zero but below MinResolution
+    [InlineData(uint.MaxValue)] // above MaxResolution
+    public void PopulateChannelsFromStatus_WithUnusableResolution_FallsBackWithoutThrowing(uint reportedResolution)
+    {
+        // A non-zero but out-of-range AnalogInRes must not reach the AnalogChannel constructor
+        // (which now rejects it) and abort channel population — it should fall back to the assumed
+        // default and flag ResolutionIsAssumed, on both the new-channel and reuse paths.
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 2,
+            AnalogInRes = reportedResolution
+        };
+
+        // First population creates the channels; second re-populates (exercises the reuse path via
+        // UpdateScalingFromStatus) — neither should throw.
+        device.PopulateChannelsFromStatus(message);
+        device.PopulateChannelsFromStatus(message);
+
+        var analogChannels = device.Channels
+            .Where(c => c.Type == ChannelType.Analog)
+            .Cast<IAnalogChannel>()
+            .ToList();
+
+        Assert.Equal(2, analogChannels.Count);
+        foreach (var ch in analogChannels)
+        {
+            Assert.Equal(65535u, ch.Resolution);
+            Assert.True(ch.ResolutionIsAssumed);
+        }
+    }
+
     [Fact]
     public void PopulateChannelsFromStatus_AnalogChannelsHaveCorrectResolution()
     {

--- a/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
@@ -230,6 +230,47 @@ public class ChannelPopulationTests
     }
 
     [Fact]
+    public void PopulateChannelsFromStatus_WithCorruptScalingValues_SubstitutesSafeDefaultsWithoutThrowing()
+    {
+        // A corrupted device response can carry NaN/Infinity or nonsensical coefficients. Population
+        // must not throw (which would abort channel population mid-stream) and must fall back to safe
+        // defaults rather than propagating garbage into every scaled sample (daqifi-core#300).
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 2,
+            AnalogInRes = 65535
+        };
+        message.AnalogInCalM.Add(float.NaN);            // ch0: invalid -> default 1.0
+        message.AnalogInCalM.Add(2.0f);                 // ch1: valid
+        message.AnalogInCalB.Add(float.PositiveInfinity); // ch0: invalid -> default 0.0
+        message.AnalogInCalB.Add(0.2f);                 // ch1: valid
+        message.AnalogInIntScaleM.Add(0.0f);            // ch0: zero scale -> default 1.0
+        message.AnalogInIntScaleM.Add(1.2f);            // ch1: valid
+        message.AnalogInPortRange.Add(-10.0f);          // ch0: negative range -> default 1.0
+        message.AnalogInPortRange.Add(5.0f);            // ch1: valid
+
+        device.PopulateChannelsFromStatus(message);
+
+        var analogChannels = device.Channels
+            .Where(c => c.Type == ChannelType.Analog)
+            .Cast<IAnalogChannel>()
+            .ToList();
+
+        // ch0 fell back to defaults across the board
+        Assert.Equal(1.0, analogChannels[0].CalibrationM, 3);
+        Assert.Equal(0.0, analogChannels[0].CalibrationB, 3);
+        Assert.Equal(1.0, analogChannels[0].InternalScaleM, 3);
+        Assert.Equal(1.0, analogChannels[0].PortRange, 3);
+
+        // ch1's valid values were preserved
+        Assert.Equal(2.0, analogChannels[1].CalibrationM, 3);
+        Assert.Equal(0.2, analogChannels[1].CalibrationB, 3);
+        Assert.Equal(1.2, analogChannels[1].InternalScaleM, 3);
+        Assert.Equal(5.0, analogChannels[1].PortRange, 3);
+    }
+
+    [Fact]
     public void PopulateChannelsFromStatus_AnalogChannelsHaveCorrectResolution()
     {
         // Arrange

--- a/src/Daqifi.Core/Channel/AnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogChannel.cs
@@ -5,6 +5,33 @@ namespace Daqifi.Core.Channel;
 /// </summary>
 public class AnalogChannel : IAnalogChannel
 {
+    /// <summary>
+    /// Smallest <see cref="Resolution"/> (maximum raw count) accepted as a physically plausible ADC
+    /// resolution — 255, i.e. 2^8 - 1 for an 8-bit converter. <see cref="Resolution"/> is stored as
+    /// the maximum raw count (2^bits - 1), not the bit depth, so this is the max-count for 8 bits.
+    /// </summary>
+    public const uint MinResolution = 255;
+
+    /// <summary>
+    /// Largest <see cref="Resolution"/> (maximum raw count) accepted as a physically plausible ADC
+    /// resolution — 16,777,216, covering 24-bit converters whether reported as 2^24 or 2^24 - 1.
+    /// </summary>
+    public const uint MaxResolution = 16_777_216;
+
+    /// <summary>
+    /// Largest absolute <see cref="PortRange"/>, in volts, accepted as physically reasonable. DAQiFi
+    /// hardware tops out at ±10V differential ranges; 50 leaves generous headroom while still
+    /// rejecting nonsensical values.
+    /// </summary>
+    public const double MaxPortRangeVolts = 50.0;
+
+    /// <summary>
+    /// Largest absolute magnitude accepted for the multiplicative/offset calibration coefficients
+    /// (<see cref="CalibrationM"/>, <see cref="CalibrationB"/>, <see cref="InternalScaleM"/>). Values
+    /// beyond this indicate a corrupted coefficient rather than a real calibration.
+    /// </summary>
+    public const double MaxCalibrationMagnitude = 1_000_000.0;
+
     private readonly object _lock = new();
     private IDataSample? _activeSample;
     private string _name;
@@ -76,7 +103,11 @@ public class AnalogChannel : IAnalogChannel
     public double MinValue
     {
         get { lock (_lock) { return _minValue; } }
-        set { lock (_lock) { _minValue = value; } }
+        set
+        {
+            RequireFinite(value, nameof(MinValue));
+            lock (_lock) { _minValue = value; }
+        }
     }
 
     /// <summary>
@@ -85,7 +116,28 @@ public class AnalogChannel : IAnalogChannel
     public double MaxValue
     {
         get { lock (_lock) { return _maxValue; } }
-        set { lock (_lock) { _maxValue = value; } }
+        set
+        {
+            RequireFinite(value, nameof(MaxValue));
+            lock (_lock) { _maxValue = value; }
+        }
+    }
+
+    /// <summary>
+    /// Gets whether the configured display range (<see cref="MinValue"/>..<see cref="MaxValue"/>) is
+    /// bipolar — i.e. spans negative voltages, as the ±1V/±5V/±10V differential ranges do — rather
+    /// than unipolar (0V-and-up). Derived purely from <see cref="MinValue"/>, which a consumer sets
+    /// when selecting a range; lets range-selection UI branch on polarity without hardcoding
+    /// per-device assumptions.
+    /// </summary>
+    /// <remarks>
+    /// Whether the device actually emits signed two's-complement raw counts and per-range calibration
+    /// for a given bipolar range is firmware-dependent and tracked separately (daqifi-core#297); this
+    /// property reflects the configured range only.
+    /// </remarks>
+    public bool IsBipolar
+    {
+        get { lock (_lock) { return _minValue < 0.0; } }
     }
 
     /// <summary>
@@ -119,7 +171,11 @@ public class AnalogChannel : IAnalogChannel
     public double CalibrationM
     {
         get { lock (_lock) { return _calibrationM; } }
-        set { lock (_lock) { _calibrationM = value; } }
+        set
+        {
+            ValidateScaleFactor(value, nameof(CalibrationM));
+            lock (_lock) { _calibrationM = value; }
+        }
     }
 
     /// <summary>
@@ -128,7 +184,11 @@ public class AnalogChannel : IAnalogChannel
     public double CalibrationB
     {
         get { lock (_lock) { return _calibrationB; } }
-        set { lock (_lock) { _calibrationB = value; } }
+        set
+        {
+            ValidateOffset(value, nameof(CalibrationB));
+            lock (_lock) { _calibrationB = value; }
+        }
     }
 
     /// <summary>
@@ -137,7 +197,11 @@ public class AnalogChannel : IAnalogChannel
     public double InternalScaleM
     {
         get { lock (_lock) { return _internalScaleM; } }
-        set { lock (_lock) { _internalScaleM = value; } }
+        set
+        {
+            ValidateScaleFactor(value, nameof(InternalScaleM));
+            lock (_lock) { _internalScaleM = value; }
+        }
     }
 
     /// <summary>
@@ -146,7 +210,11 @@ public class AnalogChannel : IAnalogChannel
     public double PortRange
     {
         get { lock (_lock) { return _portRange; } }
-        set { lock (_lock) { _portRange = value; } }
+        set
+        {
+            ValidatePortRange(value, nameof(PortRange));
+            lock (_lock) { _portRange = value; }
+        }
     }
 
     /// <summary>
@@ -167,8 +235,7 @@ public class AnalogChannel : IAnalogChannel
         if (channelNumber < 0)
             throw new ArgumentOutOfRangeException(nameof(channelNumber), "Channel number must be non-negative.");
 
-        if (resolution == 0)
-            throw new ArgumentOutOfRangeException(nameof(resolution), "Resolution must be greater than zero.");
+        ValidateResolution(resolution, nameof(resolution));
 
         ChannelNumber = channelNumber;
         _resolution = resolution;
@@ -256,5 +323,78 @@ public class AnalogChannel : IAnalogChannel
     public override string ToString()
     {
         return Name;
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="resolution"/> is a physically plausible ADC max-count, in
+    /// <see cref="MinResolution"/>..<see cref="MaxResolution"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="resolution"/> is outside the valid range.</exception>
+    internal static void ValidateResolution(uint resolution, string paramName)
+    {
+        if (resolution is < MinResolution or > MaxResolution)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName, resolution,
+                $"Resolution must be a plausible ADC max-count between {MinResolution} and {MaxResolution}.");
+        }
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="value"/> is a physically reasonable port (voltage) range:
+    /// finite, positive, and no larger than <see cref="MaxPortRangeVolts"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is not a valid range.</exception>
+    internal static void ValidatePortRange(double value, string paramName)
+    {
+        if (!double.IsFinite(value) || value <= 0.0 || value > MaxPortRangeVolts)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName, value,
+                $"Port range must be a finite value in (0, {MaxPortRangeVolts}] volts.");
+        }
+    }
+
+    /// <summary>
+    /// Validates a multiplicative scale factor (<see cref="CalibrationM"/>/<see cref="InternalScaleM"/>):
+    /// finite, non-zero, and within ±<see cref="MaxCalibrationMagnitude"/>. Negative factors are allowed
+    /// (they invert the signal); zero is not (it discards the measurement entirely).
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is not a valid scale factor.</exception>
+    internal static void ValidateScaleFactor(double value, string paramName)
+    {
+        if (!double.IsFinite(value) || value == 0.0 || Math.Abs(value) > MaxCalibrationMagnitude)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName, value,
+                $"Scale factor must be a finite, non-zero value within ±{MaxCalibrationMagnitude}.");
+        }
+    }
+
+    /// <summary>
+    /// Validates a calibration offset (<see cref="CalibrationB"/>): finite and within
+    /// ±<see cref="MaxCalibrationMagnitude"/>. Zero is a valid offset.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is not a valid offset.</exception>
+    internal static void ValidateOffset(double value, string paramName)
+    {
+        if (!double.IsFinite(value) || Math.Abs(value) > MaxCalibrationMagnitude)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName, value,
+                $"Calibration offset must be a finite value within ±{MaxCalibrationMagnitude}.");
+        }
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="value"/> is finite (rejects NaN/Infinity).
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is not finite.</exception>
+    internal static void RequireFinite(double value, string paramName)
+    {
+        if (!double.IsFinite(value))
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, "Value must be a finite number.");
+        }
     }
 }

--- a/src/Daqifi.Core/Channel/IAnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/IAnalogChannel.cs
@@ -16,6 +16,13 @@ public interface IAnalogChannel : IChannel
     double MaxValue { get; set; }
 
     /// <summary>
+    /// Gets whether the configured display range (<see cref="MinValue"/>..<see cref="MaxValue"/>) is
+    /// bipolar (spans negative voltages, as ±1V/±5V/±10V differential ranges do) rather than unipolar
+    /// (0V-and-up). Lets range-selection UI branch on polarity without hardcoding per-device assumptions.
+    /// </summary>
+    bool IsBipolar { get; }
+
+    /// <summary>
     /// Gets the resolution of the ADC, expressed as the maximum raw count (e.g., 65535 for 16-bit,
     /// 262143 for 18-bit) — i.e. 2^bits - 1, not 2^bits. This value is a direct divisor in
     /// <see cref="GetScaledValue"/>.

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1328,12 +1328,19 @@ namespace Daqifi.Core.Device
             var analogInResolution = message.AnalogInRes;
 
             var count = (int)message.AnalogInPortNum;
-            var resolutionIsAssumed = analogInResolution == 0;
-            var resolution = analogInResolution > 0 ? analogInResolution : 65535;
+
+            // Treat both a missing (0) and a physically-implausible out-of-range resolution as
+            // "assumed": the AnalogChannel constructor/setters now reject anything outside
+            // [MinResolution, MaxResolution], so passing a corrupt non-zero value straight through
+            // would throw and abort channel population mid-stream. Fall back to a safe default and
+            // log instead, so a corrupted status frame can neither crash population nor silently
+            // corrupt every scaled sample on the reuse path (UpdateScalingFromStatus below).
+            var resolutionIsAssumed = analogInResolution is < AnalogChannel.MinResolution or > AnalogChannel.MaxResolution;
+            var resolution = resolutionIsAssumed ? 65535u : analogInResolution;
 
             if (resolutionIsAssumed && count > 0)
             {
-                Trace.WriteLine($"[PopulateAnalogChannels] Device '{Name}' reported no ADC resolution (analog_in_res=0) for {count} analog channel(s); assuming {resolution}. Scaled samples on this device may be systematically wrong.");
+                Trace.WriteLine($"[PopulateAnalogChannels] Device '{Name}' reported no usable ADC resolution (analog_in_res={analogInResolution}) for {count} analog channel(s); assuming {resolution}. Scaled samples on this device may be systematically wrong.");
             }
 
             for (var i = 0; i < count; i++)

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1343,6 +1343,16 @@ namespace Daqifi.Core.Device
                 var internalScaleM = GetWithDefault(analogInInternalScaleMValues, i, 1.0f);
                 var portRange = GetWithDefault(analogInPortRanges, i, 1.0f);
 
+                // A corrupted device response can carry NaN/Infinity or physically nonsensical
+                // scaling coefficients. Feeding those into AnalogChannel would either throw from its
+                // validating setters (killing channel population mid-stream) or silently propagate
+                // garbage into every scaled sample. Fall back to safe defaults and log instead —
+                // mirroring the analog_in_res=0 handling above.
+                calibrationB = (float)SanitizeScalingValue(calibrationB, 0.0, AnalogChannel.MaxCalibrationMagnitude, requireNonZero: false, i, nameof(calibrationB));
+                calibrationM = (float)SanitizeScalingValue(calibrationM, 1.0, AnalogChannel.MaxCalibrationMagnitude, requireNonZero: true, i, nameof(calibrationM));
+                internalScaleM = (float)SanitizeScalingValue(internalScaleM, 1.0, AnalogChannel.MaxCalibrationMagnitude, requireNonZero: true, i, nameof(internalScaleM));
+                portRange = (float)SanitizePortRange(portRange, i);
+
                 if (existingByKey.TryGetValue((ChannelType.Analog, i), out var existing) && existing is AnalogChannel existingAnalog)
                 {
                     existingAnalog.UpdateScalingFromStatus(resolution, calibrationB, calibrationM, internalScaleM, portRange, resolutionIsAssumed);
@@ -1365,6 +1375,42 @@ namespace Daqifi.Core.Device
             }
 
             return count;
+        }
+
+        /// <summary>
+        /// Clamps a device-reported calibration/scale coefficient to a value <see cref="AnalogChannel"/>
+        /// will accept, substituting <paramref name="fallback"/> and logging when the reported value is
+        /// non-finite, out of magnitude range, or (when <paramref name="requireNonZero"/>) zero.
+        /// </summary>
+        private double SanitizeScalingValue(double value, double fallback, double maxMagnitude, bool requireNonZero, int channelIndex, string fieldName)
+        {
+            var invalid = !double.IsFinite(value)
+                || Math.Abs(value) > maxMagnitude
+                || (requireNonZero && value == 0.0);
+
+            if (invalid)
+            {
+                Trace.WriteLine($"[PopulateAnalogChannels] Device '{Name}' reported invalid {fieldName}={value} for analog channel {channelIndex}; substituting {fallback}. Scaled samples on this channel may be affected.");
+                return fallback;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Clamps a device-reported port range to a value <see cref="AnalogChannel"/> will accept,
+        /// substituting the 1.0 default and logging when the reported value is non-finite, non-positive,
+        /// or beyond <see cref="AnalogChannel.MaxPortRangeVolts"/>.
+        /// </summary>
+        private double SanitizePortRange(double value, int channelIndex)
+        {
+            if (!double.IsFinite(value) || value <= 0.0 || value > AnalogChannel.MaxPortRangeVolts)
+            {
+                Trace.WriteLine($"[PopulateAnalogChannels] Device '{Name}' reported invalid portRange={value} for analog channel {channelIndex}; substituting 1.0. Scaled samples on this channel may be affected.");
+                return 1.0;
+            }
+
+            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Hardens `AnalogChannel` against physically-nonsensical scaling inputs (#300) and locks in signed/bipolar scaling behavior with explicit test coverage plus a range-polarity accessor for consuming UIs (#297).

Closes #300. Closes #297.

## #300 — bounds validation
- Constructor and the `PortRange` / `CalibrationM` / `CalibrationB` / `InternalScaleM` / `MinValue` / `MaxValue` setters now reject invalid values with informative `ArgumentOutOfRangeException`s, consistent with the existing constructor style:
  - **Resolution**: must be a plausible ADC max-count in `[255, 16_777_216]` (8–24 bit).
  - **PortRange**: finite, `0 < x <= 50` V.
  - **CalibrationM / InternalScaleM**: finite, non-zero, within `±1e6`. Negative allowed (signal inversion); zero rejected (discards the measurement).
  - **CalibrationB**: finite, within `±1e6`. Zero allowed.
  - **Min/MaxValue**: reject NaN/Infinity.
  - Bounds exposed as `public const`s.
- **Device population is kept robust**: `DaqifiDevice.PopulateAnalogChannels` sanitizes device-reported coefficients (NaN/Infinity/out-of-range/zero-scale) to safe defaults with a `Trace` log before they reach the validating setters — mirroring the existing `analog_in_res=0` fallback. A corrupted status frame can neither crash channel population mid-stream nor silently propagate garbage into scaled samples.

## #297 — bipolar / signed scaling
- Added explicit `GetScaledValue` coverage for negative/signed raw counts across representative bipolar range + calibration combinations: full-/half-scale sign, zero-point, symmetry about zero, offset-after-signed-gain, and inverting slope.
- Added `IAnalogChannel.IsBipolar` (derived from the configured `MinValue`) so range-selection UIs can branch on polarity without hardcoding per-device assumptions. Firmware confirmation that differential inputs emit signed two's-complement counts remains tracked separately (out of scope here).

## Tests
- `AnalogChannelTests`: validation (valid/invalid/boundary) + signed/bipolar scaling + `IsBipolar`.
- `ChannelPopulationTests`: regression test that a status frame with corrupt scaling values yields defaulted channels without throwing.
- Full suite green (1556 passing).

## Bench test
Built the example CLI against this worktree's `Daqifi.Core` and streamed a real Nyquist over USB (`/dev/cu.usbmodem1101`, 10 Hz, ch0+1, 3 s): channels populated, samples flowed with validation active, exit code 0 — normal device data passes the new validation unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)