### PR TITLE
fix(network): reject WiFi reconfiguration over a WiFi/TCP transport (closes #352)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
@@ -44,6 +44,48 @@ namespace Daqifi.Core.Tests.Device.Network
         }
 
         [Fact]
+        public async Task UpdateNetworkConfigurationAsync_OverWifi_ThrowsRequiresUsbAndSendsNothing()
+        {
+            // Over a WiFi/TCP control connection, ApplyNetworkLan restarts the WiFi module and would
+            // drop the connection before SaveNetworkLan persists the config. The operation must be
+            // rejected up front, before any command is dispatched (#352).
+            var device = new TestableNonUsbDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            device.SentMessages.Clear();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "TestNetwork",
+                "TestPassword");
+
+            await Assert.ThrowsAsync<NetworkReconfigurationRequiresUsbException>(
+                () => device.UpdateNetworkConfigurationAsync(config));
+
+            // Nothing half-applied: no reconfiguration command left the device.
+            Assert.Empty(device.SentMessages);
+        }
+
+        [Fact]
+        public async Task UpdateNetworkConfigurationAsync_OverUsb_DoesNotThrowRequiresUsb()
+        {
+            // The USB path is unaffected by the transport guard — a WiFi module restart does not
+            // disrupt the USB control connection, so the full sequence runs.
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "TestNetwork",
+                "TestPassword");
+
+            await device.UpdateNetworkConfigurationAsync(config);
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:COMMunicate:LAN:APPLY", sentCommands);
+            Assert.Contains("SYSTem:COMMunicate:LAN:SAVE", sentCommands);
+        }
+
+        [Fact]
         public async Task UpdateNetworkConfigurationAsync_WithNullConfiguration_ThrowsArgumentNullException()
         {
             // Arrange
@@ -319,27 +361,6 @@ namespace Daqifi.Core.Tests.Device.Network
             // LAN interface preparation (disable SD, enable LAN)
             Assert.Contains("SYSTem:STORage:SD:ENAble 0", sentCommands);
             Assert.Contains("SYSTem:COMMunicate:LAN:ENAbled 1", sentCommands);
-        }
-
-        [Fact]
-        public async Task UpdateNetworkConfigurationAsync_OverWifi_StillReEnablesLan()
-        {
-            // Regression: network reconfiguration must bring the LAN back up after ApplyNetworkLan
-            // even over a non-USB (WiFi/TCP) control transport — it owns the LAN state and must NOT
-            // rely on the transport-aware PrepareLanInterface (which leaves LAN alone over WiFi).
-            var device = new TestableNonUsbDaqifiStreamingDevice("TestDevice");
-            device.Connect();
-            var config = new NetworkConfiguration(
-                WifiMode.SelfHosted,
-                WifiSecurityType.WpaPskPhrase,
-                "TestNetwork",
-                "TestPassword");
-
-            await device.UpdateNetworkConfigurationAsync(config);
-
-            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
-            Assert.Contains("SYSTem:COMMunicate:LAN:ENAbled 1", sentCommands); // EnableNetworkLan (unconditional)
-            Assert.Contains("SYSTem:STORage:SD:ENAble 0", sentCommands);       // DisableStorageSd
         }
 
         [Fact]

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1217,10 +1217,17 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Updates the device network configuration with the specified settings.
         /// </summary>
+        /// <remarks>
+        /// Requires a USB control connection. Applying the LAN settings restarts the WiFi module,
+        /// which would drop a WiFi/TCP control connection before the trailing save is delivered, so
+        /// this method throws <see cref="NetworkReconfigurationRequiresUsbException"/> over WiFi
+        /// rather than dispatch a sequence it cannot complete (#352).
+        /// </remarks>
         /// <param name="configuration">The new network configuration to apply.</param>
         /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the device is not connected.</exception>
+        /// <exception cref="NetworkReconfigurationRequiresUsbException">Thrown when the active control transport is not USB.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when an unsupported WiFi mode or security type is specified.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
@@ -1236,6 +1243,17 @@ namespace Daqifi.Core.Device
             if (!IsConnected)
             {
                 throw new InvalidOperationException("Device is not connected.");
+            }
+
+            // Reject reconfiguration over WiFi/TCP up front. ApplyNetworkLan (and the later
+            // EnableNetworkLan) restart the WiFi module, tearing down a WiFi/TCP control connection
+            // before the trailing SaveNetworkLan is delivered — leaving the new config
+            // applied-but-not-persisted (lost on power cycle) or the tail undelivered. Fail before
+            // sending any command so nothing is half-applied; the caller must reconfigure over USB
+            // (#352).
+            if (!IsUsbConnection)
+            {
+                throw new NetworkReconfigurationRequiresUsbException();
             }
 
             // Stop streaming if active
@@ -1297,11 +1315,11 @@ namespace Daqifi.Core.Device
             await Task.Delay(WIFI_MODULE_RESTART_DELAY_MS, cancellationToken);
 
             // Re-enable the LAN interface after the reconfig. ApplyNetworkLan restarts the WiFi
-            // module, so this is a network-configuration step that OWNS the LAN state and must
-            // bring LAN back up regardless of the control transport. It deliberately does NOT call
-            // PrepareLanInterface() — that is the transport-aware SD-operation restore, which
-            // leaves the LAN alone over WiFi (where #598/#599 keep it up). Here the LAN enable is
-            // unconditional.
+            // module, so this is a network-configuration step that OWNS the LAN state and brings it
+            // back up. It deliberately does NOT call PrepareLanInterface() — that is the
+            // transport-aware SD-operation restore, which leaves the LAN alone over WiFi. Here the
+            // LAN enable is unconditional; the USB-only guard above guarantees this runs only over a
+            // control connection the WiFi-module restart cannot drop (#352).
             Send(ScpiMessageProducer.DisableStorageSd);
             Send(ScpiMessageProducer.EnableNetworkLan);
 

--- a/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
+++ b/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
@@ -21,7 +21,15 @@ namespace Daqifi.Core.Device.Network
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <remarks>
         /// <para>
-        /// This method performs the following steps:
+        /// Requires a USB control connection. Applying the LAN settings restarts the WiFi module,
+        /// which would drop a WiFi/TCP control connection before the save step is delivered (leaving
+        /// the new config applied-but-not-persisted), so this method throws
+        /// <see cref="NetworkReconfigurationRequiresUsbException"/> when invoked over WiFi/TCP. The
+        /// transport is checked first: over a non-USB transport the method throws before stopping
+        /// streaming and before dispatching any command, so nothing is left half-applied.
+        /// </para>
+        /// <para>
+        /// Once the USB precondition is met, this method performs the following steps:
         /// </para>
         /// <list type="number">
         /// <item><description>Stops any active streaming</description></item>
@@ -38,12 +46,6 @@ namespace Daqifi.Core.Device.Network
         /// <para>
         /// Note: The SD card and LAN interfaces share the same SPI bus on the device hardware
         /// and cannot be used simultaneously. This method handles the interface switching automatically.
-        /// </para>
-        /// <para>
-        /// Requires a USB control connection. Applying the LAN settings restarts the WiFi module,
-        /// which would drop a WiFi/TCP control connection before the save step is delivered (leaving
-        /// the new config applied-but-not-persisted), so this method throws
-        /// <see cref="NetworkReconfigurationRequiresUsbException"/> when invoked over WiFi/TCP.
         /// </para>
         /// </remarks>
         /// <exception cref="NetworkReconfigurationRequiresUsbException">Thrown when the active control transport is not USB.</exception>

--- a/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
+++ b/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
@@ -39,7 +39,14 @@ namespace Daqifi.Core.Device.Network
         /// Note: The SD card and LAN interfaces share the same SPI bus on the device hardware
         /// and cannot be used simultaneously. This method handles the interface switching automatically.
         /// </para>
+        /// <para>
+        /// Requires a USB control connection. Applying the LAN settings restarts the WiFi module,
+        /// which would drop a WiFi/TCP control connection before the save step is delivered (leaving
+        /// the new config applied-but-not-persisted), so this method throws
+        /// <see cref="NetworkReconfigurationRequiresUsbException"/> when invoked over WiFi/TCP.
+        /// </para>
         /// </remarks>
+        /// <exception cref="NetworkReconfigurationRequiresUsbException">Thrown when the active control transport is not USB.</exception>
         Task UpdateNetworkConfigurationAsync(NetworkConfiguration configuration, CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/Daqifi.Core/Device/Network/NetworkReconfigurationRequiresUsbException.cs
+++ b/src/Daqifi.Core/Device/Network/NetworkReconfigurationRequiresUsbException.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace Daqifi.Core.Device.Network
+{
+    /// <summary>
+    /// Thrown by <see cref="INetworkConfigurable.UpdateNetworkConfigurationAsync"/> when it is
+    /// invoked over a WiFi/TCP control transport instead of USB.
+    /// </summary>
+    /// <remarks>
+    /// The reconfiguration sequence applies the new LAN settings with
+    /// <c>SYSTem:COMMunicate:LAN:APPLY</c> (and later re-enables the interface), which restarts the
+    /// WiFi module. Over a WiFi/TCP control connection that restart tears down the very channel
+    /// carrying the command stream <b>before</b> the trailing <c>SYSTem:COMMunicate:LAN:SAVE</c> can
+    /// be delivered, leaving the device with the new settings applied-but-not-persisted (lost on the
+    /// next power cycle) or the tail of the sequence undelivered entirely. Because the outcome is
+    /// unrecoverable from the caller's side once the connection drops, the operation is rejected up
+    /// front over WiFi rather than dispatched into that race. Reconnect the device over USB and
+    /// reissue the reconfiguration. See issue #352.
+    /// </remarks>
+    public sealed class NetworkReconfigurationRequiresUsbException : InvalidOperationException
+    {
+        private const string DefaultMessage =
+            "Network reconfiguration requires a USB connection. Applying LAN settings restarts the " +
+            "WiFi module, which would drop a WiFi/TCP control connection before the configuration is " +
+            "saved. Reconnect the device over USB and retry.";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NetworkReconfigurationRequiresUsbException"/>
+        /// class with a default explanatory message.
+        /// </summary>
+        public NetworkReconfigurationRequiresUsbException()
+            : base(DefaultMessage)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NetworkReconfigurationRequiresUsbException"/>
+        /// class with a custom message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public NetworkReconfigurationRequiresUsbException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NetworkReconfigurationRequiresUsbException"/>
+        /// class with a custom message and inner exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of this exception.</param>
+        public NetworkReconfigurationRequiresUsbException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`UpdateNetworkConfigurationAsync` applies LAN settings with `SYSTem:COMMunicate:LAN:APPLY` (and later re-enables the interface), which **restarts the WiFi module**. Over a WiFi/TCP control connection that restart tears down the very channel carrying the command stream **before** the trailing `SYSTem:COMMunicate:LAN:SAVE` is delivered — leaving the device with the new config *applied-but-not-persisted* (lost on the next power cycle), or the tail of the sequence undelivered. (Follow-up from #347, Qodo thread at `DaqifiStreamingDevice.cs`.)

This was latent: `UpdateNetworkConfigurationAsync` is a public `INetworkConfigurable` method with **no production callers** today.

## Approach — Option B from #352 (gate to USB)
Rather than the persist-first reorder (Option A), which depends on unverified firmware semantics for persisting *applied-but-not-yet-enabled* settings and still leaves the first `APPLY` restart racing the `SAVE` over the same link, this **rejects reconfiguration over WiFi/TCP up front**:

- New typed `NetworkReconfigurationRequiresUsbException` (derives from `InvalidOperationException`, so existing broad handlers keep working while callers can special-case the "reconnect over USB" guidance).
- The guard fires **before any command is dispatched**, so nothing is ever half-applied over WiFi.
- Over **USB** — where a WiFi-module restart cannot drop the control connection — the full sequence runs **unchanged**.

This inverts the deliberate "reconfig re-enables LAN even over WiFi" decision from #347; the obsolete `_OverWifi_StillReEnablesLan` regression test is replaced with tests for the new reject path and the unchanged USB path.

## Tests
- `UpdateNetworkConfigurationAsync_OverWifi_ThrowsRequiresUsbAndSendsNothing` — WiFi transport throws and emits **zero** commands.
- `UpdateNetworkConfigurationAsync_OverUsb_DoesNotThrowRequiresUsb` — USB transport still sends `APPLY`/`SAVE`.
- Full suite green on **net9.0 + net10.0** (1762 passed, 2 skipped) + MCP tests (23 passed). Release build 0-warning on both TFMs.

## Bench
Not bench-validated: the method rewrites the device's WiFi SSID/password and restarts the module (disruptive), and the guard only affects the WiFi-transport path — fully covered by unit tests over a USB bench.

Not merging — opened for your review.