### PR TITLE
refactor(device): consolidate SCPI error-code extraction into ScpiResponseClassifier (part of #345)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
@@ -29,5 +29,31 @@ namespace Daqifi.Core.Tests.Device
         {
             Assert.False(ScpiResponseClassifier.IsScpiErrorLine(line));
         }
+
+        [Theory]
+        [InlineData("**ERROR: -200, \"Execution error\"", -200)]
+        [InlineData("**ERROR -200, \"Execution error\"", -200)]
+        [InlineData("**ERROR\t-200, \"Execution error\"", -200)]
+        [InlineData("ERROR: -113, \"Undefined header\"", -113)]
+        [InlineData("ERROR -113", -113)]                          // no trailing comma
+        [InlineData("  ERROR: -200, \"x\"  \r\n", -200)]          // leading/trailing whitespace + CRLF
+        [InlineData("ERROR: 42, \"positive\"", 42)]               // positive code
+        public void TryExtractErrorCode_ExtractsCode_AcrossDelimiterVariants(string line, int expected)
+        {
+            Assert.True(ScpiResponseClassifier.TryExtractErrorCode(line, out var code));
+            Assert.Equal(expected, code);
+        }
+
+        [Theory]
+        [InlineData("Error !! No SD Card Detected")]  // ERROR token but non-numeric follow
+        [InlineData("error_log.bin")]                 // filename
+        [InlineData("Errors.txt")]                    // filename
+        [InlineData("OK")]                            // not an error line
+        [InlineData("")]
+        public void TryExtractErrorCode_ReturnsFalseAndZero_ForNonNumericOrNonError(string line)
+        {
+            Assert.False(ScpiResponseClassifier.TryExtractErrorCode(line, out var code));
+            Assert.Equal(0, code);
+        }
     }
 }

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1347,7 +1347,7 @@ namespace Daqifi.Core.Device
             // query at all — typically because it predates the version that introduced it — so
             // it gets the typed feature-gating exception instead of a generic operation error.
             if (lastScpiError != null
-                && TryParseScpiErrorCode(lastScpiError, out var scpiErrorCode)
+                && ScpiResponseClassifier.TryExtractErrorCode(lastScpiError, out var scpiErrorCode)
                 && scpiErrorCode == ScpiErrorCodeUndefinedHeader)
             {
                 throw new FeatureNotSupportedException(
@@ -1846,41 +1846,6 @@ namespace Daqifi.Core.Device
             return ScpiResponseClassifier.IsScpiErrorLine(line);
         }
 
-        /// <summary>
-        /// Parses the numeric error code out of a SCPI error line matched by
-        /// <see cref="IsScpiErrorLine"/> — e.g. <c>**ERROR: -113, "Undefined header"</c>,
-        /// <c>ERROR: -113,"Undefined header"</c>, or a space/tab-delimited variant like
-        /// <c>**ERROR -113, "Undefined header"</c>. The delimiter between the <c>ERROR</c>/
-        /// <c>**ERROR</c> token and the code may be <c>:</c>, space, or tab — matching the
-        /// delimiters <see cref="ScpiResponseClassifier"/> accepts — and the code is the text
-        /// up to the following comma (if any).
-        /// </summary>
-        private static bool TryParseScpiErrorCode(string line, out int code)
-        {
-            code = 0;
-            var trimmed = line.TrimStart();
-
-            string afterToken;
-            if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
-            {
-                afterToken = trimmed[7..];
-            }
-            else if (trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
-            {
-                afterToken = trimmed[5..];
-            }
-            else
-            {
-                return false;
-            }
-
-            afterToken = afterToken.TrimStart(':', ' ', '\t');
-
-            var commaIndex = afterToken.IndexOf(',');
-            var codeSpan = (commaIndex >= 0 ? afterToken[..commaIndex] : afterToken).Trim();
-            return int.TryParse(codeSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out code);
-        }
-
         // Permissive: any line that looks like a device error or status message,
         // including firmware text such as "Error !! ...". Used to recognize that
         // the parser would yield no result, without polluting LastScpiError with
@@ -1998,7 +1963,7 @@ namespace Daqifi.Core.Device
             // so the caller's retry loop can react (kick LAN:APPLY) instead of just
             // waiting out a blind delay.
             var errorLine = lines.LastOrDefault(IsScpiErrorLine);
-            if (errorLine != null && TryParseScpiErrorCode(errorLine, out var errorCode) && errorCode == -200)
+            if (errorLine != null && ScpiResponseClassifier.TryExtractErrorCode(errorLine, out var errorCode) && errorCode == -200)
             {
                 throw new LanNotInitializedException(errorLine.Trim());
             }

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -90,8 +90,9 @@ namespace Daqifi.Core.Device
 
         /// <summary>
         /// The delimiters accepted between the <c>ERROR</c>/<c>**ERROR</c> token and the error code.
-        /// Single-sourced here and consulted via <see cref="IsTokenDelimiter"/> by both
-        /// <see cref="TryExtractErrorCode"/> and the line matchers, so detection and extraction can't drift.
+        /// Single-sourced here: the line matchers test membership via <see cref="IsTokenDelimiter"/>, and
+        /// <see cref="TryExtractErrorCode"/> trims with this array directly — both draw from this one set,
+        /// so detection and extraction can't drift.
         /// </summary>
         private static readonly char[] TokenDelimiters = { ':', ' ', '\t' };
 

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -90,9 +90,13 @@ namespace Daqifi.Core.Device
 
         /// <summary>
         /// The delimiters accepted between the <c>ERROR</c>/<c>**ERROR</c> token and the error code.
-        /// Single-sourced here so <see cref="TryExtractErrorCode"/> and the line matchers stay in lockstep.
+        /// Single-sourced here and consulted via <see cref="IsTokenDelimiter"/> by both
+        /// <see cref="TryExtractErrorCode"/> and the line matchers, so detection and extraction can't drift.
         /// </summary>
         private static readonly char[] TokenDelimiters = { ':', ' ', '\t' };
+
+        /// <summary>Returns true if <paramref name="c"/> is one of the accepted <see cref="TokenDelimiters"/>.</summary>
+        private static bool IsTokenDelimiter(char c) => Array.IndexOf(TokenDelimiters, c) >= 0;
 
         private static bool MatchesErrorPrefix(string trimmed, string prefix)
         {
@@ -102,7 +106,7 @@ namespace Daqifi.Core.Device
             if (trimmed.Length == prefix.Length)
                 return true;
             var next = trimmed[prefix.Length];
-            if (next == ':' || next == ' ' || next == '\t')
+            if (IsTokenDelimiter(next))
                 return true;
             // Single '!' is ambiguous (could be a filename like "error!log.bin").
             // Require '!!' so we still catch firmware "Error!!" status text but
@@ -123,7 +127,8 @@ namespace Daqifi.Core.Device
             var next = trimmed[prefix.Length];
             if (next == ':')
                 return true;
-            if (next != ' ' && next != '\t')
+            // ':' already returned above, so this rejects anything that isn't a space/tab delimiter.
+            if (!IsTokenDelimiter(next))
                 return false;
 
             // A space/tab delimiter alone is ambiguous — firmware status text like

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 #nullable enable
 
@@ -49,6 +50,49 @@ namespace Daqifi.Core.Device
             return MatchesStrictScpiErrorPrefix(trimmed, "**ERROR")
                    || MatchesStrictScpiErrorPrefix(trimmed, "ERROR");
         }
+
+        /// <summary>
+        /// Extracts the numeric error code from a SCPI error line — e.g. <c>-200</c> from
+        /// <c>**ERROR: -200,"Execution error"</c>, <c>ERROR -113,"Undefined header"</c>, or
+        /// <c>**ERROR\t-113,...</c>. The delimiter between the <c>ERROR</c>/<c>**ERROR</c> token and
+        /// the code may be <c>:</c>, space, or tab — the same set the line matchers above accept, kept
+        /// here so the accepted delimiters can't drift between detection and extraction. The code is
+        /// the text up to the following comma (if any).
+        /// </summary>
+        /// <param name="line">The candidate error line.</param>
+        /// <param name="code">The parsed error code when the method returns <c>true</c>; otherwise 0.</param>
+        /// <returns><c>true</c> if a numeric error code was extracted; otherwise <c>false</c>.</returns>
+        internal static bool TryExtractErrorCode(string line, out int code)
+        {
+            code = 0;
+            var trimmed = line.TrimStart();
+
+            string afterToken;
+            if (trimmed.StartsWith("**ERROR", StringComparison.OrdinalIgnoreCase))
+            {
+                afterToken = trimmed[7..];
+            }
+            else if (trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase))
+            {
+                afterToken = trimmed[5..];
+            }
+            else
+            {
+                return false;
+            }
+
+            afterToken = afterToken.TrimStart(TokenDelimiters);
+
+            var commaIndex = afterToken.IndexOf(',');
+            var codeSpan = (commaIndex >= 0 ? afterToken[..commaIndex] : afterToken).Trim();
+            return int.TryParse(codeSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out code);
+        }
+
+        /// <summary>
+        /// The delimiters accepted between the <c>ERROR</c>/<c>**ERROR</c> token and the error code.
+        /// Single-sourced here so <see cref="TryExtractErrorCode"/> and the line matchers stay in lockstep.
+        /// </summary>
+        private static readonly char[] TokenDelimiters = { ':', ' ', '\t' };
 
         private static bool MatchesErrorPrefix(string trimmed, string prefix)
         {


### PR DESCRIPTION
## Summary
`DaqifiStreamingDevice.TryParseScpiErrorCode` independently re-derived the `**ERROR`/`ERROR` prefix + delimiter-trim logic that `ScpiResponseClassifier` already owns for line **detection** — the exact drift risk #345 item 3 calls out. Extraction now lives next to the matchers as `ScpiResponseClassifier.TryExtractErrorCode`, so detection and extraction share one file (and one `TokenDelimiters` set); the device's two call sites delegate to it and the private duplicate is deleted. **Behavior-preserving.**

## Changes
- **`ScpiResponseClassifier.TryExtractErrorCode(line, out code)`** (new, internal) — the moved extraction logic, plus a single-sourced `private static readonly char[] TokenDelimiters = { ':', ' ', '\t' }` documenting the accepted delimiters in one place.
- **`DaqifiStreamingDevice`** — both call sites (the SCPI-error classification and the `-200` reboot-detection path) now call `ScpiResponseClassifier.TryExtractErrorCode`; the private `TryParseScpiErrorCode` is removed.

## Testing
- `dotnet test` — **1647 passed / 0 failed / 2 skipped** (net9.0 + net10.0); existing error-parse behavior preserved through the delegating call sites.
- **12** new `TryExtractErrorCode` unit tests: all `:`/space/tab delimiter variants across `**ERROR`/`ERROR`, no-trailing-comma, positive code, leading/trailing whitespace + CRLF; and non-numeric / non-error / filename lines → `false` with `code == 0`.
- No bench validation: this is pure SCPI-text parsing relocated with identical behavior — it has no device-facing surface to exercise (fully covered by unit tests).

## Scope note
Closes **acceptance-criterion 3** of #345 — the **last** of the three batch items (item 1 = PWM skip #356, item 2 = `SetFriendlyNameAsync` #355). #345 is fully addressed once all three merge; not adding a `closes` keyword here so the issue isn't closed before #355/#356 land.

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)