### PR TITLE
feat(device): SetFriendlyNameAsync (part of #345)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceFriendlyNameTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceFriendlyNameTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class DaqifiStreamingDeviceFriendlyNameTests
+    {
+        [Fact]
+        public async Task SetFriendlyNameAsync_NullName_Throws()
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => device.SetFriendlyNameAsync(null!));
+        }
+
+        [Theory]
+        [InlineData("")]                                     // too short
+        [InlineData("this-name-is-far-too-long-to-be-valid")] // > 31 chars
+        [InlineData("bad\"quote")]                            // contains "
+        [InlineData("bad\\slash")]                            // contains \
+        public async Task SetFriendlyNameAsync_InvalidName_Throws(string name)
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+            await Assert.ThrowsAsync<ArgumentException>(() => device.SetFriendlyNameAsync(name));
+            Assert.Empty(device.Sent); // nothing sent for an invalid name
+        }
+
+        [Fact]
+        public async Task SetFriendlyNameAsync_NotConnected_Throws()
+        {
+            var device = new CapturingStreamingDevice(); // not connected
+            await Assert.ThrowsAsync<InvalidOperationException>(() => device.SetFriendlyNameAsync("Lab Nq1"));
+        }
+
+        [Fact]
+        public async Task SetFriendlyNameAsync_ValidName_SendsSetThenSave_AndUpdatesMetadata()
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+
+            await device.SetFriendlyNameAsync("Lab Nq1");
+
+            Assert.Equal(
+                new[] { "SYSTem:DEVice:NAME \"Lab Nq1\"", "SYSTem:DEVice:NAME:SAVE" },
+                device.Sent);
+            Assert.Equal("Lab Nq1", device.Metadata.FriendlyName); // optimistic local update
+        }
+
+        [Fact]
+        public async Task SetFriendlyNameAsync_Cancelled_ThrowsAndSendsNothing()
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => device.SetFriendlyNameAsync("Lab Nq1", cts.Token));
+            Assert.Empty(device.Sent);
+        }
+
+        [Fact]
+        public async Task SetFriendlyNameAsync_MaxLengthName_IsAccepted()
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+            var name = new string('a', 31); // exactly MaxFriendlyNameLength
+
+            await device.SetFriendlyNameAsync(name);
+
+            Assert.Equal(name, device.Metadata.FriendlyName);
+            Assert.Equal(2, device.Sent.Count);
+        }
+
+        private sealed class CapturingStreamingDevice : DaqifiStreamingDevice
+        {
+            public CapturingStreamingDevice() : base("TestDevice") { }
+
+            public List<string> Sent { get; } = new();
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    Sent.Add(stringMessage.Data);
+                }
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -677,6 +677,55 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
+        /// Sets and persists the device's user-defined friendly name to NVM, then optimistically
+        /// updates <see cref="DaqifiDevice.Metadata"/>'s <see cref="DeviceMetadata.FriendlyName"/>.
+        /// </summary>
+        /// <remarks>
+        /// Composes the firmware sequence <c>SYSTem:DEVice:NAME "name"</c> then
+        /// <c>SYSTem:DEVice:NAME:SAVE</c> (producer commands added in #302). The device does not echo
+        /// the new name back synchronously — and may not stream another status frame for a while — so
+        /// the local metadata is updated optimistically once both commands are sent. This is the
+        /// device-level composition desktop hand-rolled (its "no producer helper exists" note is stale).
+        /// </remarks>
+        /// <param name="name">
+        /// 1-<see cref="ScpiMessageProducer.MaxFriendlyNameLength"/> printable ASCII characters
+        /// (0x20-0x7E), excluding <c>"</c> and <c>\</c> — see <see cref="ScpiMessageProducer.IsFriendlyNameValid"/>.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token observed before the commands are sent.</param>
+        /// <returns>A task that completes once both commands have been sent.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> fails validation.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the device is not connected.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        public Task SetFriendlyNameAsync(string name, CancellationToken cancellationToken = default)
+        {
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (!ScpiMessageProducer.IsFriendlyNameValid(name))
+            {
+                throw new ArgumentException(
+                    $"Device name must be 1-{ScpiMessageProducer.MaxFriendlyNameLength} printable ASCII characters and cannot contain '\"' or '\\'.",
+                    nameof(name));
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Send(ScpiMessageProducer.SetDeviceName(name));
+            Send(ScpiMessageProducer.SaveDeviceName);
+            Metadata.FriendlyName = name;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Comma-separated PWM-capable channel numbers for error messages, derived from this
         /// device's channel collection.
         /// </summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -686,6 +686,12 @@ namespace Daqifi.Core.Device
         /// the new name back synchronously — and may not stream another status frame for a while — so
         /// the local metadata is updated optimistically once both commands are sent. This is the
         /// device-level composition desktop hand-rolled (its "no producer helper exists" note is stale).
+        ///
+        /// <para>Completion semantics: the returned task completes once the commands are enqueued to
+        /// the outbound producer — it does <b>not</b> await on-device application or NVM persistence,
+        /// which the firmware does not acknowledge. This matches the other fire-and-forget device
+        /// commands (e.g. <see cref="LoadNetworkConfigurationAsync"/>, <see cref="FactoryResetNetworkAsync"/>);
+        /// the async signature exists for cancellation and device-surface consistency.</para>
         /// </remarks>
         /// <param name="name">
         /// 1-<see cref="ScpiMessageProducer.MaxFriendlyNameLength"/> printable ASCII characters


### PR DESCRIPTION
## Summary
Adds the device-level `SetFriendlyNameAsync` that #302 left to consumers — addressing **item 2 of the #345 batch**. Composes the producer commands already in Core into the validate → set → save → optimistic-update sequence desktop currently hand-rolls (its "no producer helper exists" comment is now stale and its copy can be deleted on the next Core bump).

## Changes
- `DaqifiStreamingDevice.SetFriendlyNameAsync(string name, CancellationToken)`:
  - Validates via `ScpiMessageProducer.IsFriendlyNameValid` (throws `ArgumentException` before sending anything).
  - Requires a connected device; observes cancellation before sending.
  - Sends `SYSTem:DEVice:NAME "name"` then `SYSTem:DEVice:NAME:SAVE`, then optimistically sets `Metadata.FriendlyName` (the device doesn't echo the name back synchronously).

## Testing
- `dotnet test` — **1644 passed / 0 failed / 2 skipped** (net9.0 + net10.0).
- **8** unit tests: null → `ArgumentNullException`; invalid/too-long/`"`/`\` → `ArgumentException` with **nothing sent**; not-connected → `InvalidOperationException`; valid → sends both commands in order + updates metadata; max-length (31) accepted; pre-cancelled token → throws and sends nothing.
- **Bench-validated on Nq1 (FW 3.7.2):** read the device's current name and set it to **itself** (deliberately non-destructive — no identity change), confirming the command executes on real hardware and metadata updates.

## Scope note
This closes **acceptance-criterion 2** of #345 only. The other two items — PWM `SetPwmFrequency` skip-if-unchanged (+ removing the MCP `_lastSentPwmFrequencyHz` workaround) and consolidating SCPI error-code extraction into `ScpiResponseClassifier` — are intentionally left for separate focused PRs. **Does not close #345.**

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)