### PR TITLE
fix(firmware): cancel hard-timeout token before throwing TimeoutException (fixes flaky test + ordering race)

### DIFF
--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -216,6 +216,16 @@ public static class WifiBridgeActivator
             // same race SerialDeviceFinder guards against per #295).
             if (winner != workerTask && !workerTask.IsCompleted)
             {
+                // Cancel the hard-timeout source explicitly, up front, rather than relying on its
+                // independent timer having already fired. The Task.Delay(hardTimeoutMs) above and
+                // hardTimeoutCts's timer are two separate timers of the same duration, so the delay
+                // can win the race a hair before hardTimeoutCts fires — which would let a worker that
+                // returns late observe an as-yet-uncancelled linkedCts.Token and run one further
+                // state-changing step after the caller already got a TimeoutException (#326 finding
+                // #2). Cancelling here guarantees the worker's token is cancelled before we throw.
+                // Idempotent if the timer already fired.
+                hardTimeoutCts.Cancel();
+
                 // Open() is uncancellable, so on timeout/cancellation the worker task
                 // is ABANDONED rather than awaited — it may still be blocked in native
                 // I/O. Observe its eventual fault so it can't surface as an


### PR DESCRIPTION
## Summary
`WifiBridgeActivator.RunWithHardTimeoutAsync` had a subtle ordering gap that was intermittently failing CI (the `RunWithHardTimeoutAsync_HardTimeoutElapses_StopsWorkerBeforeLateStep` test) and, in production, could let an abandoned worker run one extra state-changing step after a timeout.

## Root cause
Two independent timers of the same duration:
1. `Task.Delay(hardTimeoutMs)` in the `WhenAny` race — decides *when to throw* `TimeoutException`.
2. `hardTimeoutCts`'s own timer — decides *when the worker's linked token is cancelled*.

Because they're separate timers, the `Task.Delay` can win a hair **before** `hardTimeoutCts` fires. In that window `TimeoutException` is thrown while the worker's `linkedCts.Token` is still un-cancelled — so a worker whose blocking `Open()` returns late sees an un-cancelled token and can perform a further step, defeating the guarantee #326 finding #2 added ("stop before performing a further state-changing step"). Under CI load the ordering varies, so the test flaked (observed failing on unrelated PRs #356 and #357).

## Fix
The abandon path now calls `hardTimeoutCts.Cancel()` **up front** (idempotent if the timer already fired), so the worker's linked token is deterministically cancelled **before** `TimeoutException` propagates. No reliance on the two timers racing in a lucky order. Placement is before the existing abandon/observe-fault/dispose logic; disposal ownership and the caller-cancellation preference are unchanged.

## Testing
- `dotnet test` — **1635 passed / 0 failed / 2 skipped** (net9.0 + net10.0); WifiBridgeActivator suite 17/17.
- The previously-flaky `RunWithHardTimeoutAsync_HardTimeoutElapses_StopsWorkerBeforeLateStep` — which is the correct regression guard for this race — **passed 30/30** consecutive runs after the fix.
- No bench validation: this is firmware-activation timeout concurrency ordering, not device-facing behavior.

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)