### PR TITLE
feat(device): wire remaining NVM persistence SCPI commands (closes #207)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -407,6 +407,54 @@ public class ScpiMessageProducerTests
     }
 
     [Fact]
+    public void LoadNetworkLan_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.LoadNetworkLan;
+        Assert.Equal("SYSTem:COMMunicate:LAN:LOAD", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void FactoryResetNetworkLan_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.FactoryResetNetworkLan;
+        Assert.Equal("SYSTem:COMMunicate:LAN:FACRESET", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SaveAdcCalibration_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SaveAdcCalibration;
+        Assert.Equal("CONFigure:ADC:SAVEcal", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void LoadAdcCalibration_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.LoadAdcCalibration;
+        Assert.Equal("CONFigure:ADC:LOADcal", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SaveVoltagePrecision_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SaveVoltagePrecision;
+        Assert.Equal("CONFigure:VOLTage:SAVE", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void LoadVoltagePrecision_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.LoadVoltagePrecision;
+        Assert.Equal("CONFigure:VOLTage:LOAD", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
     public void SetLanFirmwareUpdateMode_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.SetLanFirmwareUpdateMode;

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceTests.cs
@@ -79,6 +79,59 @@ namespace Daqifi.Core.Tests.Device
             Assert.Equal("Device is not connected.", exception.Message);
         }
 
+        // ---------------------------------------------------------------------
+        // ADC calibration & voltage-precision NVM persistence (daqifi-core#207)
+        // ---------------------------------------------------------------------
+
+        public static IEnumerable<object[]> NvmPersistenceCommands()
+        {
+            yield return new object[] { "SaveAdcCalibration", "CONFigure:ADC:SAVEcal" };
+            yield return new object[] { "LoadAdcCalibration", "CONFigure:ADC:LOADcal" };
+            yield return new object[] { "SaveVoltagePrecision", "CONFigure:VOLTage:SAVE" };
+            yield return new object[] { "LoadVoltagePrecision", "CONFigure:VOLTage:LOAD" };
+        }
+
+        private static void InvokeNvmMethod(IStreamingDevice device, string methodName)
+        {
+            switch (methodName)
+            {
+                case "SaveAdcCalibration": device.SaveAdcCalibration(); break;
+                case "LoadAdcCalibration": device.LoadAdcCalibration(); break;
+                case "SaveVoltagePrecision": device.SaveVoltagePrecision(); break;
+                case "LoadVoltagePrecision": device.LoadVoltagePrecision(); break;
+                default: throw new System.ArgumentOutOfRangeException(nameof(methodName), methodName, null);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NvmPersistenceCommands))]
+        public void NvmPersistence_WhenConnected_SendsCorrectCommand(string methodName, string expectedCommand)
+        {
+            // Arrange
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            InvokeNvmMethod(device, methodName);
+
+            // Assert
+            var sentMessage = Assert.Single(device.SentMessages);
+            Assert.Equal(expectedCommand, sentMessage.Data);
+        }
+
+        [Theory]
+        [MemberData(nameof(NvmPersistenceCommands))]
+        public void NvmPersistence_WhenDisconnected_ThrowsInvalidOperationException(string methodName, string expectedCommand)
+        {
+            // Arrange
+            _ = expectedCommand;
+            var device = new DaqifiStreamingDevice("TestDevice");
+
+            // Act & Assert
+            var exception = Assert.Throws<System.InvalidOperationException>(() => InvokeNvmMethod(device, methodName));
+            Assert.Equal("Device is not connected.", exception.Message);
+        }
+
         /// <summary>
         /// A testable version of DaqifiStreamingDevice that captures sent messages.
         /// </summary>

--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
@@ -454,6 +454,63 @@ namespace Daqifi.Core.Tests.Device.Network
             Assert.Contains("Unsupported WiFi security type", exception.Message);
         }
 
+        [Fact]
+        public async Task LoadNetworkConfigurationAsync_WhenDisconnected_ThrowsInvalidOperationException()
+        {
+            var device = new DaqifiStreamingDevice("TestDevice");
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.LoadNetworkConfigurationAsync());
+            Assert.Equal("Device is not connected.", exception.Message);
+        }
+
+        [Fact]
+        public async Task LoadNetworkConfigurationAsync_WhenConnected_SendsLoadCommand()
+        {
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+
+            await device.LoadNetworkConfigurationAsync();
+
+            var sentMessage = Assert.Single(device.SentMessages);
+            Assert.Equal("SYSTem:COMMunicate:LAN:LOAD", sentMessage.Data);
+        }
+
+        [Fact]
+        public async Task LoadNetworkConfigurationAsync_WhenCanceled_ThrowsOperationCanceledException()
+        {
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => device.LoadNetworkConfigurationAsync(cts.Token));
+            Assert.Empty(device.SentMessages);
+        }
+
+        [Fact]
+        public async Task FactoryResetNetworkAsync_WhenDisconnected_ThrowsInvalidOperationException()
+        {
+            var device = new DaqifiStreamingDevice("TestDevice");
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.FactoryResetNetworkAsync());
+            Assert.Equal("Device is not connected.", exception.Message);
+        }
+
+        [Fact]
+        public async Task FactoryResetNetworkAsync_WhenConnected_SendsFactoryResetCommand()
+        {
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+
+            await device.FactoryResetNetworkAsync();
+
+            var sentMessage = Assert.Single(device.SentMessages);
+            Assert.Equal("SYSTem:COMMunicate:LAN:FACRESET", sentMessage.Data);
+        }
+
         /// <summary>
         /// A testable version of DaqifiStreamingDevice that captures sent messages.
         /// </summary>

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2854,6 +2854,10 @@ public class FirmwareUpdateServiceTests
         public int PwmFrequencyHz => 0;
         public void SetAnalogOutput(int channelNumber, double voltage) { }
         public void Reboot() => IsConnected = false;
+        public void SaveAdcCalibration() { }
+        public void LoadAdcCalibration() { }
+        public void SaveVoltagePrecision() { }
+        public void LoadVoltagePrecision() { }
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
@@ -2941,6 +2945,10 @@ public class FirmwareUpdateServiceTests
         public int PwmFrequencyHz => 0;
         public void SetAnalogOutput(int channelNumber, double voltage) { }
         public void Reboot() => IsConnected = false;
+        public void SaveAdcCalibration() { }
+        public void LoadAdcCalibration() { }
+        public void SaveVoltagePrecision() { }
+        public void LoadVoltagePrecision() { }
         public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
             await Task.Delay(_attemptLatency, cancellationToken).ConfigureAwait(false);
@@ -3262,6 +3270,10 @@ public class FirmwareUpdateServiceTests
         public int PwmFrequencyHz => 0;
         public void SetAnalogOutput(int channelNumber, double voltage) { }
         public void Reboot() => Disconnect();
+        public void SaveAdcCalibration() { }
+        public void LoadAdcCalibration() { }
+        public void SaveVoltagePrecision() { }
+        public void LoadVoltagePrecision() { }
     }
 
     private sealed class FakeLanChipInfoStreamingDevice : IStreamingDevice, ILanChipInfoProvider
@@ -3362,6 +3374,10 @@ public class FirmwareUpdateServiceTests
         public int PwmFrequencyHz => 0;
         public void SetAnalogOutput(int channelNumber, double voltage) { }
         public void Reboot() => Disconnect();
+        public void SaveAdcCalibration() { }
+        public void LoadAdcCalibration() { }
+        public void SaveVoltagePrecision() { }
+        public void LoadVoltagePrecision() { }
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -614,6 +614,53 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> UpdateDacOutputs => new ScpiMessage("CONFigure:DAC:UPDATE");
 
+    // ---------------------------------------------------------------------
+    // ADC calibration & voltage-precision persistence
+    //
+    // Firmware persists the ADC calibration coefficients and the voltage
+    // precision setting in NVM. These commands are thin wrappers over those
+    // firmware primitives — save writes the current runtime values to NVM,
+    // load restores them from NVM into the runtime.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Creates a command message to persist the current ADC calibration coefficients to NVM.
+    /// </summary>
+    /// <remarks>
+    /// Command: CONFigure:ADC:SAVEcal
+    /// Example: messageProducer.Send(ScpiMessageProducer.SaveAdcCalibration);
+    /// </remarks>
+    public static IOutboundMessage<string> SaveAdcCalibration => new ScpiMessage("CONFigure:ADC:SAVEcal");
+
+    /// <summary>
+    /// Creates a command message to restore the ADC calibration coefficients from NVM into the runtime.
+    /// </summary>
+    /// <remarks>
+    /// The inverse of <see cref="SaveAdcCalibration"/>.
+    /// Command: CONFigure:ADC:LOADcal
+    /// Example: messageProducer.Send(ScpiMessageProducer.LoadAdcCalibration);
+    /// </remarks>
+    public static IOutboundMessage<string> LoadAdcCalibration => new ScpiMessage("CONFigure:ADC:LOADcal");
+
+    /// <summary>
+    /// Creates a command message to persist the current voltage precision setting to NVM.
+    /// </summary>
+    /// <remarks>
+    /// Command: CONFigure:VOLTage:SAVE
+    /// Example: messageProducer.Send(ScpiMessageProducer.SaveVoltagePrecision);
+    /// </remarks>
+    public static IOutboundMessage<string> SaveVoltagePrecision => new ScpiMessage("CONFigure:VOLTage:SAVE");
+
+    /// <summary>
+    /// Creates a command message to restore the voltage precision setting from NVM into the runtime.
+    /// </summary>
+    /// <remarks>
+    /// The inverse of <see cref="SaveVoltagePrecision"/>.
+    /// Command: CONFigure:VOLTage:LOAD
+    /// Example: messageProducer.Send(ScpiMessageProducer.LoadVoltagePrecision);
+    /// </remarks>
+    public static IOutboundMessage<string> LoadVoltagePrecision => new ScpiMessage("CONFigure:VOLTage:LOAD");
+
     /// <summary>
     /// Creates a command message to set the device to create its own WiFi network (Self-Hosted mode).
     /// </summary>
@@ -813,6 +860,29 @@ public class ScpiMessageProducer
     /// Command: SYSTem:COMMunicate:LAN:SAVE
     /// </remarks>
     public static IOutboundMessage<string> SaveNetworkLan => new ScpiMessage("SYSTem:COMMunicate:LAN:SAVE");
+
+    /// <summary>
+    /// Creates a command message to load the persisted LAN configuration from NVM into the device's
+    /// runtime WiFi settings.
+    /// </summary>
+    /// <remarks>
+    /// The inverse of <see cref="SaveNetworkLan"/>: it repopulates the runtime settings from the last
+    /// saved values. Apply the loaded values to the interface with <see cref="ApplyNetworkLan"/> (or a
+    /// reboot) for them to take effect on the live connection.
+    /// Command: SYSTem:COMMunicate:LAN:LOAD
+    /// </remarks>
+    public static IOutboundMessage<string> LoadNetworkLan => new ScpiMessage("SYSTem:COMMunicate:LAN:LOAD");
+
+    /// <summary>
+    /// Creates a command message to reset the LAN configuration to firmware defaults.
+    /// </summary>
+    /// <remarks>
+    /// Restores the factory default WiFi settings into the device's runtime settings. Persist the
+    /// reset with <see cref="SaveNetworkLan"/> and/or apply it with <see cref="ApplyNetworkLan"/> for
+    /// it to take effect.
+    /// Command: SYSTem:COMMunicate:LAN:FACRESET
+    /// </remarks>
+    public static IOutboundMessage<string> FactoryResetNetworkLan => new ScpiMessage("SYSTem:COMMunicate:LAN:FACRESET");
 
     /// <summary>
     /// Creates a command message to set the LAN firmware update mode.

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -704,6 +704,50 @@ namespace Daqifi.Core.Device
             Disconnect();
         }
 
+        /// <inheritdoc />
+        public void SaveAdcCalibration()
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.SaveAdcCalibration);
+        }
+
+        /// <inheritdoc />
+        public void LoadAdcCalibration()
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.LoadAdcCalibration);
+        }
+
+        /// <inheritdoc />
+        public void SaveVoltagePrecision()
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.SaveVoltagePrecision);
+        }
+
+        /// <inheritdoc />
+        public void LoadVoltagePrecision()
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.LoadVoltagePrecision);
+        }
+
         /// <summary>
         /// Sets the enabled state for a set of channels, then sends one device command per affected
         /// channel type (the ADC enable bitmask for analog, the global DIO enable for digital).
@@ -950,6 +994,46 @@ namespace Daqifi.Core.Device
             {
                 _networkConfiguration.Gateway = configuration.Gateway;
             }
+        }
+
+        /// <summary>
+        /// Loads the persisted LAN configuration from the device's NVM back into its runtime settings.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the device is not connected.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        public Task LoadNetworkConfigurationAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.LoadNetworkLan);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Resets the device's LAN configuration to firmware factory defaults.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the device is not connected.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        public Task FactoryResetNetworkAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.FactoryResetNetworkLan);
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1012,6 +1012,9 @@ namespace Daqifi.Core.Device
                 throw new InvalidOperationException("Device is not connected.");
             }
 
+            // Re-check right before the state-changing send so a cancellation requested after the
+            // entry guard still short-circuits the command (matches the pattern accepted in #324).
+            cancellationToken.ThrowIfCancellationRequested();
             Send(ScpiMessageProducer.LoadNetworkLan);
             return Task.CompletedTask;
         }
@@ -1032,6 +1035,9 @@ namespace Daqifi.Core.Device
                 throw new InvalidOperationException("Device is not connected.");
             }
 
+            // Re-check right before the state-changing send so a cancellation requested after the
+            // entry guard still short-circuits the command (matches the pattern accepted in #324).
+            cancellationToken.ThrowIfCancellationRequested();
             Send(ScpiMessageProducer.FactoryResetNetworkLan);
             return Task.CompletedTask;
         }

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -149,5 +149,39 @@ namespace Daqifi.Core.Device
         /// drops its link while restarting. Reconnect once the device is back online.
         /// </remarks>
         void Reboot();
+
+        /// <summary>
+        /// Persists the device's current ADC calibration coefficients to NVM so they survive a reboot.
+        /// </summary>
+        /// <remarks>
+        /// A thin wrapper over the firmware NVM primitive (<c>CONFigure:ADC:SAVEcal</c>). Pair with
+        /// <see cref="LoadAdcCalibration"/> to restore them.
+        /// </remarks>
+        void SaveAdcCalibration();
+
+        /// <summary>
+        /// Restores the device's ADC calibration coefficients from NVM into its runtime.
+        /// </summary>
+        /// <remarks>
+        /// The inverse of <see cref="SaveAdcCalibration"/> (firmware primitive <c>CONFigure:ADC:LOADcal</c>).
+        /// </remarks>
+        void LoadAdcCalibration();
+
+        /// <summary>
+        /// Persists the device's current voltage precision setting to NVM so it survives a reboot.
+        /// </summary>
+        /// <remarks>
+        /// A thin wrapper over the firmware NVM primitive (<c>CONFigure:VOLTage:SAVE</c>). Pair with
+        /// <see cref="LoadVoltagePrecision"/> to restore it.
+        /// </remarks>
+        void SaveVoltagePrecision();
+
+        /// <summary>
+        /// Restores the device's voltage precision setting from NVM into its runtime.
+        /// </summary>
+        /// <remarks>
+        /// The inverse of <see cref="SaveVoltagePrecision"/> (firmware primitive <c>CONFigure:VOLTage:LOAD</c>).
+        /// </remarks>
+        void LoadVoltagePrecision();
     }
 }

--- a/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
+++ b/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
@@ -43,6 +43,32 @@ namespace Daqifi.Core.Device.Network
         Task UpdateNetworkConfigurationAsync(NetworkConfiguration configuration, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Loads the persisted LAN configuration from the device's NVM back into its runtime settings.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <remarks>
+        /// The inverse of the save step performed by <see cref="UpdateNetworkConfigurationAsync"/>. This is a
+        /// thin wrapper over the firmware NVM primitive (<c>SYSTem:COMMunicate:LAN:LOAD</c>): it repopulates
+        /// the device's runtime WiFi settings from the last saved values but does not itself re-apply them to
+        /// the live interface — send an apply/reboot afterwards if the loaded values must take effect on the
+        /// active connection. The local <see cref="NetworkConfiguration"/> snapshot is not refreshed.
+        /// </remarks>
+        Task LoadNetworkConfigurationAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Resets the device's LAN configuration to firmware factory defaults.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <remarks>
+        /// A thin wrapper over the firmware NVM primitive (<c>SYSTem:COMMunicate:LAN:FACRESET</c>): it restores
+        /// the default WiFi settings into the device's runtime settings. Persist and/or apply them afterwards
+        /// for the reset to take effect. The local <see cref="NetworkConfiguration"/> snapshot is not refreshed.
+        /// </remarks>
+        Task FactoryResetNetworkAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Prepares the SD card interface for use by disabling the LAN interface.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Summary

Exposes the firmware's remaining configuration-persistence NVM primitives as thin, typed wrappers, so Core consumers can persist/restore device settings without reimplementing SCPI. Not a generic serialization framework — each command maps 1:1 to a firmware primitive.

Closes #207.

## SCPI wiring (`ScpiMessageProducer`)
| Member | Command |
| --- | --- |
| `LoadNetworkLan` | `SYSTem:COMMunicate:LAN:LOAD` |
| `FactoryResetNetworkLan` | `SYSTem:COMMunicate:LAN:FACRESET` |
| `SaveAdcCalibration` | `CONFigure:ADC:SAVEcal` |
| `LoadAdcCalibration` | `CONFigure:ADC:LOADcal` |
| `SaveVoltagePrecision` | `CONFigure:VOLTage:SAVE` |
| `LoadVoltagePrecision` | `CONFigure:VOLTage:LOAD` |

## API surface
- **`INetworkConfigurable`** gains `LoadNetworkConfigurationAsync()` and `FactoryResetNetworkAsync()`, implemented on `DaqifiStreamingDevice` next to the existing `UpdateNetworkConfigurationAsync` (connected-guard + cancellation). These are thin wrappers over the NVM primitives — they repopulate/reset the device's runtime settings but do not themselves re-apply to the live interface (send an apply/reboot afterward); the local `NetworkConfiguration` snapshot is intentionally not refreshed. Matches the async shape the interface already establishes.
- **`SaveAdcCalibration` / `LoadAdcCalibration` / `SaveVoltagePrecision` / `LoadVoltagePrecision`** land on `IStreamingDevice` — device-global NVM ops, no new interface, matching the existing `Reboot`-style fire-and-forget command methods (per the ticket: "likely on the channel/calibration subsystem, not a new interface").

## Tests
- Command-string round-trip per new producer member.
- Interface-level tests via a capturing transport: each method sends the correct command when connected and throws `InvalidOperationException` when disconnected, plus a cancellation test for the async network members.
- Full suite green (1543 passing).

## Bench test
Ran all six commands against a real Nyquist (**firmware 3.7.2**, USB `/dev/cu.usbmodem1101`) and checked the SCPI error queue after each via `DrainErrorQueueAsync`:

```
ACCEPTED* LoadAdcCalibration     (CONFigure:ADC:LOADcal)   (other error: -200,"Execution error")
ACCEPTED  SaveAdcCalibration     (CONFigure:ADC:SAVEcal)
ACCEPTED  LoadVoltagePrecision   (CONFigure:VOLTage:LOAD)
ACCEPTED  SaveVoltagePrecision   (CONFigure:VOLTage:SAVE)
ACCEPTED  LoadNetworkLan         (SYSTem:COMMunicate:LAN:LOAD)
ACCEPTED  FactoryResetNetworkLan (SYSTem:COMMunicate:LAN:FACRESET)
RESULT: all 6 commands accepted by firmware (no -113).
```

Every command header was accepted — no `-113 "Undefined header"` — confirming the command strings match firmware. `LoadAdcCalibration` returned `-200 "Execution error"`: the header is recognized, but the device had no stored calibration to load in that state — a device-state condition, not a command-string defect. (The bench harness issued `LOAD` before `SAVE` for both cal and voltage so any `SAVE` wrote back values just refreshed from NVM — a no-op persist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)