### PR TITLE
feat(device): port TimestampGapDetector for dropped-sample detection (closes #339)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
@@ -16,6 +16,80 @@ namespace Daqifi.Core.Tests.Device;
 /// </summary>
 public class DaqifiStreamingDeviceDecodeTests
 {
+    #region Gap detection
+
+    [Fact]
+    public void GapDetected_FiresOnceOnDeviceClockGap_AfterSteadyCadence()
+    {
+        var device = CreateStreamingDevice(analogCount: 1);
+        AnalogChannel(device, 0).IsEnabled = true;
+        device.StartStreaming();
+
+        var events = new List<TimestampGapEventArgs>();
+        device.GapDetected += (_, e) => events.Add(e);
+
+        // First frame (no prior reference) + steady 1000-tick cadence to seed the EMA.
+        for (uint ts = 1000; ts <= 11000; ts += 1000)
+        {
+            device.InvokeStreamMessage(AnalogFrame(ts, 1.0f));
+        }
+        Assert.Empty(events); // steady cadence -> no gap
+
+        // A 5x jump in the device clock = dropped samples.
+        device.InvokeStreamMessage(AnalogFrame(16000, 1.0f));
+
+        Assert.Single(events);
+        Assert.Equal(16000u, events[0].DeviceTimestamp);
+        Assert.True(events[0].SecondsSincePreviousMessage > 0);
+    }
+
+    [Fact]
+    public void GapDetected_DoesNotFireOnSteadyCadence()
+    {
+        var device = CreateStreamingDevice(analogCount: 1);
+        AnalogChannel(device, 0).IsEnabled = true;
+        device.StartStreaming();
+
+        var fired = false;
+        device.GapDetected += (_, _) => fired = true;
+
+        for (uint ts = 1000; ts <= 50000; ts += 1000)
+        {
+            device.InvokeStreamMessage(AnalogFrame(ts, 1.0f));
+        }
+
+        Assert.False(fired);
+    }
+
+    [Fact]
+    public void GapDetected_ResetsBetweenSessions_NoFalseGapOnDifferentCadence()
+    {
+        var device = CreateStreamingDevice(analogCount: 1);
+        AnalogChannel(device, 0).IsEnabled = true;
+
+        // Session 1: fast cadence (1000-tick deltas) trains the EMA.
+        device.StartStreaming();
+        for (uint ts = 1000; ts <= 11000; ts += 1000)
+        {
+            device.InvokeStreamMessage(AnalogFrame(ts, 1.0f));
+        }
+        device.StopStreaming();
+
+        var events = new List<TimestampGapEventArgs>();
+        device.GapDetected += (_, e) => events.Add(e);
+
+        // Session 2: slower cadence (3000-tick deltas). Were the EMA not reset at StartStreaming,
+        // the first real delta (3000) would exceed 2x the stale 1000 average and false-trip.
+        device.StartStreaming();
+        device.InvokeStreamMessage(AnalogFrame(100000, 1.0f)); // first frame — no reference
+        device.InvokeStreamMessage(AnalogFrame(103000, 1.0f)); // +3000 re-seeds the EMA
+        device.InvokeStreamMessage(AnalogFrame(106000, 1.0f)); // +3000 steady
+
+        Assert.Empty(events);
+    }
+
+    #endregion
+
     #region Analog decoding
 
     [Fact]
@@ -434,6 +508,13 @@ public class DaqifiStreamingDeviceDecodeTests
 
     private static IChannel DigitalChannel(DaqifiStreamingDevice device, int number) =>
         device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == number);
+
+    private static DaqifiOutMessage AnalogFrame(uint timestamp, float value)
+    {
+        var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+        frame.AnalogInDataFloat.Add(value);
+        return frame;
+    }
 
     /// <summary>
     /// A <see cref="DaqifiStreamingDevice"/> that captures sent SCPI commands (so streaming

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
@@ -88,6 +88,29 @@ public class DaqifiStreamingDeviceDecodeTests
         Assert.Empty(events);
     }
 
+    [Fact]
+    public void GapDetected_ThrowingSubscriber_DoesNotSkipFrameDecode()
+    {
+        var device = CreateStreamingDevice(analogCount: 1);
+        var ai0 = AnalogChannel(device, 0);
+        ai0.IsEnabled = true;
+        device.StartStreaming();
+
+        device.GapDetected += (_, _) => throw new InvalidOperationException("boom");
+
+        // Steady cadence, then a gap frame that also carries a decodable sample. The gap fires the
+        // throwing subscriber — decode of this frame must still happen.
+        for (uint ts = 1000; ts <= 11000; ts += 1000)
+        {
+            device.InvokeStreamMessage(AnalogFrame(ts, 1.0f));
+        }
+        device.InvokeStreamMessage(AnalogFrame(20000, 7.5f)); // 9x jump -> gap -> throwing handler
+
+        Assert.NotNull(ai0.ActiveSample);
+        Assert.Equal(7.5, ai0.ActiveSample!.Value);
+        Assert.Equal(20000u, ai0.ActiveSample.DeviceTimestamp);
+    }
+
     #endregion
 
     #region Analog decoding

--- a/src/Daqifi.Core.Tests/Device/TimestampGapDetectorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/TimestampGapDetectorTests.cs
@@ -1,0 +1,234 @@
+using System;
+using Daqifi.Core.Device;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class TimestampGapDetectorTests
+    {
+        private readonly TimestampGapDetector _detector = new();
+
+        /// <summary>
+        /// Seeds the detector with <paramref name="count"/> constant deltas after the first
+        /// (null) message, stabilising the EMA around <paramref name="period"/>.
+        /// </summary>
+        private void WarmUp(double period, int count)
+        {
+            _detector.IsGap(null); // first message — no prior reference
+            for (var i = 0; i < count; i++)
+            {
+                _detector.IsGap(period);
+            }
+        }
+
+        #region First-sample behavior
+
+        [Fact]
+        public void IsGap_NullDelta_ReturnsFalse()
+        {
+            Assert.False(_detector.IsGap(null));
+        }
+
+        [Fact]
+        public void IsGap_ZeroDelta_ReturnsFalse()
+        {
+            Assert.False(_detector.IsGap(0.0));
+        }
+
+        [Fact]
+        public void IsGap_NegativeDelta_ReturnsFalse()
+        {
+            Assert.False(_detector.IsGap(-5.0));
+        }
+
+        [Fact]
+        public void IsGap_FirstRealDelta_SeedsEmaAndReturnsFalse()
+        {
+            _detector.IsGap(null);
+            Assert.False(_detector.IsGap(10.0));
+        }
+
+        #endregion
+
+        #region Steady state
+
+        [Fact]
+        public void IsGap_ConsistentCadence_NeverDetectsGap()
+        {
+            const double period = 0.01; // 100 Hz
+            WarmUp(period, count: 10);
+
+            for (var i = 1; i <= 50; i++)
+            {
+                Assert.False(_detector.IsGap(period), $"Sample {i} at steady cadence should not be a gap.");
+            }
+        }
+
+        [Fact]
+        public void IsGap_DeltaExactlyAtThreshold_ReturnsFalse()
+        {
+            const double period = 0.01;
+            WarmUp(period, count: 10);
+
+            // Equal to 2x the average is not strictly greater — not a gap.
+            Assert.False(_detector.IsGap(period * 2.0));
+        }
+
+        [Fact]
+        public void IsGap_MildJitter_DoesNotFalsePositive()
+        {
+            const double period = 0.001; // 1 kHz
+            WarmUp(period, count: 20);
+
+            var rng = new Random(42);
+            for (var i = 0; i < 100; i++)
+            {
+                var jittered = period * (0.9 + rng.NextDouble() * 0.2); // +/-10%
+                Assert.False(_detector.IsGap(jittered), $"Mild jitter at step {i} should not be a gap.");
+            }
+        }
+
+        [Fact]
+        public void IsGap_GraduallySlowingRate_DoesNotFalsePositive()
+        {
+            _detector.IsGap(null);
+            _detector.IsGap(0.010);
+
+            for (var i = 1; i <= 30; i++)
+            {
+                var period = 0.010 + (0.040 / 30) * i; // ramp 10 ms -> 50 ms
+                Assert.False(_detector.IsGap(period), $"Gradual slowdown at step {i} should not be a gap.");
+            }
+        }
+
+        #endregion
+
+        #region Gap detection
+
+        [Fact]
+        public void IsGap_DeltaWellAboveThreshold_ReturnsTrue()
+        {
+            const double period = 0.01;
+            WarmUp(period, count: 10);
+
+            Assert.True(_detector.IsGap(5 * period));
+        }
+
+        [Fact]
+        public void IsGap_DeltaJustAboveThreshold_ReturnsTrue()
+        {
+            const double period = 0.01;
+            WarmUp(period, count: 20);
+
+            Assert.True(_detector.IsGap(period * 2.01));
+        }
+
+        [Fact]
+        public void IsGap_AfterGap_ResumesWithoutFalsePositives()
+        {
+            const double period = 0.01;
+            WarmUp(period, count: 10);
+
+            Assert.True(_detector.IsGap(0.5), "Large gap should be detected.");
+
+            for (var i = 1; i <= 5; i++)
+            {
+                Assert.False(_detector.IsGap(period), $"Post-gap steady sample {i} should not be a gap.");
+            }
+        }
+
+        [Fact]
+        public void IsGap_AfterGap_FutureGapStillDetected()
+        {
+            const double period = 0.01;
+            WarmUp(period, count: 10);
+
+            Assert.True(_detector.IsGap(0.5), "First gap should be detected.");
+            Assert.False(_detector.IsGap(period), "First post-gap sample re-seeds the EMA.");
+            Assert.True(_detector.IsGap(period * 2.5), "A later gap should still be detected.");
+        }
+
+        #endregion
+
+        #region Reset
+
+        [Fact]
+        public void Reset_ReturnsToUnseededState()
+        {
+            const double period = 0.01;
+            WarmUp(period, count: 10);
+
+            _detector.Reset();
+
+            // Behaves as freshly created: first delta only re-seeds, cannot be a gap.
+            Assert.False(_detector.IsGap(null));
+            Assert.False(_detector.IsGap(period));
+            Assert.False(_detector.IsGap(period), "Steady cadence after reset should not be a gap.");
+        }
+
+        [Fact]
+        public void Reset_BeforeSecondDelta_DoesNotFireOnWhatWouldHaveBeenAGap()
+        {
+            const double period = 0.01;
+            WarmUp(period, count: 10);
+            _detector.Reset();
+
+            _detector.IsGap(period); // re-seed
+            // Without reset the EMA would be ~period and 0.5 would trip; but the very next after
+            // a single seed compares against that seed.
+            Assert.True(_detector.IsGap(0.5), "A gap after re-seed is still detectable.");
+        }
+
+        #endregion
+
+        #region Configuration
+
+        [Fact]
+        public void Constructor_DefaultsMatchPublishedConstants()
+        {
+            var d = new TimestampGapDetector();
+            Assert.Equal(TimestampGapDetector.DefaultGapThresholdMultiplier, d.GapThresholdMultiplier);
+            Assert.Equal(TimestampGapDetector.DefaultEmaAlpha, d.EmaAlpha);
+        }
+
+        [Fact]
+        public void Constructor_CustomMultiplier_ChangesSensitivity()
+        {
+            var loose = new TimestampGapDetector(gapThresholdMultiplier: 3.0);
+            loose.IsGap(null);
+            for (var i = 0; i < 10; i++) loose.IsGap(0.01);
+
+            // 2.5x would trip the default (2.0x) detector but not a 3.0x one.
+            Assert.False(loose.IsGap(0.01 * 2.5), "2.5x delta should not be a gap at a 3.0x threshold.");
+            Assert.True(loose.IsGap(0.01 * 3.5), "3.5x delta should be a gap at a 3.0x threshold.");
+        }
+
+        [Theory]
+        [InlineData(1.0)]   // must be strictly greater than 1
+        [InlineData(0.5)]
+        [InlineData(0.0)]
+        [InlineData(-1.0)]
+        public void Constructor_InvalidMultiplier_Throws(double multiplier)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TimestampGapDetector(gapThresholdMultiplier: multiplier));
+        }
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(-0.1)]
+        [InlineData(1.1)]
+        public void Constructor_InvalidEmaAlpha_Throws(double alpha)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TimestampGapDetector(emaAlpha: alpha));
+        }
+
+        [Fact]
+        public void Constructor_BoundaryEmaAlphaOfOne_IsAllowed()
+        {
+            var d = new TimestampGapDetector(emaAlpha: 1.0);
+            Assert.Equal(1.0, d.EmaAlpha);
+        }
+
+        #endregion
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -343,9 +343,12 @@ namespace Daqifi.Core.Device
             var hostTimestamp = timestampResult.Timestamp;
 
             // Flag dropped samples from the device-clock delta (immune to host arrival jitter).
+            // Isolate subscriber exceptions (see RaiseGapDetected) so a throwing GapDetected handler
+            // cannot skip the per-channel decode below — which the caller's broad catch would then
+            // silently drop.
             if (_gapDetector.IsGap(timestampResult.SecondsBetweenMessages))
             {
-                GapDetected?.Invoke(this, new TimestampGapEventArgs(
+                RaiseGapDetected(new TimestampGapEventArgs(
                     hostTimestamp, timestampResult.SecondsBetweenMessages, deviceTimestamp));
             }
 
@@ -361,6 +364,30 @@ namespace Daqifi.Core.Device
             if (hasDigital)
             {
                 DecodeDigital(message, channels, hostTimestamp, deviceTimestamp);
+            }
+        }
+
+        /// <summary>
+        /// Raises <see cref="GapDetected"/>, isolating the decode pipeline from a subscriber
+        /// exception so a throwing handler cannot skip this frame's per-channel decode (which the
+        /// broad catch in <see cref="OnStreamMessageReceived"/> would then silently drop). Mirrors
+        /// <c>DaqifiDevice.RaiseClassifiedEvent</c>.
+        /// </summary>
+        private void RaiseGapDetected(TimestampGapEventArgs args)
+        {
+            var handler = GapDetected;
+            if (handler == null)
+            {
+                return;
+            }
+
+            try
+            {
+                handler(this, args);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[{nameof(GapDetected)}] Subscriber threw: {ex}");
             }
         }
 

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -82,6 +82,12 @@ namespace Daqifi.Core.Device
         private const string StreamTimestampKey = "stream";
 
         /// <summary>
+        /// Detects dropped samples from the device-clock delta between frames. Reset at the start of
+        /// every streaming session alongside <see cref="_timestampProcessor"/>. Drives <see cref="GapDetected"/>.
+        /// </summary>
+        private readonly TimestampGapDetector _gapDetector = new();
+
+        /// <summary>
         /// Gets a value indicating whether the device is currently streaming data.
         /// </summary>
         public bool IsStreaming { get; private set; }
@@ -137,6 +143,14 @@ namespace Daqifi.Core.Device
 
         /// <inheritdoc />
         public event EventHandler<LowSdSpaceWarningEventArgs>? LowSdSpaceWarning;
+
+        /// <summary>
+        /// Raised while streaming when the device-clock delta between two consecutive frames
+        /// indicates dropped samples (a real gap in the device's stream, distinct from host-side
+        /// arrival jitter). Fires once per detected gap, on the decode thread, carrying the outage
+        /// duration and the timestamp of the first frame after the gap. See <see cref="TimestampGapDetector"/>.
+        /// </summary>
+        public event EventHandler<TimestampGapEventArgs>? GapDetected;
 
         private readonly NetworkConfiguration _networkConfiguration = new NetworkConfiguration();
 
@@ -252,6 +266,7 @@ namespace Daqifi.Core.Device
             // when unreported, e.g. older firmware).
             _timestampProcessor.Reset(StreamTimestampKey);
             _timestampProcessor.SetTimestampFrequency(StreamTimestampKey, TimestampFrequency);
+            _gapDetector.Reset();
 
             IsStreaming = true;
             Send(ScpiMessageProducer.StartStreaming(StreamingFrequency));
@@ -324,9 +339,15 @@ namespace Daqifi.Core.Device
             // Reconstruct a host timestamp from the device tick counter (rollover-aware) and carry
             // the raw device tick value through to each decoded sample.
             var deviceTimestamp = message.MsgTimeStamp;
-            var hostTimestamp = _timestampProcessor
-                .ProcessTimestamp(StreamTimestampKey, deviceTimestamp)
-                .Timestamp;
+            var timestampResult = _timestampProcessor.ProcessTimestamp(StreamTimestampKey, deviceTimestamp);
+            var hostTimestamp = timestampResult.Timestamp;
+
+            // Flag dropped samples from the device-clock delta (immune to host arrival jitter).
+            if (_gapDetector.IsGap(timestampResult.SecondsBetweenMessages))
+            {
+                GapDetected?.Invoke(this, new TimestampGapEventArgs(
+                    hostTimestamp, timestampResult.SecondsBetweenMessages, deviceTimestamp));
+            }
 
             // Snapshot channels once: the consumer thread that repopulates channels is the same
             // thread that runs this decode, so the structure is stable for the duration of the call.

--- a/src/Daqifi.Core/Device/TimestampGapDetector.cs
+++ b/src/Daqifi.Core/Device/TimestampGapDetector.cs
@@ -1,0 +1,137 @@
+using System;
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Detects dropped/missing samples in a stream using the device's own hardware-timer delta
+    /// between messages (<see cref="TimestampResult.SecondsBetweenMessages"/>) rather than PC
+    /// arrival time. Keeping an exponential moving average (EMA) of the inter-message delta and
+    /// flagging a message whose delta exceeds <see cref="GapThresholdMultiplier"/> times that
+    /// average makes detection immune to TCP jitter / packet batching — only a real device-clock
+    /// gap (actual data loss) trips it.
+    /// </summary>
+    /// <remarks>
+    /// This is a per-stream primitive: one instance tracks one streaming session's cadence. The
+    /// device stamps every channel in a frame with the same <c>msg_time_stamp</c>, so a gap is a
+    /// property of the frame, not of an individual channel — feed it the per-message delta once per
+    /// frame. Ported from the daqifi-desktop utility of the same name (issue #339) so every Core
+    /// streaming consumer, not just the desktop app, gets the data-integrity signal.
+    /// </remarks>
+    public sealed class TimestampGapDetector
+    {
+        /// <summary>The default multiple of the running-average delta above which a gap is flagged.</summary>
+        public const double DefaultGapThresholdMultiplier = 2.0;
+
+        /// <summary>
+        /// The default EMA smoothing factor for inter-message deltas. Lower values adapt more slowly,
+        /// making detection more stable against jitter.
+        /// </summary>
+        public const double DefaultEmaAlpha = 0.1;
+
+        private readonly double _thresholdMultiplier;
+        private readonly double _emaAlpha;
+        private double _averageDelta;
+        private bool _seeded;
+
+        /// <summary>
+        /// Gets the multiple of the running-average delta above which a message is flagged as a gap.
+        /// </summary>
+        public double GapThresholdMultiplier => _thresholdMultiplier;
+
+        /// <summary>
+        /// Gets the EMA smoothing factor applied to inter-message deltas.
+        /// </summary>
+        public double EmaAlpha => _emaAlpha;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimestampGapDetector"/> class.
+        /// </summary>
+        /// <param name="gapThresholdMultiplier">
+        /// The multiple of the running-average delta above which a message is flagged as a gap.
+        /// Must be greater than 1.0. Defaults to <see cref="DefaultGapThresholdMultiplier"/>.
+        /// </param>
+        /// <param name="emaAlpha">
+        /// The EMA smoothing factor for inter-message deltas, in the range (0, 1]. Defaults to
+        /// <see cref="DefaultEmaAlpha"/>.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="gapThresholdMultiplier"/> is not greater than 1.0, or when
+        /// <paramref name="emaAlpha"/> is not in the range (0, 1].
+        /// </exception>
+        public TimestampGapDetector(
+            double gapThresholdMultiplier = DefaultGapThresholdMultiplier,
+            double emaAlpha = DefaultEmaAlpha)
+        {
+            if (!(gapThresholdMultiplier > 1.0))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(gapThresholdMultiplier),
+                    gapThresholdMultiplier,
+                    "Gap threshold multiplier must be greater than 1.0.");
+            }
+
+            if (!(emaAlpha > 0.0 && emaAlpha <= 1.0))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(emaAlpha),
+                    emaAlpha,
+                    "EMA alpha must be in the range (0, 1].");
+            }
+
+            _thresholdMultiplier = gapThresholdMultiplier;
+            _emaAlpha = emaAlpha;
+        }
+
+        /// <summary>
+        /// Evaluates whether the device-measured inter-message delta indicates missing samples,
+        /// and folds the delta into the running average when it does not.
+        /// </summary>
+        /// <param name="secondsBetweenMessages">
+        /// The device-clock time since the previous message, in seconds
+        /// (<see cref="TimestampResult.SecondsBetweenMessages"/>). Pass <see langword="null"/> or a
+        /// non-positive value for the first message of a session (no prior reference point).
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the delta significantly exceeds the running average — a real
+        /// gap in the device's sample stream; otherwise <see langword="false"/>. After a gap the EMA
+        /// is reset so a single large outage does not desensitise later detection.
+        /// </returns>
+        public bool IsGap(double? secondsBetweenMessages)
+        {
+            // First message, or no usable device delta — no gap possible.
+            if (secondsBetweenMessages is not > 0)
+            {
+                return false;
+            }
+
+            var delta = secondsBetweenMessages.Value;
+
+            if (!_seeded)
+            {
+                // First real delta — seed the EMA, cannot be a gap yet.
+                _seeded = true;
+                _averageDelta = delta;
+                return false;
+            }
+
+            if (_averageDelta > 0 && delta > _thresholdMultiplier * _averageDelta)
+            {
+                // Reset after a detected gap so the next message re-seeds the EMA from fresh cadence.
+                Reset();
+                return true;
+            }
+
+            _averageDelta = (1.0 - _emaAlpha) * _averageDelta + _emaAlpha * delta;
+            return false;
+        }
+
+        /// <summary>
+        /// Resets the running average, returning the detector to its unseeded (start-of-session) state.
+        /// </summary>
+        public void Reset()
+        {
+            _averageDelta = 0;
+            _seeded = false;
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/TimestampGapEventArgs.cs
+++ b/src/Daqifi.Core/Device/TimestampGapEventArgs.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Carries information about a detected gap in the device's sample stream, raised by
+    /// <see cref="DaqifiStreamingDevice.GapDetected"/> when the device-clock delta between two
+    /// consecutive frames indicates missing samples.
+    /// </summary>
+    public sealed class TimestampGapEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the reconstructed host timestamp of the first frame received after the gap.
+        /// </summary>
+        public DateTime Timestamp { get; }
+
+        /// <summary>
+        /// Gets the device-clock time, in seconds, between the frame before the gap and the frame
+        /// that triggered detection — i.e. the duration of the outage.
+        /// </summary>
+        public double SecondsSincePreviousMessage { get; }
+
+        /// <summary>
+        /// Gets the raw device tick counter value of the frame that triggered detection.
+        /// </summary>
+        public uint DeviceTimestamp { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimestampGapEventArgs"/> class.
+        /// </summary>
+        /// <param name="timestamp">The host timestamp of the first frame after the gap.</param>
+        /// <param name="secondsSincePreviousMessage">The device-clock outage duration, in seconds.</param>
+        /// <param name="deviceTimestamp">The raw device tick counter value of the triggering frame.</param>
+        public TimestampGapEventArgs(DateTime timestamp, double secondsSincePreviousMessage, uint deviceTimestamp)
+        {
+            Timestamp = timestamp;
+            SecondsSincePreviousMessage = secondsSincePreviousMessage;
+            DeviceTimestamp = deviceTimestamp;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Ports daqifi-desktop's device-generic `TimestampGapDetector` into Core (issue #339) so **every** streaming consumer gets a dropped-sample signal, not just the desktop app. Detection uses the device's own hardware-timer delta between frames (`TimestampResult.SecondsBetweenMessages`) — immune to TCP/USB arrival jitter — via an EMA of inter-message deltas: a gap is flagged when a delta exceeds a configurable multiple (default `2.0x`) of the running average, and the EMA resets after a gap so one outage doesn't desensitise later detection.

## Changes
- **`Daqifi.Core.Device.TimestampGapDetector`** (new, public) — instance-per-stream primitive, `IsGap(double? secondsBetweenMessages)` / `Reset()`, configurable `gapThresholdMultiplier` (>1) and `emaAlpha` ((0,1]) with argument validation. A gap is a property of the frame (all channels share `msg_time_stamp`), so this is per-stream rather than desktop's per-channel keying.
- **`TimestampGapEventArgs`** + **`DaqifiStreamingDevice.GapDetected`** event — raised from the decode path (`DecodeStreamFrame`) with the outage duration and the first post-gap frame's timestamp. The detector is reset in `StartStreaming` alongside the timestamp processor, so a new session's cadence never false-trips.

## Testing
- `dotnet test` — **1662 passed / 0 failed / 2 skipped** (net9.0 + net10.0).
- **24** `TimestampGapDetector` unit tests: null/zero/negative first-sample, steady cadence, exactly-at-threshold (no fire), just-above-threshold (fire), well-above (fire), post-gap resume, later-gap-still-detects, mild-jitter immunity, gradual-slowdown adaptation, reset, and constructor validation (multiplier & alpha bounds, α=1 boundary).
- **3** device-level wiring tests: fires once on a device-clock gap after steady cadence; silent on steady cadence; resets between sessions so a different cadence doesn't false-trip.
- **Bench-validated against real hardware data (Nq1, FW 3.7.2):** replayed a real 30 s / 500 Hz capture through the actual detector — it flagged **19 real dropped-sample gaps** (deltas just above 2x the ~84,000-tick period) and correctly did *not* fire on the 6 that were exactly 2x (strict-greater, matching desktop). Independently re-confirmed the malformed short first frame from #351.

## Acceptance criteria (#339)
- [x] Device-clock-driven detection (EMA, threshold multiplier, post-gap reset)
- [x] Consumable from the decoded sample pipeline (`GapDetected` event)
- [x] Unit tests: steady, real gap, EMA reset
- [ ] Desktop deletes its copy and consumes Core's — **follow-up in daqifi-desktop** (the Core primitive is now available; desktop holds one detector per stream, or a `Dictionary<channelKey, TimestampGapDetector>` if it keeps per-channel line-breaks)

Not merging myself — leaving for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)