### PR TITLE
fix(firmware): validate Intel HEX record structure to fail fast on corrupt records (closes #369)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/IntelHexParserTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/IntelHexParserTests.cs
@@ -55,6 +55,40 @@ public class IntelHexParserTests
         Assert.Throws<InvalidDataException>(() => _parser.ParseHexRecords(lines));
     }
 
+    [Fact]
+    public void ParseHexRecords_ByteCountDisagreesWithDataLength_ThrowsInvalidDataException()
+    {
+        // A data record whose byte-count field says 1 but which carries 2 data bytes (AA BB).
+        // Checksum is valid (01+00+00+00+AA+BB+9A = 0x200 -> 0), so only the byte-count/length
+        // check can reject it.
+        var lines = new[] { ":01000000AABB9A" };
+
+        var ex = Assert.Throws<InvalidDataException>(() => _parser.ParseHexRecords(lines));
+        Assert.Contains("declares", ex.Message);
+    }
+
+    [Fact]
+    public void ParseHexRecords_Type04RecordWithTooFewDataBytes_ThrowsInvalidDataExceptionNotArgumentException()
+    {
+        // Type-04 (extended linear address) record declaring 0 data bytes, with a valid checksum
+        // (00+00+00+04+FC = 0x100 -> 0). Its byte-count field (0) matches its data length (0), so
+        // ValidateRecordLength passes it — but a type-04 record must carry exactly 2 address bytes.
+        // Before the fix this reached UpdateBaseAddress and handed BitConverter.ToUInt16 a zero-length
+        // array, crashing with a raw ArgumentException instead of the documented InvalidDataException.
+        var lines = new[] { ":00000004FC" };
+
+        var ex = Assert.Throws<InvalidDataException>(() => _parser.ParseHexRecords(lines));
+        Assert.Contains("type-04", ex.Message);
+    }
+
+    [Fact]
+    public void ParseRecords_Type04RecordWithTooFewDataBytes_ThrowsInvalidDataExceptionNotArgumentException()
+    {
+        var lines = new[] { ":00000004FC" };
+
+        Assert.Throws<InvalidDataException>(() => _parser.ParseRecords(lines));
+    }
+
     #endregion
 
     #region ParseHexRecords - Checksum Validation

--- a/src/Daqifi.Core/Firmware/IntelHexParser.cs
+++ b/src/Daqifi.Core/Firmware/IntelHexParser.cs
@@ -65,9 +65,10 @@ public class IntelHexParser
             ValidateLine(line);
 
             var hexLine = ConvertLineToBytes(line);
+            ValidateRecordLength(hexLine, line);
             ValidateChecksum(hexLine, line);
 
-            baseAddress = UpdateBaseAddress(hexLine, baseAddress);
+            baseAddress = UpdateBaseAddress(hexLine, baseAddress, line);
 
             if (IsProtectedHexRecord(hexLine, baseAddress))
             {
@@ -105,10 +106,11 @@ public class IntelHexParser
             ValidateLine(line);
 
             var hexLine = ConvertLineToBytes(line);
+            ValidateRecordLength(hexLine, line);
             ValidateChecksum(hexLine, line);
             var recordType = hexLine[3];
 
-            baseAddress = UpdateBaseAddress(hexLine, baseAddress);
+            baseAddress = UpdateBaseAddress(hexLine, baseAddress, line);
 
             if (IsProtectedHexRecord(hexLine, baseAddress))
             {
@@ -144,6 +146,25 @@ public class IntelHexParser
         {
             throw new InvalidDataException(
                 $"The hex record \"{line}\" is too short to be a valid record");
+        }
+    }
+
+    private static void ValidateRecordLength(byte[] record, string line)
+    {
+        // Intel HEX structure: 1 (byte count) + 2 (address) + 1 (record type) + N (data) + 1 (checksum),
+        // where N is the value of the byte-count field (record[0]). ValidateLine already guarantees at
+        // least 5 decoded bytes, so record[0] is safely accessible. A declared count that disagrees with
+        // the actual data length means the record is truncated, padded, or corrupt. Rejecting it here as
+        // the documented InvalidDataException prevents the downstream BitConverter.ToUInt16 calls (in
+        // UpdateBaseAddress / IsProtectedHexRecord / ParseRecords) from reading a wrong-sized slice and
+        // throwing a raw ArgumentException — e.g. a type-04 record with a zero byte count would otherwise
+        // hand ToUInt16 a zero-length array and crash the whole parse.
+        int declaredDataLength = record[0];
+        int actualDataLength = record.Length - 5;
+        if (actualDataLength != declaredDataLength)
+        {
+            throw new InvalidDataException(
+                $"The hex record \"{line}\" declares {declaredDataLength} data byte(s) but contains {actualDataLength}");
         }
     }
 
@@ -183,12 +204,24 @@ public class IntelHexParser
         return hexLine;
     }
 
-    private static ushort UpdateBaseAddress(byte[] hexRecord, ushort currentBaseAddress)
+    private static ushort UpdateBaseAddress(byte[] hexRecord, ushort currentBaseAddress, string line)
     {
         var recordType = hexRecord[3];
         if (recordType == 0x04)
         {
-            var dataArray = hexRecord.Skip(4).Take(hexRecord.Length - 5).ToArray();
+            // A type-04 (extended linear address) record must carry exactly 2 data bytes — the
+            // upper 16 bits of the 32-bit address. Its byte-count field can equal its data length
+            // yet still be wrong (e.g. a zero-count type-04 record whose count "matches" its zero
+            // data bytes), so ValidateRecordLength alone doesn't cover this. Guard the slice
+            // explicitly so a short/corrupt type-04 record throws the documented InvalidDataException
+            // rather than a raw ArgumentException from BitConverter.ToUInt16 on an undersized array.
+            if (hexRecord.Length - 5 != 2)
+            {
+                throw new InvalidDataException(
+                    $"The hex record \"{line}\" is a type-04 extended-address record but does not carry exactly 2 data bytes");
+            }
+
+            var dataArray = hexRecord.Skip(4).Take(2).ToArray();
             if (BitConverter.IsLittleEndian) Array.Reverse(dataArray);
             return BitConverter.ToUInt16(dataArray, 0);
         }


### PR DESCRIPTION
Closes #369.

## Problem

`IntelHexParser` validated a record's colon prefix, character count, minimum length, hex characters, and checksum — but never validated the record's structure against its **byte-count field** (the first data byte). Per the Intel HEX spec a record's total decoded length must be exactly `5 + byteCount`, and a type-04 (extended linear address) record must carry exactly 2 data bytes.

Two concrete gaps:

1. A record whose byte-count field disagrees with its actual data length was silently accepted — and in `ParseHexRecords` forwarded as-is to the bootloader.
2. A **type-04 record with fewer than 2 data bytes** (e.g. `:00000004FC`, a zero-count type-04 whose byte count "matches" its zero data bytes and whose checksum is valid) reached `UpdateBaseAddress`, which handed `BitConverter.ToUInt16` an undersized array and crashed the whole parse with a raw `ArgumentException` instead of the `InvalidDataException` the method's XML docs promise — an uncaught crash on a corrupt/truncated `.hex` file.

## Fix

- `ValidateRecordLength`: reject any record where `record.Length - 5 != record[0]` (byte-count vs actual data length).
- Guard the type-04 slice in `UpdateBaseAddress`: require exactly 2 data bytes before the `ToUInt16`.

Both throw the documented `InvalidDataException` naming the offending line.

## Tests

Added 3 regression tests: byte-count-vs-length mismatch is rejected; a too-short type-04 record throws `InvalidDataException` (not `ArgumentException`) via both `ParseHexRecords` and `ParseRecords`. **Verified all three fail on the pre-fix source** (the type-04 cases throw `ArgumentException`, the mismatch case throws nothing) and pass after.

## Validation

- Core builds clean net9 + net10 (0 warnings).
- Full suite green: **1751 passed net9 + net10** (2 skipped each, +3 new tests), 0 failed.
- No bench: pure client-side firmware-file parsing, no wire/hardware behavior; the pathological input is a corrupt `.hex` file that can't be produced non-destructively on the device — unit tests fully cover it.

Not merging — opened for your review.