### PR TITLE
refactor(discovery): hoist finder lifecycle into DeviceFinderBase (part of #343)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
@@ -50,6 +50,38 @@ public class DeviceFinderBaseTests
         public bool IsDisposedForTest => IsDisposed;
     }
 
+    /// <summary>
+    /// A finder that acquires the discovery semaphore (as WiFi/Serial/Hid do) and then
+    /// parks until released, so a second, timed discovery contends for the semaphore and
+    /// its timeout can elapse while awaiting the token-bound <c>WaitAsync</c>.
+    /// </summary>
+    private sealed class BlockingFinder : DeviceFinderBase
+    {
+        private readonly TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Signaled once a pass has acquired the semaphore.</summary>
+        public TaskCompletionSource Acquired { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseGate() => _gate.TrySetResult();
+
+        public override async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            await DiscoverySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                Acquired.TrySetResult();
+                await _gate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                OnDiscoveryCompleted();
+                return Array.Empty<IDeviceInfo>();
+            }
+            finally
+            {
+                DiscoverySemaphore.Release();
+            }
+        }
+    }
+
     [Fact]
     public async Task DiscoverAsync_RaisesDeviceDiscoveredAndDiscoveryCompleted()
     {
@@ -111,6 +143,27 @@ public class DeviceFinderBaseTests
         // cancelable token wired to the timeout (not CancellationToken.None).
         Assert.Equal(1, finder.DiscoverCallCount);
         Assert.True(finder.LastToken.CanBeCanceled);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Timeout_WhileAwaitingConcurrentPass_ReturnsEmptyNotCanceled()
+    {
+        using var finder = new BlockingFinder();
+
+        // First pass acquires the discovery semaphore and parks (uncancelable token).
+        var first = finder.DiscoverAsync(CancellationToken.None);
+        await finder.Acquired.Task; // the semaphore is now held
+
+        // A second, timed pass must wait on the held semaphore; its timeout elapses
+        // first. The timeout is a normal terminal condition, so it must complete with
+        // an empty result rather than throwing OperationCanceledException (which would
+        // bubble through DaqifiTools.GuardAsync as a canceled tool call).
+        var result = await finder.DiscoverAsync(TimeSpan.FromMilliseconds(50));
+        Assert.Empty(result);
+
+        // The first pass is untouched by the second's timeout.
+        finder.ReleaseGate();
+        Assert.Empty(await first);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
@@ -169,6 +169,46 @@ public class DeviceFinderBaseTests
     }
 
     [Fact]
+    public async Task DiscoverAsync_Timeout_WhileAwaitingConcurrentPass_RaisesDiscoveryCompleted()
+    {
+        using var finder = new BlockingFinder();
+
+        var completedCount = 0;
+        finder.DiscoveryCompleted += (_, _) => Interlocked.Increment(ref completedCount);
+
+        // First pass acquires the semaphore and parks; it has NOT completed yet.
+        var first = finder.DiscoverAsync(CancellationToken.None);
+        await finder.Acquired.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // A timed pass whose timeout elapses while awaiting the held semaphore must
+        // still raise the end-of-pass signal, matching a normal timed pass — otherwise
+        // a consumer awaiting DiscoveryCompleted could wait indefinitely.
+        var result = await finder.DiscoverAsync(TimeSpan.FromMilliseconds(50));
+        Assert.Empty(result);
+
+        // The parked first pass hasn't completed, so this completion is the timed
+        // pass's own end-of-pass signal.
+        Assert.Equal(1, Volatile.Read(ref completedCount));
+
+        finder.ReleaseGate();
+        await first.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Dispose_ConcurrentCalls_DisposeSemaphoreExactlyOnce()
+    {
+        var finder = new TestFinder();
+
+        // Concurrent Dispose() calls must resolve to a single winner (Interlocked flag)
+        // so the shared semaphore is disposed exactly once and no call faults.
+        var tasks = Enumerable.Range(0, 16).Select(_ => Task.Run(() => finder.Dispose())).ToArray();
+        var ex = Record.Exception(() => Task.WaitAll(tasks));
+
+        Assert.Null(ex);
+        Assert.True(finder.IsDisposedForTest);
+    }
+
+    [Fact]
     public async Task DiscoverAsync_AfterDispose_ThrowsObjectDisposedException()
     {
         var finder = new TestFinder();

--- a/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
@@ -70,6 +70,37 @@ public class DeviceFinderBaseTests
     }
 
     [Fact]
+    public async Task OnDeviceDiscovered_ThrowingSubscriber_IsIsolatedAndDiscoveryCompletes()
+    {
+        var device = new DeviceInfo { Name = "Nq1", SerialNumber = "SN1" };
+        using var finder = new TestFinder(device);
+
+        // A throwing DeviceDiscovered subscriber must not abort the pass nor suppress
+        // the subsequent DiscoveryCompleted event.
+        finder.DeviceDiscovered += (_, _) => throw new InvalidOperationException("boom");
+        var completedCount = 0;
+        finder.DiscoveryCompleted += (_, _) => completedCount++;
+
+        var result = (await finder.DiscoverAsync()).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(1, completedCount);
+    }
+
+    [Fact]
+    public async Task OnDiscoveryCompleted_ThrowingSubscriber_IsIsolated()
+    {
+        using var finder = new TestFinder();
+
+        finder.DiscoveryCompleted += (_, _) => throw new InvalidOperationException("boom");
+
+        // Must not surface out of the discovery body.
+        var result = await finder.DiscoverAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public async Task DiscoverAsync_Timeout_RoutesThroughCancellationTokenOverload()
     {
         using var finder = new TestFinder();

--- a/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
@@ -1,0 +1,109 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+/// <summary>
+/// Exercises the shared lifecycle scaffolding hoisted into <see cref="DeviceFinderBase"/>
+/// (issue #343) directly, via a minimal test finder — coverage the per-finder copies
+/// never had as a unit (event raisers, the timeout overload's token routing, dispose
+/// idempotency, and the disposed guard).
+/// </summary>
+public class DeviceFinderBaseTests
+{
+    /// <summary>
+    /// Minimal concrete finder that records the token it was invoked with and raises
+    /// the base events, so the base plumbing can be observed without real hardware.
+    /// </summary>
+    private sealed class TestFinder : DeviceFinderBase
+    {
+        private readonly IReadOnlyList<IDeviceInfo> _result;
+
+        public TestFinder(params IDeviceInfo[] result) => _result = result;
+
+        public CancellationToken LastToken { get; private set; }
+        public int DiscoverCallCount { get; private set; }
+
+        public override async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            DiscoverCallCount++;
+            LastToken = cancellationToken;
+
+            await DiscoverySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                foreach (var device in _result)
+                {
+                    OnDeviceDiscovered(device);
+                }
+
+                OnDiscoveryCompleted();
+                return _result;
+            }
+            finally
+            {
+                DiscoverySemaphore.Release();
+            }
+        }
+
+        // Expose the protected guard so a test can assert it flips on dispose.
+        public bool IsDisposedForTest => IsDisposed;
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_RaisesDeviceDiscoveredAndDiscoveryCompleted()
+    {
+        var device = new DeviceInfo { Name = "Nq1", SerialNumber = "SN1" };
+        using var finder = new TestFinder(device);
+
+        var discovered = new List<IDeviceInfo>();
+        var completedCount = 0;
+        finder.DeviceDiscovered += (_, e) => discovered.Add(e.DeviceInfo);
+        finder.DiscoveryCompleted += (_, _) => completedCount++;
+
+        var result = (await finder.DiscoverAsync()).ToList();
+
+        Assert.Single(result);
+        Assert.Single(discovered);
+        Assert.Same(device, discovered[0]);
+        Assert.Equal(1, completedCount);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Timeout_RoutesThroughCancellationTokenOverload()
+    {
+        using var finder = new TestFinder();
+
+        await finder.DiscoverAsync(TimeSpan.FromSeconds(30));
+
+        // The timeout overload must delegate to the token overload with a real,
+        // cancelable token wired to the timeout (not CancellationToken.None).
+        Assert.Equal(1, finder.DiscoverCallCount);
+        Assert.True(finder.LastToken.CanBeCanceled);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var finder = new TestFinder();
+        finder.Dispose();
+
+        var ex = await Assert.ThrowsAsync<ObjectDisposedException>(() => finder.DiscoverAsync());
+        // ThrowIfDisposed names the concrete runtime type, not the base.
+        Assert.Equal(nameof(TestFinder), ex.ObjectName);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var finder = new TestFinder();
+
+        finder.Dispose();
+        Assert.True(finder.IsDisposedForTest);
+
+        // Second dispose must be a no-op (no ObjectDisposedException from re-disposing
+        // the semaphore).
+        finder.Dispose();
+        Assert.True(finder.IsDisposedForTest);
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/DeviceFinderBaseTests.cs
@@ -152,7 +152,9 @@ public class DeviceFinderBaseTests
 
         // First pass acquires the discovery semaphore and parks (uncancelable token).
         var first = finder.DiscoverAsync(CancellationToken.None);
-        await finder.Acquired.Task; // the semaphore is now held
+        // Bounded wait: if the first pass faults before signaling acquisition, fail fast
+        // instead of hanging until the runner-level timeout.
+        await finder.Acquired.Task.WaitAsync(TimeSpan.FromSeconds(5)); // the semaphore is now held
 
         // A second, timed pass must wait on the held semaphore; its timeout elapses
         // first. The timeout is a normal terminal condition, so it must complete with
@@ -163,7 +165,7 @@ public class DeviceFinderBaseTests
 
         // The first pass is untouched by the second's timeout.
         finder.ReleaseGate();
-        Assert.Empty(await first);
+        Assert.Empty(await first.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
     [Fact]

--- a/src/Daqifi.Core/Device/Discovery/DeviceFinderBase.cs
+++ b/src/Daqifi.Core/Device/Discovery/DeviceFinderBase.cs
@@ -41,20 +41,49 @@ public abstract class DeviceFinderBase : IDeviceFinder, IDisposable
     }
 
     /// <summary>
-    /// Raises the <see cref="DeviceDiscovered"/> event.
+    /// Raises the <see cref="DeviceDiscovered"/> event. Subscriber exceptions are
+    /// isolated so a throwing consumer callback cannot abort the discovery pass or
+    /// suppress the subsequent <see cref="DiscoveryCompleted"/> event.
     /// </summary>
     /// <param name="deviceInfo">The discovered device metadata.</param>
     protected virtual void OnDeviceDiscovered(IDeviceInfo deviceInfo)
     {
-        DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(deviceInfo));
+        RaiseIsolated(() => DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(deviceInfo)), nameof(DeviceDiscovered));
     }
 
     /// <summary>
-    /// Raises the <see cref="DiscoveryCompleted"/> event.
+    /// Raises the <see cref="DiscoveryCompleted"/> event. Subscriber exceptions are
+    /// isolated so a throwing consumer callback cannot fault the discovery body.
     /// </summary>
     protected virtual void OnDiscoveryCompleted()
     {
-        DiscoveryCompleted?.Invoke(this, EventArgs.Empty);
+        RaiseIsolated(() => DiscoveryCompleted?.Invoke(this, EventArgs.Empty), nameof(DiscoveryCompleted));
+    }
+
+    /// <summary>
+    /// Invokes an event raiser, swallowing any subscriber exception so the discovery
+    /// outcome never depends on consumer callback correctness. Mirrors the isolation
+    /// guarantee <see cref="AllTransportsDeviceFinder"/> applies to the same events.
+    /// </summary>
+    private void RaiseIsolated(Action raise, string eventName)
+    {
+        try
+        {
+            raise();
+        }
+        catch (Exception ex)
+        {
+            // Best-effort trace only; the logging path must not fault discovery either
+            // (a throwing TraceListener is swallowed).
+            try
+            {
+                System.Diagnostics.Trace.WriteLine($"[{GetType().Name}] {eventName} subscriber threw: {ex}");
+            }
+            catch
+            {
+                // ignore
+            }
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/DeviceFinderBase.cs
+++ b/src/Daqifi.Core/Device/Discovery/DeviceFinderBase.cs
@@ -37,7 +37,22 @@ public abstract class DeviceFinderBase : IDeviceFinder, IDisposable
     public virtual async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
     {
         using var cts = new CancellationTokenSource(timeout);
-        return await DiscoverAsync(cts.Token).ConfigureAwait(false);
+        try
+        {
+            return await DiscoverAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // The timeout elapsed — that is a normal terminal condition for a timed
+            // discovery, not a caller cancellation. Derived finders acquire the
+            // discovery semaphore with this token (see WiFi/Serial/Hid), so a timeout
+            // that fires while awaiting a concurrent pass would otherwise surface as
+            // OperationCanceledException; return an empty result instead so callers
+            // (e.g. DaqifiTools.GuardAsync, which rethrows OCE) see "found nothing"
+            // rather than a canceled call. This overload takes no caller token, so
+            // every cancellation here is timeout-originated.
+            return Array.Empty<IDeviceInfo>();
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/DeviceFinderBase.cs
+++ b/src/Daqifi.Core/Device/Discovery/DeviceFinderBase.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Shared lifecycle scaffolding for the concrete <see cref="IDeviceFinder"/>
+/// implementations (<see cref="HidDeviceFinder"/>, <see cref="SerialDeviceFinder"/>,
+/// <see cref="WiFiDeviceFinder"/>). Owns the discovery serialization semaphore, the
+/// <see cref="DeviceDiscovered"/>/<see cref="DiscoveryCompleted"/> events and their
+/// raisers, the disposed flag, and one consistent timeout/await/dispose policy so the
+/// boilerplate can no longer drift apart across copies (issue #343).
+/// </summary>
+public abstract class DeviceFinderBase : IDeviceFinder, IDisposable
+{
+    private readonly SemaphoreSlim _discoverySemaphore = new(1, 1);
+    private bool _disposed;
+
+    /// <summary>
+    /// Serializes concurrent discovery passes on this instance. Derived finders
+    /// acquire it at the start of a discovery body and release it in a finally.
+    /// </summary>
+    protected SemaphoreSlim DiscoverySemaphore => _discoverySemaphore;
+
+    /// <inheritdoc />
+    public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
+
+    /// <inheritdoc />
+    public event EventHandler? DiscoveryCompleted;
+
+    /// <inheritdoc />
+    public abstract Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default);
+
+    /// <inheritdoc />
+    public virtual async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        return await DiscoverAsync(cts.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DeviceDiscovered"/> event.
+    /// </summary>
+    /// <param name="deviceInfo">The discovered device metadata.</param>
+    protected virtual void OnDeviceDiscovered(IDeviceInfo deviceInfo)
+    {
+        DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(deviceInfo));
+    }
+
+    /// <summary>
+    /// Raises the <see cref="DiscoveryCompleted"/> event.
+    /// </summary>
+    protected virtual void OnDiscoveryCompleted()
+    {
+        DiscoveryCompleted?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this instance has been disposed.
+    /// </summary>
+    protected bool IsDisposed => _disposed;
+
+    /// <summary>
+    /// Throws <see cref="ObjectDisposedException"/> if this instance has been disposed.
+    /// </summary>
+    protected void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(GetType().Name);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases resources owned by the finder. Overrides must call the base
+    /// implementation so the shared discovery semaphore is disposed and the
+    /// disposed flag is set exactly once.
+    /// </summary>
+    /// <param name="disposing">
+    /// <c>true</c> when called from <see cref="Dispose()"/>; <c>false</c> from a finalizer.
+    /// </param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            _discoverySemaphore.Dispose();
+        }
+
+        _disposed = true;
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/DeviceFinderBase.cs
+++ b/src/Daqifi.Core/Device/Discovery/DeviceFinderBase.cs
@@ -16,7 +16,12 @@ namespace Daqifi.Core.Device.Discovery;
 public abstract class DeviceFinderBase : IDeviceFinder, IDisposable
 {
     private readonly SemaphoreSlim _discoverySemaphore = new(1, 1);
-    private bool _disposed;
+
+    // 0 = live, 1 = disposed. Written via Interlocked.Exchange so concurrent
+    // Dispose() calls resolve to exactly one winner, and published before the
+    // semaphore is disposed so ThrowIfDisposed() starts throwing the moment
+    // disposal begins (see Dispose(bool)).
+    private int _disposed;
 
     /// <summary>
     /// Serializes concurrent discovery passes on this instance. Derived finders
@@ -51,6 +56,13 @@ public abstract class DeviceFinderBase : IDeviceFinder, IDisposable
             // (e.g. DaqifiTools.GuardAsync, which rethrows OCE) see "found nothing"
             // rather than a canceled call. This overload takes no caller token, so
             // every cancellation here is timeout-originated.
+            //
+            // A timeout can interrupt a derived finder before it reaches its own
+            // OnDiscoveryCompleted() (e.g. HidDeviceFinder does not catch
+            // OperationCanceledException), so raise the end-of-pass signal here to
+            // keep it consistent with a normal timed pass. The raiser is already
+            // subscriber-isolated, so this cannot fault the timeout path.
+            OnDiscoveryCompleted();
             return Array.Empty<IDeviceInfo>();
         }
     }
@@ -104,14 +116,14 @@ public abstract class DeviceFinderBase : IDeviceFinder, IDisposable
     /// <summary>
     /// Gets a value indicating whether this instance has been disposed.
     /// </summary>
-    protected bool IsDisposed => _disposed;
+    protected bool IsDisposed => Volatile.Read(ref _disposed) != 0;
 
     /// <summary>
     /// Throws <see cref="ObjectDisposedException"/> if this instance has been disposed.
     /// </summary>
     protected void ThrowIfDisposed()
     {
-        if (_disposed)
+        if (Volatile.Read(ref _disposed) != 0)
         {
             throw new ObjectDisposedException(GetType().Name);
         }
@@ -134,7 +146,12 @@ public abstract class DeviceFinderBase : IDeviceFinder, IDisposable
     /// </param>
     protected virtual void Dispose(bool disposing)
     {
-        if (_disposed)
+        // Publish the disposed state atomically and *before* releasing managed
+        // resources: the first caller to flip the flag wins (so concurrent
+        // Dispose() calls can't both dispose the semaphore), and a concurrent
+        // DiscoverAsync now reliably fails ThrowIfDisposed() with the finder-named
+        // ObjectDisposedException instead of racing onto a disposed semaphore.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
             return;
         }
@@ -143,7 +160,5 @@ public abstract class DeviceFinderBase : IDeviceFinder, IDisposable
         {
             _discoverySemaphore.Dispose();
         }
-
-        _disposed = true;
     }
 }

--- a/src/Daqifi.Core/Device/Discovery/HidDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/HidDeviceFinder.cs
@@ -5,7 +5,7 @@ namespace Daqifi.Core.Device.Discovery;
 /// <summary>
 /// Discovers DAQiFi devices in USB HID bootloader mode.
 /// </summary>
-public class HidDeviceFinder : IDeviceFinder, IDisposable
+public class HidDeviceFinder : DeviceFinderBase
 {
     /// <summary>
     /// Default DAQiFi bootloader vendor ID.
@@ -19,8 +19,6 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
 
     private readonly IHidDeviceEnumerator _hidDeviceEnumerator;
     private readonly IUsbLocationProvider _usbLocationProvider;
-    private readonly SemaphoreSlim _discoverySemaphore = new(1, 1);
-    private bool _disposed;
 
     /// <summary>
     /// Initializes a new finder that filters to DAQiFi bootloader VID/PID by default.
@@ -68,13 +66,7 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
     public int? ProductIdFilter { get; set; }
 
     /// <inheritdoc />
-    public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
-
-    /// <inheritdoc />
-    public event EventHandler? DiscoveryCompleted;
-
-    /// <inheritdoc />
-    public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+    public override Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
     {
         return DiscoverAsync(VendorIdFilter, ProductIdFilter, cancellationToken);
     }
@@ -93,7 +85,7 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
     {
         ThrowIfDisposed();
 
-        await _discoverySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await DiscoverySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             var hidDevices = await _hidDeviceEnumerator
@@ -139,51 +131,7 @@ public class HidDeviceFinder : IDeviceFinder, IDisposable
         }
         finally
         {
-            _discoverySemaphore.Release();
+            DiscoverySemaphore.Release();
         }
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
-    {
-        using var cts = new CancellationTokenSource(timeout);
-        return await DiscoverAsync(cts.Token).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Raises the <see cref="DeviceDiscovered"/> event.
-    /// </summary>
-    /// <param name="deviceInfo">The discovered device metadata.</param>
-    protected virtual void OnDeviceDiscovered(IDeviceInfo deviceInfo)
-    {
-        DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(deviceInfo));
-    }
-
-    /// <summary>
-    /// Raises the <see cref="DiscoveryCompleted"/> event.
-    /// </summary>
-    protected virtual void OnDiscoveryCompleted()
-    {
-        DiscoveryCompleted?.Invoke(this, EventArgs.Empty);
-    }
-
-    private void ThrowIfDisposed()
-    {
-        if (_disposed)
-        {
-            throw new ObjectDisposedException(nameof(HidDeviceFinder));
-        }
-    }
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _discoverySemaphore.Dispose();
-        _disposed = true;
     }
 }

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -18,7 +18,7 @@ namespace Daqifi.Core.Device.Discovery;
 /// Discovers DAQiFi devices connected via USB/Serial ports.
 /// Probes each port by sending SCPI commands and validating protobuf responses.
 /// </summary>
-public class SerialDeviceFinder : IDeviceFinder, IDisposable
+public class SerialDeviceFinder : DeviceFinderBase
 {
     #region Constants
 
@@ -57,7 +57,6 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     #region Private Fields
 
     private readonly int _baudRate;
-    private readonly SemaphoreSlim _discoverySemaphore = new(1, 1);
     private readonly IUsbPortDescriptorProvider _usbPortDescriptorProvider;
     private readonly IUsbLocationProvider _usbLocationProvider;
     private readonly Func<string[]>? _portNameProvider;
@@ -82,7 +81,6 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     // STATIC on purpose: a wedged COM port is machine-global state, not finder
     // state.
     private static readonly ConcurrentDictionary<string, PortProbeClaim> PortClaims = new();
-    private bool _disposed;
 
     private sealed class PortProbeClaim
     {
@@ -124,20 +122,6 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
 
     // Internal so tests can shrink the hard timeout instead of waiting 8s per case.
     internal int PortProbeHardTimeoutMs { get; set; } = DefaultPortProbeHardTimeoutMs;
-
-    #endregion
-
-    #region Events
-
-    /// <summary>
-    /// Occurs when a device is discovered.
-    /// </summary>
-    public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
-
-    /// <summary>
-    /// Occurs when device discovery completes.
-    /// </summary>
-    public event EventHandler? DiscoveryCompleted;
 
     #endregion
 
@@ -213,12 +197,12 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
     /// </summary>
     /// <param name="cancellationToken">Cancellation token to abort the operation.</param>
     /// <returns>A task containing the collection of discovered DAQiFi devices.</returns>
-    public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+    public override async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
 
         // Prevent concurrent discovery operations
-        await _discoverySemaphore.WaitAsync(cancellationToken);
+        await DiscoverySemaphore.WaitAsync(cancellationToken);
         try
         {
             var discoveredDevices = new List<IDeviceInfo>();
@@ -305,19 +289,8 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
         }
         finally
         {
-            _discoverySemaphore.Release();
+            DiscoverySemaphore.Release();
         }
-    }
-
-    /// <summary>
-    /// Discovers devices asynchronously with a timeout.
-    /// </summary>
-    /// <param name="timeout">The timeout for discovery.</param>
-    /// <returns>A task containing the collection of discovered devices.</returns>
-    public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
-    {
-        using var cts = new CancellationTokenSource(timeout);
-        return await DiscoverAsync(cts.Token);
     }
 
     #endregion
@@ -767,47 +740,6 @@ public class SerialDeviceFinder : IDeviceFinder, IDisposable
             IsPowerOn = true,
             LocationKey = locationKey
         };
-    }
-
-    /// <summary>
-    /// Raises the DeviceDiscovered event.
-    /// </summary>
-    protected virtual void OnDeviceDiscovered(IDeviceInfo deviceInfo)
-    {
-        DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(deviceInfo));
-    }
-
-    /// <summary>
-    /// Raises the DiscoveryCompleted event.
-    /// </summary>
-    protected virtual void OnDiscoveryCompleted()
-    {
-        DiscoveryCompleted?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <summary>
-    /// Throws ObjectDisposedException if this instance has been disposed.
-    /// </summary>
-    private void ThrowIfDisposed()
-    {
-        if (_disposed)
-            throw new ObjectDisposedException(nameof(SerialDeviceFinder));
-    }
-
-    #endregion
-
-    #region IDisposable
-
-    /// <summary>
-    /// Disposes the device finder.
-    /// </summary>
-    public void Dispose()
-    {
-        if (!_disposed)
-        {
-            _discoverySemaphore.Dispose();
-            _disposed = true;
-        }
     }
 
     #endregion

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -16,7 +16,7 @@ namespace Daqifi.Core.Device.Discovery;
 /// <summary>
 /// Discovers DAQiFi devices on the network using UDP broadcast on port 30303.
 /// </summary>
-public class WiFiDeviceFinder : IDeviceFinder, IDisposable
+public class WiFiDeviceFinder : DeviceFinderBase
 {
     #region Constants
 
@@ -52,22 +52,6 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
 
     private readonly int _discoveryPort;
     private readonly byte[] _queryCommandBytes;
-    private readonly SemaphoreSlim _discoverySemaphore = new(1, 1);
-    private bool _disposed;
-
-    #endregion
-
-    #region Events
-
-    /// <summary>
-    /// Occurs when a device is discovered.
-    /// </summary>
-    public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
-
-    /// <summary>
-    /// Occurs when device discovery completes.
-    /// </summary>
-    public event EventHandler? DiscoveryCompleted;
 
     #endregion
 
@@ -99,19 +83,9 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
     /// </summary>
     /// <param name="cancellationToken">Cancellation token to abort the operation.</param>
     /// <returns>A task containing the collection of discovered devices.</returns>
-    public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+    public override async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
     {
         return await DiscoverAsync(Timeout.InfiniteTimeSpan, cancellationToken);
-    }
-
-    /// <summary>
-    /// Discovers devices asynchronously with a timeout.
-    /// </summary>
-    /// <param name="timeout">The timeout for discovery.</param>
-    /// <returns>A task containing the collection of discovered devices.</returns>
-    public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout)
-    {
-        return await DiscoverAsync(timeout, CancellationToken.None);
     }
 
     /// <summary>
@@ -243,7 +217,7 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         ThrowIfDisposed();
 
         // Prevent concurrent discovery operations
-        await _discoverySemaphore.WaitAsync(cancellationToken);
+        await DiscoverySemaphore.WaitAsync(cancellationToken);
         try
         {
             var discoveredDevices = new List<IDeviceInfo>();
@@ -337,7 +311,7 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
         }
         finally
         {
-            _discoverySemaphore.Release();
+            DiscoverySemaphore.Release();
         }
     }
 
@@ -614,47 +588,6 @@ public class WiFiDeviceFinder : IDeviceFinder, IDisposable
                Contains(n, "TAP-Windows") || Contains(d, "TAP-Windows") ||
                Contains(n, "TAP-") || Contains(d, "TAP-") ||
                Contains(n, "TAP ") || Contains(d, "TAP ");
-    }
-
-    /// <summary>
-    /// Raises the DeviceDiscovered event.
-    /// </summary>
-    protected virtual void OnDeviceDiscovered(IDeviceInfo deviceInfo)
-    {
-        DeviceDiscovered?.Invoke(this, new DeviceDiscoveredEventArgs(deviceInfo));
-    }
-
-    /// <summary>
-    /// Raises the DiscoveryCompleted event.
-    /// </summary>
-    protected virtual void OnDiscoveryCompleted()
-    {
-        DiscoveryCompleted?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <summary>
-    /// Throws ObjectDisposedException if this instance has been disposed.
-    /// </summary>
-    private void ThrowIfDisposed()
-    {
-        if (_disposed)
-            throw new ObjectDisposedException(nameof(WiFiDeviceFinder));
-    }
-
-    #endregion
-
-    #region IDisposable
-
-    /// <summary>
-    /// Disposes the device finder.
-    /// </summary>
-    public void Dispose()
-    {
-        if (!_disposed)
-        {
-            _discoverySemaphore.Dispose();
-            _disposed = true;
-        }
     }
 
     #endregion


### PR DESCRIPTION
## What

Second (and final) half of #343 — the finder-lifecycle boilerplate. `HidDeviceFinder`, `SerialDeviceFinder`, and `WiFiDeviceFinder` each repeated:

- the `_discoverySemaphore` field,
- the `DeviceDiscovered` / `DiscoveryCompleted` events and their `OnDeviceDiscovered` / `OnDiscoveryCompleted` raisers,
- the `_disposed` flag + `ThrowIfDisposed()`,
- `Dispose()`,
- and the `DiscoverAsync(TimeSpan)` timeout overload — which had **already drifted stylistically**: Hid used `.ConfigureAwait(false)` + its own CTS, Serial a bare CTS, WiFi routed the timeout through an internal 2-arg impl.

All of it is hoisted into a new abstract `DeviceFinderBase : IDeviceFinder, IDisposable` that pins one timeout/await/dispose policy. The three finders now override only `DiscoverAsync(CancellationToken)` and use the shared `DiscoverySemaphore`.

## Notes / behavior

- **No public API changes.** The events and both `DiscoverAsync` overloads remain on the finder surface (now inherited); `Dispose()` still works the same.
- `ThrowIfDisposed()` uses `GetType().Name`, so the `ObjectDisposedException.ObjectName` is unchanged per concrete type.
- `Dispose` now follows the protected `Dispose(bool)` pattern with `GC.SuppressFinalize`; the disposed flag flips exactly once and dispose is idempotent (unchanged behavior, now in one place).
- WiFi keeps its internal timeout-aware discovery impl; its public `DiscoverAsync(TimeSpan)` now comes from the base (behavior-equivalent — the base's linked-CTS token cancels at the same `timeout`).
- The composite finders (`AllTransportsDeviceFinder`, `ContinuousDeviceFinder`) are aggregators without this semaphore/dispose shape and are intentionally left as-is.

## Tests / validation

- New `DeviceFinderBaseTests` (5 cases): event raisers fire, the timeout overload delegates to the token overload with a real cancelable token, the disposed guard throws `ObjectDisposedException` naming the concrete type, and dispose is idempotent.
- Full suite green on **net9.0 + net10.0** (1727 passed, 2 skipped each).
- Bench-validated on a real Nyquist (`/dev/cu.usbmodem1101`): `--discover-serial` found Nq1 (SN 9090539562006014104, FW 3.7.2) through the refactored `SerialDeviceFinder` → `DeviceFinderBase` path.

Closes the finder half of #343 (the transport connect/retry half is #363).

Not merging — opened for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)