### PR TITLE
fix(consumers): fail fast on an empty LineBasedMessageParser line ending (closes #367)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/LineBasedMessageParserTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/LineBasedMessageParserTests.cs
@@ -88,6 +88,22 @@ public class LineBasedMessageParserTests
     }
 
     [Fact]
+    public void LineBasedMessageParser_Constructor_WithEmptyLineEnding_ShouldThrowArgumentException()
+    {
+        // An empty line ending encodes to zero bytes, which would make ParseMessages
+        // spin forever (searchStart never advances). Fail fast at construction instead.
+        var ex = Assert.Throws<ArgumentException>(() => new LineBasedMessageParser(""));
+        Assert.Equal("lineEnding", ex.ParamName);
+    }
+
+    [Fact]
+    public void LineBasedMessageParser_Constructor_WithNullLineEnding_ShouldThrowArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new LineBasedMessageParser(null!));
+        Assert.Equal("lineEnding", ex.ParamName);
+    }
+
+    [Fact]
     public void LineBasedMessageParser_ParseMessages_WithNoData_ShouldReturnEmpty()
     {
         // Arrange

--- a/src/Daqifi.Core/Communication/Consumers/LineBasedMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/LineBasedMessageParser.cs
@@ -15,12 +15,22 @@ public class LineBasedMessageParser : IMessageParser<string>
     /// <summary>
     /// Initializes a new instance of the LineBasedMessageParser class.
     /// </summary>
-    /// <param name="lineEnding">The line ending to split messages on. Defaults to CRLF.</param>
+    /// <param name="lineEnding">The line ending to split messages on. Defaults to CRLF. Must encode to at least one byte.</param>
     /// <param name="encoding">The text encoding to use. Defaults to UTF-8.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="lineEnding"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="lineEnding"/> encodes to zero bytes (an empty line ending would prevent the parser from making progress).</exception>
     public LineBasedMessageParser(string lineEnding = "\r\n", Encoding? encoding = null)
     {
+        if (lineEnding == null)
+            throw new ArgumentNullException(nameof(lineEnding));
+
         _encoding = encoding ?? Encoding.UTF8;
         _lineEnding = _encoding.GetBytes(lineEnding);
+
+        if (_lineEnding.Length == 0)
+            throw new ArgumentException(
+                "Line ending must encode to at least one byte; an empty line ending would prevent the parser from making progress.",
+                nameof(lineEnding));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Closes #367.

`LineBasedMessageParser` (public ctor, consumed by `CompositeMessageParser`, `DaqifiDevice`, and external consumers) hung the calling thread forever when constructed with an empty line ending: the empty ending encoded to a zero-length byte array, so `FindLineEnding` returned `searchStart` with no match-loop iterations and `searchStart` never advanced past any non-empty input — an infinite loop in `ParseMessages`.

## Fix
Fail fast in the constructor: throw `ArgumentNullException` for a null line ending and `ArgumentException` when the ending encodes to zero bytes. This converts a silent infinite hang into an immediate, actionable error at construction time.

## Why it's safe / non-breaking
- Every existing construction site passes the default CRLF or `"\n"` (verified across `src`) — nothing relies on an empty line ending.
- The only prior behavior for an empty line ending was an infinite loop, so no working consumer can regress.

## Tests
- Added 2 regression tests: constructor throws `ArgumentException` (ParamName `lineEnding`) for `""` and `ArgumentNullException` for `null`. **Verified both fail on the pre-fix source** (2/2 failed with the source change stashed) and pass after.
- Full suite green: **1750 passed net9 + net10** (2 skipped each, +2 new tests), 0 failed.
- No bench: pure client-side parser argument-validation change, no wire/hardware behavior; the pathological input is consumer misuse, not device data.

Not merging — opened for the user's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)