### PR TITLE
feat(device): DeviceFeature requirement table + Supports() seam (closes #256)

### DIFF
--- a/docs/adr/0001-firmware-feature-gating.md
+++ b/docs/adr/0001-firmware-feature-gating.md
@@ -251,6 +251,12 @@ The seam shipped. Two details differ from the sketch above, both settled during 
   known", not "hardware absent", so treating them as violations would newly refuse features on a
   device that has merely not reported its part number yet. The `-113` backstop still covers that
   window.
+- **The typed exception names only the axis that actually failed.** `EnsureSupported` reports a
+  `RequiredVersion` only when the *version* is what failed; a board or hardware shortfall on a
+  device whose firmware already meets the minimum would otherwise render as "Requires firmware
+  >= 3.7.0; the device reports '3.7.0'" and send the caller after an upgrade that cannot fix it.
+  The `-113` backstop is the deliberate exception: there the firmware itself reports it does not
+  know the command, so the table's minimum is the actionable answer.
 
 The table lives in
 [`DeviceFeatureRequirements`](../../src/Daqifi.Core/Device/DeviceFeatureRequirements.cs), seeded

--- a/docs/adr/0001-firmware-feature-gating.md
+++ b/docs/adr/0001-firmware-feature-gating.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted (2026-06-19)
 - **Issue:** [#251](https://github.com/daqifi/daqifi-core/issues/251)
-- **Follow-ups:** [#254](https://github.com/daqifi/daqifi-core/issues/254) (floor + `-113` backstop), [#255](https://github.com/daqifi/daqifi-core/issues/255) (dead-code removal), [#256](https://github.com/daqifi/daqifi-core/issues/256) (deferred table + #327 reader)
+- **Follow-ups:** [#254](https://github.com/daqifi/daqifi-core/issues/254) (floor + `-113` backstop), [#255](https://github.com/daqifi/daqifi-core/issues/255) (dead-code removal), [#256](https://github.com/daqifi/daqifi-core/issues/256) (version table + `Supports()` seam; #327 reader still deferred)
 - **Supersedes:** —
 
 > **Note on the evidence section.** §"Context — firmware audit" below is a *living*
@@ -66,12 +66,14 @@ v3.4.6b1 (2026-03-12) → v3.5.0 (2026-06-08) → v3.6.0 (2026-06-12) → v3.6.1
 >
 > **The first live, above-floor firmware-version gate is now active:** SD file transfer over
 > **WiFi/TCP** requires firmware **≥ v3.7.0** (#598/#599). This is not a hardware gate — the same
-> SD-capable WiFi device supports it on v3.7.0+ and rejects it below — so it is enforced at the
-> transport in `EnsureSdFileTransferSupportedOnTransport()` (LIST/GET/DELETE), which throws
-> `FeatureNotSupportedException(SdFileTransferOverWifi, v3.7.0, …)` when the active transport is
-> not USB and the reported firmware is older/unparseable. Over USB these operations are
-> unchanged (available on all SD-capable firmware). This is exactly the forward-looking case the
-> version-gating layer was built for — a command consumed *after* the floor.
+> SD-capable WiFi device supports it on v3.7.0+ and rejects it below. It arrived in core
+> [#347](https://github.com/daqifi/daqifi-core/pull/347) as a bespoke inline version compare;
+> that was the trigger condition for Decision 2's deferred item 3, so
+> [#256](https://github.com/daqifi/daqifi-core/issues/256) **built the version table and the
+> `Supports()` seam**, and the gate now resolves through it (see the implementation note under
+> Decision 2). Over USB these operations are unchanged (available on all SD-capable firmware).
+> This is exactly the forward-looking case the version-gating layer was built for — a command
+> consumed *after* the floor.
 
 **Breaking changes (behavior), by released version:**
 
@@ -165,8 +167,9 @@ forward-looking third:
    firmware's `**ERROR: -113` on the command path; an optional up-front version check (using
    the existing [`FirmwareVersion`](../../src/Daqifi.Core/Firmware/FirmwareVersion.cs)) can
    pre-empt the round-trip for UI.
-3. **`DeviceFeature` version table (deferred)** — introduce only when we start consuming a
-   command newer than the floor. Same shape as below; empty today, so unbuilt today.
+3. **`DeviceFeature` version table (deferred → built)** — introduce only when we start consuming
+   a command newer than the floor. That happened with SD-over-WiFi (≥ v3.7.0), so the table now
+   exists; see the implementation note below.
 4. **#327 capability document (later, non-blocking)** — when a device answers
    `CONFigure:CAPabilities:APIVersion?` ≥ 1, populate `DeviceCapabilities` from the live
    `CONFigure:CAPabilities:JSON?` document. The floor/board logic remains the bootstrap and
@@ -230,6 +233,33 @@ if (ResponseHasUndefinedHeader(lines))   // **ERROR: -113
 (`CommandRename`/version-selected emit from earlier drafts is **dropped** — Decision 1 makes
 it unnecessary. Reintroduce only if the supported floor is ever lowered below a hard rename.)
 
+### Implementation note (2026-07-24, issue [#256](https://github.com/daqifi/daqifi-core/issues/256))
+
+The seam shipped. Two details differ from the sketch above, both settled during implementation:
+
+- **`Supports` lives on the device, not on `DeviceCapabilities`.** The sketch wrote
+  `Capabilities.Supports(...)`, but `DeviceCapabilities` is board-derived and never sees the
+  firmware version, so it structurally cannot answer a version gate. `Supports(DeviceFeature)` and
+  `EnsureSupported(DeviceFeature)` are therefore on
+  [`DaqifiDevice`](../../src/Daqifi.Core/Device/DaqifiDevice.cs), which already owns
+  `MinSupportedFirmware`, `Metadata.FirmwareVersion`, and `Metadata.Capabilities`. The lazy-
+  evaluation rule above is unchanged and now enforced by test.
+- **The two axes fail differently.** The firmware-version axis **fails closed** — absent or
+  unparseable reports as unsupported, preserving #347's conservative rule. The board/hardware axis
+  is evaluated **only once the board is known**: while `DeviceType` is `Unknown`,
+  `FromDeviceType` has not run and `Capabilities` holds all-`false` defaults that mean "not yet
+  known", not "hardware absent", so treating them as violations would newly refuse features on a
+  device that has merely not reported its part number yet. The `-113` backstop still covers that
+  window.
+
+The table lives in
+[`DeviceFeatureRequirements`](../../src/Daqifi.Core/Device/DeviceFeatureRequirements.cs), seeded
+from the firmware audit table above. Both previously hand-rolled gates — the SD-over-WiFi
+transport gate and the SD-storage-query `-113` backstop — now resolve their required version and
+board through it; `EnsureSdFileTransferSupportedOnTransport()` retains only the transport
+predicate (which feature applies over WiFi vs. USB) and delegates the support question to the
+seam. Part 2 — the `CONFigure:CAPabilities:JSON?` / `:APIVersion?` reader — remains deferred.
+
 ## Alternatives considered
 
 | Option | Why not (alone) |
@@ -267,9 +297,10 @@ their place.**
 2. [#255](https://github.com/daqifi/daqifi-core/issues/255) — **Remove dead code**: the
    `GetSdLoggingState` producer + `SYSTem:STORage:SD:LOGging?` query never existed in the
    firmware SCPI table. Public-API removal, separate from the #253 fix.
-3. [#256](https://github.com/daqifi/daqifi-core/issues/256) *(deferred)* — `DeviceFeature`
-   version table + lazy `Supports(...)` (only when we consume a post-v3.5.0 command), and the
-   `CONFigure:CAPabilities:JSON?` reader (#327 growth path).
+3. [#256](https://github.com/daqifi/daqifi-core/issues/256) — `DeviceFeature` version table +
+   lazy `Supports(...)`: **done** (triggered by SD-over-WiFi @ v3.7.0; see the implementation
+   note under Decision 2). The `CONFigure:CAPabilities:JSON?` reader (#327 growth path) is
+   **still deferred** and tracked separately.
 
 ## Out of scope
 

--- a/src/Daqifi.Core.Tests/Device/DeviceFeatureSupportTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceFeatureSupportTests.cs
@@ -1,0 +1,300 @@
+using Daqifi.Core.Device;
+using Daqifi.Core.Firmware;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    /// <summary>
+    /// Covers the <see cref="DaqifiDevice.Supports"/> / <see cref="DaqifiDevice.EnsureSupported"/>
+    /// seam and the requirement table behind it (ADR 0001, issue #256). Each feature is exercised
+    /// across every axis the table can constrain: firmware version (below / at / above the minimum,
+    /// plus absent and unparseable), board variant, and hardware presence.
+    /// </summary>
+    public class DeviceFeatureSupportTests
+    {
+        private static DaqifiDevice DeviceOn(
+            DeviceType board,
+            string firmwareVersion = "",
+            DeviceCapabilities? capabilities = null)
+        {
+            var device = new DaqifiDevice("TestDevice");
+            device.Metadata.DeviceType = board;
+            device.Metadata.FirmwareVersion = firmwareVersion;
+            device.Metadata.Capabilities = capabilities ?? DeviceCapabilities.FromDeviceType(board);
+            return device;
+        }
+
+        // ---- Table integrity ------------------------------------------------------------------
+
+        [Fact]
+        public void RequirementTable_CoversEveryDeviceFeatureMember()
+        {
+            // A DeviceFeature added without a table entry would throw at the first Supports() call
+            // rather than mis-gate silently — this catches it at build time instead.
+            var members = Enum.GetValues<DeviceFeature>();
+            var defined = DeviceFeatureRequirements.DefinedFeatures.ToHashSet();
+
+            Assert.Equal(members.Length, defined.Count);
+            Assert.All(members, feature => Assert.Contains(feature, defined));
+        }
+
+        [Fact]
+        public void Supports_WhenFeatureHasNoTableEntry_ThrowsArgumentOutOfRange()
+        {
+            var device = DeviceOn(DeviceType.Nyquist1, "3.7.0");
+            var undefined = (DeviceFeature)9999;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.Supports(undefined));
+        }
+
+        [Fact]
+        public void RequirementTable_SdFileTransferOverWifi_RequiresV3_7_0()
+        {
+            // The above-floor gate migrated from PR #347 — pinned so a table edit can't silently
+            // relax it back below the version firmware #598/#599 actually shipped in.
+            var requirement = DeviceFeatureRequirements.For(DeviceFeature.SdFileTransferOverWifi);
+
+            Assert.Equal(new FirmwareVersion(3, 7, 0, null, 0), requirement.MinVersion);
+            Assert.Equal(
+                HardwareRequirement.SdCard | HardwareRequirement.WiFi,
+                requirement.Hardware);
+        }
+
+        [Fact]
+        public void RequirementTable_SdStorageQuery_ReportsTheSupportedFloorNotTheIntroducingVersion()
+        {
+            // SYSTem:STORage:SD:SPACe? shipped in v3.4.6b1, but the floor is what daqifi-core
+            // guarantees, so that is the version the typed exception reports.
+            var requirement = DeviceFeatureRequirements.For(DeviceFeature.SdStorageQuery);
+
+            Assert.Equal(DaqifiDevice.MinSupportedFirmware, requirement.MinVersion);
+        }
+
+        // ---- Firmware-version axis ------------------------------------------------------------
+
+        public static IEnumerable<object[]> VersionGatedFeatures() =>
+            new List<object[]>
+            {
+                new object[] { DeviceFeature.SdFileTransferOverWifi, "3.7.0" },
+                new object[] { DeviceFeature.CapabilityDocument, "3.5.0" },
+                new object[] { DeviceFeature.SdStorageQuery, "3.5.0" }
+            };
+
+        [Theory]
+        [MemberData(nameof(VersionGatedFeatures))]
+        public void Supports_AtMinimumFirmware_ReturnsTrue(DeviceFeature feature, string minVersion)
+        {
+            var device = DeviceOn(DeviceType.Nyquist1, minVersion);
+
+            Assert.True(device.Supports(feature));
+        }
+
+        [Theory]
+        [MemberData(nameof(VersionGatedFeatures))]
+        public void Supports_AboveMinimumFirmware_ReturnsTrue(DeviceFeature feature, string minVersion)
+        {
+            var above = FirmwareVersion.TryParse(minVersion, out var parsed)
+                ? new FirmwareVersion(parsed.Major, parsed.Minor, parsed.Patch + 1, null, 0).ToString()
+                : minVersion;
+            var device = DeviceOn(DeviceType.Nyquist1, above);
+
+            Assert.True(device.Supports(feature));
+        }
+
+        [Theory]
+        [MemberData(nameof(VersionGatedFeatures))]
+        public void Supports_BelowMinimumFirmware_ReturnsFalse(DeviceFeature feature, string minVersion)
+        {
+            var below = FirmwareVersion.TryParse(minVersion, out var parsed)
+                ? new FirmwareVersion(parsed.Major, parsed.Minor - 1, 9, null, 0).ToString()
+                : minVersion;
+            var device = DeviceOn(DeviceType.Nyquist1, below);
+
+            Assert.False(device.Supports(feature));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("not-a-version")]
+        [InlineData("999999999999999999.0.0")] // overflows Int32 — must fail closed, not crash
+        public void Supports_WhenFirmwareVersionAbsentOrUnparseable_FailsClosed(string firmwareVersion)
+        {
+            // An unknown version is not permission: dispatching an SD command over WiFi to
+            // pre-v3.7.0 firmware stalls on the shared SPI bus.
+            var device = DeviceOn(DeviceType.Nyquist1, firmwareVersion);
+
+            Assert.False(device.Supports(DeviceFeature.SdFileTransferOverWifi));
+            Assert.False(device.Supports(DeviceFeature.CapabilityDocument));
+            Assert.False(device.Supports(DeviceFeature.SdStorageQuery));
+        }
+
+        [Fact]
+        public void Supports_PreReleaseBelowMinimum_ReturnsFalse()
+        {
+            // 3.7.0b1 precedes the 3.7.0 release under FirmwareVersion's precedence rules.
+            var device = DeviceOn(DeviceType.Nyquist1, "3.7.0b1");
+
+            Assert.False(device.Supports(DeviceFeature.SdFileTransferOverWifi));
+        }
+
+        [Fact]
+        public void Supports_EvaluatesLiveAgainstCurrentMetadata()
+        {
+            // The board and the firmware version arrive in separate status-message branches, so a
+            // cached flag would be snapshotted before one of them. Guard against reintroducing one.
+            var device = DeviceOn(DeviceType.Nyquist1, "3.6.3");
+            Assert.False(device.Supports(DeviceFeature.SdFileTransferOverWifi));
+
+            device.Metadata.FirmwareVersion = "3.7.0";
+            Assert.True(device.Supports(DeviceFeature.SdFileTransferOverWifi));
+        }
+
+        // ---- Board axis -----------------------------------------------------------------------
+
+        [Fact]
+        public void Supports_AnalogOutput_OnNyquist3_ReturnsTrue()
+        {
+            var device = DeviceOn(DeviceType.Nyquist3, "3.5.0");
+
+            Assert.True(device.Supports(DeviceFeature.AnalogOutput));
+        }
+
+        [Theory]
+        [InlineData(DeviceType.Nyquist1)]
+        [InlineData(DeviceType.Nyquist2)]
+        public void Supports_AnalogOutput_OnNonNyquist3Board_ReturnsFalse(DeviceType board)
+        {
+            // Board-gated, not version-gated: the newest firmware on an NQ1 still has no DAC.
+            var device = DeviceOn(board, "3.7.2");
+
+            Assert.False(device.Supports(DeviceFeature.AnalogOutput));
+        }
+
+        [Fact]
+        public void Supports_AnalogOutput_IsNotVersionGated()
+        {
+            var device = DeviceOn(DeviceType.Nyquist3, firmwareVersion: "");
+
+            Assert.True(device.Supports(DeviceFeature.AnalogOutput));
+        }
+
+        // ---- Hardware axis --------------------------------------------------------------------
+
+        [Fact]
+        public void Supports_SdFileTransferOverWifi_WhenSdHardwareAbsent_ReturnsFalse()
+        {
+            var noSd = DeviceCapabilities.FromDeviceType(DeviceType.Nyquist1);
+            noSd.HasSdCard = false;
+            var device = DeviceOn(DeviceType.Nyquist1, "3.7.0", noSd);
+
+            Assert.False(device.Supports(DeviceFeature.SdFileTransferOverWifi));
+        }
+
+        [Fact]
+        public void Supports_SdFileTransferOverWifi_WhenWifiHardwareAbsent_ReturnsFalse()
+        {
+            var noWifi = DeviceCapabilities.FromDeviceType(DeviceType.Nyquist1);
+            noWifi.HasWiFi = false;
+            var device = DeviceOn(DeviceType.Nyquist1, "3.7.0", noWifi);
+
+            Assert.False(device.Supports(DeviceFeature.SdFileTransferOverWifi));
+        }
+
+        [Fact]
+        public void Supports_SdStorageQuery_WhenSdHardwareAbsent_ReturnsFalse()
+        {
+            var noSd = DeviceCapabilities.FromDeviceType(DeviceType.Nyquist1);
+            noSd.HasSdCard = false;
+            var device = DeviceOn(DeviceType.Nyquist1, "3.5.0", noSd);
+
+            Assert.False(device.Supports(DeviceFeature.SdStorageQuery));
+        }
+
+        [Fact]
+        public void Supports_CapabilityDocument_HasNoHardwareRequirement()
+        {
+            var bare = new DeviceCapabilities();
+            var device = DeviceOn(DeviceType.Nyquist1, "3.5.0", bare);
+
+            Assert.True(device.Supports(DeviceFeature.CapabilityDocument));
+        }
+
+        // ---- Unknown board --------------------------------------------------------------------
+
+        [Fact]
+        public void Supports_WhenBoardUnknown_SkipsBoardAndHardwareRequirements()
+        {
+            // Capabilities are all-false until FromDeviceType runs, which means "not yet known",
+            // not "hardware absent" — so a device that has reported a firmware version but not yet
+            // a part number is not refused. The wire-level -113 remains the backstop.
+            var device = DeviceOn(DeviceType.Unknown, "3.7.0");
+
+            Assert.False(device.Metadata.Capabilities.HasSdCard);
+            Assert.True(device.Supports(DeviceFeature.SdFileTransferOverWifi));
+            Assert.True(device.Supports(DeviceFeature.AnalogOutput));
+        }
+
+        [Fact]
+        public void Supports_WhenBoardUnknown_StillEnforcesTheVersionGate()
+        {
+            // The version axis is independent of the board: an unknown board does not waive it.
+            var device = DeviceOn(DeviceType.Unknown, "3.6.3");
+
+            Assert.False(device.Supports(DeviceFeature.SdFileTransferOverWifi));
+        }
+
+        // ---- EnsureSupported ------------------------------------------------------------------
+
+        [Fact]
+        public void EnsureSupported_WhenSupported_DoesNotThrow()
+        {
+            var device = DeviceOn(DeviceType.Nyquist1, "3.7.0");
+
+            device.EnsureSupported(DeviceFeature.SdFileTransferOverWifi);
+        }
+
+        [Fact]
+        public void EnsureSupported_WhenUnsupported_ThrowsWithFeatureRequiredActualAndBoard()
+        {
+            var device = DeviceOn(DeviceType.Nyquist1, "3.6.3");
+
+            var ex = Assert.Throws<FeatureNotSupportedException>(
+                () => device.EnsureSupported(DeviceFeature.SdFileTransferOverWifi));
+
+            Assert.Equal(DeviceFeature.SdFileTransferOverWifi, ex.Feature);
+            Assert.Equal(new FirmwareVersion(3, 7, 0, null, 0), ex.RequiredVersion);
+            Assert.Equal("3.6.3", ex.ActualVersion);
+            Assert.Equal(DeviceType.Nyquist1, ex.Board);
+        }
+
+        [Fact]
+        public void EnsureSupported_WhenBoardUnknown_ReportsNullBoard()
+        {
+            // DeviceType.Unknown is "not reported", so the exception says nothing about the board
+            // rather than naming a placeholder value.
+            var device = DeviceOn(DeviceType.Unknown, "3.6.3");
+
+            var ex = Assert.Throws<FeatureNotSupportedException>(
+                () => device.EnsureSupported(DeviceFeature.SdFileTransferOverWifi));
+
+            Assert.Null(ex.Board);
+            Assert.Equal("3.6.3", ex.ActualVersion);
+        }
+
+        [Fact]
+        public void EnsureSupported_ForBoardGatedFeature_ReportsNoRequiredVersion()
+        {
+            var device = DeviceOn(DeviceType.Nyquist1, "3.7.2");
+
+            var ex = Assert.Throws<FeatureNotSupportedException>(
+                () => device.EnsureSupported(DeviceFeature.AnalogOutput));
+
+            Assert.Equal(DeviceFeature.AnalogOutput, ex.Feature);
+            Assert.Null(ex.RequiredVersion);
+            Assert.Equal(DeviceType.Nyquist1, ex.Board);
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/DeviceFeatureSupportTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceFeatureSupportTests.cs
@@ -75,45 +75,33 @@ namespace Daqifi.Core.Tests.Device
 
         // ---- Firmware-version axis ------------------------------------------------------------
 
+        /// <summary>
+        /// Version-gated features with a real released firmware version on each side of the
+        /// boundary. Spelled out rather than computed from the minimum: deriving "one below" by
+        /// decrementing a component can yield an unparseable string (e.g. a 3.0.0 minimum), which
+        /// would still report unsupported — passing the test for the wrong reason.
+        /// </summary>
         public static IEnumerable<object[]> VersionGatedFeatures() =>
             new List<object[]>
             {
-                new object[] { DeviceFeature.SdFileTransferOverWifi, "3.7.0" },
-                new object[] { DeviceFeature.CapabilityDocument, "3.5.0" },
-                new object[] { DeviceFeature.SdStorageQuery, "3.5.0" }
+                //                feature                                below,    at min,   above
+                new object[] { DeviceFeature.SdFileTransferOverWifi, "3.6.3", "3.7.0", "3.7.2" },
+                new object[] { DeviceFeature.CapabilityDocument,     "3.4.4", "3.5.0", "3.6.0" },
+                new object[] { DeviceFeature.SdStorageQuery,         "3.4.3", "3.5.0", "3.6.0" }
             };
 
         [Theory]
         [MemberData(nameof(VersionGatedFeatures))]
-        public void Supports_AtMinimumFirmware_ReturnsTrue(DeviceFeature feature, string minVersion)
+        public void Supports_AcrossTheFirmwareVersionBoundary(
+            DeviceFeature feature, string below, string atMin, string above)
         {
-            var device = DeviceOn(DeviceType.Nyquist1, minVersion);
+            // Guards the data itself: a "below" that stopped parsing would report unsupported via
+            // the fail-closed path instead of the comparison under test.
+            Assert.True(FirmwareVersion.TryParse(below, out _));
 
-            Assert.True(device.Supports(feature));
-        }
-
-        [Theory]
-        [MemberData(nameof(VersionGatedFeatures))]
-        public void Supports_AboveMinimumFirmware_ReturnsTrue(DeviceFeature feature, string minVersion)
-        {
-            var above = FirmwareVersion.TryParse(minVersion, out var parsed)
-                ? new FirmwareVersion(parsed.Major, parsed.Minor, parsed.Patch + 1, null, 0).ToString()
-                : minVersion;
-            var device = DeviceOn(DeviceType.Nyquist1, above);
-
-            Assert.True(device.Supports(feature));
-        }
-
-        [Theory]
-        [MemberData(nameof(VersionGatedFeatures))]
-        public void Supports_BelowMinimumFirmware_ReturnsFalse(DeviceFeature feature, string minVersion)
-        {
-            var below = FirmwareVersion.TryParse(minVersion, out var parsed)
-                ? new FirmwareVersion(parsed.Major, parsed.Minor - 1, 9, null, 0).ToString()
-                : minVersion;
-            var device = DeviceOn(DeviceType.Nyquist1, below);
-
-            Assert.False(device.Supports(feature));
+            Assert.False(DeviceOn(DeviceType.Nyquist1, below).Supports(feature));
+            Assert.True(DeviceOn(DeviceType.Nyquist1, atMin).Supports(feature));
+            Assert.True(DeviceOn(DeviceType.Nyquist1, above).Supports(feature));
         }
 
         [Theory]

--- a/src/Daqifi.Core.Tests/Device/DeviceFeatureSupportTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceFeatureSupportTests.cs
@@ -284,5 +284,50 @@ namespace Daqifi.Core.Tests.Device
             Assert.Null(ex.RequiredVersion);
             Assert.Equal(DeviceType.Nyquist1, ex.Board);
         }
+
+        [Fact]
+        public void EnsureSupported_WhenHardwareIsTheFailingAxis_DoesNotClaimAFirmwareRequirement()
+        {
+            // Regression: the exception used to take its required version straight from the table
+            // regardless of which axis failed, so a device whose firmware already met the minimum
+            // but lacked the SD card was told "Requires firmware >= 3.7.0; the device reports
+            // '3.7.0'" — self-contradictory, and pointing at an upgrade that cannot fix it.
+            var noSd = DeviceCapabilities.FromDeviceType(DeviceType.Nyquist1);
+            noSd.HasSdCard = false;
+            var device = DeviceOn(DeviceType.Nyquist1, "3.7.0", noSd);
+
+            var ex = Assert.Throws<FeatureNotSupportedException>(
+                () => device.EnsureSupported(DeviceFeature.SdFileTransferOverWifi));
+
+            Assert.Equal(DeviceFeature.SdFileTransferOverWifi, ex.Feature);
+            Assert.Null(ex.RequiredVersion);
+            Assert.DoesNotContain("Requires firmware", ex.Message);
+            Assert.Equal(DeviceType.Nyquist1, ex.Board);
+        }
+
+        [Fact]
+        public void EnsureSupported_WhenVersionIsTheFailingAxis_StillReportsTheRequirement()
+        {
+            // The other half of the same rule: when the version *is* what failed, the required
+            // version must still be reported — that is the caller's actionable next step.
+            var device = DeviceOn(DeviceType.Nyquist1, "3.6.3");
+
+            var ex = Assert.Throws<FeatureNotSupportedException>(
+                () => device.EnsureSupported(DeviceFeature.SdFileTransferOverWifi));
+
+            Assert.Equal(new FirmwareVersion(3, 7, 0, null, 0), ex.RequiredVersion);
+            Assert.Contains("Requires firmware >= 3.7.0", ex.Message);
+        }
+
+        [Fact]
+        public void RequirementTable_BoardAllowListIsImmutable()
+        {
+            // The table hands the same instance to every caller, so a mutable allow-list would let
+            // any friend-assembly code silently re-gate the feature process-wide.
+            var boards = DeviceFeatureRequirements.For(DeviceFeature.AnalogOutput).Boards;
+
+            Assert.True(boards.HasValue);
+            Assert.Equal(new[] { DeviceType.Nyquist3 }, boards!.Value);
+        }
     }
 }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -104,7 +104,37 @@ namespace Daqifi.Core.Device
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when <paramref name="feature"/> has no entry in the requirement table.
         /// </exception>
-        public bool Supports(DeviceFeature feature)
+        public bool Supports(DeviceFeature feature) =>
+            EvaluateSupport(feature) == SupportFailure.None;
+
+        /// <summary>
+        /// Which requirement axis a device failed for a feature. Determines what the typed
+        /// exception is allowed to claim: only a <see cref="FirmwareVersion"/> failure may report a
+        /// required firmware version, since attributing a board or hardware shortfall to the
+        /// firmware would tell the caller to perform an upgrade that cannot fix it.
+        /// </summary>
+        private enum SupportFailure
+        {
+            /// <summary>Every requirement is met.</summary>
+            None,
+
+            /// <summary>The reported firmware is absent, unparseable, or older than the minimum.</summary>
+            FirmwareVersion,
+
+            /// <summary>The board variant is not on the feature's allow-list.</summary>
+            Board,
+
+            /// <summary>The device lacks hardware the feature drives.</summary>
+            Hardware
+        }
+
+        /// <summary>
+        /// Evaluates every requirement for <paramref name="feature"/> against the current
+        /// <see cref="Metadata"/> and reports the first axis that failed. The single evaluation
+        /// path behind both <see cref="Supports"/> and <see cref="EnsureSupported"/>, so the two
+        /// can never disagree about whether — or why — a feature is unavailable.
+        /// </summary>
+        private SupportFailure EvaluateSupport(DeviceFeature feature)
         {
             var requirement = DeviceFeatureRequirements.For(feature);
 
@@ -112,32 +142,32 @@ namespace Daqifi.Core.Device
                 && (!FirmwareVersion.TryParse(Metadata.FirmwareVersion, out var firmware)
                     || firmware < requirement.MinVersion.Value))
             {
-                return false;
+                return SupportFailure.FirmwareVersion;
             }
 
             var board = Metadata.DeviceType;
             if (board == DeviceType.Unknown)
             {
-                return true;
+                return SupportFailure.None;
             }
 
-            if (requirement.Boards != null && Array.IndexOf(requirement.Boards, board) < 0)
+            if (requirement.Boards.HasValue && !requirement.Boards.Value.Contains(board))
             {
-                return false;
+                return SupportFailure.Board;
             }
 
             var capabilities = Metadata.Capabilities;
             if (requirement.Hardware.HasFlag(HardwareRequirement.SdCard) && !capabilities.HasSdCard)
             {
-                return false;
+                return SupportFailure.Hardware;
             }
 
             if (requirement.Hardware.HasFlag(HardwareRequirement.WiFi) && !capabilities.HasWiFi)
             {
-                return false;
+                return SupportFailure.Hardware;
             }
 
-            return true;
+            return SupportFailure.None;
         }
 
         /// <summary>
@@ -155,32 +185,54 @@ namespace Daqifi.Core.Device
         /// </exception>
         public void EnsureSupported(DeviceFeature feature)
         {
-            if (!Supports(feature))
+            var failure = EvaluateSupport(feature);
+            if (failure == SupportFailure.None)
             {
-                throw CreateFeatureNotSupportedException(feature);
+                return;
             }
+
+            // Report a required firmware version only when the version is what failed. A board or
+            // hardware shortfall on a device whose firmware already meets the minimum would
+            // otherwise produce a self-contradictory "Requires firmware >= 3.7.0; the device
+            // reports '3.7.0'" — pointing the caller at an upgrade that cannot help.
+            throw BuildFeatureNotSupportedException(
+                feature,
+                failure == SupportFailure.FirmwareVersion
+                    ? DeviceFeatureRequirements.For(feature).MinVersion
+                    : null);
         }
 
         /// <summary>
-        /// Builds the typed <see cref="FeatureNotSupportedException"/> for <paramref name="feature"/>,
-        /// populating the required version from the requirement table and the actual version and
-        /// board from the current <see cref="Metadata"/>.
+        /// Builds the typed <see cref="FeatureNotSupportedException"/> for a feature the firmware
+        /// rejected on the wire, attributing the failure to the firmware version.
         /// </summary>
         /// <remarks>
-        /// Used by <see cref="EnsureSupported"/> and by the wire-level <c>-113</c> backstop, which
-        /// throws on the firmware's authoritative answer rather than on a table lookup and so needs
-        /// to build the exception without first re-testing <see cref="Supports"/>.
+        /// For the <c>-113</c> "Undefined header" backstop, where the device itself is the
+        /// authority: the firmware does not recognize the command at all, so the required version
+        /// from the table is the actionable answer and no table re-evaluation is wanted. Up-front
+        /// checks go through <see cref="EnsureSupported"/> instead, which reports a required
+        /// version only when the version is the axis that actually failed.
         /// </remarks>
         /// <param name="feature">The feature the device does not support.</param>
         /// <returns>The exception to throw.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when <paramref name="feature"/> has no entry in the requirement table.
         /// </exception>
-        protected FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
+        protected FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature) =>
+            BuildFeatureNotSupportedException(feature, DeviceFeatureRequirements.For(feature).MinVersion);
+
+        /// <summary>
+        /// Assembles a <see cref="FeatureNotSupportedException"/> from the current
+        /// <see cref="Metadata"/>, with the required version supplied by the caller so each entry
+        /// point controls whether a firmware version is claimed as the cause.
+        /// </summary>
+        private FeatureNotSupportedException BuildFeatureNotSupportedException(
+            DeviceFeature feature,
+            FirmwareVersion? requiredVersion)
         {
             return new FeatureNotSupportedException(
                 feature,
-                DeviceFeatureRequirements.For(feature).MinVersion,
+                requiredVersion,
                 Metadata.FirmwareVersion,
                 Metadata.DeviceType == DeviceType.Unknown ? null : Metadata.DeviceType);
         }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -67,6 +67,125 @@ namespace Daqifi.Core.Device
             FirmwareVersion.TryParse(Metadata.FirmwareVersion, out var parsed) && parsed >= MinSupportedFirmware;
 
         /// <summary>
+        /// Gets a value indicating whether this device supports <paramref name="feature"/>, per the
+        /// requirement table behind ADR 0001 (docs/adr/0001-firmware-feature-gating.md). Consumers
+        /// branch on this instead of comparing firmware version strings themselves.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Evaluated against the current <see cref="Metadata"/> on every call — never cached —
+        /// because the board variant and the firmware version arrive in separate status-message
+        /// branches, so any precomputed flag would be snapshotted before one of them and go stale.
+        /// </para>
+        /// <para>
+        /// The two axes fail differently, deliberately:
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>
+        /// <b>Firmware version fails closed.</b> A version that is absent or does not parse yields
+        /// <c>false</c> for any version-gated feature. Dispatching a command the firmware may not
+        /// implement is the more expensive mistake (over WiFi, an SD command on pre-v3.7.0 firmware
+        /// stalls on the shared SPI bus), so an unknown version is not treated as permission.
+        /// </description></item>
+        /// <item><description>
+        /// <b>Board and hardware requirements are evaluated only once the board is known.</b> While
+        /// <see cref="DeviceMetadata.DeviceType"/> is <see cref="DeviceType.Unknown"/>,
+        /// <see cref="DeviceCapabilities.FromDeviceType"/> has not run and
+        /// <see cref="DeviceMetadata.Capabilities"/> holds all-<c>false</c> defaults that mean "not
+        /// yet known", not "hardware absent" — so those requirements are skipped rather than read
+        /// as violated, which would otherwise refuse features on a device that simply has not
+        /// reported its part number yet. The firmware's wire-level <c>-113</c> reply remains the
+        /// authoritative backstop for that window.
+        /// </description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="feature">The feature to test.</param>
+        /// <returns><c>true</c> if the device meets every requirement for <paramref name="feature"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="feature"/> has no entry in the requirement table.
+        /// </exception>
+        public bool Supports(DeviceFeature feature)
+        {
+            var requirement = DeviceFeatureRequirements.For(feature);
+
+            if (requirement.MinVersion.HasValue
+                && (!FirmwareVersion.TryParse(Metadata.FirmwareVersion, out var firmware)
+                    || firmware < requirement.MinVersion.Value))
+            {
+                return false;
+            }
+
+            var board = Metadata.DeviceType;
+            if (board == DeviceType.Unknown)
+            {
+                return true;
+            }
+
+            if (requirement.Boards != null && Array.IndexOf(requirement.Boards, board) < 0)
+            {
+                return false;
+            }
+
+            var capabilities = Metadata.Capabilities;
+            if (requirement.Hardware.HasFlag(HardwareRequirement.SdCard) && !capabilities.HasSdCard)
+            {
+                return false;
+            }
+
+            if (requirement.Hardware.HasFlag(HardwareRequirement.WiFi) && !capabilities.HasWiFi)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Throws a typed <see cref="FeatureNotSupportedException"/> unless this device supports
+        /// <paramref name="feature"/>. The up-front counterpart to the firmware's wire-level
+        /// <c>-113</c> "Undefined header" backstop: it pre-empts the round-trip for a feature the
+        /// device is known to lack.
+        /// </summary>
+        /// <param name="feature">The feature the caller is about to use.</param>
+        /// <exception cref="FeatureNotSupportedException">
+        /// Thrown when <see cref="Supports"/> returns <c>false</c> for <paramref name="feature"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="feature"/> has no entry in the requirement table.
+        /// </exception>
+        public void EnsureSupported(DeviceFeature feature)
+        {
+            if (!Supports(feature))
+            {
+                throw CreateFeatureNotSupportedException(feature);
+            }
+        }
+
+        /// <summary>
+        /// Builds the typed <see cref="FeatureNotSupportedException"/> for <paramref name="feature"/>,
+        /// populating the required version from the requirement table and the actual version and
+        /// board from the current <see cref="Metadata"/>.
+        /// </summary>
+        /// <remarks>
+        /// Used by <see cref="EnsureSupported"/> and by the wire-level <c>-113</c> backstop, which
+        /// throws on the firmware's authoritative answer rather than on a table lookup and so needs
+        /// to build the exception without first re-testing <see cref="Supports"/>.
+        /// </remarks>
+        /// <param name="feature">The feature the device does not support.</param>
+        /// <returns>The exception to throw.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="feature"/> has no entry in the requirement table.
+        /// </exception>
+        protected FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
+        {
+            return new FeatureNotSupportedException(
+                feature,
+                DeviceFeatureRequirements.For(feature).MinVersion,
+                Metadata.FirmwareVersion,
+                Metadata.DeviceType == DeviceType.Unknown ? null : Metadata.DeviceType);
+        }
+
+        /// <summary>
         /// Gets the collection of channels populated from device status messages.
         /// </summary>
         /// <remarks>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1492,25 +1492,22 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
-        /// Minimum firmware for SD-card file transfer (LIST / GET / DELETE) over a WiFi/TCP
-        /// connection. Firmware <c>#598/#599</c> (first released <b>v3.7.0</b>) route the SD reply
-        /// to the requesting interface; before that the SD card and WiFi contend for the shared SPI
-        /// bus, so these operations are USB-only on older firmware. See
-        /// <see cref="DeviceFeature.SdFileTransferOverWifi"/> and ADR 0001.
+        /// Applies the transport predicate for an SD-card operation that drives the card while the
+        /// link is active (LIST / GET / DELETE and the storage-space query). Over USB (serial) these
+        /// are available on all SD-capable firmware and are not gated. Over WiFi/TCP they are gated
+        /// on <see cref="DeviceFeature.SdFileTransferOverWifi"/>, which
+        /// <see cref="DaqifiDevice.EnsureSupported"/> resolves against the requirement table
+        /// (ADR 0001) — pre-empting a command the firmware cannot service over WiFi, which would
+        /// otherwise stall on the shared SPI bus.
         /// </summary>
-        internal static readonly FirmwareVersion SdOverWifiMinFirmware = new(3, 7, 0, null, 0);
-
-        /// <summary>
-        /// Guards an SD-card file operation (LIST / GET / DELETE) against the transport it will run
-        /// on. Over USB (serial) these are always available on SD-capable firmware. Over WiFi/TCP
-        /// they require firmware &gt;= <see cref="SdOverWifiMinFirmware"/> — an unparseable or older
-        /// reported version is treated as unsupported and throws a typed, actionable
-        /// <see cref="FeatureNotSupportedException"/> up front (ADR 0001) rather than dispatching a
-        /// command the firmware cannot service over WiFi (which would stall on the shared SPI bus).
-        /// </summary>
+        /// <remarks>
+        /// This is only the transport half of the gate: which feature applies depends on the active
+        /// transport, but whether the device has that feature is the seam's answer, not this
+        /// method's.
+        /// </remarks>
         /// <exception cref="FeatureNotSupportedException">
-        /// Thrown when the active transport is not USB and the device firmware predates
-        /// <see cref="SdOverWifiMinFirmware"/>.
+        /// Thrown when the active transport is not USB and the device does not support
+        /// <see cref="DeviceFeature.SdFileTransferOverWifi"/>.
         /// </exception>
         private void EnsureSdFileTransferSupportedOnTransport()
         {
@@ -1519,15 +1516,7 @@ namespace Daqifi.Core.Device
                 return;
             }
 
-            if (!FirmwareVersion.TryParse(Metadata.FirmwareVersion, out var firmware)
-                || firmware < SdOverWifiMinFirmware)
-            {
-                throw new FeatureNotSupportedException(
-                    DeviceFeature.SdFileTransferOverWifi,
-                    SdOverWifiMinFirmware,
-                    Metadata.FirmwareVersion,
-                    Metadata.DeviceType == DeviceType.Unknown ? null : Metadata.DeviceType);
-            }
+            EnsureSupported(DeviceFeature.SdFileTransferOverWifi);
         }
 
         /// <summary>
@@ -1715,15 +1704,13 @@ namespace Daqifi.Core.Device
             // A -113 "Undefined header" reply means the firmware doesn't recognize the storage
             // query at all — typically because it predates the version that introduced it — so
             // it gets the typed feature-gating exception instead of a generic operation error.
+            // The device's answer is authoritative here, so this throws on the wire response
+            // rather than on Supports(); the seam only supplies the required version and board.
             if (lastScpiError != null
                 && ScpiResponseClassifier.TryExtractErrorCode(lastScpiError, out var scpiErrorCode)
                 && scpiErrorCode == ScpiErrorCodeUndefinedHeader)
             {
-                throw new FeatureNotSupportedException(
-                    DeviceFeature.SdStorageQuery,
-                    MinSupportedFirmware,
-                    Metadata.FirmwareVersion,
-                    Metadata.DeviceType == DeviceType.Unknown ? null : Metadata.DeviceType);
+                throw CreateFeatureNotSupportedException(DeviceFeature.SdStorageQuery);
             }
 
             throw new SdCardOperationException(

--- a/src/Daqifi.Core/Device/DeviceFeatureRequirements.cs
+++ b/src/Daqifi.Core/Device/DeviceFeatureRequirements.cs
@@ -1,0 +1,132 @@
+using Daqifi.Core.Firmware;
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Physical hardware a <see cref="DeviceFeature"/> requires the device to have, independent of
+    /// firmware version. Evaluated against <see cref="DeviceMetadata.Capabilities"/>, which is
+    /// derived from the board variant by <see cref="DeviceCapabilities.FromDeviceType"/>.
+    /// </summary>
+    [Flags]
+    internal enum HardwareRequirement
+    {
+        /// <summary>No hardware requirement beyond being a DAQiFi device.</summary>
+        None = 0,
+
+        /// <summary>Requires an SD card slot (<see cref="DeviceCapabilities.HasSdCard"/>).</summary>
+        SdCard = 1 << 0,
+
+        /// <summary>Requires WiFi connectivity (<see cref="DeviceCapabilities.HasWiFi"/>).</summary>
+        WiFi = 1 << 1
+    }
+
+    /// <summary>
+    /// What a device must satisfy to support one <see cref="DeviceFeature"/>: a minimum firmware
+    /// version, a board-variant allow-list, and/or physical hardware. A <c>null</c> version or
+    /// board list means that axis places no constraint on the feature.
+    /// </summary>
+    /// <param name="MinVersion">
+    /// Minimum firmware version, or <c>null</c> when the feature is not version-gated. Compared
+    /// against the device's reported version with <see cref="FirmwareVersion.TryParse"/>; an
+    /// absent or unparseable version fails the check (see <see cref="DaqifiDevice.Supports"/>).
+    /// </param>
+    /// <param name="Boards">
+    /// Board variants that have the feature, or <c>null</c> when every board does.
+    /// </param>
+    /// <param name="Hardware">Physical hardware the feature drives.</param>
+    internal readonly record struct FeatureRequirement(
+        FirmwareVersion? MinVersion,
+        DeviceType[]? Boards,
+        HardwareRequirement Hardware);
+
+    /// <summary>
+    /// The <see cref="DeviceFeature"/> → <see cref="FeatureRequirement"/> table behind
+    /// <see cref="DaqifiDevice.Supports"/> (ADR 0001, docs/adr/0001-firmware-feature-gating.md).
+    /// Sourced from the firmware audit table in that ADR; when daqifi-core starts consuming a new
+    /// firmware-gated command, its <see cref="DeviceFeature"/> member and its entry here are added
+    /// together — <see cref="For"/> throws for a member with no entry, and
+    /// <c>DeviceFeatureRequirementsTests</c> asserts the table stays exhaustive.
+    /// </summary>
+    internal static class DeviceFeatureRequirements
+    {
+        /// <summary>
+        /// Minimum firmware for SD-card access (file transfer and the storage-space query) over a
+        /// WiFi/TCP connection. Firmware <c>#598/#599</c> (first released <b>v3.7.0</b>) route the
+        /// SD reply to the requesting interface; before that the SD card and WiFi contend for the
+        /// shared SPI bus, so these operations were USB-only.
+        /// </summary>
+        internal static readonly FirmwareVersion SdOverWifiMinFirmware = new(3, 7, 0, null, 0);
+
+        /// <summary>
+        /// Minimum firmware for the capability document (<c>CONFigure:CAPabilities:JSON?</c> /
+        /// <c>:APIVersion?</c>), first released in v3.5.0 (firmware #327/#343).
+        /// </summary>
+        internal static readonly FirmwareVersion CapabilityDocumentMinFirmware = new(3, 5, 0, null, 0);
+
+        private static readonly DeviceType[] Nyquist3Only = { DeviceType.Nyquist3 };
+
+        private static readonly IReadOnlyDictionary<DeviceFeature, FeatureRequirement> Table =
+            new Dictionary<DeviceFeature, FeatureRequirement>
+            {
+                // Board-gated, not version-gated: the DAC commands shipped in v3.2.0 (below the
+                // floor) but the firmware rejects them on any board that isn't NQ3.
+                [DeviceFeature.AnalogOutput] = new(
+                    MinVersion: null,
+                    Boards: Nyquist3Only,
+                    Hardware: HardwareRequirement.None),
+
+                // Introduced in v3.4.6b1, below the floor, so this entry is a backstop against
+                // below-floor devices only. It reports the floor — not v3.4.6b1 — as the required
+                // version, since the floor is what daqifi-core actually guarantees.
+                [DeviceFeature.SdStorageQuery] = new(
+                    MinVersion: DaqifiDevice.MinSupportedFirmware,
+                    Boards: null,
+                    Hardware: HardwareRequirement.SdCard),
+
+                [DeviceFeature.CapabilityDocument] = new(
+                    MinVersion: CapabilityDocumentMinFirmware,
+                    Boards: null,
+                    Hardware: HardwareRequirement.None),
+
+                // The first above-floor gate (ADR 0001's trigger for building this table).
+                [DeviceFeature.SdFileTransferOverWifi] = new(
+                    MinVersion: SdOverWifiMinFirmware,
+                    Boards: null,
+                    Hardware: HardwareRequirement.SdCard | HardwareRequirement.WiFi)
+            };
+
+        /// <summary>
+        /// Gets the requirement for <paramref name="feature"/>.
+        /// </summary>
+        /// <param name="feature">The feature to look up.</param>
+        /// <returns>The feature's <see cref="FeatureRequirement"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="feature"/> has no table entry. This is a programming error
+        /// — a new <see cref="DeviceFeature"/> member added without its requirement — and throws
+        /// rather than defaulting, so the omission can't silently mis-gate the feature in either
+        /// direction.
+        /// </exception>
+        internal static FeatureRequirement For(DeviceFeature feature)
+        {
+            if (!Table.TryGetValue(feature, out var requirement))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(feature),
+                    feature,
+                    $"No feature requirement is defined for '{feature}'. Add an entry to {nameof(DeviceFeatureRequirements)}.");
+            }
+
+            return requirement;
+        }
+
+        /// <summary>
+        /// Gets the features that have a table entry. Used by tests to assert the table covers
+        /// every <see cref="DeviceFeature"/> member.
+        /// </summary>
+        internal static IEnumerable<DeviceFeature> DefinedFeatures => Table.Keys;
+    }
+}

--- a/src/Daqifi.Core/Device/DeviceFeatureRequirements.cs
+++ b/src/Daqifi.Core/Device/DeviceFeatureRequirements.cs
@@ -1,6 +1,7 @@
 using Daqifi.Core.Firmware;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 #nullable enable
 
@@ -35,12 +36,14 @@ namespace Daqifi.Core.Device
     /// absent or unparseable version fails the check (see <see cref="DaqifiDevice.Supports"/>).
     /// </param>
     /// <param name="Boards">
-    /// Board variants that have the feature, or <c>null</c> when every board does.
+    /// Board variants that have the feature, or <c>null</c> when every board does. Immutable: the
+    /// table hands the same instance to every caller, so a mutable array here would let any
+    /// friend-assembly code silently re-gate the feature process-wide.
     /// </param>
     /// <param name="Hardware">Physical hardware the feature drives.</param>
     internal readonly record struct FeatureRequirement(
         FirmwareVersion? MinVersion,
-        DeviceType[]? Boards,
+        ImmutableArray<DeviceType>? Boards,
         HardwareRequirement Hardware);
 
     /// <summary>
@@ -67,7 +70,8 @@ namespace Daqifi.Core.Device
         /// </summary>
         internal static readonly FirmwareVersion CapabilityDocumentMinFirmware = new(3, 5, 0, null, 0);
 
-        private static readonly DeviceType[] Nyquist3Only = { DeviceType.Nyquist3 };
+        private static readonly ImmutableArray<DeviceType> Nyquist3Only =
+            ImmutableArray.Create(DeviceType.Nyquist3);
 
         private static readonly IReadOnlyDictionary<DeviceFeature, FeatureRequirement> Table =
             new Dictionary<DeviceFeature, FeatureRequirement>


### PR DESCRIPTION
Closes #256.

## Why now

ADR 0001 deferred the version-gating layer until daqifi-core consumed a command introduced *above* the v3.5.0 floor. #347 did exactly that — SD file transfer over WiFi, gated at firmware >= v3.7.0 — implemented as a bespoke inline version compare in `DaqifiStreamingDevice`. That was the trigger condition, so this generalizes it into the seam the ADR specified and routes the existing gates through it.

## What changed

**`DeviceFeatureRequirements`** (new, internal) — a static `DeviceFeature -> FeatureRequirement` table carrying a minimum firmware version, a board allow-list, and hardware flags. Seeded from ADR 0001's firmware audit and covering all four current features: `AnalogOutput` (NQ3-only, no version gate), `SdStorageQuery` (floor + SD hardware), `CapabilityDocument` (v3.5.0), `SdFileTransferOverWifi` (v3.7.0 + SD + WiFi). `SdOverWifiMinFirmware` moved here from `DaqifiStreamingDevice`.

**`DaqifiDevice.Supports(DeviceFeature)` / `EnsureSupported(DeviceFeature)`** — evaluated live against `Metadata` on every call, never cached, since the board variant and firmware version arrive in separate status-message branches.

**Both hand-rolled gates now route through the seam.** `EnsureSdFileTransferSupportedOnTransport()` keeps only the transport predicate (which feature applies over WiFi vs. USB) and delegates the support question; the SD-storage-query `-113` backstop builds its typed exception from the table via `CreateFeatureNotSupportedException`. No bespoke feature checks remain in `DaqifiStreamingDevice`.

## The one design call worth reviewing

The two axes fail differently, deliberately:

- **Firmware version fails closed** — absent or unparseable reports unsupported, preserving #347's conservative rule. Dispatching an SD command over WiFi to pre-v3.7.0 firmware stalls on the shared SPI bus, so an unknown version is not treated as permission.
- **Board and hardware requirements are evaluated only once the board is known.** While `DeviceType` is `Unknown`, `FromDeviceType` has not run and `Capabilities` holds all-`false` defaults that mean "not yet known", not "hardware absent". Reading them as violations would newly refuse SD-over-WiFi on a device that has merely not reported its part number yet — a behavior regression against #347. The wire-level `-113` remains the backstop for that window. The cost asymmetry justifies the split: a DAC command on an NQ1 returns a clean SCPI error, whereas an SD command over WiFi on old firmware stalls the bus.

`Supports()` landed on `DaqifiDevice`, not on `DeviceCapabilities` as ADR 0001 sketched — `DeviceCapabilities` is board-derived and never sees the firmware version, so it structurally cannot answer a version gate. This also matches where its siblings already live (`MinSupportedFirmware`, `IsFirmwareVersionSupported`, `Metadata`), none of which are on `IDevice`. The ADR is updated with an implementation note recording both decisions.

## Testing

- **32 new table-driven tests** across every axis: below / at / above minimum, absent, unparseable, Int32-overflow, pre-release, wrong board, missing hardware, unknown board, plus a guard asserting the table stays exhaustive as `DeviceFeature` grows.
- Full suite green: **1900 passed, 0 failed** on net9.0 and net10.0; 0 build warnings under `TreatWarningsAsErrors`.
- **Bench-tested** on a Nyquist1 (FW 3.7.2) over USB with the example CLI built against this branch: 10 Hz stream (23 samples, clean stop), `--sd-list` (20 files, exit 0), `--sd-storage` (exit 0). Both refactored call sites exercised on real hardware. The below-gate SD-over-WiFi branch only exists on pre-v3.7.0 firmware and is covered by unit tests, not the bench.

## Out of scope

Part 2 of #256 — the `CONFigure:CAPabilities:JSON?` / `:APIVersion?` device self-description reader (firmware #327) — stays deferred, as the issue specifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
