### PR TITLE
feat(device): skip redundant PWM frequency sends + drop MCP workaround (part of #345)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDevicePwmFrequencyTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDevicePwmFrequencyTests.cs
@@ -95,8 +95,10 @@ namespace Daqifi.Core.Tests.Device
         {
             // An unexpected transport drop sets ConnectionStatus.Lost (not Disconnected); the cache
             // must still clear so a reconnect re-sends (the device's PWM state isn't trustworthy).
-            var transport = new DropTransport();
-            var device = new CapturingStreamingDevice(transport);
+            // using var guarantees disposal even if an assertion throws — device before transport
+            // (reverse declaration order), so the consumer/producer stop before the stream closes.
+            using var transport = new DropTransport();
+            using var device = new CapturingStreamingDevice(transport);
 
             device.Connect();
             device.SetPwmFrequency(2000);
@@ -107,7 +109,6 @@ namespace Daqifi.Core.Tests.Device
             device.SetPwmFrequency(2000); // unchanged value, but must re-send after a Lost
 
             Assert.Equal(2, device.PwmFrequencySends.Count);
-            device.Dispose();
         }
 
         private sealed class DropTransport : IStreamTransport

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDevicePwmFrequencyTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDevicePwmFrequencyTests.cs
@@ -1,6 +1,10 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using Xunit;
 
@@ -86,9 +90,64 @@ namespace Daqifi.Core.Tests.Device
             Assert.Empty(device.PwmFrequencySends);
         }
 
+        [Fact]
+        public void SetPwmFrequency_AfterConnectionLost_ReconnectReSendsEvenIfUnchanged()
+        {
+            // An unexpected transport drop sets ConnectionStatus.Lost (not Disconnected); the cache
+            // must still clear so a reconnect re-sends (the device's PWM state isn't trustworthy).
+            var transport = new DropTransport();
+            var device = new CapturingStreamingDevice(transport);
+
+            device.Connect();
+            device.SetPwmFrequency(2000);
+
+            transport.SimulateLoss(); // device -> Lost, cache cleared
+
+            device.Connect();
+            device.SetPwmFrequency(2000); // unchanged value, but must re-send after a Lost
+
+            Assert.Equal(2, device.PwmFrequencySends.Count);
+            device.Dispose();
+        }
+
+        private sealed class DropTransport : IStreamTransport
+        {
+            private readonly MemoryStream _stream = new();
+            public Stream Stream => _stream;
+            public bool IsConnected { get; private set; }
+            public string ConnectionInfo => IsConnected ? "Mock: Connected" : "Mock: Disconnected";
+            public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+            public Task ConnectAsync() => ConnectAsync(null);
+            public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+            {
+                IsConnected = true;
+                StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+                return Task.CompletedTask;
+            }
+            public Task DisconnectAsync()
+            {
+                IsConnected = false;
+                StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+                return Task.CompletedTask;
+            }
+            public void Connect() => ConnectAsync().Wait();
+            public void Disconnect() => DisconnectAsync().Wait();
+
+            /// <summary>Raises an unexpected drop (StatusChanged(false) without an intentional Disconnect).</summary>
+            public void SimulateLoss()
+            {
+                IsConnected = false;
+                StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, "Connection lost"));
+            }
+
+            public void Dispose() => _stream.Dispose();
+        }
+
         private sealed class CapturingStreamingDevice : DaqifiStreamingDevice
         {
             public CapturingStreamingDevice() : base("TestDevice") { }
+            public CapturingStreamingDevice(IStreamTransport transport) : base("TestDevice", transport) { }
 
             private readonly List<string> _sent = new();
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDevicePwmFrequencyTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDevicePwmFrequencyTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class DaqifiStreamingDevicePwmFrequencyTests
+    {
+        [Fact]
+        public void SetPwmFrequency_FirstCall_SendsAndTracksFrequency()
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+
+            device.SetPwmFrequency(2000);
+
+            Assert.Equal(new[] { "PWM:CHannel:FREQuency 0,2000" }, device.PwmFrequencySends);
+            Assert.Equal(2000, device.PwmFrequencyHz);
+        }
+
+        [Fact]
+        public void SetPwmFrequency_SameValueTwice_SecondIsSkipped()
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+
+            device.SetPwmFrequency(2000);
+            device.SetPwmFrequency(2000); // unchanged -> no second send
+
+            Assert.Single(device.PwmFrequencySends);
+            Assert.Equal(2000, device.PwmFrequencyHz);
+        }
+
+        [Fact]
+        public void SetPwmFrequency_ChangedValue_Sends()
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+
+            device.SetPwmFrequency(2000);
+            device.SetPwmFrequency(2000); // skipped
+            device.SetPwmFrequency(3000); // changed -> sends
+            device.SetPwmFrequency(3000); // skipped
+
+            Assert.Equal(
+                new[] { "PWM:CHannel:FREQuency 0,2000", "PWM:CHannel:FREQuency 0,3000" },
+                device.PwmFrequencySends);
+            Assert.Equal(3000, device.PwmFrequencyHz);
+        }
+
+        [Fact]
+        public void SetPwmFrequency_AfterReconnect_SendsAgainEvenIfUnchanged()
+        {
+            var device = new CapturingStreamingDevice();
+
+            device.Connect();
+            device.SetPwmFrequency(2000);
+            device.Disconnect(); // clears the "already-sent" cache
+
+            device.Connect();
+            device.SetPwmFrequency(2000); // fresh connection must re-send
+
+            Assert.Equal(
+                new[] { "PWM:CHannel:FREQuency 0,2000", "PWM:CHannel:FREQuency 0,2000" },
+                device.PwmFrequencySends);
+        }
+
+        [Fact]
+        public void SetPwmFrequency_NotConnected_ThrowsAndSendsNothing()
+        {
+            var device = new CapturingStreamingDevice(); // not connected
+            Assert.Throws<System.InvalidOperationException>(() => device.SetPwmFrequency(2000));
+            Assert.Empty(device.PwmFrequencySends);
+        }
+
+        [Theory]
+        [InlineData(5)]      // below MinPwmFrequencyHz (6)
+        [InlineData(50_001)] // above MaxPwmFrequencyHz (50000)
+        public void SetPwmFrequency_OutOfRange_ThrowsBeforeConnectedCheck(int hz)
+        {
+            var device = new CapturingStreamingDevice();
+            device.Connect();
+            Assert.Throws<System.ArgumentOutOfRangeException>(() => device.SetPwmFrequency(hz));
+            Assert.Empty(device.PwmFrequencySends);
+        }
+
+        private sealed class CapturingStreamingDevice : DaqifiStreamingDevice
+        {
+            public CapturingStreamingDevice() : base("TestDevice") { }
+
+            private readonly List<string> _sent = new();
+
+            /// <summary>The PWM-frequency SCPI commands actually sent (skips are absent).</summary>
+            public IReadOnlyList<string> PwmFrequencySends =>
+                _sent.Where(s => s.StartsWith("PWM:CHannel:FREQuency")).ToList();
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    _sent.Add(stringMessage.Data);
+                }
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -173,12 +173,14 @@ namespace Daqifi.Core.Device
         {
             StreamingFrequency = 100;
 
-            // Clear the "already-sent" PWM frequency cache whenever the device disconnects, so a
-            // fresh connection always re-sends the frequency (the value lives in the device's
-            // runtime settings and is not guaranteed across a reconnect). See #345.
+            // Clear the "already-sent" PWM frequency cache on any transition away from Connected —
+            // an intentional Disconnected as well as an unexpected drop (which sets Lost, not
+            // Disconnected) and the Retrying/Failed states. After any of these the device's runtime
+            // PWM state is no longer trustworthy, so a reconnect on the same instance must re-send.
+            // See #345.
             StatusChanged += (_, e) =>
             {
-                if (e.Status == ConnectionStatus.Disconnected)
+                if (e.Status != ConnectionStatus.Connected)
                 {
                     _lastSentPwmFrequencyHz = null;
                 }

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -156,7 +156,7 @@ namespace Daqifi.Core.Device
         /// <param name="ipAddress">The IP address of the device, if known.</param>
         public DaqifiStreamingDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)
         {
-            StreamingFrequency = 100;
+            InitializeStreamingDevice();
         }
 
         /// <summary>
@@ -166,7 +166,23 @@ namespace Daqifi.Core.Device
         /// <param name="transport">The transport for device communication.</param>
         public DaqifiStreamingDevice(string name, IStreamTransport transport) : base(name, transport)
         {
+            InitializeStreamingDevice();
+        }
+
+        private void InitializeStreamingDevice()
+        {
             StreamingFrequency = 100;
+
+            // Clear the "already-sent" PWM frequency cache whenever the device disconnects, so a
+            // fresh connection always re-sends the frequency (the value lives in the device's
+            // runtime settings and is not guaranteed across a reconnect). See #345.
+            StatusChanged += (_, e) =>
+            {
+                if (e.Status == ConnectionStatus.Disconnected)
+                {
+                    _lastSentPwmFrequencyHz = null;
+                }
+            };
         }
 
         /// <summary>
@@ -567,6 +583,14 @@ namespace Daqifi.Core.Device
         /// </summary>
         public int PwmFrequencyHz { get; private set; } = DefaultPwmFrequencyHz;
 
+        /// <summary>
+        /// The PWM frequency actually sent to the device this connection, or <c>null</c> if none has
+        /// been sent yet (also reset to <c>null</c> on disconnect). Distinct from
+        /// <see cref="PwmFrequencyHz"/>, which carries a session default before anything is sent —
+        /// this drives the skip-if-unchanged guard so a fresh connection always sends. See #345.
+        /// </summary>
+        private int? _lastSentPwmFrequencyHz;
+
         /// <inheritdoc />
         public void SetPwmEnabled(IChannel channel, bool enabled)
         {
@@ -669,10 +693,19 @@ namespace Daqifi.Core.Device
                 throw new InvalidOperationException("Device is not connected.");
             }
 
+            // Skip the redundant round-trip when the device already has this frequency (from a
+            // send earlier this connection). The cache is cleared on disconnect so a fresh
+            // connection always sends. PwmFrequencyHz still reflects the commanded value. See #345.
+            if (frequencyHz == _lastSentPwmFrequencyHz)
+            {
+                return;
+            }
+
             // The SCPI command is addressed to a channel, but the firmware drives all PWM from
             // one shared timer and applies the frequency to every channel. Channel 0 is used as
             // the address because it is PWM-capable on all supported hardware.
             Send(ScpiMessageProducer.SetPwmChannelFrequency(0, frequencyHz));
+            _lastSentPwmFrequencyHz = frequencyHz;
             PwmFrequencyHz = frequencyHz;
         }
 

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -25,14 +25,6 @@ public sealed class DaqifiAgent
     private readonly ConcurrentDictionary<string, DaqifiDevice> _connected = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    /// <summary>
-    /// The PWM frequency, in hertz, actually commanded to each connected device this session, so
-    /// <see cref="SetPwmOutputAsync"/> can skip resending an unchanged frequency. Cleared whenever
-    /// a device id is (re)connected, since a fresh connection's real on-device frequency is
-    /// unknown again.
-    /// </summary>
-    private readonly ConcurrentDictionary<string, int> _lastSentPwmFrequencyHz = new(StringComparer.Ordinal);
-
     public DaqifiAgent(ServerOptions options) => _options = options;
 
     // ---------------------------------------------------------------- discovery
@@ -97,7 +89,6 @@ public sealed class DaqifiAgent
                 .ConfigureAwait(false);
 
             _connected[deviceId] = device;
-            _lastSentPwmFrequencyHz.TryRemove(deviceId, out _);
             return ConnectedDeviceInfo.From(deviceId, device);
         }
         finally
@@ -115,7 +106,6 @@ public sealed class DaqifiAgent
             {
                 try { device.Disconnect(); } catch { /* best effort */ }
                 device.Dispose();
-                _lastSentPwmFrequencyHz.TryRemove(deviceId, out _);
                 return $"Disconnected '{deviceId}'.";
             }
             return $"Device '{deviceId}' was not connected.";
@@ -300,15 +290,10 @@ public sealed class DaqifiAgent
 
             streaming.SetPwmDutyCycle(ch, dutyCyclePercent);
 
-            // Only reprogram the shared device-wide timer when the frequency actually changes (or
-            // hasn't been sent to this device yet this session) — a duty-only update or re-enable
-            // shouldn't cost an extra SCPI round-trip.
-            if (!_lastSentPwmFrequencyHz.TryGetValue(deviceId, out var lastSentFrequencyHz) ||
-                lastSentFrequencyHz != desiredFrequencyHz)
-            {
-                streaming.SetPwmFrequency(desiredFrequencyHz);
-                _lastSentPwmFrequencyHz[deviceId] = desiredFrequencyHz;
-            }
+            // Reprogram the shared device-wide timer. Core skips the SCPI round-trip when the
+            // frequency is unchanged from what it last sent this connection (#345), so a duty-only
+            // update or re-enable no longer costs an extra round-trip and needs no agent-side cache.
+            streaming.SetPwmFrequency(desiredFrequencyHz);
 
             streaming.SetPwmEnabled(ch, true);
 
@@ -449,7 +434,6 @@ public sealed class DaqifiAgent
                 device.Dispose();
             }
             _connected.Clear();
-            _lastSentPwmFrequencyHz.Clear();
         }
         finally
         {


### PR DESCRIPTION
## Summary
`SetPwmFrequency` now skips the redundant SCPI round-trip when the frequency is unchanged from what it last sent **this connection** — addressing **item 1 of the #345 batch** and deleting the MCP server's `_lastSentPwmFrequencyHz` dictionary that existed purely to do this dedup consumer-side.

## Changes
- **Core** (`DaqifiStreamingDevice`):
  - New nullable `_lastSentPwmFrequencyHz` tracks the value actually sent (distinct from `PwmFrequencyHz`, which carries a session default before anything is sent). `SetPwmFrequency` returns early when the requested value equals it.
  - The cache is reset to `null` on disconnect (via a `StatusChanged` subscription), so a fresh connection always re-sends — the on-device frequency isn't guaranteed across a reconnect. Both constructors now route through a shared `InitializeStreamingDevice()`.
- **MCP** (`DaqifiAgent`): removed `_lastSentPwmFrequencyHz` and its connect/disconnect/reset bookkeeping; `SetPwmOutputAsync` calls `SetPwmFrequency` unconditionally and relies on Core's skip.

## Testing
- `dotnet test` — Core **1642 pass / 0 fail / 2 skipped**, MCP **23 pass** (net9.0 + net10.0).
- **6** unit tests: first call sends + tracks; same value twice → second skipped; changed value sends; re-send after reconnect (cache cleared on disconnect); not-connected throws + sends nothing; out-of-range throws.
- **Bench-validated on Nq1 (FW 3.7.2):** `2000 → 2000 (skipped) → 3000` executed cleanly over serial with `PwmFrequencyHz` tracking to 3000; restored the 1000 Hz default. No PWM output was enabled (only the shared timer register is programmed).

## Scope note
Closes **acceptance-criterion 1** of #345. The remaining item — consolidating SCPI error-code extraction into `ScpiResponseClassifier` — is left for a separate PR. **Does not close #345.** (Criterion 2, `SetFriendlyNameAsync`, is #355.)

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)