### PR TITLE
fix(transport): bound TCP reads so connect can't fail on a live consumer thread (closes #383)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerIntegrationTests.cs
@@ -351,8 +351,11 @@ public class StreamMessageConsumerIntegrationTests
         // The reader is stuck in Read, so a bounded stop can't join it.
         Assert.False(consumer.StopSafely(100));
 
-        // A second Start must not create a concurrent reader against the same stream.
-        var ex = Assert.Throws<InvalidOperationException>(() => consumer.Start());
+        // A second Start must not create a concurrent reader against the same stream. The refusal
+        // is typed (issue #383) so a caller that owns the consumer can recover by discarding this
+        // instance, while still deriving from InvalidOperationException for existing catch sites.
+        var ex = Assert.Throws<ConsumerThreadNotExitedException>(() => consumer.Start());
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
         Assert.Contains("not yet exited", ex.Message);
 
         // Cleanup: release the reader so the background thread can exit.

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -98,6 +98,56 @@ public class StreamMessageConsumerStallingReaderTests
     }
 
     [Fact]
+    public void Start_RacedByTwoCallersDuringGrace_SpawnsOnlyOneReader()
+    {
+        // The grace period widened an existing window: two callers restarting concurrently could
+        // both observe a cleared running flag, both wait out the grace, and then each spawn a
+        // reader — two Stream.Read loops on one stream. Start() serializes the whole transition,
+        // so exactly one replacement reader may exist.
+        //
+        // Driven through the grace window deliberately: both callers are parked in the stale-thread
+        // join when that thread is released, which is the widest the race ever gets.
+        using var stream = new ThreadCountingStallingStream();
+        using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+
+        consumer.Start();
+        Assert.True(stream.WaitForReadEntered(TimeSpan.FromSeconds(2)));
+        Assert.False(consumer.StopSafely(timeoutMs: 100));
+
+        using var bothInStart = new CountdownEvent(2);
+        var failures = new List<Exception>();
+        var starters = Enumerable.Range(0, 2).Select(_ => new Thread(() =>
+        {
+            bothInStart.Signal();
+            try
+            {
+                consumer.Start();
+            }
+            catch (Exception ex)
+            {
+                lock (failures) { failures.Add(ex); }
+            }
+        })).ToArray();
+
+        foreach (var t in starters) t.Start();
+        Assert.True(bothInStart.Wait(TimeSpan.FromSeconds(5)));
+
+        // Release the stale reader so both racers' grace joins complete at essentially the same
+        // moment — the worst case for the race.
+        Thread.Sleep(50);
+        stream.Release();
+
+        foreach (var t in starters) Assert.True(t.Join(TimeSpan.FromSeconds(10)));
+        Assert.True(consumer.StopSafely(timeoutMs: 2000));
+
+        // One original reader plus at most one replacement. Three distinct reader threads means
+        // two were spawned concurrently against the same stream.
+        Assert.True(
+            stream.DistinctReaderCount <= 2,
+            $"{stream.DistinctReaderCount} distinct reader threads touched the stream; at most 2 (original + one replacement) is correct. Failures: {failures.Count}");
+    }
+
+    [Fact]
     public void Start_CalledFromMessageReceivedCallbackAfterStop_RefusesWithoutSelfJoin()
     {
         // MessageReceived callbacks run on the consumer thread, so a handler can call Start() after
@@ -285,13 +335,75 @@ public class StreamMessageConsumerStallingReaderTests
     }
 
     /// <summary>
+    /// Blocks the first reader until released, and records how many distinct threads have entered
+    /// <see cref="Read(byte[], int, int)"/> — the observable signature of a double-start.
+    /// </summary>
+    private sealed class ThreadCountingStallingStream : Stream
+    {
+        private readonly ManualResetEventSlim _release = new(false);
+        private readonly ManualResetEventSlim _readEntered = new(false);
+        private readonly HashSet<int> _readerThreadIds = [];
+
+        public int DistinctReaderCount
+        {
+            get { lock (_readerThreadIds) { return _readerThreadIds.Count; } }
+        }
+
+        public bool WaitForReadEntered(TimeSpan timeout) => _readEntered.Wait(timeout);
+
+        public void Release() => _release.Set();
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            lock (_readerThreadIds)
+            {
+                _readerThreadIds.Add(Environment.CurrentManagedThreadId);
+            }
+
+            _readEntered.Set();
+            if (!_release.IsSet)
+            {
+                _release.Wait(TimeSpan.FromSeconds(10));
+            }
+            else
+            {
+                Thread.Sleep(10);
+            }
+
+            return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _release.Set();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
     /// Emits one payload on the first read so exactly one MessageReceived callback fires, then
     /// idles. Used to drive a handler that runs on the consumer thread.
     /// </summary>
     private sealed class SingleLineThenIdleStream : Stream
     {
         private readonly byte[] _payload;
-        private bool _sent;
+        private int _offset;
 
         public SingleLineThenIdleStream(string text) => _payload = Encoding.UTF8.GetBytes(text);
 
@@ -305,15 +417,19 @@ public class StreamMessageConsumerStallingReaderTests
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            if (_sent)
+            var remaining = _payload.Length - _offset;
+            if (remaining <= 0)
             {
                 Thread.Sleep(10);
                 return 0;
             }
 
-            _sent = true;
-            Array.Copy(_payload, 0, buffer, offset, _payload.Length);
-            return _payload.Length;
+            // Honor count: Stream.Read may never return more than the caller asked for, so serve
+            // the payload across as many partial reads as it takes.
+            var toCopy = Math.Min(count, remaining);
+            Array.Copy(_payload, _offset, buffer, offset, toCopy);
+            _offset += toCopy;
+            return toCopy;
         }
 
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -15,28 +15,46 @@ namespace Daqifi.Core.Tests.Communication.Consumers;
 public class StreamMessageConsumerStallingReaderTests
 {
     [Fact]
-    public void Start_AfterStalledReaderExits_Succeeds()
+    public void Start_WhenStoppedReaderExitsWithinGrace_WaitsAndRestartsSameInstance()
     {
-        // The double-reader refusal is transient, not terminal: once the in-flight read returns,
-        // the reader observes the cleared running flag and exits, so a restart on the same
-        // instance is allowed again. This is what makes the short operational read timeout on the
-        // TCP transport sufficient to keep the connect-time swap out of the guard (issue #383).
-        using var stream = new StallingStream(TimeSpan.FromSeconds(5));
+        // The #383 recovery: a reader that outlives the stop budget but does return is absorbed by
+        // Start()'s grace period, so the restart succeeds on the SAME instance. That is what makes
+        // a bounded read timeout sufficient, and it means no second reader is ever put on the
+        // stream. Release() lands while Start() is already waiting.
+        using var stream = new StallingStream(Timeout.InfiniteTimeSpan);
         using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
 
         consumer.Start();
         Assert.True(stream.WaitForReadEntered(TimeSpan.FromSeconds(2)));
         Assert.False(consumer.StopSafely(timeoutMs: 200));
+
+        using (var releaser = new Timer(_ => stream.Release(), null, 200, Timeout.Infinite))
+        {
+            consumer.Start();
+        }
+
+        Assert.True(consumer.IsRunning);
+        Assert.True(consumer.StopSafely(timeoutMs: 2000));
+    }
+
+    [Fact]
+    public void Start_WhenStoppedReaderNeverExits_StillRefusesASecondReader()
+    {
+        // A read that never returns means the stream is stuck. The guard must outlast the grace
+        // period — a second reader on that stream is exactly the framing corruption it prevents.
+        using var stream = new StallingStream(Timeout.InfiniteTimeSpan);
+        using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+
+        consumer.Start();
+        Assert.True(stream.WaitForReadEntered(TimeSpan.FromSeconds(2)));
+        Assert.False(consumer.StopSafely(timeoutMs: 200));
+
         Assert.Throws<ConsumerThreadNotExitedException>(() => consumer.Start());
+        Assert.False(consumer.IsRunning);
         Assert.Equal(1, stream.ReadCount);
 
         stream.Release();
-        // The stop path already cleared IsRunning, so the reader exits after this read returns.
         Assert.True(WaitUntil(() => !IsConsumerThreadAlive(consumer), TimeSpan.FromSeconds(2)));
-
-        consumer.Start();
-        Assert.True(consumer.IsRunning);
-        Assert.True(consumer.StopSafely(timeoutMs: 2000));
     }
 
     [Fact]
@@ -98,7 +116,8 @@ public class StreamMessageConsumerStallingReaderTests
                 MaxAttempts = 1,
                 ConnectionTimeout = TimeSpan.FromSeconds(10)
             });
-            using var accepted = await listener.AcceptTcpClientAsync();
+            // Bounded so a fixture failure fails fast instead of hanging the suite.
+            using var accepted = await listener.AcceptTcpClientAsync().WaitAsync(TimeSpan.FromSeconds(10));
 
             using var consumer = new StreamMessageConsumer<string>(transport.Stream, new LineBasedMessageParser());
             var errors = new List<Exception>();

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -148,6 +148,41 @@ public class StreamMessageConsumerStallingReaderTests
     }
 
     [Fact]
+    public void Dispose_AfterATimedOutStop_StillJoinsTheSurvivingReader()
+    {
+        // StopSafely short-circuits when the consumer is already stopped, which is precisely the
+        // state a timed-out stop leaves: running flag cleared, reader still alive in its read. So
+        // Dispose() must wait on that thread itself, or it returns while a reader still holds the
+        // stream — the owner believes teardown is complete when it isn't.
+        var stream = new ThreadCountingStallingStream();
+        var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+        try
+        {
+            consumer.Start();
+            Assert.True(stream.WaitForReadEntered(TimeSpan.FromSeconds(2)));
+
+            // Timed-out stop: _isRunning is now false but the reader is still parked in Read().
+            Assert.False(consumer.StopSafely(timeoutMs: 100));
+            Assert.True(IsConsumerThreadAlive(consumer), "precondition: the reader should still be alive");
+
+            // Let the read return, then dispose immediately — no sleep, so Dispose only sees an
+            // exited thread if it actually waited for one.
+            stream.Release();
+            consumer.Dispose();
+
+            Assert.False(
+                IsConsumerThreadAlive(consumer),
+                "Dispose() returned while the previously-stopped reader was still alive.");
+        }
+        finally
+        {
+            stream.Release();
+            consumer.Dispose();
+            stream.Dispose();
+        }
+    }
+
+    [Fact]
     public void Dispose_RacingAStartInItsGraceWindow_LeavesNoReaderRunning()
     {
         // Start() checks disposal, then can sit in the grace join for up to a second before
@@ -172,16 +207,26 @@ public class StreamMessageConsumerStallingReaderTests
             });
             starter.Start();
 
-            Thread.Sleep(100);           // let the starter reach the grace join
+            // Wait for the starter to actually block rather than sleeping a guessed interval: its
+            // only work is Start(), so WaitSleepJoin means it has reached the lock or the grace
+            // join. Deterministic, and fails fast if it never gets there.
+            Assert.True(
+                WaitUntil(() => starter.ThreadState.HasFlag(System.Threading.ThreadState.WaitSleepJoin), TimeSpan.FromSeconds(5)),
+                "starter thread never reached the grace join");
+
             stream.Release();            // its join can now complete
             consumer.Dispose();          // races the starter's publish
 
             Assert.True(starter.Join(TimeSpan.FromSeconds(10)));
 
             // The invariant, regardless of who won: nothing is still reading once Dispose returned.
+            // Assert the thread itself is gone, not merely that the running flag was cleared — a
+            // flag says nothing about whether the reader actually let go of the stream.
+            var outcome = starterFailure?.GetType().Name ?? "started";
+            Assert.False(consumer.IsRunning, $"IsRunning was still set after Dispose() (starter outcome: {outcome}).");
             Assert.False(
-                consumer.IsRunning,
-                $"A reader was running after Dispose() returned (starter outcome: {starterFailure?.GetType().Name ?? "started"}).");
+                IsConsumerThreadAlive(consumer),
+                $"A reader thread was still alive after Dispose() returned (starter outcome: {outcome}).");
         }
         finally
         {

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -4,6 +4,7 @@ using Daqifi.Core.Communication.Transport;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 
 namespace Daqifi.Core.Tests.Communication.Consumers;
 
@@ -94,6 +95,61 @@ public class StreamMessageConsumerStallingReaderTests
         Assert.True(consumer.StopSafely(timeoutMs: 2000));
 
         Assert.IsType<IOException>(captured);
+    }
+
+    [Fact]
+    public void Start_CalledFromMessageReceivedCallbackAfterStop_RefusesWithoutSelfJoin()
+    {
+        // MessageReceived callbacks run on the consumer thread, so a handler can call Start() after
+        // another thread has already cleared the running flag. The stale thread is then *us*:
+        // joining it would block for the whole grace period and refuse anyway. Refuse immediately
+        // instead, matching the self-join guard ClearBuffer already has.
+        // CRLF: LineBasedMessageParser's default line ending.
+        using var stream = new SingleLineThenIdleStream("hello\r\n");
+        using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+
+        using var handlerEntered = new ManualResetEventSlim(false);
+        using var proceed = new ManualResetEventSlim(false);
+        using var finished = new ManualResetEventSlim(false);
+        Exception? captured = null;
+        var elapsedMs = -1L;
+
+        consumer.MessageReceived += (_, _) =>
+        {
+            if (!handlerEntered.IsSet)
+            {
+                handlerEntered.Set();
+                proceed.Wait(TimeSpan.FromSeconds(5));
+
+                var stopwatch = Stopwatch.StartNew();
+                try
+                {
+                    consumer.Start();
+                }
+                catch (Exception ex)
+                {
+                    captured = ex;
+                }
+
+                stopwatch.Stop();
+                elapsedMs = stopwatch.ElapsedMilliseconds;
+                finished.Set();
+            }
+        };
+
+        consumer.Start();
+        Assert.True(handlerEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        // Another thread stops the consumer while the callback is parked, so the callback's
+        // Start() sees a cleared running flag and a still-alive consumer thread — itself.
+        Assert.False(consumer.StopSafely(timeoutMs: 100));
+        proceed.Set();
+
+        Assert.True(finished.Wait(TimeSpan.FromSeconds(5)));
+        Assert.IsType<ConsumerThreadNotExitedException>(captured);
+        Assert.True(
+            elapsedMs < 500,
+            $"Start() self-joined for {elapsedMs}ms; it must refuse immediately rather than wait out the grace period.");
     }
 
     [Fact]
@@ -226,6 +282,43 @@ public class StreamMessageConsumerStallingReaderTests
 
             base.Dispose(disposing);
         }
+    }
+
+    /// <summary>
+    /// Emits one payload on the first read so exactly one MessageReceived callback fires, then
+    /// idles. Used to drive a handler that runs on the consumer thread.
+    /// </summary>
+    private sealed class SingleLineThenIdleStream : Stream
+    {
+        private readonly byte[] _payload;
+        private bool _sent;
+
+        public SingleLineThenIdleStream(string text) => _payload = Encoding.UTF8.GetBytes(text);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_sent)
+            {
+                Thread.Sleep(10);
+                return 0;
+            }
+
+            _sent = true;
+            Array.Copy(_payload, 0, buffer, offset, _payload.Length);
+            return _payload.Length;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -148,6 +148,50 @@ public class StreamMessageConsumerStallingReaderTests
     }
 
     [Fact]
+    public void Dispose_RacingAStartInItsGraceWindow_LeavesNoReaderRunning()
+    {
+        // Start() checks disposal, then can sit in the grace join for up to a second before
+        // spawning. If Dispose() slips through in between, a reader outlives the Dispose() call —
+        // callbacks firing after teardown, against a stream the owner considers released.
+        // Dispose() marks disposal under the same lock Start() holds, so that cannot happen
+        // whichever side wins the race.
+        var stream = new ThreadCountingStallingStream();
+        var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+        try
+        {
+            consumer.Start();
+            Assert.True(stream.WaitForReadEntered(TimeSpan.FromSeconds(2)));
+            Assert.False(consumer.StopSafely(timeoutMs: 100));
+
+            // Parks inside Start()'s grace join, holding the lock.
+            Exception? starterFailure = null;
+            var starter = new Thread(() =>
+            {
+                try { consumer.Start(); }
+                catch (Exception ex) { starterFailure = ex; }
+            });
+            starter.Start();
+
+            Thread.Sleep(100);           // let the starter reach the grace join
+            stream.Release();            // its join can now complete
+            consumer.Dispose();          // races the starter's publish
+
+            Assert.True(starter.Join(TimeSpan.FromSeconds(10)));
+
+            // The invariant, regardless of who won: nothing is still reading once Dispose returned.
+            Assert.False(
+                consumer.IsRunning,
+                $"A reader was running after Dispose() returned (starter outcome: {starterFailure?.GetType().Name ?? "started"}).");
+        }
+        finally
+        {
+            stream.Release();
+            consumer.Dispose();
+            stream.Dispose();
+        }
+    }
+
+    [Fact]
     public void Start_CalledFromMessageReceivedCallbackAfterStop_RefusesWithoutSelfJoin()
     {
         // MessageReceived callbacks run on the consumer thread, so a handler can call Start() after

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -1,0 +1,246 @@
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Transport;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Daqifi.Core.Tests.Communication.Consumers;
+
+/// <summary>
+/// Regression coverage for issue #383 — a consumer whose reader thread is parked in a slow
+/// blocking read must still refuse a second reader on the same stream, and a read that merely
+/// hits the stream's configured timeout must not be reported as an error.
+/// </summary>
+public class StreamMessageConsumerStallingReaderTests
+{
+    [Fact]
+    public void Start_AfterStalledReaderExits_Succeeds()
+    {
+        // The double-reader refusal is transient, not terminal: once the in-flight read returns,
+        // the reader observes the cleared running flag and exits, so a restart on the same
+        // instance is allowed again. This is what makes the short operational read timeout on the
+        // TCP transport sufficient to keep the connect-time swap out of the guard (issue #383).
+        using var stream = new StallingStream(TimeSpan.FromSeconds(5));
+        using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+
+        consumer.Start();
+        Assert.True(stream.WaitForReadEntered(TimeSpan.FromSeconds(2)));
+        Assert.False(consumer.StopSafely(timeoutMs: 200));
+        Assert.Throws<ConsumerThreadNotExitedException>(() => consumer.Start());
+        Assert.Equal(1, stream.ReadCount);
+
+        stream.Release();
+        // The stop path already cleared IsRunning, so the reader exits after this read returns.
+        Assert.True(WaitUntil(() => !IsConsumerThreadAlive(consumer), TimeSpan.FromSeconds(2)));
+
+        consumer.Start();
+        Assert.True(consumer.IsRunning);
+        Assert.True(consumer.StopSafely(timeoutMs: 2000));
+    }
+
+    [Fact]
+    public void ProcessMessages_WhenReadTimesOutWithSocketTimeout_DoesNotReportError()
+    {
+        // A synchronous NetworkStream read that expires on SO_RCVTIMEO surfaces as
+        // IOException(SocketException TimedOut), not TimeoutException. With the short
+        // operational receive timeout now applied to TCP connections, treating that as an
+        // error would raise ErrorOccurred on every idle interval.
+        using var stream = new TimingOutStream(
+            () => new IOException("read timed out", new SocketException((int)SocketError.TimedOut)));
+        using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+
+        var errors = 0;
+        consumer.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        consumer.Start();
+        Assert.True(WaitUntil(() => stream.ReadCount >= 3, TimeSpan.FromSeconds(2)));
+        Assert.True(consumer.StopSafely(timeoutMs: 2000));
+
+        Assert.Equal(0, Volatile.Read(ref errors));
+    }
+
+    [Fact]
+    public void ProcessMessages_WhenReadFailsWithNonTimeoutIoError_StillReportsError()
+    {
+        // The benign-timeout carve-out must not swallow real I/O faults such as a reset peer.
+        using var stream = new TimingOutStream(
+            () => new IOException("connection reset", new SocketException((int)SocketError.ConnectionReset)));
+        using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+
+        Exception? captured = null;
+        consumer.ErrorOccurred += (_, e) => captured ??= e.Error;
+
+        consumer.Start();
+        Assert.True(WaitUntil(() => captured != null, TimeSpan.FromSeconds(2)));
+        Assert.True(consumer.StopSafely(timeoutMs: 2000));
+
+        Assert.IsType<IOException>(captured);
+    }
+
+    [Fact]
+    public async Task ProcessMessages_OverIdleTcpConnection_IsSilentAndStopsPromptly()
+    {
+        // End-to-end over a real socket rather than a hand-rolled exception: this pins down how
+        // *this* platform surfaces an expired SO_RCVTIMEO read, so the benign-timeout carve-out
+        // can't silently stop matching. Both halves of the #383 fix are asserted here — the idle
+        // connection must stay quiet, and the reader must be joinable well inside the 1s budget
+        // the consumer-swap path allows.
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            using var transport = new TcpStreamTransport(IPAddress.Loopback, port);
+            await transport.ConnectAsync(new ConnectionRetryOptions
+            {
+                Enabled = false,
+                MaxAttempts = 1,
+                ConnectionTimeout = TimeSpan.FromSeconds(10)
+            });
+            using var accepted = await listener.AcceptTcpClientAsync();
+
+            using var consumer = new StreamMessageConsumer<string>(transport.Stream, new LineBasedMessageParser());
+            var errors = new List<Exception>();
+            consumer.ErrorOccurred += (_, e) =>
+            {
+                lock (errors) { errors.Add(e.Error); }
+            };
+
+            consumer.Start();
+            // Long enough for several receive timeouts to expire with the peer sending nothing.
+            await Task.Delay(TcpStreamTransport.OperationalReceiveTimeoutMs * 3);
+
+            var stopwatch = Stopwatch.StartNew();
+            var stopped = consumer.StopSafely(timeoutMs: 1000);
+            stopwatch.Stop();
+
+            lock (errors)
+            {
+                Assert.True(
+                    errors.Count == 0,
+                    $"Idle TCP reads must not raise ErrorOccurred; got: {string.Join("; ", errors.Select(e => $"{e.GetType().Name}/{(e as IOException)?.InnerException?.GetType().Name}: {e.Message}"))}");
+            }
+
+            Assert.True(stopped, "A reader on an idle TCP connection must be joinable within the swap's 1s budget.");
+            Assert.True(
+                stopwatch.ElapsedMilliseconds < 1000,
+                $"Stop took {stopwatch.ElapsedMilliseconds}ms; the operational receive timeout should bound it.");
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static bool IsConsumerThreadAlive<T>(StreamMessageConsumer<T> consumer)
+    {
+        var thread = (Thread?)typeof(StreamMessageConsumer<T>)
+            .GetField("_consumerThread", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(consumer);
+        return thread is { IsAlive: true };
+    }
+
+    private static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            Thread.Sleep(10);
+        }
+
+        return condition();
+    }
+
+    /// <summary>
+    /// A stream whose <see cref="Read(byte[], int, int)"/> blocks until released or until the
+    /// supplied stall elapses — stands in for a reader parked in a blocking socket read.
+    /// </summary>
+    private sealed class StallingStream : Stream
+    {
+        private readonly TimeSpan _stall;
+        private readonly ManualResetEventSlim _release = new(false);
+        private readonly ManualResetEventSlim _readEntered = new(false);
+        private int _readCount;
+
+        public StallingStream(TimeSpan stall) => _stall = stall;
+
+        public int ReadCount => Volatile.Read(ref _readCount);
+
+        public bool WaitForReadEntered(TimeSpan timeout) => _readEntered.Wait(timeout);
+
+        public void Release() => _release.Set();
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Interlocked.Increment(ref _readCount);
+            _readEntered.Set();
+            _release.Wait(_stall);
+            return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _release.Set();
+                _release.Dispose();
+                _readEntered.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// A stream whose <see cref="Read(byte[], int, int)"/> always throws the exception produced by
+    /// the supplied factory, used to model socket read outcomes.
+    /// </summary>
+    private sealed class TimingOutStream : Stream
+    {
+        private readonly Func<Exception> _exceptionFactory;
+        private int _readCount;
+
+        public TimingOutStream(Func<Exception> exceptionFactory) => _exceptionFactory = exceptionFactory;
+
+        public int ReadCount => Volatile.Read(ref _readCount);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Interlocked.Increment(ref _readCount);
+            // A real socket read would block for the timeout interval before failing; pace the
+            // loop so the test doesn't spin a core while it waits.
+            Thread.Sleep(5);
+            throw _exceptionFactory();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/Daqifi.Core.Tests/Communication/Transport/TcpStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/TcpStreamTransportTests.cs
@@ -1,4 +1,5 @@
 using Daqifi.Core.Communication.Transport;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 
@@ -200,6 +201,49 @@ public class TcpStreamTransportTests
             // Assert
             Assert.True(transport.IsConnected);
             Assert.Contains("127.0.0.1", transport.ConnectionInfo);
+            await transport.DisconnectAsync();
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task TcpStreamTransport_ConnectAsync_LowersReceiveTimeoutToOperationalValue()
+    {
+        // Regression for issue #383: leaving the socket at the (multi-second) connection timeout
+        // meant a consumer thread parked in a blocking read could not be joined inside the
+        // consumer-swap window, so the restart hit the double-reader guard and a connect failed
+        // with "a previous consumer thread has not yet exited". The serial transport already
+        // lowers its ReadTimeout after opening; TCP must do the same.
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            using var transport = new TcpStreamTransport(IPAddress.Loopback, port);
+            var options = new ConnectionRetryOptions
+            {
+                Enabled = false,
+                MaxAttempts = 1,
+                ConnectionTimeout = TimeSpan.FromSeconds(10)
+            };
+
+            await transport.ConnectAsync(options);
+
+            Assert.True(transport.IsConnected);
+            Assert.Equal(TcpStreamTransport.OperationalReceiveTimeoutMs, transport.Stream.ReadTimeout);
+
+            // The short timeout must actually bound a blocking read of an idle connection, which
+            // is what lets StopSafely's Join succeed.
+            var stopwatch = Stopwatch.StartNew();
+            Assert.Throws<IOException>(() => transport.Stream.Read(new byte[16], 0, 16));
+            stopwatch.Stop();
+            Assert.True(
+                stopwatch.ElapsedMilliseconds < 5000,
+                $"Read should have expired near the operational timeout, took {stopwatch.ElapsedMilliseconds}ms.");
+
             await transport.DisconnectAsync();
         }
         finally

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceConsumerRestartTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceConsumerRestartTests.cs
@@ -1,0 +1,191 @@
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using Daqifi.Core.Communication.Messages;
+using System.Reflection;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Regression coverage for issue #383 — a connect must not fail with
+/// "a previous consumer thread has not yet exited". The text-exchange path stops the protobuf
+/// consumer and restarts it; when the reader is parked in a slow blocking read it can still be
+/// alive at restart time, which the consumer's double-reader guard rightly refuses. The device
+/// escalates instead of surfacing that as a connect failure.
+/// </summary>
+public class DaqifiDeviceConsumerRestartTests
+{
+    [Fact]
+    public async Task ExecuteTextCommand_WhenReaderDoesNotExitPromptly_RecoversWithFreshConsumer()
+    {
+        using var transport = new StallingReadMockTransport();
+        using var device = new ConsumerRestartTestableDevice("Stalling Device", transport);
+
+        device.Connect();
+        var original = GetMessageConsumer(device);
+        Assert.NotNull(original);
+
+        // Reader is now parked inside Read() for longer than the swap's stop budget.
+        Assert.True(transport.WaitForReadEntered(TimeSpan.FromSeconds(5)));
+
+        // Pre-fix this threw InvalidOperationException from the restart in the finally block.
+        var lines = await device.CallExecuteTextCommandAsync(() => { });
+        Assert.Empty(lines);
+
+        // The device recovered by binding a fresh consumer to the transport's current stream,
+        // and the stale instance was discarded rather than restarted.
+        var replacement = GetMessageConsumer(device);
+        Assert.NotNull(replacement);
+        Assert.NotSame(original, replacement);
+        Assert.True(replacement!.IsRunning);
+
+        transport.ReleaseReaders();
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_WhenReaderExitsPromptly_KeepsSameConsumer()
+    {
+        // The normal path is unchanged: a reader that exits within the stop budget is simply
+        // restarted, with no consumer churn.
+        using var transport = new StallingReadMockTransport(stallReads: false);
+        using var device = new ConsumerRestartTestableDevice("Prompt Device", transport);
+
+        device.Connect();
+        var original = GetMessageConsumer(device);
+        Assert.NotNull(original);
+
+        await device.CallExecuteTextCommandAsync(() => { });
+
+        var after = GetMessageConsumer(device);
+        Assert.Same(original, after);
+        Assert.True(after!.IsRunning);
+
+        device.Disconnect();
+    }
+
+    private static IMessageConsumer<DaqifiOutMessage>? GetMessageConsumer(DaqifiDevice device)
+    {
+        return (IMessageConsumer<DaqifiOutMessage>?)typeof(DaqifiDevice)
+            .GetField("_messageConsumer", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(device);
+    }
+
+    /// <summary>
+    /// Exposes the protected text-exchange entry point so the swap can be driven directly,
+    /// without needing a device that answers SCPI.
+    /// </summary>
+    private class ConsumerRestartTestableDevice : DaqifiDevice
+    {
+        public ConsumerRestartTestableDevice(string name, IStreamTransport transport)
+            : base(name, transport)
+        {
+        }
+
+        public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(Action setupAction)
+        {
+            return ExecuteTextCommandAsync(setupAction, responseTimeoutMs: 100, completionTimeoutMs: 50);
+        }
+    }
+
+    /// <summary>
+    /// Transport whose stream models a reader parked in a blocking socket read: the first read
+    /// blocks well past the consumer-swap stop budget, mirroring a WiFi connection whose receive
+    /// timeout outlasts the swap. Writes are accepted and discarded.
+    /// </summary>
+    private sealed class StallingReadMockTransport : IStreamTransport
+    {
+        private readonly StallingStream _stream;
+        private bool _isConnected;
+        private bool _disposed;
+
+        public StallingReadMockTransport(bool stallReads = true)
+        {
+            _stream = new StallingStream(stallReads ? TimeSpan.FromSeconds(10) : TimeSpan.Zero);
+        }
+
+        public Stream Stream => _disposed
+            ? throw new ObjectDisposedException(nameof(StallingReadMockTransport))
+            : _stream;
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "Stalling: Connected" : "Stalling: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        public bool WaitForReadEntered(TimeSpan timeout) => _stream.WaitForReadEntered(timeout);
+
+        public void ReleaseReaders() => _stream.Release();
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(StallingReadMockTransport));
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            _stream.Release();
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().Wait();
+
+        public void Disconnect() => DisconnectAsync().Wait();
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _isConnected = false;
+            _stream.Release();
+            _disposed = true;
+        }
+
+        private sealed class StallingStream : Stream
+        {
+            private readonly TimeSpan _stall;
+            private readonly ManualResetEventSlim _release = new(false);
+            private readonly ManualResetEventSlim _readEntered = new(false);
+
+            public StallingStream(TimeSpan stall) => _stall = stall;
+
+            public bool WaitForReadEntered(TimeSpan timeout) => _readEntered.Wait(timeout);
+
+            public void Release() => _release.Set();
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                _readEntered.Set();
+                if (_stall > TimeSpan.Zero)
+                {
+                    _release.Wait(_stall);
+                }
+                else
+                {
+                    Thread.Sleep(10);
+                }
+
+                return 0;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) { }
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceConsumerRestartTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceConsumerRestartTests.cs
@@ -15,29 +15,33 @@ namespace Daqifi.Core.Tests.Device;
 /// </summary>
 public class DaqifiDeviceConsumerRestartTests
 {
+    // Start()'s grace period is covered precisely in StreamMessageConsumerStallingReaderTests.
+    // It is deliberately not asserted from here: the text exchange's own internal delays add well
+    // over a second of slack before the restart, so any device-level attempt to isolate the grace
+    // would come down to timing tuning and would be flaky in CI.
+
     [Fact]
-    public async Task ExecuteTextCommand_WhenReaderDoesNotExitPromptly_RecoversWithFreshConsumer()
+    public async Task ExecuteTextCommand_WhenReaderNeverExits_LeavesConsumerStoppedWithoutThrowing()
     {
-        using var transport = new StallingReadMockTransport();
-        using var device = new ConsumerRestartTestableDevice("Stalling Device", transport);
+        // A stream whose read never returns at all. The guard must hold — no replacement consumer
+        // may be bound to that stuck stream, since it would be a second concurrent reader on it —
+        // but the failure must not surface as an unactionable internal error from a finally block.
+        using var transport = new StallingReadMockTransport(readBlock: Timeout.InfiniteTimeSpan);
+        using var device = new ConsumerRestartTestableDevice("Stuck Device", transport);
 
         device.Connect();
         var original = GetMessageConsumer(device);
         Assert.NotNull(original);
-
-        // Reader is now parked inside Read() for longer than the swap's stop budget.
         Assert.True(transport.WaitForReadEntered(TimeSpan.FromSeconds(5)));
 
-        // Pre-fix this threw InvalidOperationException from the restart in the finally block.
+        // Completes rather than propagating ConsumerThreadNotExitedException out of the finally.
         var lines = await device.CallExecuteTextCommandAsync(() => { });
         Assert.Empty(lines);
 
-        // The device recovered by binding a fresh consumer to the transport's current stream,
-        // and the stale instance was discarded rather than restarted.
-        var replacement = GetMessageConsumer(device);
-        Assert.NotNull(replacement);
-        Assert.NotSame(original, replacement);
-        Assert.True(replacement!.IsRunning);
+        // Same instance, left stopped — emphatically NOT a fresh consumer racing the stuck reader.
+        var after = GetMessageConsumer(device);
+        Assert.Same(original, after);
+        Assert.False(after!.IsRunning);
 
         transport.ReleaseReaders();
         device.Disconnect();
@@ -47,8 +51,8 @@ public class DaqifiDeviceConsumerRestartTests
     public async Task ExecuteTextCommand_WhenReaderExitsPromptly_KeepsSameConsumer()
     {
         // The normal path is unchanged: a reader that exits within the stop budget is simply
-        // restarted, with no consumer churn.
-        using var transport = new StallingReadMockTransport(stallReads: false);
+        // restarted, with no grace period needed.
+        using var transport = new StallingReadMockTransport(readBlock: TimeSpan.Zero);
         using var device = new ConsumerRestartTestableDevice("Prompt Device", transport);
 
         device.Connect();
@@ -89,19 +93,24 @@ public class DaqifiDeviceConsumerRestartTests
     }
 
     /// <summary>
-    /// Transport whose stream models a reader parked in a blocking socket read: the first read
-    /// blocks well past the consumer-swap stop budget, mirroring a WiFi connection whose receive
-    /// timeout outlasts the swap. Writes are accepted and discarded.
+    /// Transport whose stream models a reader parked in a blocking socket read, mirroring a WiFi
+    /// connection whose receive timeout outlasts the consumer-swap stop budget. Writes are accepted
+    /// and discarded.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="readBlock"/> selects the scenario: <see cref="TimeSpan.Zero"/> for a prompt
+    /// reader, a finite span for one that outlives the stop budget but does return, and
+    /// <see cref="Timeout.InfiniteTimeSpan"/> for a stream that is stuck outright.
+    /// </remarks>
     private sealed class StallingReadMockTransport : IStreamTransport
     {
         private readonly StallingStream _stream;
         private bool _isConnected;
         private bool _disposed;
 
-        public StallingReadMockTransport(bool stallReads = true)
+        public StallingReadMockTransport(TimeSpan readBlock)
         {
-            _stream = new StallingStream(stallReads ? TimeSpan.FromSeconds(10) : TimeSpan.Zero);
+            _stream = new StallingStream(readBlock);
         }
 
         public Stream Stream => _disposed
@@ -150,11 +159,11 @@ public class DaqifiDeviceConsumerRestartTests
 
         private sealed class StallingStream : Stream
         {
-            private readonly TimeSpan _stall;
+            private readonly TimeSpan _readBlock;
             private readonly ManualResetEventSlim _release = new(false);
             private readonly ManualResetEventSlim _readEntered = new(false);
 
-            public StallingStream(TimeSpan stall) => _stall = stall;
+            public StallingStream(TimeSpan readBlock) => _readBlock = readBlock;
 
             public bool WaitForReadEntered(TimeSpan timeout) => _readEntered.Wait(timeout);
 
@@ -171,13 +180,14 @@ public class DaqifiDeviceConsumerRestartTests
             public override int Read(byte[] buffer, int offset, int count)
             {
                 _readEntered.Set();
-                if (_stall > TimeSpan.Zero)
+                if (_readBlock == TimeSpan.Zero)
                 {
-                    _release.Wait(_stall);
+                    Thread.Sleep(10);
                 }
                 else
                 {
-                    Thread.Sleep(10);
+                    // Infinite means "stuck stream": only an explicit Release() ever frees it.
+                    _release.Wait(_readBlock);
                 }
 
                 return 0;

--- a/src/Daqifi.Core/Communication/Consumers/ConsumerThreadNotExitedException.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ConsumerThreadNotExitedException.cs
@@ -7,9 +7,15 @@ namespace Daqifi.Core.Communication.Consumers;
 /// </summary>
 /// <remarks>
 /// Derives from <see cref="InvalidOperationException"/> so existing callers that catch the broader
-/// type keep working; the distinct type lets callers that own the consumer recover by abandoning
-/// the stale instance and constructing a fresh one against the current stream, rather than
-/// surfacing an unactionable internal error (issue #383).
+/// type keep working; the distinct type lets callers recognize this specific condition rather than
+/// pattern-matching on a message (issue #383).
+/// <para>
+/// <see cref="StreamMessageConsumer{T}.Start"/> only raises this after waiting a grace period for
+/// the stopped reader to exit, so it means the reader's read is not returning at all — the stream
+/// itself is stuck. Constructing a fresh consumer against that same stream is <b>not</b> a valid
+/// recovery: it would be a second concurrent reader on it, which is the framing corruption the
+/// guard prevents, and it would block on the stuck stream just the same.
+/// </para>
 /// </remarks>
 public class ConsumerThreadNotExitedException : InvalidOperationException
 {

--- a/src/Daqifi.Core/Communication/Consumers/ConsumerThreadNotExitedException.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ConsumerThreadNotExitedException.cs
@@ -1,0 +1,44 @@
+namespace Daqifi.Core.Communication.Consumers;
+
+/// <summary>
+/// Thrown by <see cref="StreamMessageConsumer{T}.Start"/> when a previous consumer thread has not
+/// yet exited, so starting a new reader would put two concurrent <see cref="Stream.Read(byte[], int, int)"/>
+/// loops on the same stream.
+/// </summary>
+/// <remarks>
+/// Derives from <see cref="InvalidOperationException"/> so existing callers that catch the broader
+/// type keep working; the distinct type lets callers that own the consumer recover by abandoning
+/// the stale instance and constructing a fresh one against the current stream, rather than
+/// surfacing an unactionable internal error (issue #383).
+/// </remarks>
+public class ConsumerThreadNotExitedException : InvalidOperationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsumerThreadNotExitedException"/> class.
+    /// </summary>
+    public ConsumerThreadNotExitedException()
+        : base("Cannot start the consumer: a previous consumer thread has not yet exited.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsumerThreadNotExitedException"/> class
+    /// with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public ConsumerThreadNotExitedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsumerThreadNotExitedException"/> class
+    /// with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that caused this exception.</param>
+    public ConsumerThreadNotExitedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -480,6 +480,36 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
             _disposed = true;
         }
 
+        // StopSafely short-circuits — returning true without joining — when the consumer is already
+        // stopped. That is exactly the state a timed-out stop leaves behind: _isRunning false, the
+        // reader still alive in an in-flight read. Left as-is, Dispose would return without ever
+        // waiting on that thread. Note whether it was running so the extra wait applies only to the
+        // short-circuit case, rather than stacking a second grace on top of StopSafely's own join.
+        var wasRunning = _isRunning;
         StopSafely();
+
+        if (!wasRunning)
+        {
+            JoinStaleReader();
+        }
+    }
+
+    /// <summary>
+    /// Waits a bounded time for a stopped-but-not-yet-exited reader to finish its in-flight read
+    /// and exit.
+    /// </summary>
+    /// <remarks>
+    /// Skips the wait when called from the reader itself (for example a <see cref="Dispose"/> from
+    /// inside a <see cref="MessageReceived"/> handler), where joining would only stall that thread
+    /// until the timeout — the same self-join guard <see cref="Start"/> and <see cref="ClearBuffer"/>
+    /// carry.
+    /// </remarks>
+    private void JoinStaleReader()
+    {
+        var thread = _consumerThread;
+        if (thread is { IsAlive: true } && !ReferenceEquals(thread, Thread.CurrentThread))
+        {
+            thread.Join(StaleReaderGraceMs);
+        }
     }
 }

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -77,13 +77,32 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     public event EventHandler<MessageConsumerErrorEventArgs>? ErrorOccurred;
 
     /// <summary>
+    /// Grace period, in milliseconds, that <see cref="Start"/> waits for a stopped-but-not-yet-exited
+    /// reader thread before refusing to start.
+    /// </summary>
+    /// <remarks>
+    /// A prior stop already cleared <see cref="_isRunning"/>, so a still-alive reader is guaranteed
+    /// to be on its way out — it exits as soon as its in-flight read returns and never issues
+    /// another one. Waiting for that is therefore always correct, and it is what lets a restart
+    /// succeed on the same instance instead of failing the caller (issue #383). Only a reader whose
+    /// read never returns at all outlasts this, and that means the stream itself is stuck.
+    /// </remarks>
+    private const int StaleReaderGraceMs = 1000;
+
+    /// <summary>
     /// Starts the message consumer, beginning background message reading.
     /// </summary>
+    /// <remarks>
+    /// If a previous reader thread has been stopped but has not yet exited, this waits up to
+    /// <see cref="StaleReaderGraceMs"/> for it rather than failing immediately.
+    /// </remarks>
     /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
     /// <exception cref="ConsumerThreadNotExitedException">
-    /// Thrown when a previous consumer thread is still alive, so starting would put two concurrent
-    /// readers on the same stream. Callers that own the consumer can recover by discarding this
-    /// instance and constructing a fresh one against the current stream.
+    /// Thrown when a previous consumer thread is still alive after the grace period, so starting
+    /// would put two concurrent readers on the same stream. A reader that outlasts the grace is one
+    /// whose <see cref="Stream.Read(byte[], int, int)"/> is not returning at all, which means the
+    /// stream is stuck — constructing a fresh consumer against that same stream would not help, so
+    /// callers should surface the failure rather than start a second reader on it.
     /// </exception>
     public void Start()
     {
@@ -95,7 +114,10 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         // A prior Stop()/StopSafely() whose Join timed out leaves the old reader thread alive.
         // Refuse to spawn a second reader against the same stream/buffer — two concurrent
         // Stream.Read loops would reintroduce the framing corruption this class guards against.
-        if (_consumerThread is { IsAlive: true })
+        // The stop already cleared _isRunning, so give that reader a bounded chance to finish
+        // its in-flight read and exit before giving up on the caller.
+        var staleThread = _consumerThread;
+        if (staleThread is { IsAlive: true } && !staleThread.Join(StaleReaderGraceMs))
         {
             throw new ConsumerThreadNotExitedException();
         }

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -29,6 +29,24 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// </summary>
     private volatile bool _clearRequested;
 
+    /// <summary>
+    /// Serializes <see cref="Start"/> so the check / grace-wait / publish sequence is atomic and
+    /// only one reader thread can ever be spawned.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately <b>not</b> taken by <see cref="Stop"/> / <see cref="StopSafely"/>: those would
+    /// then block for the whole of a concurrent start's grace wait, which is the opposite of what a
+    /// stop should do. This closes the double-start hazard specifically; a caller that races
+    /// <see cref="Start"/> against a stop is asking for an ill-defined result either way.
+    /// <para>
+    /// A <see cref="MessageReceived"/> callback that calls <see cref="Start"/> while another thread
+    /// holds this lock waits, but only until that thread's grace elapses — the holder is joining the
+    /// callback's own thread, so it gives up after <see cref="StaleReaderGraceMs"/> and both callers
+    /// then refuse. Bounded, and only in an already re-entrant scenario.
+    /// </para>
+    /// </remarks>
+    private readonly object _startLock = new();
+
     private volatile bool _isRunning;
     private Thread? _consumerThread;
     private bool _disposed;
@@ -108,35 +126,42 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     {
         ThrowIfDisposed();
 
-        if (_isRunning)
-            return; // Already running
-
-        // A prior Stop()/StopSafely() whose Join timed out leaves the old reader thread alive.
-        // Refuse to spawn a second reader against the same stream/buffer — two concurrent
-        // Stream.Read loops would reintroduce the framing corruption this class guards against.
-        // The stop already cleared _isRunning, so give that reader a bounded chance to finish
-        // its in-flight read and exit before giving up on the caller.
-        //
-        // Exception: if we ARE the consumer thread (Start called from a MessageReceived callback
-        // after another thread requested stop), joining would just wait on ourselves until the
-        // grace elapses and then refuse anyway. Refuse immediately instead — same guarantee, no
-        // pointless stall on the reader thread. Mirrors the self-join guard in ClearBuffer.
-        var staleThread = _consumerThread;
-        if (staleThread is { IsAlive: true }
-            && (ReferenceEquals(staleThread, Thread.CurrentThread)
-                || !staleThread.Join(StaleReaderGraceMs)))
+        // Serialize the whole transition — check, grace wait, and publish. Without this, two
+        // callers racing a restart can both observe a cleared running flag, both wait out the
+        // grace, and then each spawn a reader: two concurrent Stream.Read loops on one stream,
+        // which is precisely what this class must never allow.
+        lock (_startLock)
         {
-            throw new ConsumerThreadNotExitedException();
+            if (_isRunning)
+                return; // Already running
+
+            // A prior Stop()/StopSafely() whose Join timed out leaves the old reader thread alive.
+            // Refuse to spawn a second reader against the same stream/buffer — two concurrent
+            // Stream.Read loops would reintroduce the framing corruption this class guards against.
+            // The stop already cleared _isRunning, so give that reader a bounded chance to finish
+            // its in-flight read and exit before giving up on the caller.
+            //
+            // Exception: if we ARE the consumer thread (Start called from a MessageReceived callback
+            // after another thread requested stop), joining would just wait on ourselves until the
+            // grace elapses and then refuse anyway. Refuse immediately instead — same guarantee, no
+            // pointless stall on the reader thread. Mirrors the self-join guard in ClearBuffer.
+            var staleThread = _consumerThread;
+            if (staleThread is { IsAlive: true }
+                && (ReferenceEquals(staleThread, Thread.CurrentThread)
+                    || !staleThread.Join(StaleReaderGraceMs)))
+            {
+                throw new ConsumerThreadNotExitedException();
+            }
+
+            _clearRequested = false;
+            _isRunning = true;
+            _consumerThread = new Thread(ProcessMessages)
+            {
+                IsBackground = true,
+                Name = $"MessageConsumer-{typeof(T).Name}"
+            };
+            _consumerThread.Start();
         }
-
-        _clearRequested = false;
-        _isRunning = true;
-        _consumerThread = new Thread(ProcessMessages)
-        {
-            IsBackground = true,
-            Name = $"MessageConsumer-{typeof(T).Name}"
-        };
-        _consumerThread.Start();
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -116,8 +116,15 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         // Stream.Read loops would reintroduce the framing corruption this class guards against.
         // The stop already cleared _isRunning, so give that reader a bounded chance to finish
         // its in-flight read and exit before giving up on the caller.
+        //
+        // Exception: if we ARE the consumer thread (Start called from a MessageReceived callback
+        // after another thread requested stop), joining would just wait on ourselves until the
+        // grace elapses and then refuse anyway. Refuse immediately instead — same guarantee, no
+        // pointless stall on the reader thread. Mirrors the self-join guard in ClearBuffer.
         var staleThread = _consumerThread;
-        if (staleThread is { IsAlive: true } && !staleThread.Join(StaleReaderGraceMs))
+        if (staleThread is { IsAlive: true }
+            && (ReferenceEquals(staleThread, Thread.CurrentThread)
+                || !staleThread.Join(StaleReaderGraceMs)))
         {
             throw new ConsumerThreadNotExitedException();
         }

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -49,7 +49,13 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
 
     private volatile bool _isRunning;
     private Thread? _consumerThread;
-    private bool _disposed;
+
+    /// <summary>
+    /// Set under <see cref="_startLock"/> by <see cref="Dispose"/>, but read from other threads
+    /// without it (<see cref="ClearBuffer"/>), so it must be volatile for those reads to be
+    /// well-defined.
+    /// </summary>
+    private volatile bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the StreamMessageConsumer class.
@@ -124,14 +130,18 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// </exception>
     public void Start()
     {
-        ThrowIfDisposed();
-
-        // Serialize the whole transition — check, grace wait, and publish. Without this, two
-        // callers racing a restart can both observe a cleared running flag, both wait out the
-        // grace, and then each spawn a reader: two concurrent Stream.Read loops on one stream,
-        // which is precisely what this class must never allow.
+        // Serialize the whole transition — disposal check, running check, grace wait, and publish.
+        // Without this, two callers racing a restart can both observe a cleared running flag, both
+        // wait out the grace, and then each spawn a reader: two concurrent Stream.Read loops on one
+        // stream, which is precisely what this class must never allow.
+        //
+        // The disposal check belongs inside the lock too. Dispose() sets _disposed under this same
+        // lock, so holding it means _disposed cannot change underneath us — checking once here is
+        // sufficient, and no reader can be spawned after disposal has begun.
         lock (_startLock)
         {
+            ThrowIfDisposed();
+
             if (_isRunning)
                 return; // Already running
 
@@ -453,12 +463,23 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// <summary>
     /// Disposes the message consumer and releases resources.
     /// </summary>
+    /// <remarks>
+    /// Marks disposal under <see cref="_startLock"/> and <em>before</em> stopping, so a concurrent
+    /// <see cref="Start"/> cannot spawn a reader that outlives this call: either it already holds
+    /// the lock (and we wait out its grace, then stop the reader it started), or it acquires the
+    /// lock afterwards and fails its disposal check. Only the flag is set under the lock — the
+    /// stop itself runs outside it, so teardown never holds the lock while joining a reader.
+    /// </remarks>
     public void Dispose()
     {
-        if (!_disposed)
+        lock (_startLock)
         {
-            StopSafely();
+            if (_disposed)
+                return;
+
             _disposed = true;
         }
+
+        StopSafely();
     }
 }

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -1,4 +1,5 @@
 using Daqifi.Core.Communication.Messages;
+using System.Net.Sockets;
 using System.Text;
 
 namespace Daqifi.Core.Communication.Consumers;
@@ -78,6 +79,12 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// <summary>
     /// Starts the message consumer, beginning background message reading.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown when this instance has been disposed.</exception>
+    /// <exception cref="ConsumerThreadNotExitedException">
+    /// Thrown when a previous consumer thread is still alive, so starting would put two concurrent
+    /// readers on the same stream. Callers that own the consumer can recover by discarding this
+    /// instance and constructing a fresh one against the current stream.
+    /// </exception>
     public void Start()
     {
         ThrowIfDisposed();
@@ -90,8 +97,7 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         // Stream.Read loops would reintroduce the framing corruption this class guards against.
         if (_consumerThread is { IsAlive: true })
         {
-            throw new InvalidOperationException(
-                "Cannot start the consumer: a previous consumer thread has not yet exited.");
+            throw new ConsumerThreadNotExitedException();
         }
 
         _clearRequested = false;
@@ -268,6 +274,14 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                     // Expected when no data is available within ReadTimeout; just loop
                     continue;
                 }
+                catch (IOException ex) when (IsReadTimeout(ex))
+                {
+                    // A socket read that hits SO_RCVTIMEO surfaces as IOException wrapping a
+                    // SocketException rather than TimeoutException, so it needs the same benign
+                    // "no data yet" treatment — otherwise every idle interval on a TCP transport
+                    // would raise ErrorOccurred (issue #383).
+                    continue;
+                }
                 catch (Exception ex)
                 {
                     OnErrorOccurred(ex);
@@ -300,6 +314,21 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                 OnErrorOccurred(ex);
             }
         }
+    }
+
+    /// <summary>
+    /// Determines whether an <see cref="IOException"/> raised by a read is just the stream's
+    /// configured read timeout expiring with no data, rather than a real I/O fault.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately narrow: only the exact shape <see cref="NetworkStream"/> produces when a
+    /// synchronous read exceeds the socket's receive timeout. Searching deeper into the cause
+    /// chain would risk classifying a genuine fault that merely happens to wrap a timeout as
+    /// "no data yet", which would silently spin instead of reporting the failure.
+    /// </remarks>
+    private static bool IsReadTimeout(IOException exception)
+    {
+        return exception.InnerException is SocketException { SocketErrorCode: SocketError.TimedOut };
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
@@ -10,6 +10,21 @@ namespace Daqifi.Core.Communication.Transport;
 /// </summary>
 public class TcpStreamTransport : IStreamTransport
 {
+    /// <summary>
+    /// Socket receive timeout applied once the connection is established, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// The connection timeout is only needed for the connect handshake and retry/backoff logic,
+    /// not for blocking reads during normal operation. Leaving the (multi-second) connect timeout
+    /// in place meant a <see cref="Consumers.StreamMessageConsumer{T}"/> reader thread parked in a
+    /// blocking <see cref="NetworkStream.Read(byte[], int, int)"/> could not be joined inside the
+    /// consumer-swap window used by the text-exchange path, which surfaced as a spurious
+    /// "a previous consumer thread has not yet exited" failure on connect (issue #383).
+    /// A short operational timeout bounds that wait, matching the serial transport's post-open
+    /// <c>ReadTimeout = 500</c>.
+    /// </remarks>
+    internal const int OperationalReceiveTimeoutMs = 500;
+
     private readonly IPEndPoint _endPoint;
     private readonly IPAddress? _localInterface;
     private TcpClient? _tcpClient;
@@ -181,6 +196,13 @@ public class TcpStreamTransport : IStreamTransport
                 }
 
                 _networkStream = _tcpClient.GetStream();
+
+                // After a successful connect, lower the receive timeout to a short operational
+                // value so consumer threads blocked in a synchronous read can always be stopped
+                // promptly (StopSafely). Only synchronous reads observe this; the async SD-card
+                // download path uses ReadAsync, which ignores SO_RCVTIMEO and keeps its own
+                // long timeout. See OperationalReceiveTimeoutMs.
+                _tcpClient.ReceiveTimeout = OperationalReceiveTimeoutMs;
             },
             onAttemptFailed: () =>
             {

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -510,19 +510,25 @@ namespace Daqifi.Core.Device
         /// Restarts the protobuf consumer after a swap (raw capture or text exchange) has stopped it.
         /// </summary>
         /// <remarks>
-        /// The stop paths join the reader thread with a bounded timeout, so a reader parked in a
-        /// slow blocking <see cref="Stream.Read(byte[], int, int)"/> can still be alive when we come
-        /// to restart. <see cref="StreamMessageConsumer{T}.Start"/> rightly refuses that — two
-        /// concurrent readers on one stream would corrupt message framing — but failing the whole
-        /// operation with an internal error the caller cannot act on is worse than recovering
-        /// (issue #383). Escalate instead: discard the stale instance and bind a fresh consumer to
-        /// the transport's current stream. The abandoned reader has already been told to stop, so it
-        /// exits as soon as its in-flight read returns and never issues another one; its events are
-        /// no longer subscribed, so anything it consumed on that last read is simply dropped.
+        /// The stop paths join the reader thread with a bounded timeout, so a reader parked in a slow
+        /// blocking <see cref="Stream.Read(byte[], int, int)"/> can still be alive here.
+        /// <see cref="StreamMessageConsumer{T}.Start"/> absorbs that case by waiting a grace period
+        /// for the stopped reader to exit, which is what keeps a normal connect from failing with
+        /// "a previous consumer thread has not yet exited" (issue #383).
         /// <para>
-        /// The consumer is snapshotted once up front: the text-exchange path holds
-        /// <c>_textExchangeLock</c> (which <see cref="Disconnect"/> also waits on), but the raw-capture
-        /// path does not, so a concurrent teardown could otherwise null the field between reads.
+        /// If it still refuses, the reader's read is not returning at all — the stream is stuck.
+        /// Deliberately do <b>not</b> recover by binding a fresh consumer to that same stream: a new
+        /// instance would be a second concurrent reader on it, which is exactly the framing
+        /// corruption the guard exists to prevent, and it would block on the stuck stream anyway.
+        /// The consumer is left stopped; the operation's own failure (or the next
+        /// <see cref="Connect"/>) surfaces the problem honestly.
+        /// </para>
+        /// <para>
+        /// Never throws: it runs from <c>finally</c> blocks, where an exception would mask the real
+        /// failure already unwinding. The consumer is also snapshotted once up front — the
+        /// text-exchange path holds <c>_textExchangeLock</c> (which <see cref="Disconnect"/> waits
+        /// on), but the raw-capture path does not, so a concurrent teardown could otherwise null the
+        /// field between reads.
         /// </para>
         /// </remarks>
         private void RestartMessageConsumerAfterSwap()
@@ -537,63 +543,19 @@ namespace Daqifi.Core.Device
             {
                 consumer.Start();
                 consumer.MessageReceived += OnInboundMessageReceived;
-                return;
             }
             catch (ConsumerThreadNotExitedException ex)
             {
-                SafeLog(() => _logger.LogWarning(
+                SafeLog(() => _logger.LogError(
                     ex,
-                    "Previous message consumer thread had not exited; replacing the consumer with a fresh instance."));
-            }
-
-            // The transport can have gone away while the swap was in flight (a concurrent
-            // Disconnect/Dispose). Nothing to rebind to in that case — leave the consumer null so
-            // the next Connect() builds one, rather than throwing from a finally block.
-            Stream? stream = null;
-            try
-            {
-                if (_transport is { IsConnected: true })
-                {
-                    stream = _transport.Stream;
-                }
-            }
-            catch (TransportNotConnectedException)
-            {
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-
-            _messageConsumer = null;
-            // Dispose does not block: the instance is already stopped, so its StopSafely
-            // short-circuits without joining the abandoned thread.
-            try
-            {
-                consumer.Dispose();
+                    "The previous message consumer thread did not exit, so the consumer was left stopped. "
+                    + "The device stream appears stuck; a reconnect is required to resume inbound messages."));
             }
             catch (Exception ex)
             {
-                SafeLog(() => _logger.LogDebug(ex, "Disposing the abandoned message consumer failed."));
-            }
-
-            if (stream == null)
-            {
-                return;
-            }
-
-            // This helper runs from finally blocks, so a failure here must not mask the exception
-            // that is already unwinding. Leaving _messageConsumer null is a recoverable state —
-            // every use site null-checks it and the next Connect() rebuilds it.
-            try
-            {
-                var replacement = new StreamMessageConsumer<DaqifiOutMessage>(stream, new ProtobufMessageParser());
-                replacement.Start();
-                replacement.MessageReceived += OnInboundMessageReceived;
-                _messageConsumer = replacement;
-            }
-            catch (Exception ex)
-            {
-                SafeLog(() => _logger.LogError(ex, "Failed to start a replacement message consumer."));
+                // e.g. ObjectDisposedException from a concurrent Dispose(). Swallow rather than let
+                // it escape a finally block and replace the operation's real exception.
+                SafeLog(() => _logger.LogError(ex, "Failed to restart the message consumer after a stream swap."));
             }
         }
 

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -519,18 +519,24 @@ namespace Daqifi.Core.Device
         /// the transport's current stream. The abandoned reader has already been told to stop, so it
         /// exits as soon as its in-flight read returns and never issues another one; its events are
         /// no longer subscribed, so anything it consumed on that last read is simply dropped.
+        /// <para>
+        /// The consumer is snapshotted once up front: the text-exchange path holds
+        /// <c>_textExchangeLock</c> (which <see cref="Disconnect"/> also waits on), but the raw-capture
+        /// path does not, so a concurrent teardown could otherwise null the field between reads.
+        /// </para>
         /// </remarks>
         private void RestartMessageConsumerAfterSwap()
         {
-            if (_messageConsumer == null)
+            var consumer = _messageConsumer;
+            if (consumer == null)
             {
                 return;
             }
 
             try
             {
-                _messageConsumer.Start();
-                _messageConsumer.MessageReceived += OnInboundMessageReceived;
+                consumer.Start();
+                consumer.MessageReceived += OnInboundMessageReceived;
                 return;
             }
             catch (ConsumerThreadNotExitedException ex)
@@ -558,13 +564,12 @@ namespace Daqifi.Core.Device
             {
             }
 
-            var stale = _messageConsumer;
             _messageConsumer = null;
             // Dispose does not block: the instance is already stopped, so its StopSafely
             // short-circuits without joining the abandoned thread.
             try
             {
-                stale.Dispose();
+                consumer.Dispose();
             }
             catch (Exception ex)
             {

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -502,12 +502,93 @@ namespace Daqifi.Core.Device
             }
             finally
             {
-                // Restart the protobuf consumer
-                if (_messageConsumer != null)
+                RestartMessageConsumerAfterSwap();
+            }
+        }
+
+        /// <summary>
+        /// Restarts the protobuf consumer after a swap (raw capture or text exchange) has stopped it.
+        /// </summary>
+        /// <remarks>
+        /// The stop paths join the reader thread with a bounded timeout, so a reader parked in a
+        /// slow blocking <see cref="Stream.Read(byte[], int, int)"/> can still be alive when we come
+        /// to restart. <see cref="StreamMessageConsumer{T}.Start"/> rightly refuses that — two
+        /// concurrent readers on one stream would corrupt message framing — but failing the whole
+        /// operation with an internal error the caller cannot act on is worse than recovering
+        /// (issue #383). Escalate instead: discard the stale instance and bind a fresh consumer to
+        /// the transport's current stream. The abandoned reader has already been told to stop, so it
+        /// exits as soon as its in-flight read returns and never issues another one; its events are
+        /// no longer subscribed, so anything it consumed on that last read is simply dropped.
+        /// </remarks>
+        private void RestartMessageConsumerAfterSwap()
+        {
+            if (_messageConsumer == null)
+            {
+                return;
+            }
+
+            try
+            {
+                _messageConsumer.Start();
+                _messageConsumer.MessageReceived += OnInboundMessageReceived;
+                return;
+            }
+            catch (ConsumerThreadNotExitedException ex)
+            {
+                SafeLog(() => _logger.LogWarning(
+                    ex,
+                    "Previous message consumer thread had not exited; replacing the consumer with a fresh instance."));
+            }
+
+            // The transport can have gone away while the swap was in flight (a concurrent
+            // Disconnect/Dispose). Nothing to rebind to in that case — leave the consumer null so
+            // the next Connect() builds one, rather than throwing from a finally block.
+            Stream? stream = null;
+            try
+            {
+                if (_transport is { IsConnected: true })
                 {
-                    _messageConsumer.Start();
-                    _messageConsumer.MessageReceived += OnInboundMessageReceived;
+                    stream = _transport.Stream;
                 }
+            }
+            catch (TransportNotConnectedException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+
+            var stale = _messageConsumer;
+            _messageConsumer = null;
+            // Dispose does not block: the instance is already stopped, so its StopSafely
+            // short-circuits without joining the abandoned thread.
+            try
+            {
+                stale.Dispose();
+            }
+            catch (Exception ex)
+            {
+                SafeLog(() => _logger.LogDebug(ex, "Disposing the abandoned message consumer failed."));
+            }
+
+            if (stream == null)
+            {
+                return;
+            }
+
+            // This helper runs from finally blocks, so a failure here must not mask the exception
+            // that is already unwinding. Leaving _messageConsumer null is a recoverable state —
+            // every use site null-checks it and the next Connect() rebuilds it.
+            try
+            {
+                var replacement = new StreamMessageConsumer<DaqifiOutMessage>(stream, new ProtobufMessageParser());
+                replacement.Start();
+                replacement.MessageReceived += OnInboundMessageReceived;
+                _messageConsumer = replacement;
+            }
+            catch (Exception ex)
+            {
+                SafeLog(() => _logger.LogError(ex, "Failed to start a replacement message consumer."));
             }
         }
 
@@ -760,11 +841,7 @@ namespace Daqifi.Core.Device
                     }
 
                     // Restart the protobuf consumer
-                    if (_messageConsumer != null)
-                    {
-                        _messageConsumer.Start();
-                        _messageConsumer.MessageReceived += OnInboundMessageReceived;
-                    }
+                    RestartMessageConsumerAfterSwap();
 
                     SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Total elapsed: {ElapsedMs}ms", sw.ElapsedMilliseconds));
                 }


### PR DESCRIPTION
Closes #383.

## What was broken

When Core connects to a device, a background thread — the "reader" — pulls bytes off the connection. During connect, Core briefly swaps that reader out: stop the protobuf reader, run some text-mode SCPI setup commands, then start it again.

To swap, it has to stop the old reader and wait for it to actually finish.

Over **USB**, `SerialStreamTransport` caps how long a single read can sit waiting — it drops `ReadTimeout` to 500 ms right after opening the port, with a comment saying exactly why:

> A short ReadTimeout ensures consumer threads can be stopped promptly (StopSafely).

Over **WiFi**, `TcpStreamTransport` never did the equivalent. The socket kept the *connection* timeout (3–10 s, from `ConnectionRetryOptions.ConnectionTimeout`). So the reader could be parked in `NetworkStream.Read` far longer than the swap was willing to wait — `StopSafely(1000)` plus `Stop()`'s `Join(1000)`, so 2 s. The swap gave up, then tried to start the new reader.

Core rightly refuses to run two readers on one stream: they'd steal bytes from each other and corrupt message framing. So it threw, and the whole connect failed with an internal message the caller could do nothing about.

That's why it was intermittent — it only failed when the device happened to be quiet at that moment. If any data arrived, the read returned instantly and everything worked. It also explains why it was only ever seen on WiFi and never on USB.

## The fix

**Give WiFi the same 500 ms cap USB always had.** That's the substance of it — the reader now always wakes within half a second, so the swap's stop budget is never exceeded and the restart succeeds.

Two supporting changes come with it:

- **Idle timeouts aren't errors.** With a short cap, an idle TCP connection times out constantly. Those surface as `IOException` wrapping `SocketException(TimedOut)`, which used to be reported through `ErrorOccurred` — measured at 3 spurious error events per 1.5 s idle. Now treated as "no data yet", the same as `TimeoutException` already was. Kept deliberately narrow (one level, the exact shape `NetworkStream` produces) so a genuine fault that merely wraps a timeout still surfaces.
- **A safety net for slow readers.** If a reader ever *is* slow to exit, `Start()` now waits up to 1 s for it rather than failing instantly. A prior stop already cleared the running flag, so that reader is guaranteed to be on its way out — waiting is always correct, and the restart then succeeds on the *same* consumer with no second reader involved.

Supporting detail: only *synchronous* reads observe the new timeout. The SD-card download path uses `ReadAsync`, which ignores `SO_RCVTIMEO` and keeps its own 30-minute timeout; firmware update runs over HID or serial, never TCP. Verified the only synchronous reads on a transport stream are inside `StreamMessageConsumer` itself.

`Start()`'s refusal is now a typed `ConsumerThreadNotExitedException` (still an `InvalidOperationException`, so existing catch sites are unaffected), and `DaqifiDevice`'s swap-restart is one helper used by both the text-exchange and raw-capture paths, which never throws — it runs from `finally` blocks, where an exception would mask the real failure.

## What changed during review

#383 suggested recovering by abandoning the consumer and building a fresh one, reasoning that *"a new instance has no shared reader state, so the double-reader hazard the guard protects against would not apply."*

**That premise is wrong, and this PR deliberately does not do it.** The hazard is the shared *stream*, not shared instance state — and the stream is unchanged here, so a fresh consumer is simply a second reader on it. Qodo flagged this on the first revision, which had implemented the issue's suggestion faithfully.

Following it through: the refusal only fires when the stale reader's read never returns, which means the stream itself is stuck — so a replacement would block on that same stuck stream anyway. **The replacement bought nothing in the only case it could trigger**, while introducing the exact corruption the guard exists to prevent.

Hence the bounded wait instead, which respects the guard by construction. If a reader still won't exit, the consumer is left stopped and the failure surfaces honestly.

The safety net also needed hardening once added — it widened three pre-existing narrow races (a self-join, a double-start, and a start-vs-dispose) from a few instructions into a full second each, making them reachable. All three are closed, each with a regression test.

## Deliberately out of scope

Three related gaps in `StreamMessageConsumer` are left alone, because each needs a decision about intended behavior rather than a mechanical fix:

- **`Stop()`/`StopSafely()` can wait on their own thread** when called from a `MessageReceived` handler. The awkward part is the return value: `StopSafely` documents true as "stopped cleanly" and false as "timed out", but in this case the stop *will* take effect as soon as the callback returns — so which is honest? Two `DaqifiDevice` call sites branch on it.
- **Start racing Stop** can leave a reader running after a `Stop()` returned. Needs a call on whether that is supported or a caller error. Note they must *not* simply go under the new start lock — a stop would then block for the whole of a concurrent start's grace wait, which is backwards.
- **`ClearBuffer()` can read the stream concurrently with a freshly started reader.** Currently theoretical: it has zero production callers inside Core.

Tracked as one follow-up so the class gets a single coherent concurrency contract, rather than being patched one spot at a time — which is what this PR ended up doing four times.

## Bench validation

Nyquist 1, fw 3.7.2, macOS, over WiFi. Builds alternated round-by-round so device drift is shared evenly between the two arms. Re-run after each rework:

| Run | pre-fix (`main`) clean | post-fix clean |
|---|---|---|
| initial | 1/6 | 6/6 |
| after recovery rework | 0/5 | 5/5 |
| after start lock | 0/4 | 4/4 |
| after dispose fix | 0/4 | 4/4 |

Every pre-fix failure is the reported error at the predicted call site:

```
System.InvalidOperationException: Cannot start the consumer: a previous consumer thread has not yet exited.
   at StreamMessageConsumer`1.Start()
   at DaqifiDevice.ExecuteTextCommandCoreAsync(...)   <-- the restart in the finally
   at DaqifiDevice.InitializeAsync(...)
   at DaqifiDeviceFactory.ConnectTcpAsync(...)
```

Also post-fix: 8/8 clean paced connects; sustained WiFi streaming at 100 Hz with zero errors (4759 samples over 60 s; 1585 over 20 s, identical before and after the start lock); and matching throughput on WiFi vs USB (632/632 vs 634 at 100 Hz over 8 s), so neither the shorter timeout nor the lock costs anything.

## Tests

Each was confirmed to **fail without** its corresponding production change:

| Test | Guards |
|---|---|
| `TcpStreamTransport_ConnectAsync_LowersReceiveTimeoutToOperationalValue` | the timeout is applied and actually bounds a blocking read |
| `ProcessMessages_OverIdleTcpConnection_IsSilentAndStopsPromptly` | end-to-end over a **real** loopback socket, pinning down how the platform surfaces an expired `SO_RCVTIMEO` read so the carve-out can't silently stop matching |
| `ProcessMessages_WhenReadTimesOutWithSocketTimeout_DoesNotReportError` / `..._WhenReadFailsWithNonTimeoutIoError_StillReportsError` | benign timeouts stay quiet; real faults still surface |
| `Start_WhenStoppedReaderExitsWithinGrace_WaitsAndRestartsSameInstance` | the grace restarts the same instance (verified failing with the grace set to 0) |
| `Start_WhenStoppedReaderNeverExits_StillRefusesASecondReader` + existing `StopSafely_StuckReader_TimesOut_AndStartRefusesSecondReader` | the guard still holds for a stuck stream |
| `Start_CalledFromMessageReceivedCallbackAfterStop_RefusesWithoutSelfJoin` | no self-join (measured 1002 ms stall without the guard) |
| `Start_RacedByTwoCallersDuringGrace_SpawnsOnlyOneReader` | no double-start (caught 3 distinct reader threads in 2 of 3 runs without the lock) |
| `Dispose_AfterATimedOutStop_StillJoinsTheSurvivingReader` | disposal waits for a reader a timed-out stop left alive (fails 3 of 3 without it) |
| `Dispose_RacingAStartInItsGraceWindow_LeavesNoReaderRunning` | no reader outlives `Dispose()` whichever side wins the race |
| `ExecuteTextCommand_WhenReaderNeverExits_LeavesConsumerStoppedWithoutThrowing` / `..._WhenReaderExitsPromptly_KeepsSameConsumer` | nothing escapes the `finally`, no second reader on a stuck stream, normal path unchanged |

The race test asserts a safety bound (at most one replacement reader), so it can only ever produce a false pass — never a spurious CI failure.

The grace period is asserted at the consumer level, where it is exact, and deliberately **not** at the device level: the text exchange's own internal delays add over a second of slack before the restart, so any device-level attempt to isolate it would come down to timing tuning and be flaky in CI.

Full suite green on net9.0 and net10.0 (1835 passed).

## Unrelated observation

The device wedged **three times** during testing — off the network entirely (100% packet loss, USB unresponsive too), needing a power cycle each time, with no self-recovery over 160 s of watching.

It tracks *cumulative* WiFi connects in a session rather than pacing alone: the first two followed unpaced rapid loops, but the third followed only 8 connects at 2 s spacing, late in a session that had already run several A/B loops and soaks. It never happened during sustained streaming (60 s and 20 s runs at 100 Hz were clean and left the device healthy every time).

A receive timeout is client-side — `recv()` returns `EAGAIN` and nothing is transmitted — so it cannot reach the device. The likeliest explanation is that post-fix connects *succeed*, exercising the firmware far more per cycle than pre-fix ones did. Flagging as a probable firmware-side limit on repeated reconnects, out of scope here.

Worth knowing for future bench work: a wedged device fails with `TimeoutException: did not report its channel configuration within 8s`, **not** with whatever bug is under test, so it can silently invalidate an A/B comparison. Check `ping` before trusting a failed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
