### PR TITLE
feat(discovery): AllTransportsDeviceFinder + DiscoverAndConnectAsync (closes #338)

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -180,6 +180,31 @@ resolve to `null`, same as `IUsbPortDescriptorProvider`'s cross-platform fallbac
 > parsing/fallback logic has automated coverage). Confirm both on a Windows bench with real
 > hardware before relying on this for anything safety-critical.
 
+### Discover Across All Transports (Recommended)
+
+To "find any DAQiFi on WiFi or USB" in one call, use `AllTransportsDeviceFinder` — it runs the
+per-transport finders concurrently and returns a single deduplicated set. Because it is itself an
+`IDeviceFinder`, wrapping it in a `ContinuousDeviceFinder` (below) gives deduplicated *continuous*
+discovery across every transport for free.
+
+```csharp
+using Daqifi.Core.Device.Discovery;
+
+// One-shot across WiFi + serial:
+using var finder = AllTransportsDeviceFinder.CreateDefault();
+var devices = await finder.DiscoverAsync(TimeSpan.FromSeconds(3));
+
+// Or the common "find one and connect" case in a single call:
+var device = await DaqifiDeviceFactory.DiscoverAndConnectAsync(
+    filter: d => d.ConnectionType == ConnectionType.Serial,   // optional; first match otherwise
+    timeout: TimeSpan.FromSeconds(5));
+```
+
+A transport finder that fails (e.g. WiFi discovery with no network) is logged and skipped, so the
+other transports still return. Deduplication reuses `ContinuousDeviceFinder`'s per-transport
+identity, so the same physical unit reachable over both WiFi and USB appears as two connection
+options; pass a custom `identitySelector` (e.g. by serial number) to collapse them.
+
 ### Continuous Discovery (Live Device Set)
 
 `IDeviceFinder.DiscoverAsync` is a single pass. For a UI that shows a live, self-updating
@@ -211,11 +236,12 @@ continuous.Dispose(); // also disposes the wrapped finder unless LeaveInnerFinde
 ```
 
 One instance wraps one finder, so it represents a single transport's cadence and live set.
-To track WiFi, Serial, and HID together, create one `ContinuousDeviceFinder` per transport —
-each with its own interval — and merge their events into a single collection. Devices are
-deduplicated per transport: the same physical unit seen over both WiFi and Serial appears as
-two distinct connection options. `continuous.Devices` returns a thread-safe snapshot of the
-current set at any time.
+To track WiFi, Serial, and HID together, prefer wrapping an `AllTransportsDeviceFinder` (above)
+in a single `ContinuousDeviceFinder` — one cadence, one deduplicated live set across every
+transport. (Only reach for the advanced path of one `ContinuousDeviceFinder` *per* transport when
+you need a different interval per transport.) Devices are deduplicated per transport: the same
+physical unit seen over both WiFi and Serial appears as two distinct connection options.
+`continuous.Devices` returns a thread-safe snapshot of the current set at any time.
 
 ### Manual Device Connection (Advanced)
 

--- a/src/Daqifi.Core.Tests/Device/Discovery/AllTransportsDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/AllTransportsDeviceFinderTests.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Discovery;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.Discovery
+{
+    public class AllTransportsDeviceFinderTests
+    {
+        [Fact]
+        public async Task DiscoverAsync_FansOutAcrossFinders_ReturnsUnion()
+        {
+            var wifi = new ListDeviceFinder(new[] { Info("A", ConnectionType.WiFi) });
+            var serial = new ListDeviceFinder(new[] { Info("B", ConnectionType.Serial) });
+            var finder = new AllTransportsDeviceFinder(new IDeviceFinder[] { wifi, serial });
+
+            var result = (await finder.DiscoverAsync()).ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, d => d.SerialNumber == "A");
+            Assert.Contains(result, d => d.SerialNumber == "B");
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_DuplicateFromTwoFindersSameTransport_DedupedFirstWins()
+        {
+            // Same serial + same transport => same default identity => one entry, first finder wins.
+            var first = new ListDeviceFinder(new[] { Info("DUP", ConnectionType.Serial, name: "first") });
+            var second = new ListDeviceFinder(new[] { Info("DUP", ConnectionType.Serial, name: "second") });
+            var finder = new AllTransportsDeviceFinder(new IDeviceFinder[] { first, second });
+
+            var result = (await finder.DiscoverAsync()).ToList();
+
+            Assert.Single(result);
+            Assert.Equal("first", result[0].Name);
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_SameDeviceOnTwoTransports_KeptAsTwoEntries()
+        {
+            // Default identity is per-transport (issue #245): a device reachable on both USB and
+            // WiFi is two genuine ways to connect, so it is intentionally NOT collapsed.
+            var wifi = new ListDeviceFinder(new[] { Info("SHARED", ConnectionType.WiFi) });
+            var serial = new ListDeviceFinder(new[] { Info("SHARED", ConnectionType.Serial) });
+            var finder = new AllTransportsDeviceFinder(new IDeviceFinder[] { wifi, serial });
+
+            var result = (await finder.DiscoverAsync()).ToList();
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_CustomIdentitySelector_CollapsesAcrossTransports()
+        {
+            var wifi = new ListDeviceFinder(new[] { Info("SHARED", ConnectionType.WiFi) });
+            var serial = new ListDeviceFinder(new[] { Info("SHARED", ConnectionType.Serial) });
+            var finder = new AllTransportsDeviceFinder(
+                new IDeviceFinder[] { wifi, serial },
+                identitySelector: d => "sn:" + d.SerialNumber);
+
+            var result = (await finder.DiscoverAsync()).ToList();
+
+            Assert.Single(result); // both share serial "SHARED" under the custom selector
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_EmptyIdentitySelectorResult_FallsBackToDefault()
+        {
+            // Selector returns empty => must fall back to the per-transport default (which keeps
+            // these two distinct), rather than collapsing everything onto one empty key.
+            var a = new ListDeviceFinder(new[] { Info("A", ConnectionType.Serial) });
+            var b = new ListDeviceFinder(new[] { Info("B", ConnectionType.Serial) });
+            var finder = new AllTransportsDeviceFinder(
+                new IDeviceFinder[] { a, b },
+                identitySelector: _ => "   ");
+
+            var result = (await finder.DiscoverAsync()).ToList();
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_OneFinderThrows_OthersStillReturned()
+        {
+            var good = new ListDeviceFinder(new[] { Info("OK", ConnectionType.Serial) });
+            var bad = new ListDeviceFinder(Array.Empty<IDeviceInfo>(), throwOnDiscover: new InvalidOperationException("wifi down"));
+            var finder = new AllTransportsDeviceFinder(new IDeviceFinder[] { bad, good });
+
+            var result = (await finder.DiscoverAsync()).ToList();
+
+            Assert.Single(result);
+            Assert.Equal("OK", result[0].SerialNumber);
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_RaisesDeviceDiscoveredPerUnique_AndCompletedOnce()
+        {
+            var wifi = new ListDeviceFinder(new[] { Info("A", ConnectionType.WiFi) });
+            var serial = new ListDeviceFinder(new[] { Info("B", ConnectionType.Serial) });
+            var finder = new AllTransportsDeviceFinder(new IDeviceFinder[] { wifi, serial });
+
+            var discovered = new List<string>();
+            var completed = 0;
+            finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo.SerialNumber);
+            finder.DiscoveryCompleted += (_, _) => completed++;
+
+            await finder.DiscoverAsync();
+
+            Assert.Equal(new[] { "A", "B" }, discovered.OrderBy(s => s).ToArray());
+            Assert.Equal(1, completed);
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_Cancelled_PropagatesCancellation()
+        {
+            var finder = new AllTransportsDeviceFinder(
+                new IDeviceFinder[] { new ListDeviceFinder(Array.Empty<IDeviceInfo>(), observeCancellation: true) });
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => finder.DiscoverAsync(cts.Token));
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_TimeoutOverload_ReturnsResults()
+        {
+            var finder = new AllTransportsDeviceFinder(
+                new IDeviceFinder[] { new ListDeviceFinder(new[] { Info("A", ConnectionType.Serial) }) });
+
+            var result = (await finder.DiscoverAsync(TimeSpan.FromSeconds(1))).ToList();
+
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void Dispose_CallerSuppliedFinders_AreNotDisposed()
+        {
+            var supplied = new ListDeviceFinder(Array.Empty<IDeviceInfo>());
+            var finder = new AllTransportsDeviceFinder(new IDeviceFinder[] { supplied });
+
+            finder.Dispose();
+
+            Assert.False(supplied.Disposed); // caller owns supplied finders
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_AfterDispose_Throws()
+        {
+            var finder = new AllTransportsDeviceFinder(
+                new IDeviceFinder[] { new ListDeviceFinder(Array.Empty<IDeviceInfo>()) });
+            finder.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => finder.DiscoverAsync());
+        }
+
+        [Fact]
+        public void Constructor_NullFinders_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AllTransportsDeviceFinder(null!));
+        }
+
+        [Fact]
+        public void Constructor_EmptyFinders_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new AllTransportsDeviceFinder(Array.Empty<IDeviceFinder>()));
+        }
+
+        [Fact]
+        public void Constructor_ContainsNull_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new AllTransportsDeviceFinder(new IDeviceFinder[] { null! }));
+        }
+
+        [Fact]
+        public void CreateDefault_ReturnsUsableFinder()
+        {
+            using var finder = AllTransportsDeviceFinder.CreateDefault();
+            Assert.NotNull(finder);
+        }
+
+        // ---- DaqifiDeviceFactory.DiscoverAndConnectAsync selection paths ----
+
+        [Fact]
+        public async Task DiscoverAndConnectAsync_NoDeviceFound_Throws()
+        {
+            var empty = new ListDeviceFinder(Array.Empty<IDeviceInfo>());
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => DaqifiDeviceFactory.DiscoverAndConnectAsync(finder: empty));
+        }
+
+        [Fact]
+        public async Task DiscoverAndConnectAsync_FilterMatchesNothing_Throws()
+        {
+            var finder = new ListDeviceFinder(new[] { Info("A", ConnectionType.Serial) });
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => DaqifiDeviceFactory.DiscoverAndConnectAsync(
+                    filter: d => d.SerialNumber == "does-not-exist",
+                    finder: finder));
+        }
+
+        [Fact]
+        public async Task DiscoverAndConnectAsync_AlreadyCancelled_Throws()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => DaqifiDeviceFactory.DiscoverAndConnectAsync(
+                    finder: new ListDeviceFinder(Array.Empty<IDeviceInfo>()),
+                    cancellationToken: cts.Token));
+        }
+
+        #region Helpers
+
+        private static FakeDeviceInfo Info(string serial, ConnectionType type, string? name = null) => new()
+        {
+            SerialNumber = serial,
+            ConnectionType = type,
+            Name = name ?? serial,
+        };
+
+        private sealed class ListDeviceFinder : IDeviceFinder, IDisposable
+        {
+            private readonly IReadOnlyList<IDeviceInfo> _devices;
+            private readonly Exception? _throw;
+            private readonly bool _observeCancellation;
+
+            public ListDeviceFinder(IEnumerable<IDeviceInfo> devices, Exception? throwOnDiscover = null, bool observeCancellation = false)
+            {
+                _devices = devices.ToList();
+                _throw = throwOnDiscover;
+                _observeCancellation = observeCancellation;
+            }
+
+            public bool Disposed { get; private set; }
+
+#pragma warning disable CS0067 // interface events unused by this fake
+            public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
+            public event EventHandler? DiscoveryCompleted;
+#pragma warning restore CS0067
+
+            public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+            {
+                if (_observeCancellation)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                if (_throw != null)
+                {
+                    throw _throw;
+                }
+
+                return Task.FromResult<IEnumerable<IDeviceInfo>>(_devices);
+            }
+
+            public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout) => DiscoverAsync(CancellationToken.None);
+
+            public void Dispose() => Disposed = true;
+        }
+
+        private sealed class FakeDeviceInfo : IDeviceInfo
+        {
+            public string Name { get; set; } = "Fake";
+            public string SerialNumber { get; set; } = "SN";
+            public string FirmwareVersion { get; set; } = "3.7.2";
+            public IPAddress? IPAddress { get; set; }
+            public string? MacAddress { get; set; }
+            public int? Port { get; set; }
+            public IPAddress? LocalInterfaceAddress { get; set; }
+            public Daqifi.Core.Device.Discovery.DeviceType Type { get; set; } = Daqifi.Core.Device.Discovery.DeviceType.Nyquist1;
+            public bool IsPowerOn { get; set; } = true;
+            public ConnectionType ConnectionType { get; set; } = ConnectionType.Unknown;
+            public string? PortName { get; set; }
+            public string? DevicePath { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/Discovery/AllTransportsDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/AllTransportsDeviceFinderTests.cs
@@ -183,6 +183,43 @@ namespace Daqifi.Core.Tests.Device.Discovery
             Assert.NotNull(finder);
         }
 
+        [Fact]
+        public async Task DiscoverAsync_ThrowingDeviceDiscoveredSubscriber_StillReturnsAllAndCompletes()
+        {
+            var a = new ListDeviceFinder(new[] { Info("A", ConnectionType.WiFi) });
+            var b = new ListDeviceFinder(new[] { Info("B", ConnectionType.Serial) });
+            var finder = new AllTransportsDeviceFinder(new IDeviceFinder[] { a, b });
+
+            finder.DeviceDiscovered += (_, _) => throw new InvalidOperationException("boom");
+            var completed = 0;
+            finder.DiscoveryCompleted += (_, _) => completed++;
+
+            // A throwing subscriber must not abort the dedup loop or skip DiscoveryCompleted.
+            var result = (await finder.DiscoverAsync()).ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1, completed);
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_Timeout_FinderThrowsCancellation_ReturnsOthersAndCompletes()
+        {
+            // A finder that throws OperationCanceledException on its timeout overload must be treated
+            // as a normal (empty) end-of-pass, not propagate out and skip DiscoveryCompleted.
+            var throwsOce = new ListDeviceFinder(new[] { Info("A", ConnectionType.WiFi) }, throwOnDiscover: new OperationCanceledException());
+            var ok = new ListDeviceFinder(new[] { Info("B", ConnectionType.Serial) });
+            var finder = new AllTransportsDeviceFinder(new IDeviceFinder[] { throwsOce, ok });
+
+            var completed = 0;
+            finder.DiscoveryCompleted += (_, _) => completed++;
+
+            var result = (await finder.DiscoverAsync(TimeSpan.FromMilliseconds(50))).ToList();
+
+            Assert.Single(result);
+            Assert.Equal("B", result[0].SerialNumber);
+            Assert.Equal(1, completed);
+        }
+
         // ---- DaqifiDeviceFactory.DiscoverAndConnectAsync selection paths ----
 
         [Fact]

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -283,6 +283,70 @@ public static class DaqifiDeviceFactory
     }
 
     /// <summary>
+    /// Discovers DAQiFi devices across all transports (WiFi + serial) concurrently and connects to
+    /// the first match — the one-call "find any DAQiFi and connect" path.
+    /// </summary>
+    /// <param name="filter">
+    /// Optional predicate to select among discovered devices (e.g. by serial number or transport).
+    /// When null, the first discovered device is used.
+    /// </param>
+    /// <param name="timeout">Discovery timeout. Defaults to 5 seconds when null.</param>
+    /// <param name="options">Optional connection options passed through to the connect step.</param>
+    /// <param name="finder">
+    /// Optional finder to discover with (e.g. a serial-only finder, or a preconfigured
+    /// <see cref="Discovery.AllTransportsDeviceFinder"/>). When null, a default all-transports finder
+    /// is created and disposed internally.
+    /// </param>
+    /// <param name="cancellationToken">A cancellation token to cancel discovery and connection.</param>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no matching device is discovered.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels the operation.</exception>
+    public static async Task<DaqifiDevice> DiscoverAndConnectAsync(
+        Func<IDeviceInfo, bool>? filter = null,
+        TimeSpan? timeout = null,
+        DeviceConnectionOptions? options = null,
+        IDeviceFinder? finder = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var ownsFinder = finder == null;
+        var actualFinder = finder ?? Discovery.AllTransportsDeviceFinder.CreateDefault();
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(5));
+
+            IEnumerable<IDeviceInfo> devices;
+            try
+            {
+                devices = await actualFinder.DiscoverAsync(cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // The discovery timeout elapsed — treat as "nothing found" rather than an error.
+                devices = Enumerable.Empty<IDeviceInfo>();
+            }
+
+            var selected = (filter != null ? devices.Where(filter) : devices).FirstOrDefault();
+            if (selected == null)
+            {
+                throw new InvalidOperationException(
+                    "No matching DAQiFi device was discovered on any transport within the timeout.");
+            }
+
+            return await ConnectFromDeviceInfoAsync(selected, options, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (ownsFinder && actualFinder is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
     /// Connects to a WiFi device using the provided device info.
     /// </summary>
     private static async Task<DaqifiDevice> ConnectWiFiDeviceAsync(

--- a/src/Daqifi.Core/Device/Discovery/AllTransportsDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/AllTransportsDeviceFinder.cs
@@ -97,10 +97,36 @@ namespace Daqifi.Core.Device.Discovery
             ThrowIfDisposed();
 
             // Fan out concurrently; results[i] corresponds to _finders[i], giving a stable,
-            // finder-ordered "first wins" for deduplication.
+            // finder-ordered "first wins" for deduplication. A caller-supplied token that fires
+            // surfaces as OperationCanceledException (SafeDiscoverAsync rethrows it).
             var results = await Task.WhenAll(_finders.Select(f => SafeDiscoverAsync(f, cancellationToken)))
                 .ConfigureAwait(false);
 
+            return MergeAndPublish(results);
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
+        {
+            ThrowIfDisposed();
+
+            // Delegate to each finder's own timeout overload so a timeout is a normal end-of-pass
+            // (return what was found), matching WiFiDeviceFinder/SerialDeviceFinder — rather than
+            // routing through the cancellation path, where a finder observing the timeout token
+            // would throw OperationCanceledException and skip DiscoveryCompleted.
+            var results = await Task.WhenAll(_finders.Select(f => SafeDiscoverAsync(f, timeout)))
+                .ConfigureAwait(false);
+
+            return MergeAndPublish(results);
+        }
+
+        /// <summary>
+        /// Deduplicates the per-finder results (finder-ordered, first-wins) and publishes the
+        /// <see cref="DeviceDiscovered"/> / <see cref="DiscoveryCompleted"/> events, isolating
+        /// subscriber exceptions so a throwing consumer callback cannot abort discovery.
+        /// </summary>
+        private IEnumerable<IDeviceInfo> MergeAndPublish(IEnumerable<IEnumerable<IDeviceInfo>> results)
+        {
             var seen = new HashSet<string>(StringComparer.Ordinal);
             var unique = new List<IDeviceInfo>();
             foreach (var device in results.SelectMany(r => r))
@@ -108,19 +134,25 @@ namespace Daqifi.Core.Device.Discovery
                 if (device != null && seen.Add(Identity(device)))
                 {
                     unique.Add(device);
-                    DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(device));
+                    RaiseIsolated(() => DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(device)), nameof(DeviceDiscovered));
                 }
             }
 
-            DiscoveryCompleted?.Invoke(this, EventArgs.Empty);
+            RaiseIsolated(() => DiscoveryCompleted?.Invoke(this, EventArgs.Empty), nameof(DiscoveryCompleted));
             return unique;
         }
 
-        /// <inheritdoc />
-        public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
+        private static void RaiseIsolated(Action raise, string eventName)
         {
-            using var cts = new CancellationTokenSource(timeout);
-            return await DiscoverAsync(cts.Token).ConfigureAwait(false);
+            try
+            {
+                raise();
+            }
+            catch (Exception ex)
+            {
+                // Discovery outcome must not depend on consumer callback correctness.
+                Trace.WriteLine($"[{nameof(AllTransportsDeviceFinder)}] {eventName} subscriber threw: {ex}");
+            }
         }
 
         private async Task<IEnumerable<IDeviceInfo>> SafeDiscoverAsync(IDeviceFinder finder, CancellationToken cancellationToken)
@@ -139,6 +171,22 @@ namespace Daqifi.Core.Device.Discovery
             {
                 // One transport failing (e.g. WiFi with no network) must not sink the whole discovery.
                 Trace.WriteLine($"[{nameof(AllTransportsDeviceFinder)}] {finder.GetType().Name} discovery failed: {ex}");
+                return Enumerable.Empty<IDeviceInfo>();
+            }
+        }
+
+        private async Task<IEnumerable<IDeviceInfo>> SafeDiscoverAsync(IDeviceFinder finder, TimeSpan timeout)
+        {
+            try
+            {
+                return await finder.DiscoverAsync(timeout).ConfigureAwait(false)
+                    ?? Enumerable.Empty<IDeviceInfo>();
+            }
+            catch (Exception ex)
+            {
+                // Timeout is a normal end-of-pass here (no caller token to honor); a finder that
+                // fails or throws on its own timeout must not sink the other transports' results.
+                Trace.WriteLine($"[{nameof(AllTransportsDeviceFinder)}] {finder.GetType().Name} timed-out discovery failed: {ex}");
                 return Enumerable.Empty<IDeviceInfo>();
             }
         }

--- a/src/Daqifi.Core/Device/Discovery/AllTransportsDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/AllTransportsDeviceFinder.cs
@@ -150,8 +150,9 @@ namespace Daqifi.Core.Device.Discovery
             }
             catch (Exception ex)
             {
-                // Discovery outcome must not depend on consumer callback correctness.
-                Trace.WriteLine($"[{nameof(AllTransportsDeviceFinder)}] {eventName} subscriber threw: {ex}");
+                // Discovery outcome must not depend on consumer callback correctness (nor on the
+                // logging path — SafeTrace swallows a throwing TraceListener).
+                SafeTrace($"[{nameof(AllTransportsDeviceFinder)}] {eventName} subscriber threw: {ex}");
             }
         }
 
@@ -170,7 +171,7 @@ namespace Daqifi.Core.Device.Discovery
             catch (Exception ex)
             {
                 // One transport failing (e.g. WiFi with no network) must not sink the whole discovery.
-                Trace.WriteLine($"[{nameof(AllTransportsDeviceFinder)}] {finder.GetType().Name} discovery failed: {ex}");
+                SafeTrace($"[{nameof(AllTransportsDeviceFinder)}] {finder.GetType().Name} discovery failed: {ex}");
                 return Enumerable.Empty<IDeviceInfo>();
             }
         }
@@ -184,10 +185,23 @@ namespace Daqifi.Core.Device.Discovery
             }
             catch (Exception ex)
             {
-                // Timeout is a normal end-of-pass here (no caller token to honor); a finder that
-                // fails or throws on its own timeout must not sink the other transports' results.
-                Trace.WriteLine($"[{nameof(AllTransportsDeviceFinder)}] {finder.GetType().Name} timed-out discovery failed: {ex}");
+                // Timeout is a normal end-of-pass here (no caller token to honor); any failure —
+                // timeout, socket error, disposed resource — must not sink the other transports'
+                // results. Message stays generic since the cause is not necessarily the timeout.
+                SafeTrace($"[{nameof(AllTransportsDeviceFinder)}] {finder.GetType().Name} discovery failed during a timed pass: {ex}");
                 return Enumerable.Empty<IDeviceInfo>();
+            }
+        }
+
+        private static void SafeTrace(string message)
+        {
+            try
+            {
+                Trace.WriteLine(message);
+            }
+            catch
+            {
+                // Best-effort logging: a misbehaving TraceListener must never affect discovery.
             }
         }
 

--- a/src/Daqifi.Core/Device/Discovery/AllTransportsDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/AllTransportsDeviceFinder.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.Discovery
+{
+    /// <summary>
+    /// An <see cref="IDeviceFinder"/> that fans a single discovery out across several transport
+    /// finders (WiFi + serial today, mDNS/#183 later) concurrently and returns one deduplicated
+    /// device set — so "find any DAQiFi on WiFi or USB" is a single call instead of the manual
+    /// instantiate-both / run-both / concatenate / dedupe dance every consumer otherwise repeats.
+    /// </summary>
+    /// <remarks>
+    /// Because <see cref="ContinuousDeviceFinder"/> wraps any <see cref="IDeviceFinder"/>, passing an
+    /// instance of this class to it yields deduplicated <b>continuous</b> discovery across all
+    /// transports for free. Deduplication reuses <see cref="ContinuousDeviceFinder.DefaultIdentity"/>
+    /// (issue #245): the same physical device reachable on two transports is intentionally kept as two
+    /// entries (two genuine ways to connect), while a device reported twice by one transport collapses
+    /// to one. A single transport finder throwing (e.g. WiFi discovery with no network) is logged and
+    /// skipped so the other transports still return results.
+    /// </remarks>
+    public sealed class AllTransportsDeviceFinder : IDeviceFinder, IDisposable
+    {
+        private readonly IReadOnlyList<IDeviceFinder> _finders;
+        private readonly Func<IDeviceInfo, string>? _identitySelector;
+        private readonly bool _ownsFinders;
+        private bool _disposed;
+
+        /// <inheritdoc />
+        public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
+
+        /// <inheritdoc />
+        public event EventHandler? DiscoveryCompleted;
+
+        /// <summary>
+        /// Initializes a new instance over the supplied transport finders. The caller retains
+        /// ownership of the finders and is responsible for disposing them.
+        /// </summary>
+        /// <param name="finders">The transport finders to aggregate. Must be non-empty.</param>
+        /// <param name="identitySelector">
+        /// Optional per-device identity used for deduplication. When null (or it returns an
+        /// empty key for a device), <see cref="ContinuousDeviceFinder.DefaultIdentity"/> is used.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="finders"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="finders"/> is empty or contains null.</exception>
+        public AllTransportsDeviceFinder(
+            IEnumerable<IDeviceFinder> finders,
+            Func<IDeviceInfo, string>? identitySelector = null)
+            : this(finders, identitySelector, ownsFinders: false)
+        {
+        }
+
+        private AllTransportsDeviceFinder(
+            IEnumerable<IDeviceFinder> finders,
+            Func<IDeviceInfo, string>? identitySelector,
+            bool ownsFinders)
+        {
+            if (finders == null)
+            {
+                throw new ArgumentNullException(nameof(finders));
+            }
+
+            var list = finders.ToList();
+            if (list.Count == 0)
+            {
+                throw new ArgumentException("At least one transport finder is required.", nameof(finders));
+            }
+
+            if (list.Any(f => f == null))
+            {
+                throw new ArgumentException("Transport finders must not contain null.", nameof(finders));
+            }
+
+            _finders = list;
+            _identitySelector = identitySelector;
+            _ownsFinders = ownsFinders;
+        }
+
+        /// <summary>
+        /// Creates a finder over the default transports (WiFi + serial). The returned instance owns
+        /// those finders and disposes them when it is disposed.
+        /// </summary>
+        /// <param name="identitySelector">Optional deduplication identity; see the constructor.</param>
+        /// <returns>A new <see cref="AllTransportsDeviceFinder"/> over the default transports.</returns>
+        public static AllTransportsDeviceFinder CreateDefault(Func<IDeviceInfo, string>? identitySelector = null)
+        {
+            var finders = new IDeviceFinder[] { new WiFiDeviceFinder(), new SerialDeviceFinder() };
+            return new AllTransportsDeviceFinder(finders, identitySelector, ownsFinders: true);
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            // Fan out concurrently; results[i] corresponds to _finders[i], giving a stable,
+            // finder-ordered "first wins" for deduplication.
+            var results = await Task.WhenAll(_finders.Select(f => SafeDiscoverAsync(f, cancellationToken)))
+                .ConfigureAwait(false);
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var unique = new List<IDeviceInfo>();
+            foreach (var device in results.SelectMany(r => r))
+            {
+                if (device != null && seen.Add(Identity(device)))
+                {
+                    unique.Add(device);
+                    DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(device));
+                }
+            }
+
+            DiscoveryCompleted?.Invoke(this, EventArgs.Empty);
+            return unique;
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            return await DiscoverAsync(cts.Token).ConfigureAwait(false);
+        }
+
+        private async Task<IEnumerable<IDeviceInfo>> SafeDiscoverAsync(IDeviceFinder finder, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await finder.DiscoverAsync(cancellationToken).ConfigureAwait(false)
+                    ?? Enumerable.Empty<IDeviceInfo>();
+            }
+            catch (OperationCanceledException)
+            {
+                // Caller-requested cancellation must surface, not be swallowed as a transport failure.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // One transport failing (e.g. WiFi with no network) must not sink the whole discovery.
+                Trace.WriteLine($"[{nameof(AllTransportsDeviceFinder)}] {finder.GetType().Name} discovery failed: {ex}");
+                return Enumerable.Empty<IDeviceInfo>();
+            }
+        }
+
+        private string Identity(IDeviceInfo device)
+        {
+            if (_identitySelector != null)
+            {
+                var key = _identitySelector(device);
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    return key;
+                }
+            }
+
+            return ContinuousDeviceFinder.DefaultIdentity(device);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(AllTransportsDeviceFinder));
+            }
+        }
+
+        /// <summary>
+        /// Disposes the transport finders this instance owns (only those created by
+        /// <see cref="CreateDefault"/>; caller-supplied finders are left to the caller).
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            if (_ownsFinders)
+            {
+                foreach (var finder in _finders.OfType<IDisposable>())
+                {
+                    finder.Dispose();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Turns the README's "find any DAQiFi on WiFi or USB" promise into a real one-call API (issue #338), deleting the instantiate-both / run-both / concatenate / dedupe fan-out that the MCP server, desktop, and example CLI otherwise each re-implement.

## Changes
- **`AllTransportsDeviceFinder : IDeviceFinder`** — fans `DiscoverAsync` out across N transport finders (WiFi + serial today, mDNS/#183 later) concurrently and returns one **deduplicated** set. A transport that throws (e.g. WiFi discovery with no network) is logged and skipped so the others still return. Dedup **reuses `ContinuousDeviceFinder.DefaultIdentity`** (#245) — the same unit on two transports stays two connection options; pass a custom `identitySelector` (e.g. by serial) to collapse them. Because it *is* an `IDeviceFinder`, wrapping it in `ContinuousDeviceFinder` gives deduplicated **continuous** discovery for free (covers the one-shot + continuous acceptance criterion).
- **`DaqifiDeviceFactory.DiscoverAndConnectAsync(filter?, timeout?, options?, finder?, ct?)`** — the common "find one and connect" case in a single call; thin wrapper over the aggregator + existing `ConnectFromDeviceInfoAsync`.
- **Docs** (`DEVICE_INTERFACES.md`) — new "Discover Across All Transports (Recommended)" section; the per-transport manual merge is reframed as the advanced path.

## Testing
- `dotnet test` — **1653 passed / 0 failed / 2 skipped** (net9.0 + net10.0).
- **18** new unit tests: fan-out union, dedup (first-wins), same-device-two-transports kept as two, custom identity selector collapses, empty-selector fallback, one-transport-throws resilience, `DeviceDiscovered`/`DiscoveryCompleted` events, cancellation propagation, `TimeSpan` overload, dispose-ownership (caller-supplied finders not disposed), post-dispose throws, constructor validation, and `DiscoverAndConnectAsync` selection paths (no-device / filter-no-match / pre-cancelled throw).
- **Bench-validated on Nq1 (FW 3.7.2):** `AllTransportsDeviceFinder.CreateDefault().DiscoverAsync(3s)` found the device over serial while WiFi returned empty without error; `DiscoverAndConnectAsync(filter: serial)` connected (`IsConnected=True`) and disconnected cleanly.

## Acceptance criteria (#338)
- [x] One call discovers across WiFi + serial concurrently, deduplicated
- [x] Works for one-shot and continuous (wrap in `ContinuousDeviceFinder`)
- [x] `DiscoverAndConnectAsync` with optional filter/timeout returns a connected device
- [x] Docs updated — per-transport merge is now the advanced path

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)