### PR TITLE
feat(device): IAsyncEnumerable<LiveSample> live sample streaming (closes #334)

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -305,9 +305,10 @@ Console.WriteLine($"Digital I/O: {caps.DigitalChannels}");
 
 ### Streaming Data
 
-Two ways to consume streamed data: decoded per-channel samples via `IChannel.SampleReceived`
-(recommended for most consumers), or the raw protobuf frame via `MessageReceived` (for hand-decoding
-or bridging into another pipeline).
+Three ways to consume streamed data: decoded per-channel samples via `IChannel.SampleReceived`
+(event, recommended for most consumers), a pull-based async stream via `StreamSamplesAsync`
+(`await foreach` with cancellation and backpressure), or the raw protobuf frame via `MessageReceived`
+(for hand-decoding or bridging into another pipeline).
 
 #### Per-channel samples (recommended)
 
@@ -347,6 +348,34 @@ carries the raw device tick count alongside the rollover-adjusted host `Timestam
 arrives outside a streaming session is still re-raised via `MessageReceived` but is not decoded into
 samples. `GetChannelsSnapshot()` is used above (rather than the live `Channels` property) because the
 channel list can be repopulated concurrently when a new device status message arrives.
+
+#### Live async stream (`await foreach`)
+
+`StreamSamplesAsync` exposes the same decoded samples as an `IAsyncEnumerable<LiveSample>`, so a
+consumer can pull them with `await foreach` — the idiom the SD-card/export paths already use — with
+cancellation and backpressure instead of hand-building an event/queue bridge. Each `LiveSample` pairs
+the decoded `IDataSample` with the `IChannel` that produced it.
+
+```csharp
+using var device = (DaqifiStreamingDevice)await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
+
+device.EnableChannels(device.GetChannelsSnapshot().Where(c => c.Type == ChannelType.Analog));
+device.StreamingFrequency = 100; // Hz
+device.StartStreaming();
+
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+await foreach (var s in device.StreamSamplesAsync(cts.Token))
+{
+    Console.WriteLine($"{s.Channel.Name}: {s.Sample.Value} (tick {s.Sample.DeviceTimestamp})");
+}
+```
+
+Samples are buffered in a bounded channel (`DefaultLiveSampleBufferCapacity`, override via the
+`bufferCapacity` argument) with a **drop-oldest** overflow policy — if the consumer falls behind, the
+oldest buffered samples are discarded (memory never grows unbounded) and `DroppedLiveSampleCount`
+increments; the decode thread is never blocked. Cancelling the token ends the enumeration promptly
+(surfaced as `OperationCanceledException`) and unsubscribes, but does **not** stop the device stream —
+call `StopStreaming()` for that. This is additive: `SampleReceived` and `MessageReceived` are unaffected.
 
 #### Raw protobuf frames
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class DaqifiStreamingDeviceLiveStreamTests
+    {
+        [Fact]
+        public async Task StreamSamplesAsync_YieldsInjectedSample_WithChannelAndValue()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            var ai0 = AnalogChannel(device, 0);
+            ai0.IsEnabled = true;
+            device.StartStreaming();
+
+            await using var e = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync(); // runs the body: subscribes synchronously, then awaits
+            device.InvokeStreamMessage(AnalogFrame(1000, 1.5f));
+
+            Assert.True(await moveNext.AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.Same(ai0, e.Current.Channel);
+            Assert.Equal(1.5, e.Current.Sample.Value);
+            Assert.Equal(1000u, e.Current.Sample.DeviceTimestamp);
+        }
+
+        [Fact]
+        public async Task StreamSamplesAsync_MultipleFrames_YieldsInOrder()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            AnalogChannel(device, 0).IsEnabled = true;
+            device.StartStreaming();
+
+            await using var e = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var first = e.MoveNextAsync(); // subscribes synchronously before we inject
+            device.InvokeStreamMessage(AnalogFrame(1000, 1f));
+            device.InvokeStreamMessage(AnalogFrame(1010, 2f));
+            device.InvokeStreamMessage(AnalogFrame(1020, 3f));
+
+            Assert.True(await first.AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.Equal(1.0, e.Current.Sample.Value);
+            Assert.True(await e.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.Equal(2.0, e.Current.Sample.Value);
+            Assert.True(await e.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.Equal(3.0, e.Current.Sample.Value);
+        }
+
+        [Fact]
+        public async Task StreamSamplesAsync_Cancellation_EndsEnumeration_ButNotDeviceStream()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            AnalogChannel(device, 0).IsEnabled = true;
+            device.StartStreaming();
+
+            using var cts = new CancellationTokenSource();
+            await using var e = device.StreamSamplesAsync(cts.Token).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await moveNext);
+            Assert.True(device.IsStreaming); // cancelling enumeration must NOT stop the device stream
+        }
+
+        [Fact]
+        public async Task StreamSamplesAsync_ConsumerFallsBehind_DropsOldest_AndCountsDrops()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            AnalogChannel(device, 0).IsEnabled = true;
+            device.StartStreaming();
+
+            await using var e = device.StreamSamplesAsync(CancellationToken.None, bufferCapacity: 2).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync(); // subscribes; reader is awaiting (not consuming synchronously)
+
+            // Push far more than the buffer holds, synchronously, before the reader runs.
+            for (uint i = 0; i < 20; i++) device.InvokeStreamMessage(AnalogFrame(1000 + i * 10, i));
+
+            Assert.True(await moveNext.AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.True(device.DroppedLiveSampleCount > 0, "drop-oldest should have dropped and counted overflow samples");
+        }
+
+        [Fact]
+        public async Task StreamSamplesAsync_InvalidBufferCapacity_Throws()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            {
+                await foreach (var _ in device.StreamSamplesAsync(CancellationToken.None, bufferCapacity: 0)) { }
+            });
+        }
+
+        #region Helpers
+
+        private static LiveStreamDevice CreateStreaming(int analogCount)
+        {
+            var device = new LiveStreamDevice("TestDevice");
+            device.Connect();
+            var status = new DaqifiOutMessage
+            {
+                AnalogInPortNum = (uint)analogCount,
+                DigitalPortNum = 0,
+                AnalogInRes = 65535,
+            };
+            for (var i = 0; i < analogCount; i++) status.AnalogInPortRange.Add(1.0f);
+            device.PopulateChannelsFromStatus(status);
+            return device;
+        }
+
+        private static IAnalogChannel AnalogChannel(DaqifiStreamingDevice device, int number) =>
+            (IAnalogChannel)device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == number);
+
+        private static DaqifiOutMessage AnalogFrame(uint timestamp, float value)
+        {
+            var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+            frame.AnalogInDataFloat.Add(value);
+            return frame;
+        }
+
+        private sealed class LiveStreamDevice : DaqifiStreamingDevice
+        {
+            public LiveStreamDevice(string name) : base(name) { }
+
+            public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+
+            public override void Send<T>(IOutboundMessage<T> message) { /* no transport in tests */ }
+        }
+
+        #endregion
+    }
+}

--- a/src/Daqifi.Core/Channel/LiveSample.cs
+++ b/src/Daqifi.Core/Channel/LiveSample.cs
@@ -1,0 +1,13 @@
+namespace Daqifi.Core.Channel
+{
+    /// <summary>
+    /// A single decoded live sample paired with the channel that produced it — the element type of
+    /// <see cref="Daqifi.Core.Device.DaqifiStreamingDevice.StreamSamplesAsync"/>. Mirrors the
+    /// pull-based element idiom the offline paths already use (SD-card log entries, export sample
+    /// rows), so a live consumer can <c>await foreach</c> device-wide samples and attribute each to
+    /// its channel without a hand-rolled event/queue bridge.
+    /// </summary>
+    /// <param name="Channel">The channel the sample was decoded for.</param>
+    /// <param name="Sample">The decoded sample (host timestamp, scaled value, raw ADC count, device tick).</param>
+    public sealed record LiveSample(IChannel Channel, IDataSample Sample);
+}

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -14,7 +14,9 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 #nullable enable
@@ -272,6 +274,87 @@ namespace Daqifi.Core.Device
 
             IsStreaming = false;
             Send(ScpiMessageProducer.StopStreaming);
+        }
+
+        /// <summary>
+        /// The default bounded-buffer capacity (in samples) used by <see cref="StreamSamplesAsync"/>.
+        /// </summary>
+        public const int DefaultLiveSampleBufferCapacity = 4096;
+
+        private long _droppedLiveSampleCount;
+
+        /// <summary>
+        /// Gets the cumulative number of live samples dropped across all <see cref="StreamSamplesAsync"/>
+        /// enumerations because a consumer could not keep up with the incoming rate (drop-oldest policy).
+        /// A non-zero and growing value means a live consumer is too slow for the current stream rate.
+        /// </summary>
+        public long DroppedLiveSampleCount => Interlocked.Read(ref _droppedLiveSampleCount);
+
+        /// <summary>
+        /// Exposes decoded live samples as an <see cref="IAsyncEnumerable{T}"/> for pull-based
+        /// <c>await foreach</c> consumption with cancellation and backpressure — bringing the live path
+        /// up to the same async-stream idiom the SD-card and export paths already use. Additive: the
+        /// per-channel <see cref="IChannel.SampleReceived"/> and raw-frame events are unaffected.
+        /// </summary>
+        /// <remarks>
+        /// Samples are buffered in a bounded channel with a <b>drop-oldest</b> overflow policy: if the
+        /// consumer falls behind, the oldest buffered samples are discarded (memory never grows
+        /// unbounded) and <see cref="DroppedLiveSampleCount"/> is incremented — the decode thread that
+        /// produces samples is never blocked. Enumeration observes the channels present when it starts;
+        /// cancelling <paramref name="cancellationToken"/> ends it promptly (surfaced as
+        /// <see cref="OperationCanceledException"/>) and unsubscribes, but does <b>not</b> stop the
+        /// device's stream — call <see cref="StopStreaming"/> for that.
+        /// </remarks>
+        /// <param name="cancellationToken">Ends enumeration when cancelled.</param>
+        /// <param name="bufferCapacity">
+        /// Bounded buffer capacity; defaults to <see cref="DefaultLiveSampleBufferCapacity"/> when null.
+        /// </param>
+        /// <returns>An async stream of <see cref="LiveSample"/> (channel + decoded sample).</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="bufferCapacity"/> is less than 1.</exception>
+        public async IAsyncEnumerable<LiveSample> StreamSamplesAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default,
+            int? bufferCapacity = null)
+        {
+            var capacity = bufferCapacity ?? DefaultLiveSampleBufferCapacity;
+            if (capacity < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(bufferCapacity), capacity, "Buffer capacity must be at least 1.");
+            }
+
+            var buffer = System.Threading.Channels.Channel.CreateBounded<LiveSample>(
+                new BoundedChannelOptions(capacity)
+                {
+                    FullMode = BoundedChannelFullMode.DropOldest,
+                    SingleReader = true,
+                    SingleWriter = false,
+                },
+                _ => Interlocked.Increment(ref _droppedLiveSampleCount));
+
+            void OnSample(object? sender, SampleReceivedEventArgs e) =>
+                buffer.Writer.TryWrite(new LiveSample(e.Channel, e.Sample));
+
+            var channels = SnapshotChannels();
+            foreach (var channel in channels)
+            {
+                channel.SampleReceived += OnSample;
+            }
+
+            try
+            {
+                await foreach (var sample in buffer.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    yield return sample;
+                }
+            }
+            finally
+            {
+                foreach (var channel in channels)
+                {
+                    channel.SampleReceived -= OnSample;
+                }
+                buffer.Writer.TryComplete();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Brings the **live** sample path up to the same async-stream idiom the library's **offline** paths already use (`SdCardLogSession.Samples`, `ISampleSource.StreamSamples`). `DaqifiStreamingDevice.StreamSamplesAsync` exposes decoded samples as an `IAsyncEnumerable<LiveSample>` so consumers can `await foreach` with cancellation and backpressure instead of hand-building an event/queue bridge over `SampleReceived`. **Additive** — the `SampleReceived` and `MessageReceived` events are unchanged.

## Changes
- **`StreamSamplesAsync([EnumeratorCancellation] CancellationToken ct = default, int? bufferCapacity = null)`** on `DaqifiStreamingDevice` — bridges the per-channel `SampleReceived` events into a bounded `System.Threading.Channels` channel and yields `LiveSample` (channel + `IDataSample`).
- **Bounded buffer, drop-oldest policy** (`DefaultLiveSampleBufferCapacity = 4096`, overridable): if the consumer falls behind, oldest buffered samples are discarded (memory never grows unbounded) and **`DroppedLiveSampleCount`** increments — the decode thread is never blocked (never applies backpressure into the device consumer).
- Cancelling the token ends enumeration promptly (`OperationCanceledException`) and unsubscribes, but does **not** stop the device stream (`StopStreaming()` does that).
- New **`LiveSample`** record; **docs** add a third "Live async stream (`await foreach`)" option alongside per-channel samples and raw frames.

## Testing
- `dotnet test` — **1640 passed / 0 failed / 2 skipped** (net9.0 + net10.0).
- **5** unit tests: yields an injected sample with correct channel + value + tick; multi-frame in-order; cancellation ends enumeration but leaves `IsStreaming` true; consumer-falls-behind drops oldest and increments the counter; invalid `bufferCapacity` throws.
- **Bench-validated on Nq1 (FW 3.7.2):** `await foreach (var s in device.StreamSamplesAsync(ct))` consumed **25 live samples @100 Hz** across 2 analog channels with correct AI0/AI1 attribution, values, and device ticks; `DroppedLiveSampleCount=0`; clean stop + disconnect.

## Acceptance criteria (#334)
- [x] `await foreach (var sample in device.StreamSamplesAsync(ct))` works end-to-end over a live stream
- [x] Cancellation stops enumeration promptly without stopping the device stream
- [x] Bounded buffering with explicit overflow policy (drop-oldest + `DroppedLiveSampleCount`) — no unbounded growth
- [x] Docs section alongside "Per-channel samples" / "Raw protobuf frames"

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)