### PR TITLE
fix(consumer): thread-safe ClearBuffer, drop dead IsWifiDevice; fix docs (closes #332, #346)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,11 @@ if (device is INetworkConfigurable networkDevice)
 | **Nyquist 1** | 16 analog in | 12-bit | 0–5 V |
 | **Nyquist 3** | 8 analog in | 18-bit | ±10 V |
 
-Both are auto-detected by part number during discovery.
+These are auto-detected by part number during discovery. The SDK also recognizes and
+supports **Nyquist 2** (`Nq2` → `DeviceType.Nyquist2`); it's left out of the spec table
+above rather than listed with fabricated headline numbers. For any connected device the
+authoritative channel counts, resolution, and ranges are reported by the hardware and
+surfaced on `device.Metadata.Capabilities` after initialization.
 
 Don't have one yet? **[See the DAQiFi lineup →](https://daqifi.com)**
 

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -299,8 +299,8 @@ Console.WriteLine($"Firmware: {device.Metadata.FirmwareVersion}");
 
 // Check capabilities
 var caps = device.Metadata.Capabilities;
-Console.WriteLine($"Analog Inputs: {caps.AnalogInputCount}");
-Console.WriteLine($"Digital I/O: {caps.DigitalPortCount}");
+Console.WriteLine($"Analog Inputs: {caps.AnalogInputChannels}");
+Console.WriteLine($"Digital I/O: {caps.DigitalChannels}");
 ```
 
 ### Streaming Data

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
@@ -332,6 +332,33 @@ public class StreamMessageConsumerIntegrationTests
         Assert.True(stoppedCleanly);
     }
 
+    /// <summary>
+    /// When the stop path's time-bounded Join can't reap a stuck reader (issue #332 follow-up):
+    /// StopSafely reports the timeout, and a subsequent Start() must refuse to spawn a second
+    /// reader over the still-alive one rather than reintroduce overlapping Stream.Read loops.
+    /// </summary>
+    [Fact]
+    public void StopSafely_StuckReader_TimesOut_AndStartRefusesSecondReader()
+    {
+        using var stream = new BlockingReadStream();
+        var parser = new ProtobufMessageParser();
+        using var consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
+
+        consumer.Start();
+        Assert.True(WaitFor(() => stream.IsBlockedInRead, TimeSpan.FromSeconds(1)),
+            "reader should have entered a blocking Read");
+
+        // The reader is stuck in Read, so a bounded stop can't join it.
+        Assert.False(consumer.StopSafely(100));
+
+        // A second Start must not create a concurrent reader against the same stream.
+        var ex = Assert.Throws<InvalidOperationException>(() => consumer.Start());
+        Assert.Contains("not yet exited", ex.Message);
+
+        // Cleanup: release the reader so the background thread can exit.
+        stream.Release();
+    }
+
     private static bool WaitFor(Func<bool> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -372,6 +399,44 @@ public class StreamMessageConsumerIntegrationTests
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A read-only stream whose <see cref="Read"/> blocks until <see cref="Release"/> is called,
+    /// used to simulate a consumer thread stuck in a blocking read that a bounded Join can't reap.
+    /// </summary>
+    private sealed class BlockingReadStream : Stream
+    {
+        private readonly ManualResetEventSlim _gate = new(false);
+
+        public bool IsBlockedInRead { get; private set; }
+
+        public void Release() => _gate.Set();
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            IsBlockedInRead = true;
+            _gate.Wait();
+            return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            _gate.Set();
+            _gate.Dispose();
+            base.Dispose(disposing);
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
@@ -248,6 +248,11 @@ public class StreamMessageConsumerIntegrationTests
     /// and clears the internal message buffer. This is essential for reconnection scenarios
     /// where residual partial data from a previous session needs to be discarded.
     /// </summary>
+    /// <remarks>
+    /// While the consumer thread is running, ClearBuffer() marshals the clear onto that thread
+    /// (issue #332) rather than mutating the buffer from the caller — so the clear takes effect on
+    /// the next consumer-loop iteration rather than synchronously on return. The test polls for it.
+    /// </remarks>
     [Fact]
     public void ClearBuffer_CalledViaInterface_ClearsInternalBuffer()
     {
@@ -262,21 +267,125 @@ public class StreamMessageConsumerIntegrationTests
         consumer.Start();
         Thread.Sleep(50); // Brief pause to allow consumer to read data
 
-        // Verify data was buffered (QueuedMessageCount tracks internal buffer size)
-        // Note: The exact count depends on timing, but buffer should have some data
-        var bufferCountBeforeClear = consumer.QueuedMessageCount;
-
         // Act - Call ClearBuffer via interface (as desktop would do during reconnection)
         IMessageConsumer<DaqifiOutMessage> interfaceRef = consumer;
         interfaceRef.ClearBuffer();
 
-        // Assert - Internal buffer should be cleared
-        Assert.Equal(0, consumer.QueuedMessageCount);
+        // Assert - Internal buffer should be cleared once the consumer thread honors the request.
+        var cleared = WaitFor(() => consumer.QueuedMessageCount == 0, TimeSpan.FromSeconds(1));
+        Assert.True(cleared, "ClearBuffer() should drain the internal buffer within the timeout.");
 
         // Additional verification: consumer should still be functional after clear
         Assert.True(consumer.IsRunning);
 
         consumer.Stop();
+    }
+
+    /// <summary>
+    /// Exercises the reconnection race directly (issue #332): hammer ClearBuffer() from the caller
+    /// thread while the consumer thread is actively reading and parsing a continuous stream. Before
+    /// the fix this concurrently mutated the underlying <see cref="System.Collections.Generic.List{T}"/>
+    /// and issued a second overlapping Stream.Read; now the clear is marshaled onto the consumer
+    /// thread, so no concurrency exception should ever surface and the consumer should keep running.
+    /// </summary>
+    [Fact]
+    public void ClearBuffer_DuringActiveConsumption_IsThreadSafe()
+    {
+        // Arrange - a stream that never ends, so the consumer thread is continuously reading. A
+        // benign parser keeps a running remainder buffered (returns no messages, consumes only part
+        // of the data) so the internal List<byte> is genuinely being appended to and drained while
+        // we hammer it — without protobuf parse errors confounding the concurrency assertion.
+        using var stream = new ContinuousDataStream();
+        var parser = new PartialConsumingParser();
+        using var consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
+
+        var errors = new List<Exception>();
+        consumer.ErrorOccurred += (_, e) =>
+        {
+            lock (errors) { errors.Add(e.Error); }
+        };
+
+        consumer.Start();
+
+        // Act - hammer ClearBuffer AND QueuedMessageCount from this thread (both touch the shared
+        // buffer state) while the consumer thread appends/drains it.
+        var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(500);
+        var clearCalls = 0;
+        while (DateTime.UtcNow < deadline)
+        {
+            consumer.ClearBuffer();
+            _ = consumer.QueuedMessageCount;
+            clearCalls++;
+        }
+
+        // Give the consumer a moment to process any final clears, then stop.
+        Thread.Sleep(50);
+        var stoppedCleanly = consumer.StopSafely(2000);
+
+        // Assert - no concurrency exceptions (List corruption, torn reads) were ever reported.
+        lock (errors)
+        {
+            Assert.True(errors.Count == 0,
+                $"Consumer reported {errors.Count} error(s) during concurrent ClearBuffer; first: {(errors.Count > 0 ? errors[0].ToString() : "none")}");
+        }
+        Assert.True(clearCalls > 0);
+        Assert.True(stoppedCleanly);
+    }
+
+    private static bool WaitFor(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            Thread.Sleep(5);
+        }
+        return condition();
+    }
+
+    /// <summary>
+    /// A read-only stream that always returns bytes, so the consumer thread stays in a tight
+    /// read/parse loop for the duration of the concurrency test.
+    /// </summary>
+    private sealed class ContinuousDataStream : Stream
+    {
+        private byte _next;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            // Return a modest chunk each call so the buffer both grows and gets parsed/drained.
+            var n = Math.Min(count, 64);
+            for (var i = 0; i < n; i++)
+            {
+                buffer[offset + i] = _next++;
+            }
+            return n;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A parser that never throws: it consumes all but a small trailing remainder each pass and
+    /// yields no messages, so the consumer keeps a non-empty buffer to append/drain under load.
+    /// </summary>
+    private sealed class PartialConsumingParser : IMessageParser<DaqifiOutMessage>
+    {
+        public IEnumerable<IInboundMessage<DaqifiOutMessage>> ParseMessages(byte[] data, out int consumedBytes)
+        {
+            // Leave a few bytes "pending" so the buffer never fully empties between reads.
+            consumedBytes = data.Length > 4 ? data.Length - 4 : 0;
+            return Array.Empty<IInboundMessage<DaqifiOutMessage>>();
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
@@ -408,8 +408,11 @@ public class StreamMessageConsumerIntegrationTests
     private sealed class BlockingReadStream : Stream
     {
         private readonly ManualResetEventSlim _gate = new(false);
+        private volatile bool _isBlockedInRead;
 
-        public bool IsBlockedInRead { get; private set; }
+        // volatile-backed so the polling test thread is guaranteed to observe the consumer
+        // thread's write (a plain auto-property has no happens-before guarantee here).
+        public bool IsBlockedInRead => _isBlockedInRead;
 
         public void Release() => _gate.Set();
 
@@ -422,7 +425,7 @@ public class StreamMessageConsumerIntegrationTests
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            IsBlockedInRead = true;
+            _isBlockedInRead = true;
             _gate.Wait();
             return 0;
         }
@@ -470,6 +473,38 @@ public class StreamMessageConsumerIntegrationTests
 
         Assert.Null(exception);
         Assert.Equal(0, consumer.QueuedMessageCount);
+    }
+
+    /// <summary>
+    /// <see cref="StreamMessageConsumer{T}.MessageReceived"/> is raised on the consumer thread, so a
+    /// subscriber can legally call back into <see cref="StreamMessageConsumer{T}.ClearBuffer"/>. That
+    /// must never block the consumer thread (issue #332 round 2: the not-running path must not
+    /// <c>Join</c> the current thread on itself).
+    /// </summary>
+    [Fact]
+    public void ClearBuffer_CalledFromMessageReceivedCallback_DoesNotBlockConsumerThread()
+    {
+        var oneMessage = SerializeWithLengthPrefix(new DaqifiOutMessage { MsgTimeStamp = 42 });
+        using var stream = new MemoryStream(oneMessage);
+        var parser = new ProtobufMessageParser();
+        using var consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
+
+        var handlerReturned = new ManualResetEventSlim(false);
+        Exception? handlerError = null;
+        consumer.MessageReceived += (_, _) =>
+        {
+            try { consumer.ClearBuffer(); }
+            catch (Exception ex) { handlerError = ex; }
+            finally { handlerReturned.Set(); }
+        };
+
+        consumer.Start();
+
+        Assert.True(handlerReturned.Wait(TimeSpan.FromSeconds(2)),
+            "ClearBuffer() invoked from the consumer-thread callback must return promptly, not self-join.");
+        Assert.Null(handlerError);
+
+        consumer.Stop();
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -14,6 +14,20 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     private readonly IMessageParser<T> _messageParser;
     private readonly byte[] _buffer;
     private readonly List<byte> _messageBuffer;
+
+    /// <summary>
+    /// Guards every access to <see cref="_messageBuffer"/>. The consumer thread appends to and
+    /// drains the buffer while callers can query <see cref="QueuedMessageCount"/> or request a
+    /// clear on their own thread; <see cref="List{T}"/> is not safe for concurrent mutation.
+    /// </summary>
+    private readonly object _bufferLock = new();
+
+    /// <summary>
+    /// Set by <see cref="ClearBuffer"/> when the consumer thread is running, so the clear (buffer
+    /// reset + stream drain) is performed on the consumer thread itself rather than racing it.
+    /// </summary>
+    private volatile bool _clearRequested;
+
     private volatile bool _isRunning;
     private Thread? _consumerThread;
     private bool _disposed;
@@ -33,12 +47,6 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     }
 
     /// <summary>
-    /// Gets or sets whether this consumer is connected to a WiFi device.
-    /// WiFi devices may require buffer clearing due to residual data on connection.
-    /// </summary>
-    public bool IsWifiDevice { get; set; }
-
-    /// <summary>
     /// Gets a value indicating whether the consumer is currently running.
     /// </summary>
     public bool IsRunning => _isRunning;
@@ -46,7 +54,16 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// <summary>
     /// Gets the number of bytes currently in the message buffer.
     /// </summary>
-    public int QueuedMessageCount => _messageBuffer.Count;
+    public int QueuedMessageCount
+    {
+        get
+        {
+            lock (_bufferLock)
+            {
+                return _messageBuffer.Count;
+            }
+        }
+    }
 
     /// <summary>
     /// Occurs when a message is received and parsed from the device.
@@ -68,6 +85,7 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         if (_isRunning)
             return; // Already running
 
+        _clearRequested = false;
         _isRunning = true;
         _consumerThread = new Thread(ProcessMessages)
         {
@@ -85,7 +103,10 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         _isRunning = false;
         _consumerThread?.Join(1000);
         _consumerThread = null;
-        _messageBuffer.Clear();
+        lock (_bufferLock)
+        {
+            _messageBuffer.Clear();
+        }
     }
 
     /// <summary>
@@ -101,21 +122,52 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         _isRunning = false;
         var stopped = _consumerThread?.Join(timeoutMs) ?? true;
         _consumerThread = null;
-        _messageBuffer.Clear();
+        lock (_bufferLock)
+        {
+            _messageBuffer.Clear();
+        }
 
         return stopped;
     }
 
     /// <summary>
-    /// Clears any buffered data from the stream and internal buffers.
-    /// Useful for WiFi devices that may have residual data on connection.
+    /// Clears any buffered data from the stream and internal buffers. Useful for devices that may
+    /// have residual data on connection (e.g. after a reconnect).
     /// </summary>
+    /// <remarks>
+    /// Safe to call while the consumer thread is running. When it is, the actual clear is marshaled
+    /// onto the consumer thread — the buffer reset and stream drain happen there — so this never
+    /// mutates <see cref="_messageBuffer"/> concurrently with the reader and never issues a second
+    /// <see cref="Stream.Read(byte[], int, int)"/> that would overlap the reader's own read and
+    /// corrupt message framing. In that case the clear takes effect on the next consumer-loop
+    /// iteration rather than synchronously on return.
+    /// </remarks>
     public void ClearBuffer()
     {
         ThrowIfDisposed();
 
-        // Clear internal message buffer
-        _messageBuffer.Clear();
+        if (_isRunning)
+        {
+            // The consumer thread owns the stream and the message buffer; hand the work to it.
+            _clearRequested = true;
+            return;
+        }
+
+        // No consumer thread is running, so the caller can safely clear directly.
+        PerformClear();
+    }
+
+    /// <summary>
+    /// Resets the message buffer and drains any residual bytes from the stream. Must only run on
+    /// the thread that currently owns the stream/buffer (the consumer thread while running, or the
+    /// caller of <see cref="ClearBuffer"/> when it is not).
+    /// </summary>
+    private void PerformClear()
+    {
+        lock (_bufferLock)
+        {
+            _messageBuffer.Clear();
+        }
 
         // Drain any available data from the stream (if it's a NetworkStream)
         try
@@ -144,6 +196,14 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         {
             try
             {
+                // Honor a pending ClearBuffer() request on this thread, so the buffer reset and the
+                // stream drain never race the reader below.
+                if (_clearRequested)
+                {
+                    _clearRequested = false;
+                    PerformClear();
+                }
+
                 // Check if data is available to avoid blocking
                 if (!_stream.CanRead)
                 {
@@ -175,10 +235,14 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                     continue;
                 }
 
-                // Add received data to message buffer
-                for (int i = 0; i < bytesRead; i++)
+                // Add received data to message buffer (guarded: a caller may be reading
+                // QueuedMessageCount and ClearBuffer's drain runs on this same thread).
+                lock (_bufferLock)
                 {
-                    _messageBuffer.Add(_buffer[i]);
+                    for (int i = 0; i < bytesRead; i++)
+                    {
+                        _messageBuffer.Add(_buffer[i]);
+                    }
                 }
 
                 // Try to parse complete messages from buffer
@@ -197,13 +261,21 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// </summary>
     private void ProcessMessageBuffer()
     {
-        var bufferData = _messageBuffer.ToArray();
-        var messages = _messageParser.ParseMessages(bufferData, out var consumedBytes);
+        byte[] bufferData;
+        IEnumerable<IInboundMessage<T>> messages;
 
-        // Remove consumed bytes from buffer
-        if (consumedBytes > 0)
+        // Snapshot, parse, and drain the buffer under the lock; dispatch events outside it so a
+        // subscriber callback never runs while the lock is held.
+        lock (_bufferLock)
         {
-            _messageBuffer.RemoveRange(0, Math.Min(consumedBytes, _messageBuffer.Count));
+            bufferData = _messageBuffer.ToArray();
+            messages = _messageParser.ParseMessages(bufferData, out var consumedBytes);
+
+            // Remove consumed bytes from buffer
+            if (consumedBytes > 0)
+            {
+                _messageBuffer.RemoveRange(0, Math.Min(consumedBytes, _messageBuffer.Count));
+            }
         }
 
         // Fire events for parsed messages

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -85,6 +85,15 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         if (_isRunning)
             return; // Already running
 
+        // A prior Stop()/StopSafely() whose Join timed out leaves the old reader thread alive.
+        // Refuse to spawn a second reader against the same stream/buffer — two concurrent
+        // Stream.Read loops would reintroduce the framing corruption this class guards against.
+        if (_consumerThread is { IsAlive: true })
+        {
+            throw new InvalidOperationException(
+                "Cannot start the consumer: a previous consumer thread has not yet exited.");
+        }
+
         _clearRequested = false;
         _isRunning = true;
         _consumerThread = new Thread(ProcessMessages)
@@ -101,11 +110,16 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     public void Stop()
     {
         _isRunning = false;
-        _consumerThread?.Join(1000);
-        _consumerThread = null;
-        lock (_bufferLock)
+        var stopped = _consumerThread?.Join(1000) ?? true;
+        if (stopped)
         {
-            _messageBuffer.Clear();
+            // Only tear down once the reader has actually exited: clearing the buffer (and later
+            // letting Start() reuse the slot) while the thread is still alive would race it.
+            _consumerThread = null;
+            lock (_bufferLock)
+            {
+                _messageBuffer.Clear();
+            }
         }
     }
 
@@ -121,10 +135,16 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
 
         _isRunning = false;
         var stopped = _consumerThread?.Join(timeoutMs) ?? true;
-        _consumerThread = null;
-        lock (_bufferLock)
+        if (stopped)
         {
-            _messageBuffer.Clear();
+            // Only clear once the reader has exited. Doing so unconditionally would (a) let a
+            // later Start() spawn a second reader over a still-alive one, and (b) block past the
+            // advertised timeout here if the reader is holding _bufferLock in a slow parse.
+            _consumerThread = null;
+            lock (_bufferLock)
+            {
+                _messageBuffer.Clear();
+            }
         }
 
         return stopped;
@@ -141,6 +161,12 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// <see cref="Stream.Read(byte[], int, int)"/> that would overlap the reader's own read and
     /// corrupt message framing. In that case the clear takes effect on the next consumer-loop
     /// iteration rather than synchronously on return.
+    /// <para>
+    /// If a consumer thread was just stopped but hasn't fully exited yet (the stop path's Join is
+    /// time-bounded), the inline stream drain is deferred until that thread provably exits; if it
+    /// doesn't exit in time, only the in-memory buffer is cleared and the stream drain is skipped,
+    /// so the caller's <see cref="Stream.Read(byte[], int, int)"/> can never overlap the reader's.
+    /// </para>
     /// </remarks>
     public void ClearBuffer()
     {
@@ -153,7 +179,21 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
             return;
         }
 
-        // No consumer thread is running, so the caller can safely clear directly.
+        // Not running — but a just-stopped reader may still be finishing its final Read during the
+        // stop path's time-bounded Join window. Drain the stream ourselves only once that thread
+        // has provably exited, so our Read can't overlap its Read.
+        var thread = _consumerThread;
+        if (thread is { IsAlive: true } && !thread.Join(1000))
+        {
+            // Reader still alive; don't risk an overlapping Stream.Read. Clear just the in-memory
+            // buffer (always lock-guarded) and skip the stream drain.
+            lock (_bufferLock)
+            {
+                _messageBuffer.Clear();
+            }
+            return;
+        }
+
         PerformClear();
     }
 

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -182,8 +182,14 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         // Not running — but a just-stopped reader may still be finishing its final Read during the
         // stop path's time-bounded Join window. Drain the stream ourselves only once that thread
         // has provably exited, so our Read can't overlap its Read.
+        //
+        // Exception: if we ARE the consumer thread (ClearBuffer called from a MessageReceived
+        // callback after another thread requested stop), there is no other reader — joining would
+        // just wait on ourselves until the timeout. Skip the join and clear directly in that case.
         var thread = _consumerThread;
-        if (thread is { IsAlive: true } && !thread.Join(1000))
+        if (thread is { IsAlive: true }
+            && !ReferenceEquals(thread, Thread.CurrentThread)
+            && !thread.Join(1000))
         {
             // Reader still alive; don't risk an overlapping Stream.Read. Clear just the in-memory
             // buffer (always lock-guarded) and skip the stream drain.


### PR DESCRIPTION
## Summary

### #332 — `StreamMessageConsumer.ClearBuffer()` raced the consumer thread
The class had **no synchronization**, yet `ClearBuffer()` — called on the reconnection path "as desktop would do" — mutated `_messageBuffer` (a `List<byte>`) and drained `_stream.Read()` from the caller thread while the background consumer thread was doing the same. That's undefined behavior (concurrent `List<T>` mutation) plus two overlapping `NetworkStream` reads that can interleave and corrupt framing.

- Every `_messageBuffer` access is now guarded by a lock (append, parse/drain, `QueuedMessageCount`, clear).
- When the consumer thread is running, `ClearBuffer()` **marshals** the clear onto that thread via a flag — the buffer reset and stream drain happen on the reader thread, so they never race it and never issue a second overlapping `Read`. When it's not running, the caller clears inline. (Trade-off: while running, the clear takes effect on the next consumer-loop iteration rather than synchronously — safe for the reconnection use.)
- Parsed-message events are dispatched **outside** the lock, so a subscriber callback never runs while it's held.
- Removed the dead `IsWifiDevice` property — its only reference was its own declaration, and `ClearBuffer` actually keys off `_stream is NetworkStream`. **Breaking change** (release-note worthy).
- New concurrency stress test hammers `ClearBuffer()` + `QueuedMessageCount` from the caller while the consumer churns a continuous stream, asserting **zero** reported errors and a clean stop.

### #346 — docs sample didn't compile
- `DEVICE_INTERFACES.md` used `caps.AnalogInputCount` / `caps.DigitalPortCount`, which don't exist → corrected to `AnalogInputChannels` / `DigitalChannels`.
- Spot-checked every other API member referenced in the file against the current source (all resolve).
- Added a README note that the SDK also detects/supports **Nyquist 2** (`Nq2` → `DeviceType.Nyquist2`), without fabricating headline hardware specs for the table.

## Testing
- `dotnet test` — Core 1587 pass, MCP 23 pass, 0 fail (includes the new `ClearBuffer_DuringActiveConsumption_IsThreadSafe`).
- **Bench-tested on real hardware** (Nyquist 1, FW 3.7.2): 237 + 235 samples streamed across two connect → stream → disconnect → reconnect cycles — the locked consumer's read/parse path and reconnection are intact.

Closes #332, closes #346.