### PR TITLE
refactor(transport): extract shared connect-with-retry helper (part of #343)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/ConnectRetryExecutorTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/ConnectRetryExecutorTests.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using Daqifi.Core.Communication.Transport;
+
+namespace Daqifi.Core.Tests.Communication.Transport;
+
+/// <summary>
+/// Directly exercises the shared retry/backoff scaffolding used by both
+/// <see cref="TcpStreamTransport"/> and <see cref="SerialStreamTransport"/>.
+/// These attempt-loop semantics were previously duplicated (and untested) in
+/// each transport; centralizing them here pins the behavior both rely on.
+/// </summary>
+public class ConnectRetryExecutorTests
+{
+    private static ConnectionRetryOptions FastRetry(int maxAttempts) => new()
+    {
+        Enabled = true,
+        MaxAttempts = maxAttempts,
+        InitialDelay = TimeSpan.Zero,
+        MaxDelay = TimeSpan.Zero,
+        BackoffMultiplier = 1.0,
+        ConnectionTimeout = TimeSpan.FromSeconds(1)
+    };
+
+    [Fact]
+    public async Task ExecuteAsync_SucceedsFirstAttempt_ReportsConnectedOnce()
+    {
+        var attempts = 0;
+        var failedCleanups = 0;
+        var statuses = new List<(bool Connected, Exception? Error)>();
+
+        await ConnectRetryExecutor.ExecuteAsync(
+            FastRetry(3),
+            connectAttempt: _ => { attempts++; return Task.CompletedTask; },
+            onAttemptFailed: () => failedCleanups++,
+            onStatusChanged: (c, e) => statuses.Add((c, e)));
+
+        Assert.Equal(1, attempts);
+        Assert.Equal(0, failedCleanups);
+        var status = Assert.Single(statuses);
+        Assert.True(status.Connected);
+        Assert.Null(status.Error);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReceivesResolvedOptions_InConnectAttempt()
+    {
+        var options = FastRetry(2);
+        ConnectionRetryOptions? seen = null;
+
+        await ConnectRetryExecutor.ExecuteAsync(
+            options,
+            connectAttempt: o => { seen = o; return Task.CompletedTask; },
+            onAttemptFailed: () => { },
+            onStatusChanged: (_, _) => { });
+
+        Assert.Same(options, seen);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullOptions_UsesSingleNoRetryAttempt()
+    {
+        var attempts = 0;
+        var failedCleanups = 0;
+        var boom = new InvalidOperationException("boom");
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ConnectRetryExecutor.ExecuteAsync(
+                retryOptions: null,
+                connectAttempt: _ => { attempts++; throw boom; },
+                onAttemptFailed: () => failedCleanups++,
+                onStatusChanged: (_, _) => { }));
+
+        Assert.Same(boom, thrown);
+        Assert.Equal(1, attempts);          // NoRetry => exactly one attempt
+        Assert.Equal(1, failedCleanups);    // cleanup ran for the failed handle
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RetriesUntilSuccess_CleansUpEachFailedAttempt()
+    {
+        var attempts = 0;
+        var failedCleanups = 0;
+        var statuses = new List<(bool Connected, Exception? Error)>();
+
+        await ConnectRetryExecutor.ExecuteAsync(
+            FastRetry(3),
+            connectAttempt: _ =>
+            {
+                attempts++;
+                if (attempts < 3)
+                {
+                    throw new InvalidOperationException($"fail {attempts}");
+                }
+                return Task.CompletedTask;
+            },
+            onAttemptFailed: () => failedCleanups++,
+            onStatusChanged: (c, e) => statuses.Add((c, e)));
+
+        Assert.Equal(3, attempts);
+        Assert.Equal(2, failedCleanups);
+
+        // Two "retrying..." failure notifications, then a final success.
+        Assert.Equal(3, statuses.Count);
+        Assert.False(statuses[0].Connected);
+        Assert.Contains("retrying", statuses[0].Error!.Message);
+        Assert.False(statuses[1].Connected);
+        Assert.Contains("retrying", statuses[1].Error!.Message);
+        Assert.True(statuses[2].Connected);
+        Assert.Null(statuses[2].Error);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AllAttemptsFail_ThrowsLastExceptionAndReportsItUnwrapped()
+    {
+        var attempts = 0;
+        var failedCleanups = 0;
+        var statuses = new List<(bool Connected, Exception? Error)>();
+        var lastBoom = new InvalidOperationException("final");
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ConnectRetryExecutor.ExecuteAsync(
+                FastRetry(3),
+                connectAttempt: _ =>
+                {
+                    attempts++;
+                    throw attempts < 3 ? new InvalidOperationException($"fail {attempts}") : lastBoom;
+                },
+                onAttemptFailed: () => failedCleanups++,
+                onStatusChanged: (c, e) => statuses.Add((c, e))));
+
+        Assert.Same(lastBoom, thrown);
+        Assert.Equal(3, attempts);
+        Assert.Equal(3, failedCleanups);
+
+        // Two "retrying..." notifications, then the terminal failure carrying the
+        // original exception (not the retry wrapper).
+        Assert.Equal(3, statuses.Count);
+        Assert.Contains("retrying", statuses[0].Error!.Message);
+        Assert.Contains("retrying", statuses[1].Error!.Message);
+        Assert.False(statuses[2].Connected);
+        Assert.Same(lastBoom, statuses[2].Error);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RetryDisabledWithMultipleMaxAttempts_TriesOnce()
+    {
+        var attempts = 0;
+        var options = new ConnectionRetryOptions
+        {
+            Enabled = false,
+            MaxAttempts = 5,
+            InitialDelay = TimeSpan.Zero
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ConnectRetryExecutor.ExecuteAsync(
+                options,
+                connectAttempt: _ => { attempts++; throw new InvalidOperationException("boom"); },
+                onAttemptFailed: () => { },
+                onStatusChanged: (_, _) => { }));
+
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AppliesBackoffDelayBetweenAttempts()
+    {
+        var options = new ConnectionRetryOptions
+        {
+            Enabled = true,
+            MaxAttempts = 2,
+            InitialDelay = TimeSpan.FromMilliseconds(150),
+            MaxDelay = TimeSpan.FromSeconds(1),
+            BackoffMultiplier = 2.0
+        };
+
+        var attempts = 0;
+        var sw = Stopwatch.StartNew();
+
+        await ConnectRetryExecutor.ExecuteAsync(
+            options,
+            connectAttempt: _ =>
+            {
+                attempts++;
+                if (attempts == 1)
+                {
+                    throw new InvalidOperationException("first fails");
+                }
+                return Task.CompletedTask;
+            },
+            onAttemptFailed: () => { },
+            onStatusChanged: (_, _) => { });
+
+        sw.Stop();
+        Assert.Equal(2, attempts);
+        // A backoff delay must have elapsed before the second attempt. Use a loose
+        // lower bound (well under the ~150ms configured delay) to avoid flakiness.
+        Assert.True(sw.ElapsedMilliseconds >= 80,
+            $"Expected a backoff delay before retry, but only {sw.ElapsedMilliseconds}ms elapsed.");
+    }
+}

--- a/src/Daqifi.Core/Communication/Transport/ConnectRetryExecutor.cs
+++ b/src/Daqifi.Core/Communication/Transport/ConnectRetryExecutor.cs
@@ -1,0 +1,82 @@
+namespace Daqifi.Core.Communication.Transport;
+
+/// <summary>
+/// Shared retry/backoff scaffolding for stream transport connect operations.
+/// Both <see cref="TcpStreamTransport"/> and <see cref="SerialStreamTransport"/>
+/// drive their <c>ConnectAsync</c> through this executor so the attempt loop,
+/// backoff delay, status reporting, and final-throw semantics stay in one place
+/// (a retry/backoff fix can no longer land in one transport and miss the other).
+/// Only the transport-specific "create + open handle" body and the "dispose the
+/// failed handle" cleanup differ, and those are supplied by the caller.
+/// </summary>
+internal static class ConnectRetryExecutor
+{
+    /// <summary>
+    /// Runs <paramref name="connectAttempt"/> under the retry policy described by
+    /// <paramref name="retryOptions"/> (null selects <see cref="ConnectionRetryOptions.NoRetry"/>).
+    /// </summary>
+    /// <param name="retryOptions">Retry configuration, or null for a single no-retry attempt.</param>
+    /// <param name="connectAttempt">
+    /// Opens the transport handle. Receives the resolved options so it can honor the
+    /// connection timeout. Throwing signals a failed attempt.
+    /// </param>
+    /// <param name="onAttemptFailed">
+    /// Disposes/nulls the transport handle after a failed attempt, before the next
+    /// attempt or the terminal throw.
+    /// </param>
+    /// <param name="onStatusChanged">
+    /// Reports connection status: <c>(true, null)</c> on success, and
+    /// <c>(false, error)</c> on each failure (a retry-in-progress exception between
+    /// attempts, the real exception on the terminal failure).
+    /// </param>
+    public static async Task ExecuteAsync(
+        ConnectionRetryOptions? retryOptions,
+        Func<ConnectionRetryOptions, Task> connectAttempt,
+        Action onAttemptFailed,
+        Action<bool, Exception?> onStatusChanged)
+    {
+        var options = retryOptions ?? ConnectionRetryOptions.NoRetry;
+        var maxAttempts = options.Enabled ? options.MaxAttempts : 1;
+        Exception? lastException = null;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                // Calculate delay for this attempt
+                if (attempt > 1)
+                {
+                    var delay = options.CalculateDelay(attempt);
+                    if (delay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(delay);
+                    }
+                }
+
+                await connectAttempt(options);
+                onStatusChanged(true, null);
+                return; // Success!
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+                onAttemptFailed();
+
+                // If this is not the last attempt and retry is enabled, continue
+                if (attempt < maxAttempts && options.Enabled)
+                {
+                    onStatusChanged(false, new Exception($"Connection attempt {attempt}/{maxAttempts} failed, retrying...", ex));
+                    continue;
+                }
+
+                // Last attempt failed or retry disabled
+                onStatusChanged(false, ex);
+                throw;
+            }
+        }
+
+        // Should not reach here, but just in case
+        onStatusChanged(false, lastException);
+        throw lastException ?? new InvalidOperationException("Connection failed after all retry attempts.");
+    }
+}

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -156,24 +156,10 @@ public class SerialStreamTransport : IStreamTransport
         if (IsConnected)
             return;
 
-        var options = retryOptions ?? ConnectionRetryOptions.NoRetry;
-        var maxAttempts = options.Enabled ? options.MaxAttempts : 1;
-        Exception? lastException = null;
-
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            try
+        await ConnectRetryExecutor.ExecuteAsync(
+            retryOptions,
+            connectAttempt: options =>
             {
-                // Calculate delay for this attempt
-                if (attempt > 1)
-                {
-                    var delay = options.CalculateDelay(attempt);
-                    if (delay > TimeSpan.Zero)
-                    {
-                        await Task.Delay(delay);
-                    }
-                }
-
                 var timeout = (int)options.ConnectionTimeout.TotalMilliseconds;
                 _serialPort = new SerialPort(_portName, _baudRate, _parity, _dataBits, _stopBits)
                 {
@@ -191,31 +177,14 @@ public class SerialStreamTransport : IStreamTransport
                 // ensures consumer threads can be stopped promptly (StopSafely).
                 _serialPort.ReadTimeout = 500;
 
-                OnStatusChanged(true, null);
-                return; // Success!
-            }
-            catch (Exception ex)
+                return Task.CompletedTask;
+            },
+            onAttemptFailed: () =>
             {
-                lastException = ex;
                 _serialPort?.Dispose();
                 _serialPort = null;
-
-                // If this is not the last attempt and retry is enabled, continue
-                if (attempt < maxAttempts && options.Enabled)
-                {
-                    OnStatusChanged(false, new Exception($"Connection attempt {attempt}/{maxAttempts} failed, retrying...", ex));
-                    continue;
-                }
-
-                // Last attempt failed or retry disabled
-                OnStatusChanged(false, ex);
-                throw;
-            }
-        }
-
-        // Should not reach here, but just in case
-        OnStatusChanged(false, lastException);
-        throw lastException ?? new InvalidOperationException("Connection failed after all retry attempts.");
+            },
+            onStatusChanged: OnStatusChanged);
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
@@ -145,24 +145,10 @@ public class TcpStreamTransport : IStreamTransport
         if (IsConnected)
             return;
 
-        var options = retryOptions ?? ConnectionRetryOptions.NoRetry;
-        var maxAttempts = options.Enabled ? options.MaxAttempts : 1;
-        Exception? lastException = null;
-
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            try
+        await ConnectRetryExecutor.ExecuteAsync(
+            retryOptions,
+            connectAttempt: async options =>
             {
-                // Calculate delay for this attempt
-                if (attempt > 1)
-                {
-                    var delay = options.CalculateDelay(attempt);
-                    if (delay > TimeSpan.Zero)
-                    {
-                        await Task.Delay(delay);
-                    }
-                }
-
                 _tcpClient = _localInterface != null
                     ? new TcpClient(new IPEndPoint(_localInterface, 0))
                     : new TcpClient();
@@ -195,32 +181,14 @@ public class TcpStreamTransport : IStreamTransport
                 }
 
                 _networkStream = _tcpClient.GetStream();
-                OnStatusChanged(true, null);
-                return; // Success!
-            }
-            catch (Exception ex)
+            },
+            onAttemptFailed: () =>
             {
-                lastException = ex;
                 _tcpClient?.Dispose();
                 _tcpClient = null;
                 _networkStream = null;
-
-                // If this is not the last attempt and retry is enabled, continue
-                if (attempt < maxAttempts && options.Enabled)
-                {
-                    OnStatusChanged(false, new Exception($"Connection attempt {attempt}/{maxAttempts} failed, retrying...", ex));
-                    continue;
-                }
-
-                // Last attempt failed or retry disabled
-                OnStatusChanged(false, ex);
-                throw;
-            }
-        }
-
-        // Should not reach here, but just in case
-        OnStatusChanged(false, lastException);
-        throw lastException ?? new InvalidOperationException("Connection failed after all retry attempts.");
+            },
+            onStatusChanged: OnStatusChanged);
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Extracts the duplicated connect retry/backoff scaffolding shared by `TcpStreamTransport.ConnectAsync` and `SerialStreamTransport.ConnectAsync` into a single internal `ConnectRetryExecutor.ExecuteAsync`. Addresses the first acceptance criterion of #343 ("One shared retry implementation used by both stream transports; behavior unchanged").

## Why

The two `ConnectAsync(ConnectionRetryOptions?)` methods carried a near-identical loop — `NoRetry` fallback, attempt counter, `CalculateDelay`/`Task.Delay` backoff, dispose-and-null cleanup, retry-vs-terminal status reporting, and the trailing throw. Only the transport-specific "create + open handle" body differed. As #343 notes, a retry/backoff fix in one copy silently missed the other.

## How

`ConnectRetryExecutor.ExecuteAsync` owns the loop and takes two callbacks:
- `connectAttempt(options)` — the transport-specific handle open (receives the resolved options so it still honors the connection timeout).
- `onAttemptFailed()` — disposes/nulls the failed handle.

Status reporting is forwarded through each transport's existing `OnStatusChanged`. No public API changes.

## Tests

Adds `ConnectRetryExecutorTests` with direct coverage the duplicated loops never had: first-attempt success, retry-until-success with per-attempt cleanup, all-attempts-fail throwing the **last** exception unwrapped, `null`/disabled options collapsing to a single attempt, and backoff delay applied between attempts.

- Full suite green on net9 + net10 (1730 passed each).
- Bench-validated on hardware (Nyquist, `/dev/cu.usbmodem1101`): serial connect via the refactored path (`--connect-attempts 2`) connected, streamed, and disconnected cleanly.

## Scope note

This PR covers only the transport-retry half of #343. The finder-lifecycle base-class half (`DeviceFinderBase`) is left for a follow-up, hence "part of #343" rather than "closes".

Not merging — opened for review.