### PR TITLE
feat(device): connected-device registry with duplicate-across-transport detection

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -243,6 +243,81 @@ you need a different interval per transport.) Devices are deduplicated per trans
 physical unit seen over both WiFi and Serial appears as two distinct connection options.
 `continuous.Devices` returns a thread-safe snapshot of the current set at any time.
 
+### Managing Multiple Devices (`DaqifiDeviceRegistry`)
+
+Multi-device is the normal DAQ case, and `DaqifiDeviceFactory` hands back one device at a time
+without tracking the live set. `DaqifiDeviceRegistry` is that missing layer: a thread-safe set of
+connected devices that owns their lifetime, raises add/remove events, and — the part every
+consumer otherwise reimplements — recognizes **the same physical unit reached over two transports
+at once**, the classic "already connected via USB, now discovered over WiFi" support trap.
+
+```csharp
+using Daqifi.Core.Device;
+
+using var registry = new DaqifiDeviceRegistry();
+
+registry.DeviceAdded += (_, e) => devices.Add(e.Registration);       // bind to your UI list
+registry.DeviceRemoved += (_, e) => devices.Remove(e.Registration);  // e.Reason says why
+
+foreach (var info in await finder.DiscoverAsync(TimeSpan.FromSeconds(3)))
+{
+    var result = await registry.ConnectAsync(info);
+
+    // Not an error: the unit was already connected over another transport, and the registry
+    // handed back that live connection instead of opening a redundant second one.
+    if (result.Outcome == DeviceRegistrationOutcome.DuplicateRejected)
+    {
+        logger.LogInformation("{Name} is already connected as {Key}", info.Name, result.Key);
+    }
+}
+
+// Later: the registry disconnects and disposes whatever it removes.
+registry.Remove(key);
+```
+
+**Keys vs. identity.** Two separate concepts run through the API:
+
+| | What it is | Used for |
+|---|---|---|
+| **Key** (`DeviceRegistration.Key`) | The handle you look a device up by. Defaults to `DeviceIdentity.Key`; pass your own to `ConnectAsync`/`Register` if you already mint device ids. | `TryGet`, `Remove` |
+| **Identity** (`DeviceIdentity`) | The fingerprint of the physical unit: serial number → MAC address → USB `LocationKey`. | Duplicate detection |
+
+Identity matching walks those three discriminators and is decided by the first one **both** sides
+report: serial numbers compare case-insensitively and decisively (different serials are different
+units, full stop), MAC comparison ignores separators, and the USB location key is the last resort
+for identical units that report no serial. A device that reports none of the three never matches
+another — two unidentifiable devices are treated as two devices, not one.
+
+**Duplicate policy.** The check runs twice: once from `IDeviceInfo` before connecting (free to
+reject — nothing is open yet) and again from `DaqifiDevice.Metadata` afterwards, because a
+serial-port device's serial number is often only known once it has answered its first status
+message. With no callback set the existing connection wins and the new one is rejected. To decide
+yourself — for example by prompting the user:
+
+```csharp
+registry.DuplicatePolicy = check =>
+{
+    var message = $"{check.Existing.Device.Name} is already connected via " +
+                  $"{check.ExistingConnectionType}. Switch to {check.NewConnectionType}?";
+
+    return PromptUser(message)
+        ? DuplicateDeviceAction.SwitchToNew   // drop the existing connection, keep the new one
+        : DuplicateDeviceAction.KeepExisting; // or Cancel to abandon the attempt entirely
+};
+```
+
+**Ownership and liveness.** The registry disconnects and disposes every device it removes,
+including duplicates it rejects — once a device is passed to `ConnectAsync` or `Register`, don't
+dispose it yourself. Registrations whose device stops reporting `IsConnected` are pruned before
+every registration attempt (and by `PruneDisconnected()` on demand), so a unit that was unplugged
+never blocks a later reconnect. The registry does not reconnect on its own.
+
+All members are safe to call from any thread; reads return snapshots, and the duplicate policy is
+always invoked without the internal lock held, so a policy that blocks on a user prompt never
+blocks other threads. Two concurrent `ConnectAsync` calls for the *same* physical device may both
+open a connection — the loser is detected after connecting and disposed — so serialize your own
+calls if a single connect attempt matters.
+
 ### Manual Device Connection (Advanced)
 
 For cases where you need more control over the connection process:
@@ -576,6 +651,8 @@ However, for connection state changes (Connect/Disconnect), coordinate access fr
 ## Features
 
 - **Simple Factory API**: Single-call connection with `DaqifiDeviceFactory`
+- **Multi-Device Registry**: `DaqifiDeviceRegistry` tracks the live device set and detects the same
+  unit connected over two transports
 - **Clean Abstraction**: Hardware details hidden behind well-defined interfaces
 - **Event-Driven**: Status changes and messages handled via events
 - **Type Safety**: Generic message types provide compile-time safety

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -306,6 +306,12 @@ registry.DuplicatePolicy = check =>
 };
 ```
 
+`SwitchToNew` opens the replacement *before* dropping the existing connection, so switching to a
+transport that turns out not to answer leaves the original in place rather than costing you both.
+The trade-off is that switching to a connection needing the same resource the old one holds (the
+same serial port) fails instead of freeing it first — for that, `Remove(key)` then `ConnectAsync`.
+The policy is asked once per connection attempt, not again after connecting.
+
 **Ownership and liveness.** The registry disconnects and disposes every device it removes,
 including duplicates it rejects — once a device is passed to `ConnectAsync` or `Register`, don't
 dispose it yourself. Registrations whose device stops reporting `IsConnected` are pruned before

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -309,8 +309,14 @@ registry.DuplicatePolicy = check =>
 **Ownership and liveness.** The registry disconnects and disposes every device it removes,
 including duplicates it rejects — once a device is passed to `ConnectAsync` or `Register`, don't
 dispose it yourself. Registrations whose device stops reporting `IsConnected` are pruned before
-every registration attempt (and by `PruneDisconnected()` on demand), so a unit that was unplugged
-never blocks a later reconnect. The registry does not reconnect on its own.
+every registration attempt (and by `PruneDisconnected()` on demand). The registry does not
+reconnect on its own.
+
+> **Know this limit:** pruning is only as good as the transport's drop detection.
+> `SerialStreamTransport.IsConnected` reports the OS handle's state, which stays open after a USB
+> device is physically unplugged, so that device keeps reporting `IsConnected` and is *not* pruned —
+> a later `ConnectAsync` under the same key hands back the dead handle rather than reconnecting.
+> Devices you `Disconnect()` yourself, and drops a transport does report, prune as described.
 
 All members are safe to call from any thread; reads return snapshots, and the duplicate policy is
 always invoked without the internal lock held, so a policy that blocks on a user prompt never

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
@@ -756,6 +756,34 @@ public class DaqifiDeviceRegistryTests
     }
 
     [Fact]
+    public async Task ConnectAsync_RegistryDisposedWhileThePolicyDecides_NeverReachesTheConnector()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connectorRuns = 0;
+        using var registry = new DaqifiDeviceRegistry((_, _, _) =>
+        {
+            connectorRuns++;
+            return Task.FromResult(ConnectedDevice($"device-{connectorRuns}", serialNumber));
+        });
+
+        await registry.ConnectAsync(UsbInfo(serialNumber));
+        Assert.Equal(1, connectorRuns);
+
+        // The policy may block indefinitely on a user prompt, and the app can shut the registry
+        // down while that prompt is up. No new transport activity may start on the way down.
+        registry.DuplicatePolicy = _ =>
+        {
+            registry.Dispose();
+            return DuplicateDeviceAction.SwitchToNew;
+        };
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => registry.ConnectAsync(WifiInfo(serialNumber)));
+
+        Assert.Equal(1, connectorRuns);
+    }
+
+    [Fact]
     public async Task DisposedRegistry_RejectsFurtherRegistrations()
     {
         var registry = new DaqifiDeviceRegistry();

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
@@ -319,11 +319,28 @@ public class DaqifiDeviceRegistryTests
     {
         const string serialNumber = "DAQ-12345";
         var overUsb = ConnectedDevice("usb", serialNumber);
-        var overWifi = ConnectedDevice("wifi", serialNumber);
+
+        // Deliberately left disconnected: the replacement opens inside the connector below and
+        // nowhere earlier, which is what makes the ordering assertion meaningful. Connecting it
+        // during setup (as the ConnectedDevice helper does) would make the assertion tautological —
+        // true whether or not the registry actually waits.
+        var overWifi = new DaqifiDevice("wifi");
+        overWifi.Metadata.SerialNumber = serialNumber;
+
         var policyCalls = new List<DuplicateCheckPhase>();
-        var connectedWhileOldStillRegistered = false;
-        var connects = new List<int>();
-        using var registry = RegistryReturning(connects, overUsb, overWifi);
+        var replacementWasOpenWhenOldWasDropped = false;
+        var connectorRuns = 0;
+
+        using var registry = new DaqifiDeviceRegistry((_, _, _) =>
+        {
+            if (connectorRuns++ == 0)
+            {
+                return Task.FromResult(overUsb);
+            }
+
+            overWifi.Connect();
+            return Task.FromResult(overWifi);
+        });
 
         await registry.ConnectAsync(UsbInfo(serialNumber));
 
@@ -335,15 +352,18 @@ public class DaqifiDeviceRegistryTests
         registry.DeviceRemoved += (_, _) =>
         {
             // At the moment the old registration is dropped, the replacement must already be live.
-            connectedWhileOldStillRegistered = overWifi.IsConnected;
+            // Drop-the-old-first ordering would observe it still disconnected here.
+            replacementWasOpenWhenOldWasDropped = overWifi.IsConnected;
         };
 
         var result = await registry.ConnectAsync(WifiInfo(serialNumber));
 
         Assert.Equal(DeviceRegistrationOutcome.ReplacedExisting, result.Outcome);
-        Assert.True(connectedWhileOldStillRegistered);
+        Assert.True(replacementWasOpenWhenOldWasDropped);
+        Assert.Equal(2, connectorRuns);
         Assert.False(overUsb.IsConnected);
         Assert.Equal(1, registry.Count);
+        Assert.Same(overWifi, Assert.Single(registry.Devices).Device);
         // Asked once, pre-connect — a consumer prompting its user must not see two dialogs.
         Assert.Equal(DuplicateCheckPhase.BeforeConnect, Assert.Single(policyCalls));
     }
@@ -366,6 +386,60 @@ public class DaqifiDeviceRegistryTests
         Assert.Null(result.Key);
         Assert.Equal(1, registry.Count);
         Assert.True(overUsb.IsConnected);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_PolicyRemovesTheExistingRegistrationWhileDeciding_NeverReturnsTheDeadHandle()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connects = new List<int>();
+        var overUsb = ConnectedDevice("usb", serialNumber);
+        var overWifi = ConnectedDevice("wifi", serialNumber);
+        using var registry = RegistryReturning(connects, overUsb, overWifi);
+
+        await registry.ConnectAsync(UsbInfo(serialNumber));
+
+        // The policy runs without the registry lock and may block on a user prompt, so the live
+        // set can change underneath it — here the existing connection is torn down while the
+        // prompt is up. KeepExisting must not then hand back the registration that just died.
+        registry.DuplicatePolicy = check =>
+        {
+            registry.Remove(check.Existing.Key);
+            return DuplicateDeviceAction.KeepExisting;
+        };
+
+        var result = await registry.ConnectAsync(WifiInfo(serialNumber));
+
+        Assert.Equal(DeviceRegistrationOutcome.Registered, result.Outcome);
+        Assert.Same(overWifi, result.Device);
+        Assert.True(result.Device!.IsConnected);
+        Assert.Equal(1, registry.Count);
+        Assert.False(overUsb.IsConnected);
+    }
+
+    [Fact]
+    public void Register_PolicyRemovesTheExistingRegistrationWhileDeciding_RegistersTheNewDevice()
+    {
+        const string serialNumber = "DAQ-12345";
+        using var registry = new DaqifiDeviceRegistry();
+        var existing = ConnectedDevice("usb", serialNumber);
+        var replacement = ConnectedDevice("wifi", serialNumber);
+        registry.Register(existing);
+
+        // Same race on the post-connect path, where the device has already been connected: it must
+        // be registered rather than disposed in favor of a registration that no longer exists.
+        registry.DuplicatePolicy = check =>
+        {
+            registry.Remove(check.Existing.Key);
+            return DuplicateDeviceAction.KeepExisting;
+        };
+
+        var result = registry.Register(replacement);
+
+        Assert.Equal(DeviceRegistrationOutcome.Registered, result.Outcome);
+        Assert.Same(replacement, result.Device);
+        Assert.True(replacement.IsConnected);
+        Assert.Equal(1, registry.Count);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
@@ -284,6 +284,71 @@ public class DaqifiDeviceRegistryTests
     }
 
     [Fact]
+    public async Task ConnectAsync_SwitchToNew_WhenTheNewConnectionFails_KeepsTheExistingOne()
+    {
+        const string serialNumber = "DAQ-12345";
+        var overUsb = ConnectedDevice("usb", serialNumber);
+        var attempt = 0;
+        using var registry = new DaqifiDeviceRegistry((_, _, _) =>
+        {
+            attempt++;
+            return attempt == 1
+                ? Task.FromResult(overUsb)
+                : Task.FromException<DaqifiDevice>(
+                    new TimeoutException("TCP connect to 192.0.2.1:9760 timed out after 5s."));
+        });
+        var removals = new List<DeviceRemovedEventArgs>();
+        registry.DeviceRemoved += (_, e) => removals.Add(e);
+
+        await registry.ConnectAsync(UsbInfo(serialNumber));
+        registry.DuplicatePolicy = _ => DuplicateDeviceAction.SwitchToNew;
+
+        // The replacement transport refuses the connection — the real case that caught this: a
+        // device that answers UDP discovery but is not listening on its TCP data port. Switching
+        // to it must not cost the caller the healthy USB session they already had.
+        await Assert.ThrowsAsync<TimeoutException>(() => registry.ConnectAsync(WifiInfo(serialNumber)));
+
+        Assert.Equal(1, registry.Count);
+        Assert.True(overUsb.IsConnected);
+        Assert.Same(overUsb, Assert.Single(registry.Devices).Device);
+        Assert.Empty(removals);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_SwitchToNew_DropsTheOldConnectionOnlyAfterTheNewOneIsOpen()
+    {
+        const string serialNumber = "DAQ-12345";
+        var overUsb = ConnectedDevice("usb", serialNumber);
+        var overWifi = ConnectedDevice("wifi", serialNumber);
+        var policyCalls = new List<DuplicateCheckPhase>();
+        var connectedWhileOldStillRegistered = false;
+        var connects = new List<int>();
+        using var registry = RegistryReturning(connects, overUsb, overWifi);
+
+        await registry.ConnectAsync(UsbInfo(serialNumber));
+
+        registry.DuplicatePolicy = check =>
+        {
+            policyCalls.Add(check.Phase);
+            return DuplicateDeviceAction.SwitchToNew;
+        };
+        registry.DeviceRemoved += (_, _) =>
+        {
+            // At the moment the old registration is dropped, the replacement must already be live.
+            connectedWhileOldStillRegistered = overWifi.IsConnected;
+        };
+
+        var result = await registry.ConnectAsync(WifiInfo(serialNumber));
+
+        Assert.Equal(DeviceRegistrationOutcome.ReplacedExisting, result.Outcome);
+        Assert.True(connectedWhileOldStillRegistered);
+        Assert.False(overUsb.IsConnected);
+        Assert.Equal(1, registry.Count);
+        // Asked once, pre-connect — a consumer prompting its user must not see two dialogs.
+        Assert.Equal(DuplicateCheckPhase.BeforeConnect, Assert.Single(policyCalls));
+    }
+
+    [Fact]
     public async Task ConnectAsync_Cancel_LeavesTheExistingConnectionAndRegistersNothing()
     {
         const string serialNumber = "DAQ-12345";

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
@@ -1,0 +1,700 @@
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Registry behavior, including the cross-transport duplicate-detection cases ported from the
+/// desktop app's <c>DuplicateDeviceDetectionTests</c> (the reference implementation this type
+/// replaces).
+/// </summary>
+public class DaqifiDeviceRegistryTests
+{
+    #region Helpers
+
+    /// <summary>
+    /// A device that reports itself connected without touching any transport — the no-transport
+    /// constructor short-circuits <see cref="DaqifiDevice.Connect"/> to a status change.
+    /// </summary>
+    private static DaqifiDevice ConnectedDevice(string name = "device", string? serialNumber = null, string? macAddress = null)
+    {
+        var device = new DaqifiDevice(name);
+        if (serialNumber != null)
+        {
+            device.Metadata.SerialNumber = serialNumber;
+        }
+        if (macAddress != null)
+        {
+            device.Metadata.MacAddress = macAddress;
+        }
+
+        device.Connect();
+        return device;
+    }
+
+    private static DeviceInfo UsbInfo(string serialNumber = "", string portName = "COM3", string? locationKey = null) => new()
+    {
+        Name = "usb-device",
+        ConnectionType = ConnectionType.Serial,
+        SerialNumber = serialNumber,
+        PortName = portName,
+        LocationKey = locationKey
+    };
+
+    private static DeviceInfo WifiInfo(string serialNumber = "", string? macAddress = null) => new()
+    {
+        Name = "wifi-device",
+        ConnectionType = ConnectionType.WiFi,
+        SerialNumber = serialNumber,
+        MacAddress = macAddress,
+        IPAddress = System.Net.IPAddress.Parse("192.168.1.50"),
+        Port = 9760
+    };
+
+    /// <summary>
+    /// Builds a registry whose connect step is a stub, so the duplicate-policy paths can be
+    /// exercised without hardware. The stub hands out the queued devices in order.
+    /// </summary>
+    private static DaqifiDeviceRegistry RegistryReturning(List<int> connectCalls, params DaqifiDevice[] devices)
+    {
+        var index = 0;
+        return new DaqifiDeviceRegistry((_, _, _) =>
+        {
+            var next = devices[index++];
+            connectCalls.Add(index);
+            return Task.FromResult(next);
+        });
+    }
+
+    #endregion
+
+    #region Duplicate detection (ported from desktop's DuplicateDeviceDetectionTests)
+
+    [Fact]
+    public async Task ConnectAsync_DuplicateSerialNumber_KeepsExistingAndRejectsNew()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connects = new List<int>();
+        var overUsb = ConnectedDevice("usb", serialNumber);
+        var overWifi = ConnectedDevice("wifi", serialNumber);
+        using var registry = RegistryReturning(connects, overUsb, overWifi);
+
+        await registry.ConnectAsync(UsbInfo(serialNumber));
+        var result = await registry.ConnectAsync(WifiInfo(serialNumber));
+
+        Assert.Equal(DeviceRegistrationOutcome.DuplicateRejected, result.Outcome);
+        Assert.True(result.WasDuplicate);
+        Assert.False(result.IsRegistered);
+        Assert.Same(overUsb, result.Device);
+        Assert.Equal(1, registry.Count);
+        // The duplicate was caught from discovery metadata, so no second connection was opened.
+        Assert.Single(connects);
+        Assert.True(overUsb.IsConnected);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_DifferentSerialNumbers_RegistersBoth()
+    {
+        var connects = new List<int>();
+        using var registry = RegistryReturning(
+            connects,
+            ConnectedDevice("usb", "DAQ-12345"),
+            ConnectedDevice("wifi", "DAQ-67890"));
+
+        var first = await registry.ConnectAsync(UsbInfo("DAQ-12345"));
+        var second = await registry.ConnectAsync(WifiInfo("DAQ-67890"));
+
+        Assert.Equal(DeviceRegistrationOutcome.Registered, first.Outcome);
+        Assert.Equal(DeviceRegistrationOutcome.Registered, second.Outcome);
+        Assert.Equal(2, registry.Count);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_DevicesWithoutIdentity_NeverMatchEachOther()
+    {
+        var connects = new List<int>();
+        using var registry = RegistryReturning(connects, ConnectedDevice("first"), ConnectedDevice("second"));
+
+        var first = await registry.ConnectAsync(UsbInfo(serialNumber: "", portName: "COM3"));
+        var second = await registry.ConnectAsync(UsbInfo(serialNumber: "", portName: "COM4"));
+
+        Assert.Equal(DeviceRegistrationOutcome.Registered, first.Outcome);
+        Assert.Equal(DeviceRegistrationOutcome.Registered, second.Outcome);
+        Assert.Equal(2, registry.Count);
+        Assert.NotEqual(first.Key, second.Key);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_DuplicatePolicy_IsInvokedWithBothTransports()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connects = new List<int>();
+        var checks = new List<DuplicateDeviceCheck>();
+        using var registry = RegistryReturning(
+            connects,
+            ConnectedDevice("usb", serialNumber),
+            ConnectedDevice("wifi", serialNumber));
+        registry.DuplicatePolicy = check =>
+        {
+            checks.Add(check);
+            return DuplicateDeviceAction.KeepExisting;
+        };
+
+        await registry.ConnectAsync(UsbInfo(serialNumber));
+        await registry.ConnectAsync(WifiInfo(serialNumber));
+
+        var check = Assert.Single(checks);
+        Assert.Equal(DuplicateCheckPhase.BeforeConnect, check.Phase);
+        Assert.Equal(ConnectionType.Serial, check.ExistingConnectionType);
+        Assert.Equal(ConnectionType.WiFi, check.NewConnectionType);
+        Assert.Null(check.NewDevice);
+        Assert.Equal(serialNumber, check.NewIdentity.SerialNumber);
+        Assert.Equal(1, registry.Count);
+    }
+
+    #endregion
+
+    #region Duplicate detection: identity fallbacks and phases
+
+    [Fact]
+    public async Task ConnectAsync_SerialMatch_IsCaseInsensitive()
+    {
+        var connects = new List<int>();
+        using var registry = RegistryReturning(
+            connects,
+            ConnectedDevice("usb", "DAQ-12345"),
+            ConnectedDevice("wifi", "daq-12345"));
+
+        await registry.ConnectAsync(UsbInfo("DAQ-12345"));
+        var result = await registry.ConnectAsync(WifiInfo("daq-12345"));
+
+        Assert.Equal(DeviceRegistrationOutcome.DuplicateRejected, result.Outcome);
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_MatchesOnMac_WhenSerialIsBlank()
+    {
+        var connects = new List<int>();
+        using var registry = RegistryReturning(
+            connects,
+            ConnectedDevice("first", macAddress: "AA-BB-CC-DD-EE-FF"),
+            ConnectedDevice("second", macAddress: "aa:bb:cc:dd:ee:ff"));
+
+        await registry.ConnectAsync(WifiInfo(macAddress: "AA-BB-CC-DD-EE-FF"));
+        var result = await registry.ConnectAsync(WifiInfo(macAddress: "aa:bb:cc:dd:ee:ff"));
+
+        Assert.Equal(DeviceRegistrationOutcome.DuplicateRejected, result.Outcome);
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_MatchesOnLocationKey_WhenSerialAndMacAreBlank()
+    {
+        var connects = new List<int>();
+        using var registry = RegistryReturning(connects, ConnectedDevice("first"), ConnectedDevice("second"));
+
+        await registry.ConnectAsync(UsbInfo(portName: "COM3", locationKey: "Port_#0001.Hub_#0001"));
+        var result = await registry.ConnectAsync(UsbInfo(portName: "COM7", locationKey: "Port_#0001.Hub_#0001"));
+
+        Assert.Equal(DeviceRegistrationOutcome.DuplicateRejected, result.Outcome);
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_SerialOnlyKnownAfterConnect_IsCaughtByThePostConnectCheck()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connects = new List<int>();
+        var phases = new List<DuplicateCheckPhase>();
+        var overWifi = ConnectedDevice("wifi", serialNumber);
+        var overUsb = ConnectedDevice("usb", serialNumber);
+        using var registry = RegistryReturning(connects, overUsb);
+        registry.Register(overWifi, WifiInfo(serialNumber));
+        registry.DuplicatePolicy = check =>
+        {
+            phases.Add(check.Phase);
+            return DuplicateDeviceAction.KeepExisting;
+        };
+
+        // Serial-port discovery could not read a serial number, so the duplicate only becomes
+        // visible once the device has answered its first status message.
+        var result = await registry.ConnectAsync(UsbInfo(serialNumber: "", portName: "COM3"));
+
+        Assert.Equal(DeviceRegistrationOutcome.DuplicateRejected, result.Outcome);
+        Assert.Same(overWifi, result.Device);
+        Assert.Equal(1, registry.Count);
+        Assert.Single(connects);
+        Assert.Equal(DuplicateCheckPhase.AfterConnect, Assert.Single(phases));
+        // The connection opened only to discover it was redundant is disposed by the registry.
+        Assert.False(overUsb.IsConnected);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_PostConnectCheck_ReportsTheConnectedDeviceToThePolicy()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connects = new List<int>();
+        var newDevice = ConnectedDevice("usb", serialNumber);
+        using var registry = RegistryReturning(connects, newDevice);
+        registry.Register(ConnectedDevice("wifi", serialNumber), WifiInfo(serialNumber));
+        DuplicateDeviceCheck? seen = null;
+        registry.DuplicatePolicy = check =>
+        {
+            seen = check;
+            return DuplicateDeviceAction.KeepExisting;
+        };
+
+        await registry.ConnectAsync(UsbInfo(serialNumber: "", portName: "COM3"));
+
+        Assert.NotNull(seen);
+        Assert.Same(newDevice, seen!.NewDevice);
+        Assert.Equal(ConnectionType.Serial, seen.NewConnectionType);
+        Assert.Equal(serialNumber, seen.NewIdentity.SerialNumber);
+    }
+
+    #endregion
+
+    #region Duplicate policy actions
+
+    [Fact]
+    public async Task ConnectAsync_SwitchToNew_ReplacesTheExistingConnection()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connects = new List<int>();
+        var overUsb = ConnectedDevice("usb", serialNumber);
+        var overWifi = ConnectedDevice("wifi", serialNumber);
+        var removals = new List<DeviceRemovedEventArgs>();
+        using var registry = RegistryReturning(connects, overUsb, overWifi);
+        registry.DeviceRemoved += (_, e) => removals.Add(e);
+        registry.DuplicatePolicy = _ => DuplicateDeviceAction.SwitchToNew;
+
+        await registry.ConnectAsync(UsbInfo(serialNumber));
+        var result = await registry.ConnectAsync(WifiInfo(serialNumber));
+
+        Assert.Equal(DeviceRegistrationOutcome.ReplacedExisting, result.Outcome);
+        Assert.True(result.IsRegistered);
+        Assert.Same(overWifi, result.Device);
+        Assert.Equal(1, registry.Count);
+        Assert.False(overUsb.IsConnected);
+
+        var removal = Assert.Single(removals);
+        Assert.Equal(DeviceRemovalReason.Replaced, removal.Reason);
+        Assert.Same(overUsb, removal.Registration.Device);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_Cancel_LeavesTheExistingConnectionAndRegistersNothing()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connects = new List<int>();
+        var overUsb = ConnectedDevice("usb", serialNumber);
+        using var registry = RegistryReturning(connects, overUsb, ConnectedDevice("wifi", serialNumber));
+        registry.DuplicatePolicy = _ => DuplicateDeviceAction.Cancel;
+
+        await registry.ConnectAsync(UsbInfo(serialNumber));
+        var result = await registry.ConnectAsync(WifiInfo(serialNumber));
+
+        Assert.Equal(DeviceRegistrationOutcome.Canceled, result.Outcome);
+        Assert.Null(result.Registration);
+        Assert.Null(result.Device);
+        Assert.Null(result.Key);
+        Assert.Equal(1, registry.Count);
+        Assert.True(overUsb.IsConnected);
+    }
+
+    [Fact]
+    public void Register_PolicyReturnsUndefinedAction_FallsBackToKeepingTheExistingDevice()
+    {
+        const string serialNumber = "DAQ-12345";
+        using var registry = new DaqifiDeviceRegistry();
+        var existing = ConnectedDevice("usb", serialNumber);
+        var duplicate = ConnectedDevice("wifi", serialNumber);
+        registry.Register(existing);
+        registry.DuplicatePolicy = _ => (DuplicateDeviceAction)42;
+
+        var result = registry.Register(duplicate);
+
+        Assert.Equal(DeviceRegistrationOutcome.DuplicateRejected, result.Outcome);
+        Assert.Same(existing, result.Device);
+        Assert.False(duplicate.IsConnected);
+    }
+
+    [Fact]
+    public void Register_PolicyThrows_PropagatesAndStillDisposesTheDevice()
+    {
+        const string serialNumber = "DAQ-12345";
+        using var registry = new DaqifiDeviceRegistry();
+        registry.Register(ConnectedDevice("usb", serialNumber));
+        var duplicate = ConnectedDevice("wifi", serialNumber);
+        registry.DuplicatePolicy = _ => throw new InvalidOperationException("policy failed");
+
+        Assert.Throws<InvalidOperationException>(() => registry.Register(duplicate));
+
+        Assert.Equal(1, registry.Count);
+        Assert.False(duplicate.IsConnected);
+    }
+
+    #endregion
+
+    #region Registration and keys
+
+    [Fact]
+    public void Register_ConnectedDevice_IsFiledUnderItsIdentityKey()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var device = ConnectedDevice("usb", "DAQ-12345");
+
+        var result = registry.Register(device, UsbInfo("DAQ-12345"));
+
+        Assert.Equal(DeviceRegistrationOutcome.Registered, result.Outcome);
+        Assert.Equal("sn:daq-12345", result.Key);
+        Assert.True(registry.TryGetDevice("sn:daq-12345", out var found));
+        Assert.Same(device, found);
+        Assert.Equal(ConnectionType.Serial, result.Registration!.ConnectionType);
+    }
+
+    [Fact]
+    public void Register_CallerSuppliedKey_IsUsedForLookups()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var device = ConnectedDevice("usb", "DAQ-12345");
+
+        var result = registry.Register(device, UsbInfo("DAQ-12345"), key: "serial:COM3");
+
+        Assert.Equal("serial:COM3", result.Key);
+        Assert.True(registry.TryGet("serial:COM3", out var registration));
+        Assert.Same(device, registration!.Device);
+    }
+
+    [Fact]
+    public void Register_SameKeyTwice_IsTreatedAsADuplicate()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var first = ConnectedDevice("first");
+        var second = ConnectedDevice("second");
+        registry.Register(first, key: "my-device");
+
+        var result = registry.Register(second, key: "my-device");
+
+        Assert.Equal(DeviceRegistrationOutcome.DuplicateRejected, result.Outcome);
+        Assert.Same(first, result.Device);
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void Register_DeviceWithoutIdentity_GetsAMintedUniqueKey()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+
+        var first = registry.Register(ConnectedDevice("first"));
+        var second = registry.Register(ConnectedDevice("second"));
+
+        Assert.Equal(2, registry.Count);
+        Assert.NotEqual(first.Key, second.Key);
+        Assert.All(new[] { first.Key, second.Key }, key => Assert.False(string.IsNullOrEmpty(key)));
+    }
+
+    [Fact]
+    public void Register_UsesDiscoveryIdentityWhenMetadataHasNotFilledItInYet()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+
+        var result = registry.Register(ConnectedDevice("usb"), UsbInfo("DAQ-12345", locationKey: "Port_#0001"));
+
+        Assert.Equal("DAQ-12345", result.Registration!.Identity.SerialNumber);
+        Assert.Equal("Port_#0001", result.Registration.Identity.LocationKey);
+    }
+
+    [Fact]
+    public void Register_SameDeviceInstanceTwice_IsANoOpAndKeepsItAlive()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var device = ConnectedDevice("usb", "DAQ-12345");
+        var first = registry.Register(device);
+
+        var again = registry.Register(device);
+
+        // The device must not be treated as a duplicate of itself: disposing it would leave the
+        // registry holding a dead handle.
+        Assert.Equal(DeviceRegistrationOutcome.Registered, again.Outcome);
+        Assert.Same(first.Registration, again.Registration);
+        Assert.Equal(1, registry.Count);
+        Assert.True(device.IsConnected);
+    }
+
+    [Fact]
+    public void Register_SameDeviceInstanceUnderAnotherKey_ReturnsTheOriginalRegistration()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var device = ConnectedDevice("anonymous");
+        var first = registry.Register(device, key: "first-key");
+
+        var again = registry.Register(device, key: "second-key");
+
+        Assert.Equal("first-key", again.Key);
+        Assert.Same(first.Registration, again.Registration);
+        Assert.Equal(1, registry.Count);
+        Assert.True(device.IsConnected);
+    }
+
+    [Fact]
+    public void Register_NullDevice_Throws()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+
+        Assert.Throws<ArgumentNullException>(() => registry.Register(null!));
+    }
+
+    [Fact]
+    public void Register_DisconnectedDevice_ThrowsWithoutTakingOwnership()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var device = new DaqifiDevice("never-connected");
+
+        Assert.Throws<ArgumentException>(() => registry.Register(device));
+        Assert.Equal(0, registry.Count);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_NullDeviceInfo_Throws()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => registry.ConnectAsync(null!));
+    }
+
+    #endregion
+
+    #region Lookups
+
+    [Fact]
+    public void TryGet_UnknownOrBlankKey_ReturnsFalse()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+
+        Assert.False(registry.TryGet("nope", out var missing));
+        Assert.Null(missing);
+        Assert.False(registry.TryGetDevice("", out var blank));
+        Assert.Null(blank);
+    }
+
+    [Fact]
+    public void Find_MatchesByIdentity_AndIgnoresEmptyIdentities()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var device = ConnectedDevice("usb", "DAQ-12345");
+        registry.Register(device);
+
+        Assert.Same(device, registry.Find(DeviceIdentity.Create("daq-12345"))!.Device);
+        Assert.Null(registry.Find(DeviceIdentity.Create("DAQ-99999")));
+        Assert.Null(registry.Find(DeviceIdentity.Empty));
+    }
+
+    [Fact]
+    public void Devices_ReturnsAnIndependentSnapshot()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        registry.Register(ConnectedDevice("first", "DAQ-1"));
+
+        var snapshot = registry.Devices;
+        registry.Register(ConnectedDevice("second", "DAQ-2"));
+
+        Assert.Single(snapshot);
+        Assert.Equal(2, registry.Count);
+    }
+
+    #endregion
+
+    #region Removal, pruning, and disposal
+
+    [Fact]
+    public void Remove_ByKey_DisconnectsDisposesAndAnnounces()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var device = ConnectedDevice("usb", "DAQ-12345");
+        var removals = new List<DeviceRemovedEventArgs>();
+        registry.DeviceRemoved += (_, e) => removals.Add(e);
+        var key = registry.Register(device).Key!;
+
+        Assert.True(registry.Remove(key));
+
+        Assert.Equal(0, registry.Count);
+        Assert.False(device.IsConnected);
+        Assert.Equal(DeviceRemovalReason.Removed, Assert.Single(removals).Reason);
+        Assert.False(registry.Remove(key));
+    }
+
+    [Fact]
+    public void Remove_ByDevice_RemovesOnlyThatInstance()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var first = ConnectedDevice("first", "DAQ-1");
+        var second = ConnectedDevice("second", "DAQ-2");
+        registry.Register(first);
+        registry.Register(second);
+
+        Assert.True(registry.Remove(first));
+
+        Assert.Equal(1, registry.Count);
+        Assert.False(first.IsConnected);
+        Assert.True(second.IsConnected);
+        Assert.False(registry.Remove(ConnectedDevice("unregistered")));
+    }
+
+    [Fact]
+    public void PruneDisconnected_DropsStaleRegistrations()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var dropped = ConnectedDevice("dropped", "DAQ-1");
+        var live = ConnectedDevice("live", "DAQ-2");
+        registry.Register(dropped);
+        registry.Register(live);
+        var removals = new List<DeviceRemovedEventArgs>();
+        registry.DeviceRemoved += (_, e) => removals.Add(e);
+
+        // The device dropped off the bus behind the registry's back.
+        dropped.Disconnect();
+
+        Assert.Equal(1, registry.PruneDisconnected());
+        Assert.Equal(1, registry.Count);
+        Assert.Equal(DeviceRemovalReason.Disconnected, Assert.Single(removals).Reason);
+        Assert.Equal(0, registry.PruneDisconnected());
+    }
+
+    [Fact]
+    public async Task ConnectAsync_StaleRegistrationUnderTheSameKey_IsPrunedAndReconnected()
+    {
+        var connects = new List<int>();
+        var dropped = ConnectedDevice("dropped", "DAQ-12345");
+        var reconnected = ConnectedDevice("reconnected", "DAQ-12345");
+        using var registry = RegistryReturning(connects, dropped, reconnected);
+
+        await registry.ConnectAsync(UsbInfo("DAQ-12345"), key: "serial:COM3");
+        dropped.Disconnect();
+        var result = await registry.ConnectAsync(UsbInfo("DAQ-12345"), key: "serial:COM3");
+
+        Assert.Equal(DeviceRegistrationOutcome.Registered, result.Outcome);
+        Assert.Same(reconnected, result.Device);
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void Clear_RemovesAndDisposesEverything()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var first = ConnectedDevice("first", "DAQ-1");
+        var second = ConnectedDevice("second", "DAQ-2");
+        registry.Register(first);
+        registry.Register(second);
+        var removals = new List<DeviceRemovedEventArgs>();
+        registry.DeviceRemoved += (_, e) => removals.Add(e);
+
+        registry.Clear();
+
+        Assert.Equal(0, registry.Count);
+        Assert.False(first.IsConnected);
+        Assert.False(second.IsConnected);
+        Assert.Equal(2, removals.Count);
+        Assert.All(removals, r => Assert.Equal(DeviceRemovalReason.Cleared, r.Reason));
+    }
+
+    [Fact]
+    public void Dispose_DisposesDevicesWithoutAnnouncingRemovals()
+    {
+        var registry = new DaqifiDeviceRegistry();
+        var device = ConnectedDevice("usb", "DAQ-12345");
+        registry.Register(device);
+        var removals = 0;
+        registry.DeviceRemoved += (_, _) => removals++;
+
+        registry.Dispose();
+        registry.Dispose();
+
+        Assert.False(device.IsConnected);
+        Assert.Equal(0, removals);
+        Assert.Equal(0, registry.Count);
+    }
+
+    [Fact]
+    public async Task DisposedRegistry_RejectsFurtherRegistrations()
+    {
+        var registry = new DaqifiDeviceRegistry();
+        registry.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => registry.Register(ConnectedDevice("usb", "DAQ-1")));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => registry.ConnectAsync(UsbInfo("DAQ-1")));
+    }
+
+    #endregion
+
+    #region Events
+
+    [Fact]
+    public void DeviceAdded_IsRaisedWithTheRegistration()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        var device = ConnectedDevice("usb", "DAQ-12345");
+        var added = new List<DeviceRegisteredEventArgs>();
+        registry.DeviceAdded += (_, e) => added.Add(e);
+
+        registry.Register(device, UsbInfo("DAQ-12345"));
+
+        var registration = Assert.Single(added).Registration;
+        Assert.Same(device, registration.Device);
+        Assert.Equal("DAQ-12345", registration.Identity.SerialNumber);
+    }
+
+    [Fact]
+    public void FaultyEventSubscriber_DoesNotFailTheRegistryOperation()
+    {
+        using var registry = new DaqifiDeviceRegistry();
+        registry.DeviceAdded += (_, _) => throw new InvalidOperationException("subscriber blew up");
+        registry.DeviceRemoved += (_, _) => throw new InvalidOperationException("subscriber blew up");
+        var device = ConnectedDevice("usb", "DAQ-12345");
+
+        var key = registry.Register(device).Key!;
+        Assert.Equal(1, registry.Count);
+
+        Assert.True(registry.Remove(key));
+        Assert.Equal(0, registry.Count);
+    }
+
+    #endregion
+
+    #region Concurrency
+
+    [Fact]
+    public async Task Register_IsSafeUnderConcurrency()
+    {
+        const int deviceCount = 50;
+        using var registry = new DaqifiDeviceRegistry();
+        var devices = Enumerable.Range(0, deviceCount)
+            .Select(i => ConnectedDevice($"device-{i}", $"DAQ-{i}"))
+            .ToList();
+
+        await Task.WhenAll(devices.Select(d => Task.Run(() => registry.Register(d))));
+
+        Assert.Equal(deviceCount, registry.Count);
+        Assert.Equal(deviceCount, registry.Devices.Select(r => r.Key).Distinct().Count());
+    }
+
+    [Fact]
+    public async Task Register_ConcurrentDuplicates_LeaveExactlyOneRegistration()
+    {
+        const string serialNumber = "DAQ-12345";
+        using var registry = new DaqifiDeviceRegistry();
+        var devices = Enumerable.Range(0, 20)
+            .Select(i => ConnectedDevice($"device-{i}", serialNumber))
+            .ToList();
+
+        var results = await Task.WhenAll(devices.Select(d => Task.Run(() => registry.Register(d))));
+
+        Assert.Equal(1, registry.Count);
+        Assert.Single(results, r => r.Outcome == DeviceRegistrationOutcome.Registered);
+        Assert.Equal(devices.Count - 1, results.Count(r => r.Outcome == DeviceRegistrationOutcome.DuplicateRejected));
+        Assert.Single(devices, d => d.IsConnected);
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceRegistryTests.cs
@@ -784,6 +784,37 @@ public class DaqifiDeviceRegistryTests
     }
 
     [Fact]
+    public async Task ConnectAsync_CancelledWhileThePolicyDecides_NeverReachesTheConnector()
+    {
+        const string serialNumber = "DAQ-12345";
+        var connectorRuns = 0;
+        using var registry = new DaqifiDeviceRegistry((_, _, _) =>
+        {
+            connectorRuns++;
+            return Task.FromResult(ConnectedDevice($"device-{connectorRuns}", serialNumber));
+        });
+        using var cancellation = new CancellationTokenSource();
+
+        await registry.ConnectAsync(UsbInfo(serialNumber), cancellationToken: cancellation.Token);
+        Assert.Equal(1, connectorRuns);
+
+        // Cancellation requested while the policy blocks must be observed before connecting, not
+        // left to the connector — this stub ignores the token, as a custom connector may.
+        registry.DuplicatePolicy = _ =>
+        {
+            cancellation.Cancel();
+            return DuplicateDeviceAction.SwitchToNew;
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => registry.ConnectAsync(WifiInfo(serialNumber), cancellationToken: cancellation.Token));
+
+        Assert.Equal(1, connectorRuns);
+        // The existing registration is untouched: a cancelled switch costs nothing.
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
     public async Task DisposedRegistry_RejectsFurtherRegistrations()
     {
         var registry = new DaqifiDeviceRegistry();

--- a/src/Daqifi.Core.Tests/Device/DeviceIdentityTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceIdentityTests.cs
@@ -1,0 +1,184 @@
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Tests.Device;
+
+public class DeviceIdentityTests
+{
+    #region Construction
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_BlankDiscriminators_AreTreatedAsNotReported(string? blank)
+    {
+        var identity = DeviceIdentity.Create(blank, blank, blank);
+
+        Assert.Null(identity.SerialNumber);
+        Assert.Null(identity.MacAddress);
+        Assert.Null(identity.LocationKey);
+        Assert.True(identity.IsEmpty);
+        Assert.Equal(string.Empty, identity.Key);
+    }
+
+    [Fact]
+    public void Create_TrimsDiscriminators()
+    {
+        var identity = DeviceIdentity.Create("  1234  ");
+
+        Assert.Equal("1234", identity.SerialNumber);
+    }
+
+    [Fact]
+    public void Key_PrefersSerialThenMacThenLocation()
+    {
+        Assert.Equal("sn:1234", DeviceIdentity.Create("1234", "AA-BB-CC-DD-EE-FF", "Port_#0001").Key);
+        Assert.Equal("mac:aabbccddeeff", DeviceIdentity.Create(null, "AA-BB-CC-DD-EE-FF", "Port_#0001").Key);
+        Assert.Equal("loc:port_#0001", DeviceIdentity.Create(null, null, "Port_#0001").Key);
+    }
+
+    [Fact]
+    public void FromDiscovery_ReadsSerialMacAndLocationKey()
+    {
+        var identity = DeviceIdentity.FromDiscovery(new DeviceInfo
+        {
+            SerialNumber = "1234",
+            MacAddress = "AA-BB-CC-DD-EE-FF",
+            LocationKey = "Port_#0001.Hub_#0001"
+        });
+
+        Assert.Equal("1234", identity.SerialNumber);
+        Assert.Equal("AA-BB-CC-DD-EE-FF", identity.MacAddress);
+        Assert.Equal("Port_#0001.Hub_#0001", identity.LocationKey);
+    }
+
+    [Fact]
+    public void FromMetadata_ReadsSerialAndMac_AndCarriesTheSuppliedLocationKey()
+    {
+        var metadata = new DeviceMetadata { SerialNumber = "1234", MacAddress = "AA-BB-CC-DD-EE-FF" };
+
+        var identity = DeviceIdentity.FromMetadata(metadata, "Port_#0001");
+
+        Assert.Equal("1234", identity.SerialNumber);
+        Assert.Equal("AA-BB-CC-DD-EE-FF", identity.MacAddress);
+        Assert.Equal("Port_#0001", identity.LocationKey);
+    }
+
+    [Fact]
+    public void Factories_NullArgument_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => DeviceIdentity.FromDiscovery(null!));
+        Assert.Throws<ArgumentNullException>(() => DeviceIdentity.FromMetadata(null!));
+    }
+
+    #endregion
+
+    #region Matching
+
+    [Fact]
+    public void Matches_SameSerial_IsCaseInsensitive()
+    {
+        var usb = DeviceIdentity.Create("DAQ-12345");
+        var wifi = DeviceIdentity.Create("daq-12345");
+
+        Assert.True(usb.Matches(wifi));
+        Assert.True(wifi.Matches(usb));
+    }
+
+    [Fact]
+    public void Matches_DifferentSerials_DoNotMatch_EvenWhenAWeakerDiscriminatorAgrees()
+    {
+        // A serial-number mismatch is decisive: two units that both answered with a serial number
+        // are different units, whatever the location key says.
+        var first = DeviceIdentity.Create("1234", locationKey: "Port_#0001");
+        var second = DeviceIdentity.Create("5678", locationKey: "Port_#0001");
+
+        Assert.False(first.Matches(second));
+    }
+
+    [Fact]
+    public void Matches_FallsBackToMac_WhenOneSideHasNoSerial()
+    {
+        var discovered = DeviceIdentity.Create(null, "AA-BB-CC-DD-EE-FF");
+        var connected = DeviceIdentity.Create("1234", "aa:bb:cc:dd:ee:ff");
+
+        Assert.True(discovered.Matches(connected));
+    }
+
+    [Fact]
+    public void Matches_DifferentMacs_DoNotMatch()
+    {
+        var first = DeviceIdentity.Create(null, "AA-BB-CC-DD-EE-FF", "Port_#0001");
+        var second = DeviceIdentity.Create(null, "11-22-33-44-55-66", "Port_#0001");
+
+        Assert.False(first.Matches(second));
+    }
+
+    [Fact]
+    public void Matches_FallsBackToLocationKey_WhenNeitherSideReportsSerialOrMac()
+    {
+        var first = DeviceIdentity.Create(null, null, "PORT_#0001.HUB_#0001");
+        var second = DeviceIdentity.Create(null, null, "port_#0001.hub_#0001");
+
+        Assert.True(first.Matches(second));
+    }
+
+    [Fact]
+    public void Matches_EmptyIdentities_NeverMatch()
+    {
+        Assert.False(DeviceIdentity.Empty.Matches(DeviceIdentity.Empty));
+        Assert.False(DeviceIdentity.Create("1234").Matches(DeviceIdentity.Empty));
+        Assert.False(DeviceIdentity.Empty.Matches(DeviceIdentity.Create("1234")));
+    }
+
+    [Fact]
+    public void Matches_NoSharedDiscriminator_DoesNotMatch()
+    {
+        // One device only reported a MAC, the other only a location key: nothing to compare.
+        var wifi = DeviceIdentity.Create(null, "AA-BB-CC-DD-EE-FF");
+        var usb = DeviceIdentity.Create(null, null, "Port_#0001");
+
+        Assert.False(wifi.Matches(usb));
+    }
+
+    [Fact]
+    public void Matches_Null_DoesNotMatch()
+    {
+        Assert.False(DeviceIdentity.Create("1234").Matches(null));
+    }
+
+    #endregion
+
+    #region Merging
+
+    [Fact]
+    public void MergeWith_FillsOnlyMissingDiscriminators()
+    {
+        var metadata = DeviceIdentity.Create("1234");
+        var discovery = DeviceIdentity.Create("9999", "AA-BB-CC-DD-EE-FF", "Port_#0001");
+
+        var merged = metadata.MergeWith(discovery);
+
+        Assert.Equal("1234", merged.SerialNumber);
+        Assert.Equal("AA-BB-CC-DD-EE-FF", merged.MacAddress);
+        Assert.Equal("Port_#0001", merged.LocationKey);
+    }
+
+    [Fact]
+    public void MergeWith_Null_ReturnsSameIdentity()
+    {
+        var identity = DeviceIdentity.Create("1234");
+
+        Assert.Same(identity, identity.MergeWith(null));
+    }
+
+    #endregion
+
+    [Fact]
+    public void ToString_ListsPopulatedDiscriminators()
+    {
+        Assert.Equal("(unidentified)", DeviceIdentity.Empty.ToString());
+        Assert.Equal("sn=1234, location=Port_#0001", DeviceIdentity.Create("1234", null, "Port_#0001").ToString());
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
@@ -30,9 +30,13 @@ namespace Daqifi.Core.Device;
 /// </para>
 /// <para>
 /// <b>Liveness.</b> Registrations whose device stops reporting <see cref="DaqifiDevice.IsConnected"/>
-/// are pruned before every registration attempt (and by <see cref="PruneDisconnected"/> on demand),
-/// so a device that was unplugged never blocks a reconnect. The registry does not subscribe to
-/// device status events or reconnect on its own; automatic reconnect is issue #379.
+/// are pruned before every registration attempt (and by <see cref="PruneDisconnected"/> on demand).
+/// Pruning is only as good as the transport's drop detection, which is a real limit today: the
+/// serial transport reports the OS handle's state, and that stays open after a USB device is
+/// physically unplugged, so such a device keeps reporting <c>IsConnected</c> and is not pruned.
+/// Devices you disconnect yourself, and drops a transport does report, are pruned as described.
+/// The registry does not subscribe to device status events or reconnect on its own; automatic
+/// reconnect is issue #379.
 /// </para>
 /// <para>
 /// <b>Concurrency.</b> All members are safe to call from any thread. Reads snapshot the live set,

--- a/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
@@ -193,28 +193,25 @@ public sealed class DaqifiDeviceRegistry : IDisposable
         cancellationToken.ThrowIfCancellationRequested();
 
         var discoveryIdentity = DeviceIdentity.FromDiscovery(deviceInfo);
-        var replacedExisting = false;
 
-        // Pre-connect check. Rejecting here is free: nothing has been opened yet.
-        while (true)
+        // Pre-connect check. Rejecting here is free: nothing has been opened yet. The check that
+        // actually guards the live set runs after connecting, atomically with the add.
+        DeviceRegistration? existing;
+        List<DeviceRegistration>? stale;
+
+        lock (_lock)
         {
-            DeviceRegistration? existing;
-            List<DeviceRegistration>? stale;
+            ThrowIfDisposed();
+            stale = PruneLocked();
+            existing = FindDuplicateLocked(key, discoveryIdentity);
+        }
 
-            lock (_lock)
-            {
-                ThrowIfDisposed();
-                stale = PruneLocked();
-                existing = FindDuplicateLocked(key, discoveryIdentity);
-            }
+        CompleteRemoval(stale, DeviceRemovalReason.Disconnected);
 
-            CompleteRemoval(stale, DeviceRemovalReason.Disconnected);
+        DeviceRegistration? approvedReplacement = null;
 
-            if (existing == null)
-            {
-                break;
-            }
-
+        if (existing != null)
+        {
             var action = InvokePolicy(new DuplicateDeviceCheck(
                 existing,
                 discoveryIdentity,
@@ -223,26 +220,27 @@ public sealed class DaqifiDeviceRegistry : IDisposable
                 deviceInfo.ConnectionType,
                 DuplicateCheckPhase.BeforeConnect));
 
-            switch (action)
+            if (action == DuplicateDeviceAction.Cancel)
             {
-                case DuplicateDeviceAction.SwitchToNew:
-                    // Drop the existing connection first: it may be holding the very resource
-                    // (serial port, device-side socket) the new connection needs.
-                    RemoveRegistration(existing, DeviceRemovalReason.Replaced);
-                    replacedExisting = true;
-                    continue;
-
-                case DuplicateDeviceAction.Cancel:
-                    return new DeviceRegistrationResult(DeviceRegistrationOutcome.Canceled, null);
-
-                default:
-                    return new DeviceRegistrationResult(DeviceRegistrationOutcome.DuplicateRejected, existing);
+                return new DeviceRegistrationResult(DeviceRegistrationOutcome.Canceled, null);
             }
+
+            if (action != DuplicateDeviceAction.SwitchToNew)
+            {
+                return new DeviceRegistrationResult(DeviceRegistrationOutcome.DuplicateRejected, existing);
+            }
+
+            // Record the decision but keep the existing connection until the new one is actually
+            // open. Dropping it first would leave the caller with nothing when the new transport
+            // fails to connect — switching a healthy USB session to a WiFi address that turns out
+            // not to answer must not cost them the session they had. Registration drops it once
+            // the replacement is live, without asking the policy a second time.
+            approvedReplacement = existing;
         }
 
         var device = await _connector(deviceInfo, options, cancellationToken).ConfigureAwait(false);
 
-        return RegisterCore(device, deviceInfo, key, replacedExisting);
+        return RegisterCore(device, deviceInfo, key, approvedReplacement);
     }
 
     /// <summary>
@@ -284,7 +282,7 @@ public sealed class DaqifiDeviceRegistry : IDisposable
                 "Only a connected device can be registered. Connect the device first.", nameof(device));
         }
 
-        return RegisterCore(device, deviceInfo, key, replacedExisting: false);
+        return RegisterCore(device, deviceInfo, key, approvedReplacement: null);
     }
 
     /// <summary>
@@ -481,16 +479,19 @@ public sealed class DaqifiDeviceRegistry : IDisposable
     /// <param name="device">The connected device being registered.</param>
     /// <param name="deviceInfo">The discovery metadata, if available.</param>
     /// <param name="key">The requested key, or <c>null</c> to derive one.</param>
-    /// <param name="replacedExisting">
-    /// Whether an earlier (pre-connect) duplicate check already dropped a registration for this
-    /// unit, so the outcome should be reported as <see cref="DeviceRegistrationOutcome.ReplacedExisting"/>.
+    /// <param name="approvedReplacement">
+    /// A registration the pre-connect check already got approval to replace. Finding it again here
+    /// is not a fresh duplicate: it is dropped without re-consulting the policy, so a consumer that
+    /// prompts its user is asked once per connection attempt rather than twice.
     /// </param>
     private DeviceRegistrationResult RegisterCore(
         DaqifiDevice device,
         IDeviceInfo? deviceInfo,
         string? key,
-        bool replacedExisting)
+        DeviceRegistration? approvedReplacement)
     {
+        var replacedExisting = false;
+
         try
         {
             // Metadata is authoritative once connected, but it never carries the USB location key
@@ -549,13 +550,17 @@ public sealed class DaqifiDeviceRegistry : IDisposable
                         added);
                 }
 
-                var action = InvokePolicy(new DuplicateDeviceCheck(
-                    existing!,
-                    identity,
-                    deviceInfo,
-                    device,
-                    connectionType,
-                    DuplicateCheckPhase.AfterConnect));
+                // A registration the caller already approved replacing before we connected is not
+                // a fresh duplicate — dropping it now is finishing that decision, not making one.
+                var action = ReferenceEquals(existing, approvedReplacement)
+                    ? DuplicateDeviceAction.SwitchToNew
+                    : InvokePolicy(new DuplicateDeviceCheck(
+                        existing!,
+                        identity,
+                        deviceInfo,
+                        device,
+                        connectionType,
+                        DuplicateCheckPhase.AfterConnect));
 
                 switch (action)
                 {

--- a/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
@@ -258,17 +258,19 @@ public sealed class DaqifiDeviceRegistry : IDisposable
             }
         }
 
-        // Re-check immediately before opening anything. The policy above runs without the lock and
-        // may block indefinitely on a user prompt, so a registry disposed during that window would
-        // otherwise still reach the connector and start fresh transport activity on the way down.
-        // This narrows that window to a few instructions rather than closing it: a Dispose landing
-        // between here and the connector, or during the connect itself, still lets the connection
-        // open, and RegisterCore then throws and disposes it. Guaranteeing no transport activity
-        // outlives the registry needs in-flight tracking on Dispose, which is out of scope here.
+        // Re-check both shutdown signals immediately before opening anything. The policy above runs
+        // without the lock and may block indefinitely on a user prompt, so a registry disposed — or
+        // a token cancelled — during that window would otherwise still reach the connector.
+        // This narrows the window rather than closing it: either signal landing between here and
+        // the connector, or during the connect itself, still lets the connection open, and
+        // RegisterCore then throws and disposes it. Guaranteeing no transport activity outlives the
+        // registry needs in-flight tracking on Dispose, which is out of scope here.
         lock (_lock)
         {
             ThrowIfDisposed();
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         var device = await _connector(deviceInfo, options, cancellationToken).ConfigureAwait(false);
 

--- a/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
@@ -1,0 +1,814 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// Thread-safe registry of connected DAQiFi devices. Tracks the live device set, recognizes the
+/// same physical unit reached over two transports at once (the classic "already connected via USB,
+/// now discovered over WiFi" case), and owns the lifetime of everything it holds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two distinct concepts run through this API:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b>Key</b> — the handle a caller looks a device up by (<see cref="TryGet"/>,
+/// <see cref="Remove(string)"/>). It defaults to <see cref="DeviceIdentity.Key"/>, but a consumer
+/// that already has its own device ids (an MCP server, a UI list) can supply one. Keys are unique;
+/// registering under a key that is already taken is treated as a duplicate.
+/// </description></item>
+/// <item><description>
+/// <b>Identity</b> — the <see cref="DeviceIdentity"/> fingerprint of the physical unit, used for
+/// duplicate detection across transports. Two registrations may never share an identity.
+/// </description></item>
+/// </list>
+/// <para>
+/// <b>Ownership.</b> The registry disconnects and disposes every device it removes — including a
+/// device it rejects as a duplicate and stale registrations it prunes. Once a device is passed to
+/// <see cref="ConnectAsync"/> or <see cref="Register"/>, do not dispose it yourself.
+/// </para>
+/// <para>
+/// <b>Liveness.</b> Registrations whose device stops reporting <see cref="DaqifiDevice.IsConnected"/>
+/// are pruned before every registration attempt (and by <see cref="PruneDisconnected"/> on demand),
+/// so a device that was unplugged never blocks a reconnect. The registry does not subscribe to
+/// device status events or reconnect on its own; automatic reconnect is issue #379.
+/// </para>
+/// <para>
+/// <b>Concurrency.</b> All members are safe to call from any thread. Reads snapshot the live set,
+/// and the duplicate policy is always invoked without the internal lock held, so a policy that
+/// blocks on a user prompt never blocks other threads. Two concurrent
+/// <see cref="ConnectAsync"/> calls for the <em>same</em> physical device may both open a
+/// connection — the loser is detected after connecting and disposed — so a consumer that wants a
+/// single connect attempt should serialize its own calls (see issue #342).
+/// </para>
+/// </remarks>
+public sealed class DaqifiDeviceRegistry : IDisposable
+{
+    #region Private Types
+
+    /// <summary>
+    /// Opens a connection for <see cref="ConnectAsync"/>. Exists as a seam so the duplicate-policy
+    /// paths can be tested without hardware; production always uses
+    /// <see cref="DaqifiDeviceFactory.ConnectFromDeviceInfoAsync"/>.
+    /// </summary>
+    internal delegate Task<DaqifiDevice> DeviceConnector(
+        IDeviceInfo deviceInfo,
+        DeviceConnectionOptions? options,
+        CancellationToken cancellationToken);
+
+    #endregion
+
+    #region Private Fields
+
+    private readonly Dictionary<string, DeviceRegistration> _devices = new(StringComparer.Ordinal);
+    private readonly object _lock = new();
+    private readonly DeviceConnector _connector;
+
+    private int _mintedKeyCounter;
+    private volatile bool _disposed;
+
+    #endregion
+
+    #region Constructors
+
+    /// <summary>
+    /// Initializes a new, empty registry.
+    /// </summary>
+    public DaqifiDeviceRegistry()
+        : this(null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new, empty registry with a custom connector (test seam).
+    /// </summary>
+    /// <param name="connector">
+    /// The connector <see cref="ConnectAsync"/> opens connections with, or <c>null</c> for the
+    /// default factory connect.
+    /// </param>
+    internal DaqifiDeviceRegistry(DeviceConnector? connector)
+    {
+        _connector = connector ?? ((info, options, cancellationToken) =>
+            DaqifiDeviceFactory.ConnectFromDeviceInfoAsync(info, options, cancellationToken));
+    }
+
+    #endregion
+
+    #region Public Surface
+
+    /// <summary>
+    /// Gets or sets the policy consulted when a device being registered turns out to be a
+    /// duplicate of one already in the live set. When <c>null</c> (the default) the existing
+    /// connection is kept and the new one is rejected — the safe choice that needs no callback.
+    /// </summary>
+    /// <remarks>
+    /// Invoked without the registry lock held, so it may block on a user prompt. It is called for
+    /// both the pre-connect and post-connect checks; use <see cref="DuplicateDeviceCheck.Phase"/>
+    /// to tell them apart. An exception thrown by the policy propagates to the caller, and the
+    /// device being registered is disposed.
+    /// </remarks>
+    public Func<DuplicateDeviceCheck, DuplicateDeviceAction>? DuplicatePolicy { get; set; }
+
+    /// <summary>
+    /// Occurs after a device has been added to the live set.
+    /// </summary>
+    /// <remarks>
+    /// Raised without the registry lock held. An exception thrown by a subscriber is swallowed so
+    /// one faulty handler cannot fail the registration or suppress sibling notifications.
+    /// </remarks>
+    public event EventHandler<DeviceRegisteredEventArgs>? DeviceAdded;
+
+    /// <summary>
+    /// Occurs after a device has been removed from the live set, disconnected, and disposed.
+    /// Not raised by <see cref="Dispose"/>, which tears the whole registry down.
+    /// </summary>
+    /// <remarks>
+    /// Raised without the registry lock held. An exception thrown by a subscriber is swallowed so
+    /// one faulty handler cannot suppress sibling notifications.
+    /// </remarks>
+    public event EventHandler<DeviceRemovedEventArgs>? DeviceRemoved;
+
+    /// <summary>
+    /// Gets a point-in-time snapshot of the live set. The returned list is a copy and is safe to
+    /// enumerate from any thread.
+    /// </summary>
+    public IReadOnlyList<DeviceRegistration> Devices
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return new List<DeviceRegistration>(_devices.Values);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of devices currently in the live set.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _devices.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Connects to a discovered device and adds it to the live set, running the duplicate check
+    /// twice: once from <paramref name="deviceInfo"/> before connecting, and again from the
+    /// device's <see cref="DaqifiDevice.Metadata"/> afterwards — the serial number of a serial-port
+    /// device is often only known once it has answered its first status message.
+    /// </summary>
+    /// <param name="deviceInfo">The device information from discovery.</param>
+    /// <param name="key">
+    /// The key to file the device under. When <c>null</c>, <see cref="DeviceIdentity.Key"/> is used
+    /// (or a minted unique key when the device reports no identity at all).
+    /// </param>
+    /// <param name="options">Optional connection options passed through to the connect step.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the connection.</param>
+    /// <returns>
+    /// The outcome. On <see cref="DeviceRegistrationOutcome.DuplicateRejected"/> the result carries
+    /// the existing registration — the live connection to the same unit — and the device just
+    /// connected has already been disposed.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="deviceInfo"/> is <c>null</c>.</exception>
+    /// <exception cref="ObjectDisposedException">The registry has been disposed.</exception>
+    public async Task<DeviceRegistrationResult> ConnectAsync(
+        IDeviceInfo deviceInfo,
+        string? key = null,
+        DeviceConnectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(deviceInfo);
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var discoveryIdentity = DeviceIdentity.FromDiscovery(deviceInfo);
+        var replacedExisting = false;
+
+        // Pre-connect check. Rejecting here is free: nothing has been opened yet.
+        while (true)
+        {
+            DeviceRegistration? existing;
+            List<DeviceRegistration>? stale;
+
+            lock (_lock)
+            {
+                ThrowIfDisposed();
+                stale = PruneLocked();
+                existing = FindDuplicateLocked(key, discoveryIdentity);
+            }
+
+            CompleteRemoval(stale, DeviceRemovalReason.Disconnected);
+
+            if (existing == null)
+            {
+                break;
+            }
+
+            var action = InvokePolicy(new DuplicateDeviceCheck(
+                existing,
+                discoveryIdentity,
+                deviceInfo,
+                newDevice: null,
+                deviceInfo.ConnectionType,
+                DuplicateCheckPhase.BeforeConnect));
+
+            switch (action)
+            {
+                case DuplicateDeviceAction.SwitchToNew:
+                    // Drop the existing connection first: it may be holding the very resource
+                    // (serial port, device-side socket) the new connection needs.
+                    RemoveRegistration(existing, DeviceRemovalReason.Replaced);
+                    replacedExisting = true;
+                    continue;
+
+                case DuplicateDeviceAction.Cancel:
+                    return new DeviceRegistrationResult(DeviceRegistrationOutcome.Canceled, null);
+
+                default:
+                    return new DeviceRegistrationResult(DeviceRegistrationOutcome.DuplicateRejected, existing);
+            }
+        }
+
+        var device = await _connector(deviceInfo, options, cancellationToken).ConfigureAwait(false);
+
+        return RegisterCore(device, deviceInfo, key, replacedExisting);
+    }
+
+    /// <summary>
+    /// Adds an already-connected device to the live set, running the duplicate check against its
+    /// <see cref="DaqifiDevice.Metadata"/>. Use this when the connection was opened elsewhere (for
+    /// example by <see cref="DaqifiDeviceFactory"/> directly); <see cref="ConnectAsync"/> is the
+    /// one-call path.
+    /// </summary>
+    /// <param name="device">The connected device. The registry takes ownership of it.</param>
+    /// <param name="deviceInfo">
+    /// The discovery metadata the device was connected from, if available. Supplying it lets the
+    /// registry report the device's transport and keeps discovery-only discriminators (the USB
+    /// location key, and the MAC address on a device whose metadata has not filled one in yet).
+    /// </param>
+    /// <param name="key">
+    /// The key to file the device under. When <c>null</c>, <see cref="DeviceIdentity.Key"/> is used
+    /// (or a minted unique key when the device reports no identity at all).
+    /// </param>
+    /// <returns>
+    /// The outcome, in the same shape <see cref="ConnectAsync"/> returns. Registering a device
+    /// that is already in the live set is an idempotent no-op that reports
+    /// <see cref="DeviceRegistrationOutcome.Registered"/> with its existing registration.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="device"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="device"/> is not connected.</exception>
+    /// <exception cref="ObjectDisposedException">The registry has been disposed.</exception>
+    public DeviceRegistrationResult Register(
+        DaqifiDevice device,
+        IDeviceInfo? deviceInfo = null,
+        string? key = null)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+        ThrowIfDisposed();
+
+        // Validate before taking ownership, so a caller mistake never costs them their device.
+        if (!device.IsConnected)
+        {
+            throw new ArgumentException(
+                "Only a connected device can be registered. Connect the device first.", nameof(device));
+        }
+
+        return RegisterCore(device, deviceInfo, key, replacedExisting: false);
+    }
+
+    /// <summary>
+    /// Looks up a registration by key.
+    /// </summary>
+    /// <param name="key">The key the device was filed under.</param>
+    /// <param name="registration">The registration, or <c>null</c> when the key is unknown.</param>
+    /// <returns><c>true</c> when a registration was found.</returns>
+    /// <remarks>
+    /// A lookup never prunes, so a device that dropped since it was registered is still returned;
+    /// check <see cref="DaqifiDevice.IsConnected"/> if that matters to the caller.
+    /// </remarks>
+    public bool TryGet(string key, out DeviceRegistration? registration)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            registration = null;
+            return false;
+        }
+
+        lock (_lock)
+        {
+            return _devices.TryGetValue(key, out registration);
+        }
+    }
+
+    /// <summary>
+    /// Looks up a device by key. Shorthand for <see cref="TryGet"/> followed by
+    /// <see cref="DeviceRegistration.Device"/>.
+    /// </summary>
+    /// <param name="key">The key the device was filed under.</param>
+    /// <param name="device">The device, or <c>null</c> when the key is unknown.</param>
+    /// <returns><c>true</c> when a device was found.</returns>
+    public bool TryGetDevice(string key, out DaqifiDevice? device)
+    {
+        var found = TryGet(key, out var registration);
+        device = registration?.Device;
+        return found;
+    }
+
+    /// <summary>
+    /// Finds the registration whose device is the same physical unit as
+    /// <paramref name="identity"/> — the duplicate-detection primitive, exposed for consumers that
+    /// want to check before opening a connection of their own.
+    /// </summary>
+    /// <param name="identity">The identity to match against.</param>
+    /// <returns>The matching registration, or <c>null</c> when the unit is not in the live set.</returns>
+    public DeviceRegistration? Find(DeviceIdentity identity)
+    {
+        if (identity is null || identity.IsEmpty)
+        {
+            return null;
+        }
+
+        lock (_lock)
+        {
+            return FindByIdentityLocked(identity);
+        }
+    }
+
+    /// <summary>
+    /// Removes a device from the live set, disconnecting and disposing it.
+    /// </summary>
+    /// <param name="key">The key the device was filed under.</param>
+    /// <returns><c>true</c> when a device was removed.</returns>
+    public bool Remove(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return false;
+        }
+
+        DeviceRegistration? removed;
+        lock (_lock)
+        {
+            if (!_devices.Remove(key, out removed))
+            {
+                return false;
+            }
+        }
+
+        CompleteRemoval(new List<DeviceRegistration> { removed! }, DeviceRemovalReason.Removed);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes a device from the live set by reference, disconnecting and disposing it.
+    /// </summary>
+    /// <param name="device">The device to remove.</param>
+    /// <returns><c>true</c> when the device was in the live set and was removed.</returns>
+    public bool Remove(DaqifiDevice device)
+    {
+        if (device is null)
+        {
+            return false;
+        }
+
+        DeviceRegistration? removed = null;
+        lock (_lock)
+        {
+            foreach (var registration in _devices.Values)
+            {
+                if (ReferenceEquals(registration.Device, device))
+                {
+                    removed = registration;
+                    break;
+                }
+            }
+
+            if (removed == null)
+            {
+                return false;
+            }
+
+            _devices.Remove(removed.Key);
+        }
+
+        CompleteRemoval(new List<DeviceRegistration> { removed }, DeviceRemovalReason.Removed);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes every registration whose device is no longer connected, disposing each one. Called
+    /// automatically before each registration attempt; exposed for consumers that poll the live set.
+    /// </summary>
+    /// <returns>The number of stale registrations removed.</returns>
+    public int PruneDisconnected()
+    {
+        List<DeviceRegistration>? stale;
+        lock (_lock)
+        {
+            stale = PruneLocked();
+        }
+
+        CompleteRemoval(stale, DeviceRemovalReason.Disconnected);
+        return stale?.Count ?? 0;
+    }
+
+    /// <summary>
+    /// Removes every device from the live set, disconnecting and disposing each one.
+    /// </summary>
+    public void Clear()
+    {
+        List<DeviceRegistration> removed;
+        lock (_lock)
+        {
+            if (_devices.Count == 0)
+            {
+                return;
+            }
+
+            removed = new List<DeviceRegistration>(_devices.Values);
+            _devices.Clear();
+        }
+
+        CompleteRemoval(removed, DeviceRemovalReason.Cleared);
+    }
+
+    /// <summary>
+    /// Disconnects and disposes every device in the live set and marks the registry unusable.
+    /// <see cref="DeviceRemoved"/> is not raised: the registry itself is going away, so there is no
+    /// live set left to keep in sync.
+    /// </summary>
+    public void Dispose()
+    {
+        List<DeviceRegistration> removed;
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            removed = new List<DeviceRegistration>(_devices.Values);
+            _devices.Clear();
+        }
+
+        foreach (var registration in removed)
+        {
+            DisposeDevice(registration.Device);
+        }
+    }
+
+    #endregion
+
+    #region Registration
+
+    /// <summary>
+    /// Runs the post-connect duplicate check and adds the device, taking ownership of it: on any
+    /// outcome other than a successful add — including a policy callback that throws — the device
+    /// is disconnected and disposed.
+    /// </summary>
+    /// <param name="device">The connected device being registered.</param>
+    /// <param name="deviceInfo">The discovery metadata, if available.</param>
+    /// <param name="key">The requested key, or <c>null</c> to derive one.</param>
+    /// <param name="replacedExisting">
+    /// Whether an earlier (pre-connect) duplicate check already dropped a registration for this
+    /// unit, so the outcome should be reported as <see cref="DeviceRegistrationOutcome.ReplacedExisting"/>.
+    /// </param>
+    private DeviceRegistrationResult RegisterCore(
+        DaqifiDevice device,
+        IDeviceInfo? deviceInfo,
+        string? key,
+        bool replacedExisting)
+    {
+        try
+        {
+            // Metadata is authoritative once connected, but it never carries the USB location key
+            // and may not have filled in a MAC address yet, so fall back to what discovery saw.
+            var identity = DeviceIdentity
+                .FromMetadata(device.Metadata, deviceInfo?.LocationKey)
+                .MergeWith(deviceInfo != null ? DeviceIdentity.FromDiscovery(deviceInfo) : null);
+
+            var connectionType = deviceInfo?.ConnectionType ?? ConnectionType.Unknown;
+
+            while (true)
+            {
+                DeviceRegistration? existing;
+                DeviceRegistration? added = null;
+                DeviceRegistration? alreadyRegistered = null;
+                List<DeviceRegistration>? stale;
+
+                lock (_lock)
+                {
+                    ThrowIfDisposed();
+                    stale = PruneLocked();
+                    existing = FindDuplicateLocked(key, identity, device);
+
+                    if (existing == null)
+                    {
+                        // Resolving the key and adding under the same lock as the duplicate check
+                        // is what makes concurrent registrations safe: no second thread can slip a
+                        // duplicate in between the two steps.
+                        added = new DeviceRegistration(ResolveKeyLocked(key, identity), device, identity, deviceInfo);
+                        _devices.Add(added.Key, added);
+                    }
+                    else if (ReferenceEquals(existing.Device, device))
+                    {
+                        // This exact device is already in the live set. Re-registering it is a
+                        // no-op — emphatically not a duplicate to dispose, which would leave the
+                        // registry holding a dead handle.
+                        alreadyRegistered = existing;
+                    }
+                }
+
+                CompleteRemoval(stale, DeviceRemovalReason.Disconnected);
+
+                if (alreadyRegistered != null)
+                {
+                    return new DeviceRegistrationResult(
+                        DeviceRegistrationOutcome.Registered, alreadyRegistered);
+                }
+
+                if (added != null)
+                {
+                    RaiseDeviceAdded(added);
+                    return new DeviceRegistrationResult(
+                        replacedExisting
+                            ? DeviceRegistrationOutcome.ReplacedExisting
+                            : DeviceRegistrationOutcome.Registered,
+                        added);
+                }
+
+                var action = InvokePolicy(new DuplicateDeviceCheck(
+                    existing!,
+                    identity,
+                    deviceInfo,
+                    device,
+                    connectionType,
+                    DuplicateCheckPhase.AfterConnect));
+
+                switch (action)
+                {
+                    case DuplicateDeviceAction.SwitchToNew:
+                        RemoveRegistration(existing!, DeviceRemovalReason.Replaced);
+                        replacedExisting = true;
+                        continue;
+
+                    case DuplicateDeviceAction.Cancel:
+                        DisposeDevice(device);
+                        return new DeviceRegistrationResult(DeviceRegistrationOutcome.Canceled, null);
+
+                    default:
+                        DisposeDevice(device);
+                        return new DeviceRegistrationResult(
+                            DeviceRegistrationOutcome.DuplicateRejected, existing);
+                }
+            }
+        }
+        catch
+        {
+            // Ownership already transferred, so the device is ours to clean up.
+            DisposeDevice(device);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Finds the registration a device being registered would collide with: the entry already
+    /// filed under the requested key, the entry holding this very device instance, or one
+    /// describing the same physical unit. Caller must hold <see cref="_lock"/>.
+    /// </summary>
+    private DeviceRegistration? FindDuplicateLocked(string? key, DeviceIdentity identity, DaqifiDevice? device = null)
+    {
+        if (!string.IsNullOrEmpty(key) && _devices.TryGetValue(key!, out var byKey))
+        {
+            return byKey;
+        }
+
+        if (device != null)
+        {
+            foreach (var registration in _devices.Values)
+            {
+                if (ReferenceEquals(registration.Device, device))
+                {
+                    return registration;
+                }
+            }
+        }
+
+        return FindByIdentityLocked(identity);
+    }
+
+    /// <summary>
+    /// Finds the registration describing the same physical unit as <paramref name="identity"/>.
+    /// Caller must hold <see cref="_lock"/>.
+    /// </summary>
+    private DeviceRegistration? FindByIdentityLocked(DeviceIdentity identity)
+    {
+        if (identity.IsEmpty)
+        {
+            return null;
+        }
+
+        foreach (var registration in _devices.Values)
+        {
+            if (registration.Identity.Matches(identity))
+            {
+                return registration;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Picks the key a new registration is filed under. A caller-supplied key is used as-is (the
+    /// duplicate check has already proven it free); otherwise the identity key is used, falling
+    /// back to a minted unique key so devices that report no identity never collide. Caller must
+    /// hold <see cref="_lock"/>.
+    /// </summary>
+    private string ResolveKeyLocked(string? requestedKey, DeviceIdentity identity)
+    {
+        if (!string.IsNullOrEmpty(requestedKey))
+        {
+            return requestedKey!;
+        }
+
+        if (!identity.IsEmpty && !_devices.ContainsKey(identity.Key))
+        {
+            return identity.Key;
+        }
+
+        string minted;
+        do
+        {
+            minted = "device-" + (++_mintedKeyCounter);
+        }
+        while (_devices.ContainsKey(minted));
+
+        return minted;
+    }
+
+    /// <summary>
+    /// Removes every registration whose device is no longer connected and returns them, or
+    /// <c>null</c> when there were none. Disposal and notification happen outside the lock, in
+    /// <see cref="CompleteRemoval"/>. Caller must hold <see cref="_lock"/>.
+    /// </summary>
+    private List<DeviceRegistration>? PruneLocked()
+    {
+        List<DeviceRegistration>? stale = null;
+
+        foreach (var registration in _devices.Values)
+        {
+            if (!registration.Device.IsConnected)
+            {
+                (stale ??= new List<DeviceRegistration>()).Add(registration);
+            }
+        }
+
+        if (stale != null)
+        {
+            foreach (var registration in stale)
+            {
+                _devices.Remove(registration.Key);
+            }
+        }
+
+        return stale;
+    }
+
+    /// <summary>
+    /// Removes one registration and disposes its device.
+    /// </summary>
+    private void RemoveRegistration(DeviceRegistration registration, DeviceRemovalReason reason)
+    {
+        lock (_lock)
+        {
+            // Only remove the exact entry we resolved: a concurrent operation may already have
+            // replaced it with a different device under the same key.
+            if (!_devices.TryGetValue(registration.Key, out var current) || !ReferenceEquals(current, registration))
+            {
+                return;
+            }
+
+            _devices.Remove(registration.Key);
+        }
+
+        CompleteRemoval(new List<DeviceRegistration> { registration }, reason);
+    }
+
+    /// <summary>
+    /// Disposes the devices of already-removed registrations and announces them. Always called
+    /// without the lock held: disconnecting touches the transport, and subscribers must be free to
+    /// call back into the registry.
+    /// </summary>
+    private void CompleteRemoval(List<DeviceRegistration>? removed, DeviceRemovalReason reason)
+    {
+        if (removed == null || removed.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var registration in removed)
+        {
+            DisposeDevice(registration.Device);
+            RaiseDeviceRemoved(registration, reason);
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    /// <summary>
+    /// Asks the duplicate policy what to do, defaulting to keeping the existing connection when no
+    /// policy is set or an out-of-range action is returned.
+    /// </summary>
+    private DuplicateDeviceAction InvokePolicy(DuplicateDeviceCheck check)
+    {
+        var policy = DuplicatePolicy;
+        if (policy == null)
+        {
+            return DuplicateDeviceAction.KeepExisting;
+        }
+
+        var action = policy(check);
+        return Enum.IsDefined(action) ? action : DuplicateDeviceAction.KeepExisting;
+    }
+
+    /// <summary>
+    /// Disconnects and disposes a device the registry owns. Disconnect failures are ignored: the
+    /// transport is being torn down either way, and disposal must still run.
+    /// </summary>
+    private static void DisposeDevice(DaqifiDevice device)
+    {
+        try
+        {
+            device.Disconnect();
+        }
+        catch
+        {
+            // Best effort — Dispose below tears the transport down regardless.
+        }
+
+        try
+        {
+            device.Dispose();
+        }
+        catch
+        {
+            // Best effort — a device that fails to dispose must not fail the registry operation.
+        }
+    }
+
+    /// <summary>
+    /// Raises <see cref="DeviceAdded"/>, swallowing subscriber exceptions so a faulty handler
+    /// cannot fail a registration that has already happened.
+    /// </summary>
+    private void RaiseDeviceAdded(DeviceRegistration registration)
+    {
+        try
+        {
+            DeviceAdded?.Invoke(this, new DeviceRegisteredEventArgs(registration));
+        }
+        catch
+        {
+            // Intentionally swallowed: the device is registered either way.
+        }
+    }
+
+    /// <summary>
+    /// Raises <see cref="DeviceRemoved"/>, swallowing subscriber exceptions so a faulty handler
+    /// cannot suppress sibling notifications.
+    /// </summary>
+    private void RaiseDeviceRemoved(DeviceRegistration registration, DeviceRemovalReason reason)
+    {
+        try
+        {
+            DeviceRemoved?.Invoke(this, new DeviceRemovedEventArgs(registration, reason));
+        }
+        catch
+        {
+            // Intentionally swallowed: the device is already removed and disposed.
+        }
+    }
+
+    /// <summary>
+    /// Throws <see cref="ObjectDisposedException"/> if this registry has been disposed.
+    /// </summary>
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(DaqifiDeviceRegistry));
+        }
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
@@ -41,9 +41,12 @@ namespace Daqifi.Core.Device;
 /// <para>
 /// <b>Concurrency.</b> All members are safe to call from any thread. Reads snapshot the live set,
 /// and the duplicate policy is always invoked without the internal lock held, so a policy that
-/// blocks on a user prompt never blocks other threads. Two concurrent
-/// <see cref="ConnectAsync"/> calls for the <em>same</em> physical device may both open a
-/// connection — the loser is detected after connecting and disposed — so a consumer that wants a
+/// blocks on a user prompt never blocks other threads. Because the set can change while the policy
+/// is deciding, a registration handed back as a duplicate is revalidated afterwards: it is in the
+/// live set at the moment it is returned, and if it went away the check is re-resolved against the
+/// current set instead. Like any handle, it can still be removed by another thread later. Two
+/// concurrent <see cref="ConnectAsync"/> calls for the <em>same</em> physical device may both open
+/// a connection — the loser is detected after connecting and disposed — so a consumer that wants a
 /// single connect attempt should serialize its own calls (see issue #342).
 /// </para>
 /// </remarks>
@@ -196,22 +199,27 @@ public sealed class DaqifiDeviceRegistry : IDisposable
 
         // Pre-connect check. Rejecting here is free: nothing has been opened yet. The check that
         // actually guards the live set runs after connecting, atomically with the add.
-        DeviceRegistration? existing;
-        List<DeviceRegistration>? stale;
-
-        lock (_lock)
-        {
-            ThrowIfDisposed();
-            stale = PruneLocked();
-            existing = FindDuplicateLocked(key, discoveryIdentity);
-        }
-
-        CompleteRemoval(stale, DeviceRemovalReason.Disconnected);
-
         DeviceRegistration? approvedReplacement = null;
 
-        if (existing != null)
+        while (true)
         {
+            DeviceRegistration? existing;
+            List<DeviceRegistration>? stale;
+
+            lock (_lock)
+            {
+                ThrowIfDisposed();
+                stale = PruneLocked();
+                existing = FindDuplicateLocked(key, discoveryIdentity);
+            }
+
+            CompleteRemoval(stale, DeviceRemovalReason.Disconnected);
+
+            if (existing == null)
+            {
+                break;
+            }
+
             var action = InvokePolicy(new DuplicateDeviceCheck(
                 existing,
                 discoveryIdentity,
@@ -225,17 +233,29 @@ public sealed class DaqifiDeviceRegistry : IDisposable
                 return new DeviceRegistrationResult(DeviceRegistrationOutcome.Canceled, null);
             }
 
-            if (action != DuplicateDeviceAction.SwitchToNew)
+            if (action == DuplicateDeviceAction.SwitchToNew)
+            {
+                // Record the decision but keep the existing connection until the new one is
+                // actually open. Dropping it first would leave the caller with nothing when the
+                // new transport fails to connect — switching a healthy USB session to a WiFi
+                // address that turns out not to answer must not cost them the session they had.
+                // Registration drops it once the replacement is live, without asking the policy a
+                // second time. If it vanishes in the meantime the reference simply matches nothing
+                // there, and the new device is registered on its own merits.
+                approvedReplacement = existing;
+                break;
+            }
+
+            // KeepExisting. Only hand that registration back if it is still the live one: the
+            // policy ran without the lock and is documented as free to block on a user prompt, so
+            // another thread (or the policy itself) may have removed or replaced it meanwhile, and
+            // returning it then would deliver a disposed handle as "the live connection". When it
+            // has gone, re-resolve against the current set instead — which either finds a
+            // different duplicate to ask about or clears the way to connect.
+            if (IsStillRegistered(existing))
             {
                 return new DeviceRegistrationResult(DeviceRegistrationOutcome.DuplicateRejected, existing);
             }
-
-            // Record the decision but keep the existing connection until the new one is actually
-            // open. Dropping it first would leave the caller with nothing when the new transport
-            // fails to connect — switching a healthy USB session to a WiFi address that turns out
-            // not to answer must not cost them the session they had. Registration drops it once
-            // the replacement is live, without asking the policy a second time.
-            approvedReplacement = existing;
         }
 
         var device = await _connector(deviceInfo, options, cancellationToken).ConfigureAwait(false);
@@ -574,6 +594,16 @@ public sealed class DaqifiDeviceRegistry : IDisposable
                         return new DeviceRegistrationResult(DeviceRegistrationOutcome.Canceled, null);
 
                     default:
+                        // KeepExisting. Same revalidation as the pre-connect path: the policy ran
+                        // without the lock, so only hand back a registration that is still the
+                        // live one. If it has gone, loop rather than disposing the device we just
+                        // connected — re-resolving may now find no duplicate at all, in which case
+                        // this device is what the caller should end up with.
+                        if (!IsStillRegistered(existing!))
+                        {
+                            continue;
+                        }
+
                         DisposeDevice(device);
                         return new DeviceRegistrationResult(
                             DeviceRegistrationOutcome.DuplicateRejected, existing);
@@ -734,6 +764,22 @@ public sealed class DaqifiDeviceRegistry : IDisposable
     #endregion
 
     #region Helpers
+
+    /// <summary>
+    /// Reports whether a registration captured earlier is still the entry filed under its key.
+    /// Used to revalidate a registration across the duplicate-policy call, which runs without the
+    /// lock held and may block indefinitely, so the live set can change underneath it.
+    /// </summary>
+    /// <param name="registration">The registration captured before the policy ran.</param>
+    /// <returns><c>true</c> when that exact instance is still in the live set.</returns>
+    private bool IsStillRegistered(DeviceRegistration registration)
+    {
+        lock (_lock)
+        {
+            return _devices.TryGetValue(registration.Key, out var current)
+                && ReferenceEquals(current, registration);
+        }
+    }
 
     /// <summary>
     /// Asks the duplicate policy what to do, defaulting to keeping the existing connection when no

--- a/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
@@ -258,6 +258,18 @@ public sealed class DaqifiDeviceRegistry : IDisposable
             }
         }
 
+        // Re-check immediately before opening anything. The policy above runs without the lock and
+        // may block indefinitely on a user prompt, so a registry disposed during that window would
+        // otherwise still reach the connector and start fresh transport activity on the way down.
+        // This narrows that window to a few instructions rather than closing it: a Dispose landing
+        // between here and the connector, or during the connect itself, still lets the connection
+        // open, and RegisterCore then throws and disposes it. Guaranteeing no transport activity
+        // outlives the registry needs in-flight tracking on Dispose, which is out of scope here.
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+        }
+
         var device = await _connector(deviceInfo, options, cancellationToken).ConfigureAwait(false);
 
         return RegisterCore(device, deviceInfo, key, approvedReplacement);
@@ -466,6 +478,12 @@ public sealed class DaqifiDeviceRegistry : IDisposable
     /// <see cref="DeviceRemoved"/> is not raised: the registry itself is going away, so there is no
     /// live set left to keep in sync.
     /// </summary>
+    /// <remarks>
+    /// Does not wait for work already in flight. A <see cref="ConnectAsync"/> that has already
+    /// reached its connector finishes opening the connection, and is then rejected and disposed by
+    /// the registration step — so nothing leaks, but the transport activity does complete. Callers
+    /// that need connect attempts to stop promptly should cancel the token they passed in.
+    /// </remarks>
     public void Dispose()
     {
         List<DeviceRegistration> removed;

--- a/src/Daqifi.Core/Device/DeviceIdentity.cs
+++ b/src/Daqifi.Core/Device/DeviceIdentity.cs
@@ -1,0 +1,224 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// Fingerprints a physical DAQiFi unit independently of the transport it was reached over, so the
+/// same device seen via USB and via WiFi can be recognized as one unit rather than two.
+/// </summary>
+/// <remarks>
+/// Three discriminators are used, in decreasing order of reliability:
+/// <list type="number">
+/// <item><description>
+/// Serial number — reported by every transport once the device has answered a status message
+/// (<see cref="IDeviceInfo.SerialNumber"/> pre-connect, <see cref="DeviceMetadata.SerialNumber"/>
+/// post-connect). Compared case-insensitively.
+/// </description></item>
+/// <item><description>
+/// MAC address — network-only, but present before a serial number is known on the WiFi path.
+/// Separators are ignored, so <c>AA-BB-CC-DD-EE-FF</c> and <c>aa:bb:cc:dd:ee:ff</c> compare equal.
+/// </description></item>
+/// <item><description>
+/// USB physical-location key (<see cref="IDeviceInfo.LocationKey"/>) — the last resort for
+/// identical USB units that report no serial number. Windows-only in v1; null elsewhere.
+/// </description></item>
+/// </list>
+/// Matching walks that list and is decided by the first discriminator that <em>both</em> identities
+/// carry: two units with different serial numbers are never the same device even if some later
+/// discriminator happens to agree. When no discriminator is populated on both sides the identities
+/// simply do not match — an unidentifiable device never collides with another unidentifiable one.
+/// </remarks>
+public sealed class DeviceIdentity
+{
+    /// <summary>
+    /// An identity with no discriminators at all. Never matches anything, including itself.
+    /// </summary>
+    public static readonly DeviceIdentity Empty = new(null, null, null);
+
+    private DeviceIdentity(string? serialNumber, string? macAddress, string? locationKey)
+    {
+        SerialNumber = Normalize(serialNumber);
+        MacAddress = Normalize(macAddress);
+        LocationKey = Normalize(locationKey);
+
+        Key = SerialNumber != null ? "sn:" + SerialNumber.ToLowerInvariant()
+            : MacAddress != null ? "mac:" + NormalizeMac(MacAddress)
+            : LocationKey != null ? "loc:" + LocationKey.ToLowerInvariant()
+            : string.Empty;
+    }
+
+    /// <summary>
+    /// Gets the device serial number, or <c>null</c> when the device did not report one.
+    /// </summary>
+    public string? SerialNumber { get; }
+
+    /// <summary>
+    /// Gets the device MAC address, or <c>null</c> when the device did not report one.
+    /// </summary>
+    public string? MacAddress { get; }
+
+    /// <summary>
+    /// Gets the USB physical-location key, or <c>null</c> when it could not be resolved.
+    /// </summary>
+    public string? LocationKey { get; }
+
+    /// <summary>
+    /// Gets a stable key derived from the strongest discriminator this identity carries
+    /// (for example <c>sn:1234</c>), or <see cref="string.Empty"/> when it carries none.
+    /// Two identities with the same non-empty key always <see cref="Matches"/>.
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this identity carries no discriminator at all and can
+    /// therefore never be matched against another device.
+    /// </summary>
+    public bool IsEmpty => Key.Length == 0;
+
+    /// <summary>
+    /// Creates an identity from raw discriminators. Null, empty, and whitespace-only values are
+    /// all treated as "not reported".
+    /// </summary>
+    /// <param name="serialNumber">The device serial number, if known.</param>
+    /// <param name="macAddress">The device MAC address, if known.</param>
+    /// <param name="locationKey">The USB physical-location key, if known.</param>
+    /// <returns>The identity described by the supplied discriminators.</returns>
+    public static DeviceIdentity Create(string? serialNumber, string? macAddress = null, string? locationKey = null)
+        => new(serialNumber, macAddress, locationKey);
+
+    /// <summary>
+    /// Creates an identity from discovery metadata — the identity available <em>before</em> a
+    /// device is connected.
+    /// </summary>
+    /// <param name="deviceInfo">The discovered device information.</param>
+    /// <returns>The identity described by <paramref name="deviceInfo"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="deviceInfo"/> is <c>null</c>.</exception>
+    public static DeviceIdentity FromDiscovery(IDeviceInfo deviceInfo)
+    {
+        ArgumentNullException.ThrowIfNull(deviceInfo);
+        return new DeviceIdentity(deviceInfo.SerialNumber, deviceInfo.MacAddress, deviceInfo.LocationKey);
+    }
+
+    /// <summary>
+    /// Creates an identity from a connected device's metadata — the identity available
+    /// <em>after</em> the device has answered its initial status message. Metadata carries no USB
+    /// location key, so pass through the one discovery reported (if any) to keep that discriminator.
+    /// </summary>
+    /// <param name="metadata">The connected device's metadata.</param>
+    /// <param name="locationKey">The USB physical-location key from discovery, if known.</param>
+    /// <returns>The identity described by <paramref name="metadata"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="metadata"/> is <c>null</c>.</exception>
+    public static DeviceIdentity FromMetadata(DeviceMetadata metadata, string? locationKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+        return new DeviceIdentity(metadata.SerialNumber, metadata.MacAddress, locationKey);
+    }
+
+    /// <summary>
+    /// Determines whether this identity and <paramref name="other"/> describe the same physical
+    /// unit, using the first discriminator both identities carry. Returns <c>false</c> when they
+    /// share no populated discriminator, so unidentifiable devices never match each other.
+    /// </summary>
+    /// <param name="other">The identity to compare against.</param>
+    /// <returns><c>true</c> when both identities describe the same physical device.</returns>
+    public bool Matches(DeviceIdentity? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+
+        if (SerialNumber != null && other.SerialNumber != null)
+        {
+            return SerialNumber.Equals(other.SerialNumber, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (MacAddress != null && other.MacAddress != null)
+        {
+            return NormalizeMac(MacAddress).Equals(NormalizeMac(other.MacAddress), StringComparison.Ordinal);
+        }
+
+        if (LocationKey != null && other.LocationKey != null)
+        {
+            return LocationKey.Equals(other.LocationKey, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns an identity that keeps this instance's discriminators and fills in any it is
+    /// missing from <paramref name="fallback"/>. Used to carry a pre-connect discriminator (such as
+    /// the USB location key, which metadata never reports) into the post-connect identity.
+    /// </summary>
+    /// <param name="fallback">The identity to take missing discriminators from.</param>
+    /// <returns>The merged identity.</returns>
+    public DeviceIdentity MergeWith(DeviceIdentity? fallback)
+    {
+        if (fallback == null)
+        {
+            return this;
+        }
+
+        return new DeviceIdentity(
+            SerialNumber ?? fallback.SerialNumber,
+            MacAddress ?? fallback.MacAddress,
+            LocationKey ?? fallback.LocationKey);
+    }
+
+    /// <summary>
+    /// Returns a diagnostic string listing the populated discriminators.
+    /// </summary>
+    public override string ToString()
+    {
+        if (IsEmpty)
+        {
+            return "(unidentified)";
+        }
+
+        var parts = new List<string>(3);
+        if (SerialNumber != null)
+        {
+            parts.Add("sn=" + SerialNumber);
+        }
+        if (MacAddress != null)
+        {
+            parts.Add("mac=" + MacAddress);
+        }
+        if (LocationKey != null)
+        {
+            parts.Add("location=" + LocationKey);
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    /// <summary>
+    /// Trims a discriminator and collapses "not reported" spellings (null, empty, whitespace)
+    /// onto <c>null</c> so they are never compared as values.
+    /// </summary>
+    private static string? Normalize(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    /// <summary>
+    /// Strips separators and case from a MAC address so the hyphenated form Core produces
+    /// compares equal to the colon-separated form other tooling uses.
+    /// </summary>
+    private static string NormalizeMac(string macAddress)
+    {
+        var buffer = new char[macAddress.Length];
+        var length = 0;
+
+        foreach (var c in macAddress)
+        {
+            if (c is '-' or ':' or '.' or ' ')
+            {
+                continue;
+            }
+
+            buffer[length++] = char.ToLowerInvariant(c);
+        }
+
+        return new string(buffer, 0, length);
+    }
+}

--- a/src/Daqifi.Core/Device/DeviceRegistration.cs
+++ b/src/Daqifi.Core/Device/DeviceRegistration.cs
@@ -1,0 +1,53 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// One entry in a <see cref="DaqifiDeviceRegistry"/>: a connected device, the key it is filed
+/// under, and the identity used to recognize it across transports.
+/// </summary>
+public sealed class DeviceRegistration
+{
+    internal DeviceRegistration(string key, DaqifiDevice device, DeviceIdentity identity, IDeviceInfo? discoveryInfo)
+    {
+        Key = key;
+        Device = device;
+        Identity = identity;
+        DiscoveryInfo = discoveryInfo;
+    }
+
+    /// <summary>
+    /// Gets the key this device is filed under — the handle callers pass to
+    /// <see cref="DaqifiDeviceRegistry.TryGet"/> and <see cref="DaqifiDeviceRegistry.Remove(string)"/>.
+    /// Defaults to <see cref="DeviceIdentity.Key"/> unless the caller supplied its own.
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// Gets the connected device. The registry owns it: it is disconnected and disposed when the
+    /// registration is removed.
+    /// </summary>
+    public DaqifiDevice Device { get; }
+
+    /// <summary>
+    /// Gets the identity used to recognize this physical unit across transports.
+    /// </summary>
+    public DeviceIdentity Identity { get; }
+
+    /// <summary>
+    /// Gets the discovery metadata this device was connected from, or <c>null</c> when an
+    /// already-connected device was registered without it.
+    /// </summary>
+    public IDeviceInfo? DiscoveryInfo { get; }
+
+    /// <summary>
+    /// Gets the transport this device is connected over, or <see cref="ConnectionType.Unknown"/>
+    /// when it was registered without discovery metadata.
+    /// </summary>
+    public ConnectionType ConnectionType => DiscoveryInfo?.ConnectionType ?? ConnectionType.Unknown;
+
+    /// <summary>
+    /// Returns a diagnostic string naming the key, transport, and identity.
+    /// </summary>
+    public override string ToString() => $"{Key} [{ConnectionType}] {Identity}";
+}

--- a/src/Daqifi.Core/Device/DeviceRegistrationResult.cs
+++ b/src/Daqifi.Core/Device/DeviceRegistrationResult.cs
@@ -1,0 +1,84 @@
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// How a <see cref="DaqifiDeviceRegistry"/> registration attempt ended.
+/// </summary>
+public enum DeviceRegistrationOutcome
+{
+    /// <summary>
+    /// The device was added to the live set.
+    /// </summary>
+    Registered,
+
+    /// <summary>
+    /// The device was added to the live set after a duplicate registration was dropped, because
+    /// the duplicate policy returned <see cref="DuplicateDeviceAction.SwitchToNew"/>.
+    /// </summary>
+    ReplacedExisting,
+
+    /// <summary>
+    /// The device was rejected as a duplicate of one already in the live set, because the
+    /// duplicate policy returned <see cref="DuplicateDeviceAction.KeepExisting"/> (the default).
+    /// The existing registration is reported in <see cref="DeviceRegistrationResult.Registration"/>.
+    /// </summary>
+    DuplicateRejected,
+
+    /// <summary>
+    /// The registration was abandoned because the duplicate policy returned
+    /// <see cref="DuplicateDeviceAction.Cancel"/>.
+    /// </summary>
+    Canceled
+}
+
+/// <summary>
+/// The result of a <see cref="DaqifiDeviceRegistry"/> registration attempt.
+/// </summary>
+public sealed class DeviceRegistrationResult
+{
+    internal DeviceRegistrationResult(DeviceRegistrationOutcome outcome, DeviceRegistration? registration)
+    {
+        Outcome = outcome;
+        Registration = registration;
+    }
+
+    /// <summary>
+    /// Gets how the attempt ended.
+    /// </summary>
+    public DeviceRegistrationOutcome Outcome { get; }
+
+    /// <summary>
+    /// Gets the registration the caller should now use, or <c>null</c> when the attempt was
+    /// canceled. On <see cref="DeviceRegistrationOutcome.DuplicateRejected"/> this is the existing
+    /// registration that won — the live connection to the same physical unit — not the rejected
+    /// device, which the registry has already disposed.
+    /// </summary>
+    public DeviceRegistration? Registration { get; }
+
+    /// <summary>
+    /// Gets the device the caller should now use, or <c>null</c> when the attempt was canceled.
+    /// Shorthand for <see cref="DeviceRegistration.Device"/> on <see cref="Registration"/>.
+    /// </summary>
+    public DaqifiDevice? Device => Registration?.Device;
+
+    /// <summary>
+    /// Gets the key <see cref="Registration"/> is filed under, or <c>null</c> when the attempt was
+    /// canceled.
+    /// </summary>
+    public string? Key => Registration?.Key;
+
+    /// <summary>
+    /// Gets a value indicating whether the attempt added the device that was passed in, as opposed
+    /// to rejecting it in favor of an existing registration or canceling.
+    /// </summary>
+    public bool IsRegistered =>
+        Outcome is DeviceRegistrationOutcome.Registered or DeviceRegistrationOutcome.ReplacedExisting;
+
+    /// <summary>
+    /// Gets a value indicating whether a duplicate of the device was already in the live set,
+    /// whichever connection ended up winning.
+    /// </summary>
+    public bool WasDuplicate =>
+        Outcome is DeviceRegistrationOutcome.ReplacedExisting
+            or DeviceRegistrationOutcome.DuplicateRejected
+            or DeviceRegistrationOutcome.Canceled;
+}

--- a/src/Daqifi.Core/Device/DeviceRegistryEventArgs.cs
+++ b/src/Daqifi.Core/Device/DeviceRegistryEventArgs.cs
@@ -1,0 +1,82 @@
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// Why a device left a <see cref="DaqifiDeviceRegistry"/>.
+/// </summary>
+public enum DeviceRemovalReason
+{
+    /// <summary>
+    /// The caller removed it explicitly.
+    /// </summary>
+    Removed,
+
+    /// <summary>
+    /// It was dropped in favor of a duplicate connection to the same physical unit, because the
+    /// duplicate policy returned <see cref="DuplicateDeviceAction.SwitchToNew"/>.
+    /// </summary>
+    Replaced,
+
+    /// <summary>
+    /// The registry found the device no longer reporting <see cref="DaqifiDevice.IsConnected"/>
+    /// (unplugged, rebooted, or dropped by the transport) and pruned the stale registration.
+    /// </summary>
+    Disconnected,
+
+    /// <summary>
+    /// The whole live set was cleared by <see cref="DaqifiDeviceRegistry.Clear"/>.
+    /// </summary>
+    Cleared
+}
+
+/// <summary>
+/// Event data for <see cref="DaqifiDeviceRegistry.DeviceAdded"/>.
+/// </summary>
+public sealed class DeviceRegisteredEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeviceRegisteredEventArgs"/> class.
+    /// </summary>
+    /// <param name="registration">The registration that was added.</param>
+    public DeviceRegisteredEventArgs(DeviceRegistration registration)
+    {
+        Registration = registration;
+    }
+
+    /// <summary>
+    /// Gets the registration that was added to the live set.
+    /// </summary>
+    public DeviceRegistration Registration { get; }
+}
+
+/// <summary>
+/// Event data for <see cref="DaqifiDeviceRegistry.DeviceRemoved"/>.
+/// </summary>
+/// <remarks>
+/// The registry disconnects and disposes the device before raising this event, so subscribers must
+/// treat <see cref="DeviceRegistration.Device"/> as a dead handle — read its
+/// <see cref="DaqifiDevice.Name"/> or <see cref="DeviceRegistration.Identity"/> for a message, but
+/// do not send to it.
+/// </remarks>
+public sealed class DeviceRemovedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeviceRemovedEventArgs"/> class.
+    /// </summary>
+    /// <param name="registration">The registration that was removed.</param>
+    /// <param name="reason">Why it was removed.</param>
+    public DeviceRemovedEventArgs(DeviceRegistration registration, DeviceRemovalReason reason)
+    {
+        Registration = registration;
+        Reason = reason;
+    }
+
+    /// <summary>
+    /// Gets the registration that was removed from the live set.
+    /// </summary>
+    public DeviceRegistration Registration { get; }
+
+    /// <summary>
+    /// Gets why the device was removed.
+    /// </summary>
+    public DeviceRemovalReason Reason { get; }
+}

--- a/src/Daqifi.Core/Device/DuplicateDeviceCheck.cs
+++ b/src/Daqifi.Core/Device/DuplicateDeviceCheck.cs
@@ -16,7 +16,9 @@ public enum DuplicateDeviceAction
 
     /// <summary>
     /// Drop the already-registered connection (disconnecting and disposing it) and continue with
-    /// the new one.
+    /// the new one. The existing connection is not dropped until the new one is actually open, so
+    /// a replacement that fails to connect leaves the original in place rather than costing the
+    /// caller both.
     /// </summary>
     SwitchToNew,
 

--- a/src/Daqifi.Core/Device/DuplicateDeviceCheck.cs
+++ b/src/Daqifi.Core/Device/DuplicateDeviceCheck.cs
@@ -1,0 +1,108 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// The action a <see cref="DaqifiDeviceRegistry.DuplicatePolicy"/> takes when the registry is asked
+/// to register a device that is already in the live set under a different transport.
+/// </summary>
+public enum DuplicateDeviceAction
+{
+    /// <summary>
+    /// Keep the already-registered connection and reject the new one. This is the default when no
+    /// policy is supplied.
+    /// </summary>
+    KeepExisting,
+
+    /// <summary>
+    /// Drop the already-registered connection (disconnecting and disposing it) and continue with
+    /// the new one.
+    /// </summary>
+    SwitchToNew,
+
+    /// <summary>
+    /// Abandon the registration entirely, leaving the existing connection in place. Differs from
+    /// <see cref="KeepExisting"/> only in the reported outcome: the caller asked to cancel rather
+    /// than being handed the existing device.
+    /// </summary>
+    Cancel
+}
+
+/// <summary>
+/// When a duplicate was detected, relative to the connection attempt.
+/// </summary>
+public enum DuplicateCheckPhase
+{
+    /// <summary>
+    /// Detected from discovery metadata before the new connection was opened. Nothing has been
+    /// connected yet, so rejecting costs nothing.
+    /// </summary>
+    BeforeConnect,
+
+    /// <summary>
+    /// Detected from device metadata after the new connection was opened — the case where the
+    /// serial number only becomes known once the device answers its first status message.
+    /// </summary>
+    AfterConnect
+}
+
+/// <summary>
+/// Describes a detected duplicate: the same physical unit reached over two transports at once
+/// (typically USB and WiFi). Passed to <see cref="DaqifiDeviceRegistry.DuplicatePolicy"/> so a
+/// consumer can decide which connection wins — for example by prompting the user.
+/// </summary>
+public sealed class DuplicateDeviceCheck
+{
+    internal DuplicateDeviceCheck(
+        DeviceRegistration existing,
+        DeviceIdentity newIdentity,
+        IDeviceInfo? newDeviceInfo,
+        DaqifiDevice? newDevice,
+        ConnectionType newConnectionType,
+        DuplicateCheckPhase phase)
+    {
+        Existing = existing;
+        NewIdentity = newIdentity;
+        NewDeviceInfo = newDeviceInfo;
+        NewDevice = newDevice;
+        NewConnectionType = newConnectionType;
+        Phase = phase;
+    }
+
+    /// <summary>
+    /// Gets the registration already in the live set.
+    /// </summary>
+    public DeviceRegistration Existing { get; }
+
+    /// <summary>
+    /// Gets the identity computed for the device being registered.
+    /// </summary>
+    public DeviceIdentity NewIdentity { get; }
+
+    /// <summary>
+    /// Gets the discovery metadata the new connection was made from, or <c>null</c> when an
+    /// already-connected device was registered without it.
+    /// </summary>
+    public IDeviceInfo? NewDeviceInfo { get; }
+
+    /// <summary>
+    /// Gets the device being registered, or <c>null</c> when the duplicate was caught in
+    /// <see cref="DuplicateCheckPhase.BeforeConnect"/> and nothing has been connected yet.
+    /// </summary>
+    public DaqifiDevice? NewDevice { get; }
+
+    /// <summary>
+    /// Gets the transport the new connection uses.
+    /// </summary>
+    public ConnectionType NewConnectionType { get; }
+
+    /// <summary>
+    /// Gets the transport the existing connection uses.
+    /// </summary>
+    public ConnectionType ExistingConnectionType => Existing.ConnectionType;
+
+    /// <summary>
+    /// Gets when the duplicate was detected, relative to the new connection being opened.
+    /// </summary>
+    public DuplicateCheckPhase Phase { get; }
+}

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -9,7 +9,7 @@ namespace Daqifi.Mcp;
 /// <summary>
 /// Agent-facing facade over <c>Daqifi.Core</c>. Owns device discovery results and the set of
 /// connected devices, and translates the high-level tool surface into the real SDK calls
-/// (static <see cref="DaqifiDeviceFactory"/>, <see cref="IStreamingDevice"/> channel APIs,
+/// (<see cref="DaqifiDeviceRegistry"/>, <see cref="IStreamingDevice"/> channel APIs,
 /// <see cref="ISdCardOperations"/>). One instance is shared by all tool calls.
 /// </summary>
 /// <remarks>
@@ -17,12 +17,15 @@ namespace Daqifi.Mcp;
 /// disconnects, or mutates device state is serialized behind <see cref="_gate"/>. Read-only
 /// introspection snapshots the channel collection instead, so it never blocks and never folds the
 /// live <c>Channels</c> view while the device's consumer thread repopulates it.
+/// The live set of connections is owned by a <see cref="DaqifiDeviceRegistry"/> keyed by our own
+/// <c>device_id</c>, which also supplies stale-handle pruning, disposal, and cross-transport
+/// duplicate detection (the same unit reached over both USB and WiFi).
 /// </remarks>
 public sealed class DaqifiAgent
 {
     private readonly ServerOptions _options;
     private readonly ConcurrentDictionary<string, IDeviceInfo> _discovered = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, DaqifiDevice> _connected = new(StringComparer.Ordinal);
+    private readonly DaqifiDeviceRegistry _registry = new();
     private readonly SemaphoreSlim _gate = new(1, 1);
 
     public DaqifiAgent(ServerOptions options) => _options = options;
@@ -61,35 +64,37 @@ public sealed class DaqifiAgent
 
     // ------------------------------------------------------------- connection
 
+    /// <summary>
+    /// Connects to a discovered device and files it in the registry under its <c>device_id</c>.
+    /// Reconnecting an id that is already live (or connecting a second transport to a device that
+    /// is already connected) is not an error: the registry's default duplicate policy hands back
+    /// the existing connection, whose id is the one returned — so always use the returned
+    /// <c>device_id</c> for follow-up calls rather than assuming it is the one passed in.
+    /// </summary>
     public async Task<ConnectedDeviceInfo> ConnectAsync(string deviceId, CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (_connected.TryGetValue(deviceId, out var already))
-            {
-                if (already.IsConnected)
-                {
-                    return ConnectedDeviceInfo.From(deviceId, already);
-                }
-
-                // Stale handle (device dropped); discard it and reconnect.
-                _connected.TryRemove(new KeyValuePair<string, DaqifiDevice>(deviceId, already));
-                already.Dispose();
-            }
-
             if (!_discovered.TryGetValue(deviceId, out var info))
             {
                 throw new InvalidOperationException(
                     $"Unknown device_id '{deviceId}'. Call discover_devices first and use a device_id from its result.");
             }
 
-            var device = await DaqifiDeviceFactory
-                .ConnectFromDeviceInfoAsync(info, null, cancellationToken)
+            // The registry prunes stale handles (device dropped since it was registered) before
+            // the duplicate check, so a dropped device reconnects instead of returning a dead one.
+            var result = await _registry
+                .ConnectAsync(info, deviceId, options: null, cancellationToken)
                 .ConfigureAwait(false);
 
-            _connected[deviceId] = device;
-            return ConnectedDeviceInfo.From(deviceId, device);
+            if (result.Registration is null)
+            {
+                throw new InvalidOperationException(
+                    $"Connection to '{deviceId}' was canceled by the duplicate-device policy.");
+            }
+
+            return ConnectedDeviceInfo.From(result.Registration.Key, result.Registration.Device);
         }
         finally
         {
@@ -102,13 +107,10 @@ public sealed class DaqifiAgent
         await _gate.WaitAsync().ConfigureAwait(false);
         try
         {
-            if (_connected.TryRemove(deviceId, out var device))
-            {
-                try { device.Disconnect(); } catch { /* best effort */ }
-                device.Dispose();
-                return $"Disconnected '{deviceId}'.";
-            }
-            return $"Device '{deviceId}' was not connected.";
+            // Remove owns the teardown: disconnect then dispose.
+            return _registry.Remove(deviceId)
+                ? $"Disconnected '{deviceId}'."
+                : $"Device '{deviceId}' was not connected.";
         }
         finally
         {
@@ -117,7 +119,7 @@ public sealed class DaqifiAgent
     }
 
     public IReadOnlyList<ConnectedDeviceInfo> ListConnected() =>
-        _connected.Select(kvp => ConnectedDeviceInfo.From(kvp.Key, kvp.Value)).ToList();
+        _registry.Devices.Select(r => ConnectedDeviceInfo.From(r.Key, r.Device)).ToList();
 
     // ----------------------------------------------------------- introspection
 
@@ -419,21 +421,20 @@ public sealed class DaqifiAgent
         await _gate.WaitAsync().ConfigureAwait(false);
         try
         {
-            foreach (var device in _connected.Values)
+            foreach (var registration in _registry.Devices)
             {
                 try
                 {
-                    if (device is ISdCardOperations { IsLoggingToSdCard: true } sd)
+                    if (registration.Device is ISdCardOperations { IsLoggingToSdCard: true } sd)
                     {
                         await sd.StopSdCardLoggingAsync().ConfigureAwait(false);
                     }
                 }
                 catch { /* best effort */ }
-
-                try { device.Disconnect(); } catch { /* best effort */ }
-                device.Dispose();
             }
-            _connected.Clear();
+
+            // Clear disconnects and disposes every registered device.
+            _registry.Clear();
         }
         finally
         {
@@ -445,19 +446,19 @@ public sealed class DaqifiAgent
 
     private DaqifiDevice Require(string deviceId)
     {
-        if (!_connected.TryGetValue(deviceId, out var device))
+        if (!_registry.TryGet(deviceId, out var registration))
         {
             throw new InvalidOperationException(
                 $"Device '{deviceId}' is not connected. Call connect_device first.");
         }
-        if (!device.IsConnected)
+        if (!registration!.Device.IsConnected)
         {
-            // Only evict the exact stale instance we inspected (a concurrent reconnect may have
-            // already replaced it with a live one under the same id).
-            _connected.TryRemove(new KeyValuePair<string, DaqifiDevice>(deviceId, device));
+            // Evict by reference so only the exact stale instance we inspected is removed: a
+            // concurrent reconnect may already have replaced it with a live one under the same id.
+            _registry.Remove(registration.Device);
             throw new InvalidOperationException($"Device '{deviceId}' is no longer connected.");
         }
-        return device;
+        return registration.Device;
     }
 
     private (DaqifiDevice device, IStreamingDevice streaming) RequireStreaming(string deviceId)

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -25,7 +25,7 @@ public static class DaqifiTools
         => GuardAsync(() => agent.DiscoverAsync(timeoutMs, wifi, serial, cancellationToken));
 
     [McpServerTool(Name = "connect_device")]
-    [Description("Connect to a previously-discovered device. Pass a device_id from discover_devices. Channels are populated on connect.")]
+    [Description("Connect to a previously-discovered device. Pass a device_id from discover_devices. Channels are populated on connect. If that physical device is already connected (including over a different transport), the existing connection is returned — use the device_id from the result for follow-up calls.")]
     public static Task<ConnectedDeviceInfo> ConnectDevice(
         DaqifiAgent agent,
         [Description("The device_id from discover_devices.")] string deviceId,


### PR DESCRIPTION
Closes #380.

## The problem, plainly

A DAQiFi box can be reached two ways at the same time — plugged in over USB *and* sitting on the WiFi network. To discovery those look like two completely different devices: one has a COM port, the other has an IP address. Nothing in Core knew they were the same physical unit.

So an app would happily connect to both, and the user would end up with one box showing up twice in their device list, two connections competing for the same hardware, and duplicated data. The desktop app hit this in the field and solved it in its own UI layer. Every other consumer had to solve it again — the in-repo MCP server hand-rolled two `ConcurrentDictionary`s plus its own stale-handle eviction, and still had no cross-transport detection at all.

This PR moves that whole layer into Core.

## What a user experiences now

**"I plugged it in, and it's also on WiFi."** The second connection is recognized as the same box *before* anything is opened. The app hands back the connection it already has instead of making a second one. By default the existing connection quietly wins; if the app wants to ask the user ("It's connected over USB — switch to WiFi?"), it can, and the answer can be *keep*, *switch*, or *cancel*.

**"Switch this to WiFi."** The new connection is opened first, and only then is the old one dropped. If the WiFi address turns out not to answer, the user keeps the USB session they had instead of ending up with nothing. (This is a bug this PR originally shipped with — see Findings below.)

**"I'm done with this device."** Removing it disconnects and disposes it properly, and the serial port is actually released — verified by reconnecting to the same port immediately afterward.

**Talking to the MCP agent.** The one place with visible behavior change today. Before, asking the agent to connect to a device already connected under a different id opened a redundant second connection. Now it returns the live one and tells the agent which id to use going forward.

For the desktop app nothing changes *yet* — it still has its own `ConnectionManager`. This is the Core layer it migrates onto, which is the point: that logic stops being desktop-only and stops being reimplemented per consumer.

## What a developer writes

Before, you tracked devices yourself:

```csharp
var connected = new ConcurrentDictionary<string, DaqifiDevice>();
// ...plus your own duplicate check, stale eviction, and disposal
```

Now:

```csharp
using var registry = new DaqifiDeviceRegistry();
registry.DeviceAdded   += (_, e) => list.Add(e.Registration);
registry.DeviceRemoved += (_, e) => list.Remove(e.Registration);   // e.Reason says why

var result = await registry.ConnectAsync(info);
if (result.Outcome == DeviceRegistrationOutcome.DuplicateRejected)
    log($"Already connected as {result.Key}");
```

The registry owns the devices — it disconnects and disposes anything it removes or rejects, so you never double-dispose or leak a port.

## How it works

| Type | Role |
|---|---|
| `DaqifiDeviceRegistry` | The live set: add/remove events, `ConnectAsync`/`Register`/`Remove`/`Clear`, stale pruning |
| `DeviceIdentity` | Fingerprint of a physical unit: serial number → MAC → USB `LocationKey` |
| `DuplicateDeviceCheck` / `DuplicateDeviceAction` | The policy callback's input, and its `KeepExisting`/`SwitchToNew`/`Cancel` answer |
| `DeviceRegistration` / `DeviceRegistrationResult` | An entry in the set, and how an attempt ended |

**Two concepts kept deliberately separate.** A *key* is the handle you look a device up by; it defaults to the identity key, but a consumer that already mints its own device ids (the MCP server, a UI list) can supply one. An *identity* is only ever used for duplicate detection.

**Identity matching** is decided by the first discriminator *both* sides report. Serial numbers compare case-insensitively and decisively — different serials are different boxes, whatever a weaker discriminator says. MAC comparison ignores separators. The USB location key is the last resort for identical units reporting no serial. A device reporting none of the three never matches another, so two unidentifiable devices stay two devices — the worst possible failure here would be silently merging two real boxes into one.

**The check runs twice**: pre-connect from `IDeviceInfo` (free to reject — nothing is open yet) and again post-connect from `DeviceMetadata`, because a serial-port device's serial number is often only known once it has answered its first status message. That mirrors desktop's `ConnectionManager.cs:95` / `:131` pair.

## Deltas from the desktop reference implementation

- The policy is consulted on the **post-connect** check too (desktop rejects unconditionally there), so `SwitchToNew` works when the duplicate is only discoverable after connecting.
- An existing entry under the requested **key** also counts as a duplicate hit. That is what lets the MCP server's stale-handle/reconnect logic disappear.
- The policy is always invoked **without the registry lock held**, so a policy that blocks on a user prompt never blocks other threads — and it is asked once per connection attempt, not twice.
- `SwitchToNew` **opens the replacement before dropping the original** (desktop drops first).
- The registry **owns disposal** of everything it removes, prunes, or rejects.

## MCP server

`_connected`, the stale-handle eviction, and the disposal paths collapse onto the registry. `_discovered` and `_gate` stay (the latter pending #342). `connect_device` now returns the id of the connection that *won*, so an agent reconnecting a unit already live on another transport is handed that connection instead of opening a redundant second one — the tool description says so.

## Testing

Unit: ports of desktop's `DuplicateDeviceDetectionTests` cases, plus identity fallbacks, both check phases, every policy action, `SwitchToNew` ordering, events, key minting, pruning, disposal ownership, and concurrency. Full suite green on net9.0 and net10.0 (1819 Core + 23 MCP).

Hardware, against a Nyquist 1 (fw 3.7.2) reachable over USB and WiFi at once — full detail in the [validation comment](https://github.com/daqifi/daqifi-core/pull/381#issuecomment-5047802245):

| Scenario | Result |
|---|---|
| USB connect | `Registered`, MAC merged in from post-connect metadata, 32 channels |
| Same unit on WiFi, default policy | `DuplicateRejected`, same handle, no TCP connection opened |
| `SwitchToNew` | `ReplacedExisting` — TCP opened first, then USB dropped; new transport live |
| Serial port after the switch | free, reconnects immediately |
| USB attempted while WiFi is live | `DuplicateRejected` (reverse direction) |
| MCP agent end to end | connect, reconnect-reuse, cross-transport reuse, disconnect, actionable errors, shutdown |

## Findings the hardware testing produced

**1. `SwitchToNew` could lose a working connection** — fixed in 0a59df3. The pre-connect check dropped the existing registration *before* opening the replacement, so when a WiFi TCP connect timed out the registry was left empty and the exception escaped: a user clicking "switch to WiFi" lost their healthy USB session. Now the approved replacement is recorded and the drop deferred until the new connection is live. The unit tests were structurally blind to this — every one used a stub connector that always succeeded. Trade-off: switching to a connection needing the same resource the old one holds now fails rather than freeing it first; that case is degenerate (a dead handle is pruned before the check, and forcing a fresh connection to a port you already hold is `Remove()` then `ConnectAsync()`), and it beats losing a live connection.

**2. Core never notices a physical USB unplug** — filed as #382, pre-existing and out of scope here. `SerialStreamTransport.IsConnected` is the OS handle's `IsOpen`, which stays true after the cable is pulled; consumer read failures and producer write failures never feed back into transport status. So `ConnectionStatus.Lost` is unreachable over serial, and this registry's stale pruning cannot fire for an unplug. Behavior is unchanged from the MCP server's previous tracking, which gated on the same flag — but the docs now state the limit plainly instead of implying pruning covers it. It is a hard blocker for #379.

## Scope

MVP per the issue: registry + duplicate policy. Automatic reconnect stays with #379, per-device operation serialization with #342, and the registry surfaces whatever type the factory settles on in #333. Aggregate status strings and UI concerns stay in consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)