### PR TITLE
feat(scpi): expose per-channel ADC calibration-constant write path (closes #386)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -454,6 +454,167 @@ public class ScpiMessageProducerTests
         AssertMessageFormat(message);
     }
 
+    // ---------------------------------------------------------------------
+    // Per-channel ADC calibration-constant write path (daqifi-core#386)
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void SetAdcCalibrationSlope_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetAdcCalibrationSlope(2, 1.0025);
+        Assert.Equal("CONFigure:ADC:chanCALM 2,1.0025", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetAdcCalibrationSlope_FormatsFractionalValueWithInvariantDecimalPoint()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            // A culture whose decimal separator is a comma must not corrupt the SCPI argument.
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var message = ScpiMessageProducer.SetAdcCalibrationSlope(0, 2.5);
+            Assert.Equal("CONFigure:ADC:chanCALM 0,2.5", message.Data);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void SetAdcCalibrationSlope_WithNegativeValue_FormatsLeadingMinus()
+    {
+        var message = ScpiMessageProducer.SetAdcCalibrationSlope(1, -0.5);
+        Assert.Equal("CONFigure:ADC:chanCALM 1,-0.5", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetAdcCalibrationSlope_WithNegativeChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAdcCalibrationSlope(-1, 1.0));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void SetAdcCalibrationSlope_WithNonFiniteValue_Throws(double calM)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAdcCalibrationSlope(0, calM));
+    }
+
+    [Fact]
+    public void SetAdcCalibrationOffset_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SetAdcCalibrationOffset(3, -0.0031);
+        Assert.Equal("CONFigure:ADC:chanCALB 3,-0.0031", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetAdcCalibrationOffset_FormatsFractionalValueWithInvariantDecimalPoint()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var message = ScpiMessageProducer.SetAdcCalibrationOffset(0, 1.5);
+            Assert.Equal("CONFigure:ADC:chanCALB 0,1.5", message.Data);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void SetAdcCalibrationOffset_WithNegativeChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAdcCalibrationOffset(-1, 1.0));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void SetAdcCalibrationOffset_WithNonFiniteValue_Throws(double calB)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAdcCalibrationOffset(0, calB));
+    }
+
+    [Fact]
+    public void GetAdcCalibrationSlope_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetAdcCalibrationSlope(0);
+        Assert.Equal("CONFigure:ADC:chanCALM? 0", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void GetAdcCalibrationSlope_WithNegativeChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.GetAdcCalibrationSlope(-1));
+    }
+
+    [Fact]
+    public void GetAdcCalibrationOffset_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetAdcCalibrationOffset(5);
+        Assert.Equal("CONFigure:ADC:chanCALB? 5", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void GetAdcCalibrationOffset_WithNegativeChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.GetAdcCalibrationOffset(-1));
+    }
+
+    [Fact]
+    public void SaveFactoryAdcCalibration_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.SaveFactoryAdcCalibration;
+        Assert.Equal("CONFigure:ADC:SAVEFcal", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void LoadFactoryAdcCalibration_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.LoadFactoryAdcCalibration;
+        Assert.Equal("CONFigure:ADC:LOADFcal", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void UseAdcCalibration_ReturnsCorrectCommand(int bank)
+    {
+        var message = ScpiMessageProducer.UseAdcCalibration(bank);
+        Assert.Equal($"CONFigure:ADC:USECal {bank}", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void UseAdcCalibration_WithInvalidBank_Throws(int bank)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.UseAdcCalibration(bank));
+    }
+
+    [Fact]
+    public void GetAdcCalibrationBank_ReturnsCorrectCommand()
+    {
+        var message = ScpiMessageProducer.GetAdcCalibrationBank;
+        Assert.Equal("CONFigure:ADC:USECal?", message.Data);
+        AssertMessageFormat(message);
+    }
+
     [Fact]
     public void SetLanFirmwareUpdateMode_ReturnsCorrectCommand()
     {

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceTests.cs
@@ -164,6 +164,9 @@ namespace Daqifi.Core.Tests.Device
             yield return new object[] { "LoadAdcCalibration", "CONFigure:ADC:LOADcal" };
             yield return new object[] { "SaveVoltagePrecision", "CONFigure:VOLTage:SAVE" };
             yield return new object[] { "LoadVoltagePrecision", "CONFigure:VOLTage:LOAD" };
+            // Factory-bank persistence (daqifi-core#386).
+            yield return new object[] { "SaveFactoryAdcCalibration", "CONFigure:ADC:SAVEFcal" };
+            yield return new object[] { "LoadFactoryAdcCalibration", "CONFigure:ADC:LOADFcal" };
         }
 
         private static void InvokeNvmMethod(IStreamingDevice device, string methodName)
@@ -174,6 +177,8 @@ namespace Daqifi.Core.Tests.Device
                 case "LoadAdcCalibration": device.LoadAdcCalibration(); break;
                 case "SaveVoltagePrecision": device.SaveVoltagePrecision(); break;
                 case "LoadVoltagePrecision": device.LoadVoltagePrecision(); break;
+                case "SaveFactoryAdcCalibration": device.SaveFactoryAdcCalibration(); break;
+                case "LoadFactoryAdcCalibration": device.LoadFactoryAdcCalibration(); break;
                 default: throw new System.ArgumentOutOfRangeException(nameof(methodName), methodName, null);
             }
         }
@@ -205,6 +210,105 @@ namespace Daqifi.Core.Tests.Device
             // Act & Assert
             var exception = Assert.Throws<System.InvalidOperationException>(() => InvokeNvmMethod(device, methodName));
             Assert.Equal("Device is not connected.", exception.Message);
+        }
+
+        // ---------------------------------------------------------------------
+        // Per-channel ADC calibration-constant write path (daqifi-core#386)
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public void SetAdcCalibrationSlope_WhenConnected_SendsCorrectCommand()
+        {
+            // Arrange
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            device.SetAdcCalibrationSlope(2, 1.0025);
+
+            // Assert
+            var sentMessage = Assert.Single(device.SentMessages);
+            Assert.Equal("CONFigure:ADC:chanCALM 2,1.0025", sentMessage.Data);
+        }
+
+        [Fact]
+        public void SetAdcCalibrationOffset_WhenConnected_SendsCorrectCommand()
+        {
+            // Arrange
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            device.SetAdcCalibrationOffset(3, -0.0031);
+
+            // Assert
+            var sentMessage = Assert.Single(device.SentMessages);
+            Assert.Equal("CONFigure:ADC:chanCALB 3,-0.0031", sentMessage.Data);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void UseAdcCalibration_WhenConnected_SendsCorrectCommand(int bank)
+        {
+            // Arrange
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+
+            // Act
+            device.UseAdcCalibration(bank);
+
+            // Assert
+            var sentMessage = Assert.Single(device.SentMessages);
+            Assert.Equal($"CONFigure:ADC:USECal {bank}", sentMessage.Data);
+        }
+
+        [Fact]
+        public void SetAdcCalibrationSlope_WhenDisconnected_ThrowsInvalidOperationException()
+        {
+            var device = new DaqifiStreamingDevice("TestDevice");
+            var exception = Assert.Throws<System.InvalidOperationException>(() => device.SetAdcCalibrationSlope(0, 1.0));
+            Assert.Equal("Device is not connected.", exception.Message);
+        }
+
+        [Fact]
+        public void SetAdcCalibrationOffset_WhenDisconnected_ThrowsInvalidOperationException()
+        {
+            var device = new DaqifiStreamingDevice("TestDevice");
+            var exception = Assert.Throws<System.InvalidOperationException>(() => device.SetAdcCalibrationOffset(0, 1.0));
+            Assert.Equal("Device is not connected.", exception.Message);
+        }
+
+        [Fact]
+        public void UseAdcCalibration_WhenDisconnected_ThrowsInvalidOperationException()
+        {
+            var device = new DaqifiStreamingDevice("TestDevice");
+            var exception = Assert.Throws<System.InvalidOperationException>(() => device.UseAdcCalibration(1));
+            Assert.Equal("Device is not connected.", exception.Message);
+        }
+
+        [Fact]
+        public void SetAdcCalibrationSlope_WithNegativeChannel_ThrowsArgumentOutOfRange()
+        {
+            // Validation runs before the connection check, so a bad channel throws even when disconnected.
+            var device = new DaqifiStreamingDevice("TestDevice");
+            Assert.Throws<System.ArgumentOutOfRangeException>(() => device.SetAdcCalibrationSlope(-1, 1.0));
+        }
+
+        [Fact]
+        public void SetAdcCalibrationOffset_WithNegativeChannel_ThrowsArgumentOutOfRange()
+        {
+            var device = new DaqifiStreamingDevice("TestDevice");
+            Assert.Throws<System.ArgumentOutOfRangeException>(() => device.SetAdcCalibrationOffset(-1, 1.0));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(2)]
+        public void UseAdcCalibration_WithInvalidBank_ThrowsArgumentOutOfRange(int bank)
+        {
+            var device = new DaqifiStreamingDevice("TestDevice");
+            Assert.Throws<System.ArgumentOutOfRangeException>(() => device.UseAdcCalibration(bank));
         }
 
         /// <summary>

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2870,6 +2870,11 @@ public class FirmwareUpdateServiceTests
         public void LoadAdcCalibration() { }
         public void SaveVoltagePrecision() { }
         public void LoadVoltagePrecision() { }
+        public void SetAdcCalibrationSlope(int channelNumber, double calM) { }
+        public void SetAdcCalibrationOffset(int channelNumber, double calB) { }
+        public void SaveFactoryAdcCalibration() { }
+        public void LoadFactoryAdcCalibration() { }
+        public void UseAdcCalibration(int bank) { }
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
@@ -2961,6 +2966,11 @@ public class FirmwareUpdateServiceTests
         public void LoadAdcCalibration() { }
         public void SaveVoltagePrecision() { }
         public void LoadVoltagePrecision() { }
+        public void SetAdcCalibrationSlope(int channelNumber, double calM) { }
+        public void SetAdcCalibrationOffset(int channelNumber, double calB) { }
+        public void SaveFactoryAdcCalibration() { }
+        public void LoadFactoryAdcCalibration() { }
+        public void UseAdcCalibration(int bank) { }
         public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
             await Task.Delay(_attemptLatency, cancellationToken).ConfigureAwait(false);
@@ -3286,6 +3296,11 @@ public class FirmwareUpdateServiceTests
         public void LoadAdcCalibration() { }
         public void SaveVoltagePrecision() { }
         public void LoadVoltagePrecision() { }
+        public void SetAdcCalibrationSlope(int channelNumber, double calM) { }
+        public void SetAdcCalibrationOffset(int channelNumber, double calB) { }
+        public void SaveFactoryAdcCalibration() { }
+        public void LoadFactoryAdcCalibration() { }
+        public void UseAdcCalibration(int bank) { }
     }
 
     private sealed class FakeLanChipInfoStreamingDevice : IStreamingDevice, ILanChipInfoProvider
@@ -3390,6 +3405,11 @@ public class FirmwareUpdateServiceTests
         public void LoadAdcCalibration() { }
         public void SaveVoltagePrecision() { }
         public void LoadVoltagePrecision() { }
+        public void SetAdcCalibrationSlope(int channelNumber, double calM) { }
+        public void SetAdcCalibrationOffset(int channelNumber, double calB) { }
+        public void SaveFactoryAdcCalibration() { }
+        public void LoadFactoryAdcCalibration() { }
+        public void UseAdcCalibration(int bank) { }
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -624,23 +624,180 @@ public class ScpiMessageProducer
     // ---------------------------------------------------------------------
 
     /// <summary>
-    /// Creates a command message to persist the current ADC calibration coefficients to NVM.
+    /// Creates a command message to persist the current runtime ADC calibration coefficients to the <b>user</b> NVM bank.
     /// </summary>
     /// <remarks>
+    /// Writes every channel's live CalM/CalB (set via <see cref="SetAdcCalibrationSlope"/> /
+    /// <see cref="SetAdcCalibrationOffset"/>, which are RAM-only until saved) into the user bank. Use
+    /// <see cref="SaveFactoryAdcCalibration"/> to write the factory bank instead, and
+    /// <see cref="UseAdcCalibration"/> to choose which bank the device applies at boot.
     /// Command: CONFigure:ADC:SAVEcal
     /// Example: messageProducer.Send(ScpiMessageProducer.SaveAdcCalibration);
     /// </remarks>
     public static IOutboundMessage<string> SaveAdcCalibration => new ScpiMessage("CONFigure:ADC:SAVEcal");
 
     /// <summary>
-    /// Creates a command message to restore the ADC calibration coefficients from NVM into the runtime.
+    /// Creates a command message to restore the ADC calibration coefficients from the <b>user</b> NVM bank into the runtime.
     /// </summary>
     /// <remarks>
-    /// The inverse of <see cref="SaveAdcCalibration"/>.
+    /// The inverse of <see cref="SaveAdcCalibration"/>. Use <see cref="LoadFactoryAdcCalibration"/> to restore the
+    /// factory bank instead.
     /// Command: CONFigure:ADC:LOADcal
     /// Example: messageProducer.Send(ScpiMessageProducer.LoadAdcCalibration);
     /// </remarks>
     public static IOutboundMessage<string> LoadAdcCalibration => new ScpiMessage("CONFigure:ADC:LOADcal");
+
+    /// <summary>
+    /// Creates a command message to set a single channel's ADC calibration slope (CalM) in device RAM.
+    /// </summary>
+    /// <param name="channel">The analog input channel number.</param>
+    /// <param name="calM">The calibration slope (gain) coefficient.</param>
+    /// <remarks>
+    /// <b>RAM only.</b> This changes the live coefficient the firmware applies to incoming samples but does
+    /// <i>not</i> persist it — the value is lost on reboot unless written to an NVM bank with
+    /// <see cref="SaveAdcCalibration"/> (user bank) or <see cref="SaveFactoryAdcCalibration"/> (factory bank).
+    /// The slope is formatted with an invariant decimal point so the command is locale-independent.
+    /// Command: CONFigure:ADC:chanCALM channel,calM
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetAdcCalibrationSlope(0, 1.0025));
+    /// </remarks>
+    public static IOutboundMessage<string> SetAdcCalibrationSlope(int channel, double calM)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        if (!double.IsFinite(calM))
+        {
+            // NaN/Infinity would render as "NaN"/"Infinity" — tokens the firmware cannot parse.
+            throw new ArgumentOutOfRangeException(nameof(calM), calM, "Calibration slope must be a finite number.");
+        }
+
+        return new ScpiMessage($"CONFigure:ADC:chanCALM {channel},{calM.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    /// <summary>
+    /// Creates a command message to set a single channel's ADC calibration offset (CalB) in device RAM.
+    /// </summary>
+    /// <param name="channel">The analog input channel number.</param>
+    /// <param name="calB">The calibration offset coefficient.</param>
+    /// <remarks>
+    /// <b>RAM only.</b> This changes the live coefficient the firmware applies to incoming samples but does
+    /// <i>not</i> persist it — the value is lost on reboot unless written to an NVM bank with
+    /// <see cref="SaveAdcCalibration"/> (user bank) or <see cref="SaveFactoryAdcCalibration"/> (factory bank).
+    /// The offset is formatted with an invariant decimal point so the command is locale-independent.
+    /// Command: CONFigure:ADC:chanCALB channel,calB
+    /// Example: messageProducer.Send(ScpiMessageProducer.SetAdcCalibrationOffset(0, -0.0031));
+    /// </remarks>
+    public static IOutboundMessage<string> SetAdcCalibrationOffset(int channel, double calB)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        if (!double.IsFinite(calB))
+        {
+            // NaN/Infinity would render as "NaN"/"Infinity" — tokens the firmware cannot parse.
+            throw new ArgumentOutOfRangeException(nameof(calB), calB, "Calibration offset must be a finite number.");
+        }
+
+        return new ScpiMessage($"CONFigure:ADC:chanCALB {channel},{calB.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    /// <summary>
+    /// Creates a query message to read a channel's ADC calibration slope (CalM) currently in device RAM.
+    /// </summary>
+    /// <param name="channel">The analog input channel number.</param>
+    /// <remarks>
+    /// Returns the live runtime coefficient, which may differ from either NVM bank if it was changed with
+    /// <see cref="SetAdcCalibrationSlope"/> since the last save/load.
+    /// Command: CONFigure:ADC:chanCALM? channel
+    /// Example: messageProducer.Send(ScpiMessageProducer.GetAdcCalibrationSlope(0));
+    /// </remarks>
+    public static IOutboundMessage<string> GetAdcCalibrationSlope(int channel)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        return new ScpiMessage($"CONFigure:ADC:chanCALM? {channel}");
+    }
+
+    /// <summary>
+    /// Creates a query message to read a channel's ADC calibration offset (CalB) currently in device RAM.
+    /// </summary>
+    /// <param name="channel">The analog input channel number.</param>
+    /// <remarks>
+    /// Returns the live runtime coefficient, which may differ from either NVM bank if it was changed with
+    /// <see cref="SetAdcCalibrationOffset"/> since the last save/load.
+    /// Command: CONFigure:ADC:chanCALB? channel
+    /// Example: messageProducer.Send(ScpiMessageProducer.GetAdcCalibrationOffset(0));
+    /// </remarks>
+    public static IOutboundMessage<string> GetAdcCalibrationOffset(int channel)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        return new ScpiMessage($"CONFigure:ADC:chanCALB? {channel}");
+    }
+
+    /// <summary>
+    /// Creates a command message to persist the current runtime ADC calibration coefficients to the <b>factory</b> NVM bank.
+    /// </summary>
+    /// <remarks>
+    /// Writes every channel's live CalM/CalB into the factory bank. Contrast with <see cref="SaveAdcCalibration"/>,
+    /// which writes the <i>user</i> bank. Which bank the device applies is chosen by <see cref="UseAdcCalibration"/>.
+    /// Command: CONFigure:ADC:SAVEFcal
+    /// Example: messageProducer.Send(ScpiMessageProducer.SaveFactoryAdcCalibration);
+    /// </remarks>
+    public static IOutboundMessage<string> SaveFactoryAdcCalibration => new ScpiMessage("CONFigure:ADC:SAVEFcal");
+
+    /// <summary>
+    /// Creates a command message to restore the ADC calibration coefficients from the <b>factory</b> NVM bank into the runtime.
+    /// </summary>
+    /// <remarks>
+    /// The inverse of <see cref="SaveFactoryAdcCalibration"/>. Contrast with <see cref="LoadAdcCalibration"/>,
+    /// which restores the <i>user</i> bank.
+    /// Command: CONFigure:ADC:LOADFcal
+    /// Example: messageProducer.Send(ScpiMessageProducer.LoadFactoryAdcCalibration);
+    /// </remarks>
+    public static IOutboundMessage<string> LoadFactoryAdcCalibration => new ScpiMessage("CONFigure:ADC:LOADFcal");
+
+    /// <summary>
+    /// Creates a command message to select which ADC calibration bank the device applies.
+    /// </summary>
+    /// <param name="bank">The calibration bank: <c>0</c> = factory, <c>1</c> = user.</param>
+    /// <remarks>
+    /// <b>Persisted.</b> The choice is written to NVM and the runtime coefficients are immediately reloaded from the
+    /// selected bank; the same bank is then loaded automatically on every subsequent boot. Firmware rejects any value
+    /// other than 0 or 1, so this method validates the argument before producing a command.
+    /// Command: CONFigure:ADC:USECal bank
+    /// Example: messageProducer.Send(ScpiMessageProducer.UseAdcCalibration(1)); // apply the user bank
+    /// </remarks>
+    public static IOutboundMessage<string> UseAdcCalibration(int bank)
+    {
+        if (bank is < 0 or > 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bank), bank, "Calibration bank must be 0 (factory) or 1 (user).");
+        }
+
+        return new ScpiMessage($"CONFigure:ADC:USECal {bank}");
+    }
+
+    /// <summary>
+    /// Creates a query message to read which ADC calibration bank is currently active.
+    /// </summary>
+    /// <remarks>
+    /// The device replies with <c>0</c> (factory) or <c>1</c> (user), matching the argument accepted by
+    /// <see cref="UseAdcCalibration"/>.
+    /// Command: CONFigure:ADC:USECal?
+    /// Example: messageProducer.Send(ScpiMessageProducer.GetAdcCalibrationBank);
+    /// </remarks>
+    public static IOutboundMessage<string> GetAdcCalibrationBank => new ScpiMessage("CONFigure:ADC:USECal?");
 
     /// <summary>
     /// Creates a command message to persist the current voltage precision setting to NVM.

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1054,6 +1054,76 @@ namespace Daqifi.Core.Device
         }
 
         /// <inheritdoc />
+        public void SetAdcCalibrationSlope(int channelNumber, double calM)
+        {
+            if (channelNumber < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.SetAdcCalibrationSlope(channelNumber, calM));
+        }
+
+        /// <inheritdoc />
+        public void SetAdcCalibrationOffset(int channelNumber, double calB)
+        {
+            if (channelNumber < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.SetAdcCalibrationOffset(channelNumber, calB));
+        }
+
+        /// <inheritdoc />
+        public void SaveFactoryAdcCalibration()
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.SaveFactoryAdcCalibration);
+        }
+
+        /// <inheritdoc />
+        public void LoadFactoryAdcCalibration()
+        {
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.LoadFactoryAdcCalibration);
+        }
+
+        /// <inheritdoc />
+        public void UseAdcCalibration(int bank)
+        {
+            if (bank is < 0 or > 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bank), bank, "Calibration bank must be 0 (factory) or 1 (user).");
+            }
+
+            if (!IsConnected)
+            {
+                throw new InvalidOperationException("Device is not connected.");
+            }
+
+            Send(ScpiMessageProducer.UseAdcCalibration(bank));
+        }
+
+        /// <inheritdoc />
         public void SaveVoltagePrecision()
         {
             if (!IsConnected)

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -151,11 +151,12 @@ namespace Daqifi.Core.Device
         void Reboot();
 
         /// <summary>
-        /// Persists the device's current ADC calibration coefficients to NVM so they survive a reboot.
+        /// Persists the device's current ADC calibration coefficients to the <b>user</b> NVM bank so they survive a reboot.
         /// </summary>
         /// <remarks>
         /// A thin wrapper over the firmware NVM primitive (<c>CONFigure:ADC:SAVEcal</c>). Pair with
-        /// <see cref="LoadAdcCalibration"/> to restore them.
+        /// <see cref="LoadAdcCalibration"/> to restore them. Use <see cref="SaveFactoryAdcCalibration"/> to write the
+        /// <b>factory</b> bank instead, and <see cref="UseAdcCalibration"/> to choose which bank the device applies.
         /// </remarks>
         void SaveAdcCalibration();
 

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -160,12 +160,64 @@ namespace Daqifi.Core.Device
         void SaveAdcCalibration();
 
         /// <summary>
-        /// Restores the device's ADC calibration coefficients from NVM into its runtime.
+        /// Restores the device's ADC calibration coefficients from the <b>user</b> NVM bank into its runtime.
         /// </summary>
         /// <remarks>
         /// The inverse of <see cref="SaveAdcCalibration"/> (firmware primitive <c>CONFigure:ADC:LOADcal</c>).
         /// </remarks>
         void LoadAdcCalibration();
+
+        /// <summary>
+        /// Sets a single channel's ADC calibration slope (CalM) in device RAM.
+        /// </summary>
+        /// <param name="channelNumber">The analog input channel number.</param>
+        /// <param name="calM">The calibration slope (gain) coefficient.</param>
+        /// <remarks>
+        /// <b>RAM only</b> (firmware primitive <c>CONFigure:ADC:chanCALM</c>). The value is lost on reboot unless
+        /// persisted with <see cref="SaveAdcCalibration"/> (user bank) or <see cref="SaveFactoryAdcCalibration"/>
+        /// (factory bank).
+        /// </remarks>
+        void SetAdcCalibrationSlope(int channelNumber, double calM);
+
+        /// <summary>
+        /// Sets a single channel's ADC calibration offset (CalB) in device RAM.
+        /// </summary>
+        /// <param name="channelNumber">The analog input channel number.</param>
+        /// <param name="calB">The calibration offset coefficient.</param>
+        /// <remarks>
+        /// <b>RAM only</b> (firmware primitive <c>CONFigure:ADC:chanCALB</c>). The value is lost on reboot unless
+        /// persisted with <see cref="SaveAdcCalibration"/> (user bank) or <see cref="SaveFactoryAdcCalibration"/>
+        /// (factory bank).
+        /// </remarks>
+        void SetAdcCalibrationOffset(int channelNumber, double calB);
+
+        /// <summary>
+        /// Persists the device's current ADC calibration coefficients to the <b>factory</b> NVM bank.
+        /// </summary>
+        /// <remarks>
+        /// Firmware primitive <c>CONFigure:ADC:SAVEFcal</c>. Contrast with <see cref="SaveAdcCalibration"/>, which
+        /// writes the user bank. Which bank the device applies is chosen with <see cref="UseAdcCalibration"/>.
+        /// </remarks>
+        void SaveFactoryAdcCalibration();
+
+        /// <summary>
+        /// Restores the device's ADC calibration coefficients from the <b>factory</b> NVM bank into its runtime.
+        /// </summary>
+        /// <remarks>
+        /// The inverse of <see cref="SaveFactoryAdcCalibration"/> (firmware primitive <c>CONFigure:ADC:LOADFcal</c>).
+        /// </remarks>
+        void LoadFactoryAdcCalibration();
+
+        /// <summary>
+        /// Selects which ADC calibration bank the device applies (<c>0</c> = factory, <c>1</c> = user).
+        /// </summary>
+        /// <param name="bank">The calibration bank: <c>0</c> = factory, <c>1</c> = user.</param>
+        /// <remarks>
+        /// <b>Persisted</b> (firmware primitive <c>CONFigure:ADC:USECal</c>). The choice is written to NVM, the
+        /// runtime coefficients are immediately reloaded from the selected bank, and that bank is loaded on every
+        /// subsequent boot. Values other than 0 or 1 are rejected.
+        /// </remarks>
+        void UseAdcCalibration(int bank);
 
         /// <summary>
         /// Persists the device's current voltage precision setting to NVM so it survives a reboot.


### PR DESCRIPTION
## What & why

Closes #386. `ScpiMessageProducer` (and `IStreamingDevice`/`DaqifiStreamingDevice`) previously wrapped only the ADC-cal NVM persistence primitives (`SAVEcal`/`LOADcal`) — there was **no way to set the coefficients themselves**. This adds the full ADC calibration write path so consumers (e.g. a manufacturing calibration station, tracked at [daqifi/calibration#7](https://github.com/daqifi/calibration/issues/7)) never need to hand-roll SCPI strings.

## Changes

**`ScpiMessageProducer`** — new static factory methods adjacent to the existing ADC-cal block, mirroring the `SetAnalogOutputVoltage` convention (`CultureInfo.InvariantCulture`, finite-value guard):

| Method | SCPI | Semantics |
|---|---|---|
| `SetAdcCalibrationSlope(int, double)` | `CONFigure:ADC:chanCALM ch,val` | set CalM — **RAM only** |
| `SetAdcCalibrationOffset(int, double)` | `CONFigure:ADC:chanCALB ch,val` | set CalB — **RAM only** |
| `GetAdcCalibrationSlope(int)` | `CONFigure:ADC:chanCALM? ch` | query CalM |
| `GetAdcCalibrationOffset(int)` | `CONFigure:ADC:chanCALB? ch` | query CalB |
| `SaveFactoryAdcCalibration` | `CONFigure:ADC:SAVEFcal` | persist RAM → **factory** NVM bank |
| `LoadFactoryAdcCalibration` | `CONFigure:ADC:LOADFcal` | restore factory bank → RAM |
| `UseAdcCalibration(int)` | `CONFigure:ADC:USECal 0\|1` | select factory(0)/user(1) bank; **persisted**, reloads runtime |
| `GetAdcCalibrationBank` | `CONFigure:ADC:USECal?` | query active bank |

**`IStreamingDevice`/`DaqifiStreamingDevice`** — matching **write-path** convenience methods following the `SaveAdcCalibration` fire-and-forget pattern: `SetAdcCalibrationSlope`, `SetAdcCalibrationOffset`, `SaveFactoryAdcCalibration`, `LoadFactoryAdcCalibration`, `UseAdcCalibration`.

**Docs** — XML docs spell out the RAM-vs-NVM and factory-vs-user-bank semantics (easy to get wrong — a caller might assume `chanCALM`/`chanCALB` persist immediately). Existing `SaveAdcCalibration`/`LoadAdcCalibration` docs are clarified to name the **user** bank (firmware `SCPI_ADCCalSave` → `DaqifiSettings_UserAInCalParams`).

## Design notes

- **Query getters are producer-only, not on the device surface.** The device has no synchronous query/response round-trip (queries like `GetDeviceInfo` are fire-and-forget, responses arrive via the async consumer pipeline). Adding value-returning device getters would require new infra out of scope here — so the device exposes the write path only, exactly as it does today for `SaveAdcCalibration`.
- **`UseAdcCalibration` validates 0/1** client-side — firmware rejects any other value.
- Boot behavior documented against firmware `app_freertos.c`: the factory bank loads at boot and is overwritten by the user bank iff `calVals == 1`.

## Validation

- **Unit tests** assert the exact SCPI string for every new command, including locale-independent decimal formatting (de-DE culture test) and argument validation (negative channel, non-finite value, invalid bank). Full suite green: **1874 passed, 0 failed** (net9.0 + net10.0); whole solution builds with **0 warnings**.
- **Wire format cross-checked** against firmware ground truth — `SCPIInterface.c` command table (5103-5120) and `SCPIADC.c` handlers (param order: int32 channel, then double value).
- **Validated on real hardware** over serial (RAM-only, non-destructive): `chanCALM?`/`chanCALB?` queries round-trip, `chanCALM`/`chanCALB` sets update RAM and read back, `USECal?` returns the active bank. Channel-0 constants were recorded and restored to originals; **NVM was never written**. Full persist-path HW validation (`SAVEFcal`/`USECal` set) is tracked separately at [daqifi/calibration#3](https://github.com/daqifi/calibration/issues/3) per the issue.

## Not in scope

The `AnalogChannel.GetScaledValue` / firmware `CalB`-scaling divergence noted in the issue is a separate correctness bug, filed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)