### PR TITLE
feat(firmware): make FirmwareUpdateService logger optional (NullLogger default) (part of #340)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -14,6 +14,18 @@ namespace Daqifi.Core.Tests.Firmware;
 public class FirmwareUpdateServiceTests
 {
     [Fact]
+    public void Constructor_WithoutLogger_UsesNullLogger_DoesNotThrow()
+    {
+        // #340: the service is usable without wiring a logger (falls back to NullLogger).
+        var ex = Record.Exception(() => new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner()));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
     public async Task UpdateFirmwareAsync_HappyPath_TransitionsThroughExpectedStatesAndReportsProgress()
     {
         var device = new FakeStreamingDevice("COM3");

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateService.cs
@@ -7,6 +7,7 @@ using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Discovery;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Daqifi.Core.Firmware;
 
@@ -143,16 +144,18 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
     private bool _disposed;
 
     /// <summary>
-    /// Initializes a new firmware update service. <paramref name="usbLocationProvider"/> resolves
-    /// an enumerated bootloader's USB physical-location key when targeting by
-    /// <c>targetLocationKey</c>; when null, a platform-default provider is used (Windows → WMI,
-    /// others → no-op fallback, which makes location-key targeting a no-op).
+    /// Initializes a new firmware update service. The optional <paramref name="logger"/> defaults to
+    /// a no-op logger (<see cref="NullLogger{T}.Instance"/>) when omitted, so the service is usable
+    /// without wiring up logging. <paramref name="usbLocationProvider"/> resolves an enumerated
+    /// bootloader's USB physical-location key when targeting by <c>targetLocationKey</c>; when null,
+    /// a platform-default provider is used (Windows → WMI, others → no-op fallback, which makes
+    /// location-key targeting a no-op).
     /// </summary>
     public FirmwareUpdateService(
         IHidTransport hidTransport,
         IFirmwareDownloadService firmwareDownloadService,
         IExternalProcessRunner externalProcessRunner,
-        ILogger<FirmwareUpdateService> logger,
+        ILogger<FirmwareUpdateService>? logger = null,
         IBootloaderProtocol? bootloaderProtocol = null,
         IHidDeviceEnumerator? hidDeviceEnumerator = null,
         FirmwareUpdateServiceOptions? options = null,
@@ -161,7 +164,7 @@ public sealed class FirmwareUpdateService : IFirmwareUpdateService, IDisposable
         _hidTransport = hidTransport ?? throw new ArgumentNullException(nameof(hidTransport));
         FirmwareDownloadService = firmwareDownloadService ?? throw new ArgumentNullException(nameof(firmwareDownloadService));
         _externalProcessRunner = externalProcessRunner ?? throw new ArgumentNullException(nameof(externalProcessRunner));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger ?? NullLogger<FirmwareUpdateService>.Instance;
         _bootloaderProtocol = bootloaderProtocol ?? new Pic32BootloaderProtocol();
         _hidDeviceEnumerator = hidDeviceEnumerator ?? new HidLibraryDeviceEnumerator();
         _options = options ?? new FirmwareUpdateServiceOptions();


### PR DESCRIPTION
## Summary
`FirmwareUpdateService` required a non-nullable `ILogger<FirmwareUpdateService>`, so a DI-less consumer had to construct and pass one just to use the service. The `logger` parameter is now **optional**, defaulting to `NullLogger<FirmwareUpdateService>.Instance` — matching the optional-logger convention `MessageProducer` (and #360's `DaqifiDevice`) already use. Addresses **acceptance-criterion 4** of #340.

## Changes
- Constructor `logger` parameter: `ILogger<FirmwareUpdateService> logger` → `ILogger<FirmwareUpdateService>? logger = null`; the `?? throw ArgumentNullException` fallback becomes `?? NullLogger<FirmwareUpdateService>.Instance`. **Non-breaking** — the parameter already sits before the existing optional parameters, and callers passing a logger are unaffected. No flash-path logic changed.

## Testing
- `dotnet test` — **1636 pass / 0 fail / 2 skipped** (net9.0 + net10.0); FirmwareUpdateService suite 64/64.
- New test: constructing the service without a logger does not throw.
- No bench validation: a DI-ergonomics change with no device-facing behavior.

## Scope note
Closes acceptance-criterion 4 of #340. The remaining item — optional loggers on the **device finders and transports** — is a separate follow-up. **Does not close #340** (criteria 1–2 are #360, this is criterion 4).

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)