### PR TITLE
feat(discovery): resolve TCP data port for manually-entered IPs (closes #244)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -229,14 +229,17 @@ public class WiFiDeviceFinderTests
             () => WiFiDeviceFinder.ProbeTcpDataPortAsync(IPAddress.Loopback, 70000, TimeSpan.FromSeconds(1)));
     }
 
+    // The probe now binds the local socket to the discovery port itself (so it catches firmware that
+    // replies to the well-known port). A test responder therefore occupies that port on IPAddress.Any,
+    // which deterministically forces the probe's own bind to fail over to an ephemeral local port —
+    // and the responder then replies to the probe's source endpoint, modelling firmware that answers
+    // to the sender's port. Binding the responder on Any (not Loopback) guarantees the bind conflict.
     [Fact]
     public async Task ProbeTcpDataPortAsync_WhenHostAnswers_ReturnsAdvertisedDataPort()
     {
         const int advertisedPort = 12345;
 
-        // A loopback stand-in for a device: it answers the DAQiFi discovery query with a delimited
-        // status protobuf carrying its DevicePort, exactly as real firmware replies over UDP-30303.
-        using var responder = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        using var responder = new UdpClient(new IPEndPoint(IPAddress.Any, 0));
         var discoveryPort = ((IPEndPoint)responder.Client.LocalEndPoint!).Port;
         using var responderDone = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
@@ -255,11 +258,35 @@ public class WiFiDeviceFinderTests
     }
 
     [Fact]
+    public async Task ProbeTcpDataPortAsync_WhenHostAdvertisesOutOfRangePort_ReturnsNull()
+    {
+        // A device reporting a DevicePort outside the valid 1..65535 TCP range is not a usable port;
+        // the probe must not hand it back (which would defeat the caller's default-port fallback).
+        using var responder = new UdpClient(new IPEndPoint(IPAddress.Any, 0));
+        var discoveryPort = ((IPEndPoint)responder.Client.LocalEndPoint!).Port;
+        using var responderDone = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var replyBytes = BuildDiscoveryReply(devicePort: 70000, hostName: "BadPortDevice");
+        var responderTask = Task.Run(async () =>
+        {
+            var query = await responder.ReceiveAsync(responderDone.Token);
+            await responder.SendAsync(replyBytes, replyBytes.Length, query.RemoteEndPoint);
+        });
+
+        var resolved = await WiFiDeviceFinder.ProbeTcpDataPortAsync(
+            IPAddress.Loopback, discoveryPort, TimeSpan.FromMilliseconds(600));
+
+        try { await responderTask; } catch (OperationCanceledException) { /* responder may outlive the probe */ }
+        responderDone.Cancel();
+        Assert.Null(resolved);
+    }
+
+    [Fact]
     public async Task ProbeTcpDataPortAsync_WhenNoHostAnswers_ReturnsNull()
     {
         // Bind (but never read from) a socket so the port is occupied yet silent — nothing answers
         // the query, so the probe should time out and return null rather than throw.
-        using var silent = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        using var silent = new UdpClient(new IPEndPoint(IPAddress.Any, 0));
         var discoveryPort = ((IPEndPoint)silent.Client.LocalEndPoint!).Port;
 
         var resolved = await WiFiDeviceFinder.ProbeTcpDataPortAsync(
@@ -271,7 +298,7 @@ public class WiFiDeviceFinderTests
     [Fact]
     public async Task ProbeTcpDataPortAsync_WhenCallerCancels_ThrowsOperationCanceled()
     {
-        using var silent = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        using var silent = new UdpClient(new IPEndPoint(IPAddress.Any, 0));
         var discoveryPort = ((IPEndPoint)silent.Client.LocalEndPoint!).Port;
         using var cts = new CancellationTokenSource();
         cts.Cancel();

--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device.Discovery;
+using Google.Protobuf;
 
 namespace Daqifi.Core.Tests.Device.Discovery;
 
@@ -191,5 +196,103 @@ public class WiFiDeviceFinderTests
             var actual = WiFiDeviceFinder.ShouldIncludeInterface(nic.Name, nic.Description, nic.Status, nic.Type, nic.IPv4);
             Assert.True(actual == nic.Expected, $"NIC '{nic.Name}' expected {nic.Expected} but got {actual}");
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // TCP data-port resolution (daqifi-core#244)
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void DefaultTcpDataPort_IsFirmwareDefault()
+    {
+        Assert.Equal(9760, Daqifi.Core.Device.DaqifiDeviceFactory.DefaultTcpDataPort);
+    }
+
+    [Fact]
+    public async Task ProbeTcpDataPortAsync_WithNullHost_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => WiFiDeviceFinder.ProbeTcpDataPortAsync(null!, TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public async Task ProbeTcpDataPortAsync_WithNonPositiveTimeout_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => WiFiDeviceFinder.ProbeTcpDataPortAsync(IPAddress.Loopback, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public async Task ProbeTcpDataPortAsync_WithOutOfRangeDiscoveryPort_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => WiFiDeviceFinder.ProbeTcpDataPortAsync(IPAddress.Loopback, 70000, TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public async Task ProbeTcpDataPortAsync_WhenHostAnswers_ReturnsAdvertisedDataPort()
+    {
+        const int advertisedPort = 12345;
+
+        // A loopback stand-in for a device: it answers the DAQiFi discovery query with a delimited
+        // status protobuf carrying its DevicePort, exactly as real firmware replies over UDP-30303.
+        using var responder = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var discoveryPort = ((IPEndPoint)responder.Client.LocalEndPoint!).Port;
+        using var responderDone = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var replyBytes = BuildDiscoveryReply(devicePort: advertisedPort, hostName: "ProbeTestDevice");
+        var responderTask = Task.Run(async () =>
+        {
+            var query = await responder.ReceiveAsync(responderDone.Token);
+            await responder.SendAsync(replyBytes, replyBytes.Length, query.RemoteEndPoint);
+        });
+
+        var resolved = await WiFiDeviceFinder.ProbeTcpDataPortAsync(
+            IPAddress.Loopback, discoveryPort, TimeSpan.FromSeconds(3));
+
+        await responderTask;
+        Assert.Equal(advertisedPort, resolved);
+    }
+
+    [Fact]
+    public async Task ProbeTcpDataPortAsync_WhenNoHostAnswers_ReturnsNull()
+    {
+        // Bind (but never read from) a socket so the port is occupied yet silent — nothing answers
+        // the query, so the probe should time out and return null rather than throw.
+        using var silent = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var discoveryPort = ((IPEndPoint)silent.Client.LocalEndPoint!).Port;
+
+        var resolved = await WiFiDeviceFinder.ProbeTcpDataPortAsync(
+            IPAddress.Loopback, discoveryPort, TimeSpan.FromMilliseconds(500));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public async Task ProbeTcpDataPortAsync_WhenCallerCancels_ThrowsOperationCanceled()
+    {
+        using var silent = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var discoveryPort = ((IPEndPoint)silent.Client.LocalEndPoint!).Port;
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => WiFiDeviceFinder.ProbeTcpDataPortAsync(
+                IPAddress.Loopback, discoveryPort, TimeSpan.FromSeconds(5), cts.Token));
+    }
+
+    private static byte[] BuildDiscoveryReply(int devicePort, string hostName)
+    {
+        var message = new DaqifiOutMessage
+        {
+            HostName = hostName,
+            DevicePort = (uint)devicePort,
+            DeviceSn = 1,
+            DevicePn = "nq1"
+        };
+
+        using var stream = new MemoryStream();
+        message.WriteDelimitedTo(stream);
+        return stream.ToArray();
     }
 }

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -22,6 +22,19 @@ internal static class SerialDefaults
 public static class DaqifiDeviceFactory
 {
     /// <summary>
+    /// The firmware-default TCP data port DAQiFi devices listen on for streaming connections.
+    /// </summary>
+    /// <remarks>
+    /// Discovery normally reports each device's actual data port via the UDP-30303 broadcast
+    /// (<c>IDeviceInfo.Port</c>), so prefer that when available. For a manually-entered IP address that
+    /// never answered the broadcast, resolve the real port with
+    /// <see cref="Discovery.WiFiDeviceFinder.ProbeTcpDataPortAsync(IPAddress, System.TimeSpan, System.Threading.CancellationToken)"/>
+    /// and fall back to this constant only when the probe returns <c>null</c>. Use it instead of a
+    /// hardcoded literal so a single place documents the default.
+    /// </remarks>
+    public const int DefaultTcpDataPort = 9760;
+
+    /// <summary>
     /// Connects to a DAQiFi device over TCP asynchronously using a hostname.
     /// </summary>
     /// <param name="host">The hostname or IP address string to connect to.</param>

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -168,6 +168,24 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         var target = new IPEndPoint(host, discoveryPort);
 
         using var udp = new UdpClient(host.AddressFamily);
+
+        // Bind the local socket to the discovery port (not an ephemeral one) so replies reach us even
+        // when the firmware answers to the well-known port rather than our source port — the same
+        // reason the broadcast sweep binds to it. ReuseAddress lets this coexist with a concurrent
+        // broadcast discovery already holding the port; if the bind still fails, fall back to an
+        // ephemeral port (devices that do reply to the source port are then still handled).
+        var bindAddress = host.AddressFamily == AddressFamily.InterNetworkV6 ? IPAddress.IPv6Any : IPAddress.Any;
+        udp.ExclusiveAddressUse = false;
+        udp.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+        try
+        {
+            udp.Client.Bind(new IPEndPoint(bindAddress, discoveryPort));
+        }
+        catch (SocketException)
+        {
+            udp.Client.Bind(new IPEndPoint(bindAddress, 0));
+        }
+
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(timeout);
 
@@ -193,11 +211,12 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                 }
 
                 var info = ParseDeviceInfo(result.Buffer, result.RemoteEndPoint, null);
-                if (info?.Port is int port and > 0)
+                if (info?.Port is int port and > 0 and <= IPEndPoint.MaxPort)
                 {
                     return port;
                 }
-                // Parsed but no usable port; keep waiting within the timeout window.
+                // Parsed but no usable port (missing, or out of the valid 1..65535 TCP range);
+                // keep waiting within the timeout window so callers can fall back to the default.
             }
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -114,6 +114,104 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         return await DiscoverAsync(timeout, CancellationToken.None);
     }
 
+    /// <summary>
+    /// Resolves a single host's TCP data port by unicasting the discovery query directly to it and
+    /// reading the <c>DevicePort</c> from its reply. Use this for a manually-entered IP address that
+    /// never answered the broadcast sweep, so its data port need not be assumed.
+    /// </summary>
+    /// <param name="host">The device IP address to probe.</param>
+    /// <param name="timeout">How long to wait for the host to answer before giving up.</param>
+    /// <param name="cancellationToken">A cancellation token to abort the probe.</param>
+    /// <returns>
+    /// The device's advertised TCP data port, or <c>null</c> if the host did not answer within
+    /// <paramref name="timeout"/> (or answered without a usable port). On <c>null</c>, callers can fall
+    /// back to <see cref="DaqifiDeviceFactory.DefaultTcpDataPort"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="host"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="timeout"/> is not positive.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is canceled.</exception>
+    public static Task<int?> ProbeTcpDataPortAsync(
+        IPAddress host,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        return ProbeTcpDataPortAsync(host, DefaultDiscoveryPort, timeout, cancellationToken);
+    }
+
+    /// <inheritdoc cref="ProbeTcpDataPortAsync(IPAddress, TimeSpan, CancellationToken)"/>
+    /// <param name="host">The device IP address to probe.</param>
+    /// <param name="discoveryPort">The UDP discovery port to query (defaults to 30303 in the other overload).</param>
+    /// <param name="timeout">How long to wait for the host to answer before giving up.</param>
+    /// <param name="cancellationToken">A cancellation token to abort the probe.</param>
+    public static async Task<int?> ProbeTcpDataPortAsync(
+        IPAddress host,
+        int discoveryPort,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        if (host is null)
+        {
+            throw new ArgumentNullException(nameof(host));
+        }
+
+        if (discoveryPort is < IPEndPoint.MinPort or > IPEndPoint.MaxPort)
+        {
+            throw new ArgumentOutOfRangeException(nameof(discoveryPort), discoveryPort, "Discovery port is out of range.");
+        }
+
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout must be positive.");
+        }
+
+        var query = Encoding.ASCII.GetBytes(DaqifiFinderQuery);
+        var target = new IPEndPoint(host, discoveryPort);
+
+        using var udp = new UdpClient(host.AddressFamily);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+
+        try
+        {
+            await udp.SendAsync(query, query.Length, target).ConfigureAwait(false);
+
+            // The reply may be broadcast, and other DAQiFi devices on the segment could answer the
+            // same query, so keep reading until we hear from the exact host we probed (or time out).
+            while (true)
+            {
+                var result = await udp.ReceiveAsync(cts.Token).ConfigureAwait(false);
+
+                if (!result.RemoteEndPoint.Address.Equals(host))
+                {
+                    continue; // a different device answered; ignore it
+                }
+
+                var receivedText = Encoding.ASCII.GetString(result.Buffer);
+                if (!IsValidDiscoveryMessage(receivedText))
+                {
+                    continue; // our own query echoed back or a non-device frame
+                }
+
+                var info = ParseDeviceInfo(result.Buffer, result.RemoteEndPoint, null);
+                if (info?.Port is int port and > 0)
+                {
+                    return port;
+                }
+                // Parsed but no usable port; keep waiting within the timeout window.
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Our own timeout elapsed (not a caller cancellation) — the host did not answer.
+            return null;
+        }
+        catch (SocketException)
+        {
+            // Host unreachable / no route — treat as "did not answer" so callers can fall back.
+            return null;
+        }
+    }
+
     #endregion
 
     #region Private Methods


### PR DESCRIPTION
## Summary

A host that never answered the UDP-30303 broadcast (a manually-entered IP) had no data port to connect with, forcing consumers like daqifi-desktop to hardcode `9760`. This gives Core both a documented default and a way to resolve the real port.

Closes #244.

## Changes
- **`DaqifiDeviceFactory.DefaultTcpDataPort` (9760)** — the firmware-default TCP data port, so consumers reference one documented constant instead of a magic literal for manual connections.
- **`WiFiDeviceFinder.ProbeTcpDataPortAsync(host, [discoveryPort,] timeout, ct)`** — unicasts the discovery query directly to a single host and returns the `DevicePort` from its reply, or `null` if it does not answer within the timeout (callers then fall back to `DefaultTcpDataPort`). It reuses the finder's existing query constant and `ParseDeviceInfo`/`IsValidDiscoveryMessage` rather than duplicating discovery parsing, ignores replies from other devices on the segment, maps its own timeout to `null`, and rethrows only genuine caller cancellation.

Together these implement both options the ticket proposed (a documented default **and** an active probe).

## Tests
- Argument validation (null host, non-positive timeout, out-of-range discovery port).
- A loopback responder that answers with a delimited status protobuf, asserting the advertised port is returned end-to-end.
- A silent host → probe times out and returns `null`.
- Caller cancellation propagates an `OperationCanceledException`.
- Full suite green (1550 passing).

## Bench validation
The bench rig is USB-serial, so the probe's UDP round-trip was exercised via the loopback integration test above rather than a WiFi device. The pieces that touch real hardware were confirmed against a live Nyquist (firmware 3.7.2): the device reports **`DevicePort = 9760`** in its status frame — the same field `ProbeTcpDataPortAsync` reads — validating both `DefaultTcpDataPort` and the value the probe resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)