### PR TITLE
fix(network): persist WiFi config before applying it (closes #352)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
@@ -343,6 +343,88 @@ namespace Daqifi.Core.Tests.Device.Network
         }
 
         [Fact]
+        public async Task UpdateNetworkConfigurationAsync_SavesBeforeApplying()
+        {
+            // Regression (#352): the save MUST precede the apply. ApplyNetworkLan restarts the WiFi
+            // module; a save sent afterwards can be lost to that restart, leaving the device
+            // applied-but-not-persisted (new config live now, gone on the next power cycle). The
+            // firmware persists the *staged* settings, so saving first is both valid and durable.
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "TestNetwork",
+                "TestPassword");
+
+            await device.UpdateNetworkConfigurationAsync(config);
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            var saveIndex = sentCommands.IndexOf("SYSTem:COMMunicate:LAN:SAVE");
+            var applyIndex = sentCommands.IndexOf("SYSTem:COMMunicate:LAN:APPLY");
+
+            Assert.True(saveIndex >= 0, "Expected a LAN:SAVE command to be sent.");
+            Assert.True(applyIndex >= 0, "Expected a LAN:APPLY command to be sent.");
+            Assert.True(
+                saveIndex < applyIndex,
+                $"LAN:SAVE (index {saveIndex}) must be sent before LAN:APPLY (index {applyIndex}).");
+        }
+
+        [Fact]
+        public async Task UpdateNetworkConfigurationAsync_OverWifi_SavesBeforeApplying()
+        {
+            // The field case this ordering exists for: switching the device from one hotspot to
+            // another over a WiFi/TCP control link, with no USB cable available. The apply drops the
+            // connection by design — that is inherent to leaving the current network — so the config
+            // must already be in NVM before it fires.
+            var device = new TestableNonUsbDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "OtherHotspot",
+                "OtherPassword");
+
+            await device.UpdateNetworkConfigurationAsync(config);
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            var saveIndex = sentCommands.IndexOf("SYSTem:COMMunicate:LAN:SAVE");
+            var applyIndex = sentCommands.IndexOf("SYSTem:COMMunicate:LAN:APPLY");
+
+            Assert.True(saveIndex >= 0, "Expected a LAN:SAVE command to be sent over WiFi.");
+            Assert.True(applyIndex >= 0, "Expected a LAN:APPLY command to be sent over WiFi.");
+            Assert.True(
+                saveIndex < applyIndex,
+                $"Over WiFi, LAN:SAVE (index {saveIndex}) must be sent before LAN:APPLY (index {applyIndex}).");
+        }
+
+        [Fact]
+        public async Task UpdateNetworkConfigurationAsync_SendsNothingAfterApply()
+        {
+            // The apply is the last command by design: anything sent after it races the WiFi module
+            // restart and can be silently dropped over a WiFi/TCP transport. Guards against a future
+            // change appending a trailing command to the sequence.
+            var device = new TestableNonUsbDaqifiStreamingDevice("TestDevice");
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "TestNetwork",
+                "TestPassword");
+
+            await device.UpdateNetworkConfigurationAsync(config);
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            var applyIndex = sentCommands.IndexOf("SYSTem:COMMunicate:LAN:APPLY");
+
+            Assert.True(applyIndex >= 0, "Expected a LAN:APPLY command to be sent.");
+            Assert.True(
+                applyIndex == sentCommands.Count - 1,
+                "LAN:APPLY must be the final command sent; commands after it can be lost to the " +
+                $"WiFi module restart. Trailing commands: [{string.Join(", ", sentCommands.Skip(applyIndex + 1))}]");
+        }
+
+        [Fact]
         public void PrepareSdInterface_WhenDisconnected_ThrowsInvalidOperationException()
         {
             // Arrange

--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurableTests.cs
@@ -425,6 +425,58 @@ namespace Daqifi.Core.Tests.Device.Network
         }
 
         [Fact]
+        public async Task UpdateNetworkConfigurationAsync_CanceledBeforeCommit_SendsNeitherSaveNorApply()
+        {
+            // Cancellation before the save is a clean abort: everything sent so far only staged
+            // values in the device's runtime settings, so nothing is persisted or applied.
+            using var cts = new CancellationTokenSource();
+            var device = new CancelOnCommandDaqifiStreamingDevice(
+                "TestDevice", cancelAfterCommand: "SYSTem:STORage:SD:ENAble 0", cts: cts);
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "TestNetwork",
+                "TestPassword");
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => device.UpdateNetworkConfigurationAsync(config, cts.Token));
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.DoesNotContain("SYSTem:COMMunicate:LAN:SAVE", sentCommands);
+            Assert.DoesNotContain("SYSTem:COMMunicate:LAN:APPLY", sentCommands);
+        }
+
+        [Fact]
+        public async Task UpdateNetworkConfigurationAsync_CanceledDuringRestartWait_CompletesAndUpdatesLocalState()
+        {
+            // Past the save/apply the device has already committed. Cancelling during the restart
+            // wait must end the wait rather than fail the call — surfacing "canceled" here would
+            // tell the caller nothing happened while the device sits on the new configuration, and
+            // would strand NetworkConfiguration holding the old values.
+            using var cts = new CancellationTokenSource();
+            var device = new CancelOnCommandDaqifiStreamingDevice(
+                "TestDevice", cancelAfterCommand: "SYSTem:COMMunicate:LAN:APPLY", cts: cts);
+            device.Connect();
+            var config = new NetworkConfiguration(
+                WifiMode.ExistingNetwork,
+                WifiSecurityType.WpaPskPhrase,
+                "NewNetwork",
+                "NewPassword");
+
+            // Cancelling as APPLY goes out puts the token in a canceled state before the wait.
+            await device.UpdateNetworkConfigurationAsync(config, cts.Token);
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:COMMunicate:LAN:SAVE", sentCommands);
+            Assert.Contains("SYSTem:COMMunicate:LAN:APPLY", sentCommands);
+
+            // Local state must reflect what the device actually committed.
+            Assert.Equal("NewNetwork", device.NetworkConfiguration.Ssid);
+            Assert.Equal(WifiMode.ExistingNetwork, device.NetworkConfiguration.Mode);
+        }
+
+        [Fact]
         public void PrepareSdInterface_WhenDisconnected_ThrowsInvalidOperationException()
         {
             // Arrange
@@ -648,6 +700,42 @@ namespace Daqifi.Core.Tests.Device.Network
         /// <summary>
         /// A testable version of DaqifiStreamingDevice that captures sent messages.
         /// </summary>
+        /// <summary>
+        /// Captures sent messages like <see cref="TestableDaqifiStreamingDevice"/>, but also trips a
+        /// <see cref="CancellationTokenSource"/> the moment a nominated command is dispatched. This
+        /// is how the cancellation tests land the cancel at an exact point mid-sequence — before the
+        /// save (a clean abort) or as the apply goes out (already committed).
+        /// </summary>
+        private class CancelOnCommandDaqifiStreamingDevice : DaqifiStreamingDevice
+        {
+            public List<IOutboundMessage<string>> SentMessages { get; } = new();
+
+            private readonly string _cancelAfterCommand;
+            private readonly CancellationTokenSource _cts;
+
+            public CancelOnCommandDaqifiStreamingDevice(
+                string name, string cancelAfterCommand, CancellationTokenSource cts)
+                : base(name)
+            {
+                _cancelAfterCommand = cancelAfterCommand;
+                _cts = cts;
+            }
+
+            public override bool IsUsbConnection => true;
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    SentMessages.Add(stringMessage);
+                    if (stringMessage.Data == _cancelAfterCommand)
+                    {
+                        _cts.Cancel();
+                    }
+                }
+            }
+        }
+
         private class TestableDaqifiStreamingDevice : DaqifiStreamingDevice
         {
             public List<IOutboundMessage<string>> SentMessages { get; } = new();

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1238,7 +1238,12 @@ namespace Daqifi.Core.Device
         /// <exception cref="InvalidOperationException">Thrown when the device is not connected.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when an unsupported WiFi mode or security type is specified.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        /// <exception cref="OperationCanceledException">
+        /// Thrown when the operation is canceled <b>before</b> the configuration is committed to the
+        /// device. Once the save and apply have been dispatched the operation always completes
+        /// successfully: cancelling during the restart wait ends the wait early instead of failing,
+        /// because the device has already persisted and applied the new settings.
+        /// </exception>
         public async Task UpdateNetworkConfigurationAsync(NetworkConfiguration configuration, CancellationToken cancellationToken = default)
         {
             if (configuration == null)
@@ -1315,6 +1320,11 @@ namespace Daqifi.Core.Device
             Send(ScpiMessageProducer.DisableStorageSd);
             Send(ScpiMessageProducer.EnableNetworkLan);
 
+            // Last point at which abandoning the operation is harmless: everything staged above
+            // lives only in the device's runtime settings — nothing persisted, nothing applied.
+            // Past the save below the device has committed, so cancellation stops being a way out.
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Persist BEFORE applying (#352). LAN:SAVE copies the staged runtime settings straight
             // to NVM; it does NOT require them to have been applied first. Sending it here — while
             // the control link is still guaranteed alive — is what makes the reconfiguration
@@ -1331,7 +1341,18 @@ namespace Daqifi.Core.Device
 
             // Hold for the module restart window before returning, so the apply is flushed to the
             // transport rather than left buffered in a connection that is about to go away.
-            await Task.Delay(WIFI_MODULE_RESTART_DELAY_MS, cancellationToken);
+            // Cancelling here ends the wait but does NOT fail the operation: the device has already
+            // persisted and applied the new configuration, so reporting "canceled" — and skipping
+            // the local-state update below — would leave the caller believing nothing happened
+            // while the device is sitting on a different network.
+            try
+            {
+                await Task.Delay(WIFI_MODULE_RESTART_DELAY_MS, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Already committed on the device; stop waiting early and complete normally.
+            }
 
             // Update local configuration. Static IP fields use null = "leave
             // unchanged" semantics, so only overwrite when the caller provided

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1217,6 +1217,21 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Updates the device network configuration with the specified settings.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Supported over any transport, including WiFi/TCP. The settings are staged, persisted to
+        /// NVM, and only then applied, so the configuration is durable before the applying restart
+        /// can disturb the control connection (#352).
+        /// </para>
+        /// <para>
+        /// <b>Over a WiFi/TCP control connection this method is expected to drop the connection.</b>
+        /// Applying the settings restarts the WiFi module, and when the new configuration points at
+        /// a different network the device necessarily leaves the one carrying the control link.
+        /// That is normal: the configuration has already been saved at that point. Callers should
+        /// treat the device as disconnected once this method returns over WiFi and rediscover or
+        /// reconnect on the new network — typically at a new address.
+        /// </para>
+        /// </remarks>
         /// <param name="configuration">The new network configuration to apply.</param>
         /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
@@ -1290,23 +1305,33 @@ namespace Daqifi.Core.Device
                 Send(ScpiMessageProducer.SetLanGateway(configuration.Gateway));
             }
 
-            // Apply configuration
-            Send(ScpiMessageProducer.ApplyNetworkLan);
-
-            // Wait for WiFi module to restart
-            await Task.Delay(WIFI_MODULE_RESTART_DELAY_MS, cancellationToken);
-
-            // Re-enable the LAN interface after the reconfig. ApplyNetworkLan restarts the WiFi
-            // module, so this is a network-configuration step that OWNS the LAN state and must
-            // bring LAN back up regardless of the control transport. It deliberately does NOT call
-            // PrepareLanInterface() — that is the transport-aware SD-operation restore, which
-            // leaves the LAN alone over WiFi (where #598/#599 keep it up). Here the LAN enable is
-            // unconditional.
+            // Stage the LAN interface state alongside the credentials above. LAN:ENAbled writes
+            // isEnabled into the same runtime settings struct the SET commands populate and does
+            // not restart anything itself, so it belongs before the save (to be persisted) and
+            // before the apply (the firmware only fires a module REINIT when isEnabled is set).
+            // This deliberately does NOT call PrepareLanInterface() — that is the transport-aware
+            // SD-operation restore, which leaves the LAN alone over WiFi (where #598/#599 keep it
+            // up). Here the LAN enable is unconditional: reconfiguration owns the LAN state.
             Send(ScpiMessageProducer.DisableStorageSd);
             Send(ScpiMessageProducer.EnableNetworkLan);
 
-            // Save configuration to persist across restarts
+            // Persist BEFORE applying (#352). LAN:SAVE copies the staged runtime settings straight
+            // to NVM; it does NOT require them to have been applied first. Sending it here — while
+            // the control link is still guaranteed alive — is what makes the reconfiguration
+            // durable regardless of what the apply below does to the connection.
             Send(ScpiMessageProducer.SaveNetworkLan);
+
+            // Apply last: this restarts the WiFi module. Over a WiFi/TCP control connection that
+            // restart necessarily tears down the link — inherent to moving the device onto a
+            // different network, not a fault to be avoided. Because the save above already
+            // committed the configuration to NVM, losing the link here costs nothing: the device
+            // comes back on the new network with the settings intact. Nothing is sent after this
+            // command, so there is no tail left to drop.
+            Send(ScpiMessageProducer.ApplyNetworkLan);
+
+            // Hold for the module restart window before returning, so the apply is flushed to the
+            // transport rather than left buffered in a connection that is about to go away.
+            await Task.Delay(WIFI_MODULE_RESTART_DELAY_MS, cancellationToken);
 
             // Update local configuration. Static IP fields use null = "leave
             // unchanged" semantics, so only overwrite when the caller provided

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1320,9 +1320,17 @@ namespace Daqifi.Core.Device
             Send(ScpiMessageProducer.DisableStorageSd);
             Send(ScpiMessageProducer.EnableNetworkLan);
 
-            // Last point at which abandoning the operation is harmless: everything staged above
-            // lives only in the device's runtime settings — nothing persisted, nothing applied.
-            // Past the save below the device has committed, so cancellation stops being a way out.
+            // Cancellation boundary. This is the last point where abandoning still avoids the two
+            // things that matter: nothing has been persisted (no LAN:SAVE) and no module restart
+            // has been triggered (no LAN:APPLY), so the device keeps serving the network
+            // configuration it already had. Past the save below it has committed, and cancellation
+            // stops being a way out.
+            //
+            // This is deliberately NOT a side-effect-free point. The staged credentials, the LAN
+            // enable flag and the SD disable above have all reached the device's runtime state, and
+            // a later LAN:APPLY from any caller would pick up those staged values. No side-effect-
+            // free abort exists once the sequence has begun — only the check at the top of this
+            // method precedes every Send.
             cancellationToken.ThrowIfCancellationRequested();
 
             // Persist BEFORE applying (#352). LAN:SAVE copies the staged runtime settings straight

--- a/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
+++ b/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
@@ -42,6 +42,12 @@ namespace Daqifi.Core.Device.Network
         /// follows the restart, so none can be lost to it (#352).
         /// </para>
         /// <para>
+        /// Cancellation applies only up to that save: past it the device has committed, so
+        /// cancelling during the restart wait ends the wait early rather than failing the call.
+        /// Reporting a cancellation there would tell the caller nothing happened while the device
+        /// was in fact already sitting on the new configuration.
+        /// </para>
+        /// <para>
         /// <b>Over a WiFi/TCP control connection this is expected to drop the connection.</b>
         /// Restarting the WiFi module takes the device off the network carrying the control link
         /// whenever the new configuration points somewhere else — unavoidable when switching

--- a/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
+++ b/src/Daqifi.Core/Device/Network/INetworkConfigurable.cs
@@ -30,11 +30,25 @@ namespace Daqifi.Core.Device.Network
         /// <item><description>Sets the security type</description></item>
         /// <item><description>Sets the password (if security is enabled)</description></item>
         /// <item><description>Sets the static IP, subnet mask, and gateway (only those provided as non-null)</description></item>
-        /// <item><description>Applies the LAN configuration</description></item>
-        /// <item><description>Waits for the WiFi module to restart</description></item>
-        /// <item><description>Re-enables the LAN interface</description></item>
+        /// <item><description>Enables the LAN interface</description></item>
         /// <item><description>Saves the configuration to persist across restarts</description></item>
+        /// <item><description>Applies the LAN configuration, restarting the WiFi module</description></item>
+        /// <item><description>Waits for the WiFi module to restart</description></item>
         /// </list>
+        /// <para>
+        /// The save deliberately precedes the apply. The device persists the staged settings rather
+        /// than only the live ones, so saving first makes the new configuration durable before the
+        /// applying restart can disturb the control connection. Applying last also means no command
+        /// follows the restart, so none can be lost to it (#352).
+        /// </para>
+        /// <para>
+        /// <b>Over a WiFi/TCP control connection this is expected to drop the connection.</b>
+        /// Restarting the WiFi module takes the device off the network carrying the control link
+        /// whenever the new configuration points somewhere else — unavoidable when switching
+        /// networks, and harmless here because the configuration is already saved. Callers should
+        /// treat the device as disconnected once this method returns over WiFi and rediscover or
+        /// reconnect on the new network, typically at a new address.
+        /// </para>
         /// <para>
         /// Note: The SD card and LAN interfaces share the same SPI bus on the device hardware
         /// and cannot be used simultaneously. This method handles the interface switching automatically.


### PR DESCRIPTION
## Summary

Alternative to #376, which fixes #352 by **gating network reconfiguration to USB**. This fixes it by **reordering two commands**, keeping WiFi reconfiguration working.

The field case that motivated this: switching a DAQiFi from one hotspot to another *out in the field*, with no USB cable to hand.

## The premise #376 rests on doesn't hold

#376 treats the dropped control connection as the defect. But if you move a device onto a different network, the connection carrying your commands **must** die — that is the operation succeeding, not a race to be avoided. #376 makes that impossible-to-avoid outcome unreachable by forbidding the workflow.

The real defect is narrower: Core saves **last**, so the save is what gets lost.

```
before: SET… -> APPLY -> delay -> SD off -> LAN on -> SAVE   # SAVE stranded behind the restart
after:  SET… -> SD off -> LAN on -> SAVE -> APPLY -> delay   # durable before anything restarts
```

## Why persist-first is valid (firmware-verified)

#352 and #376 both flagged persist-first as depending on unverified firmware semantics. It's now verified, in the firmware source and on hardware:

- **`LAN:SAVE` persists the _staged_ settings, not the active ones.** `SCPI_LANSettingsSave` memcpy's `BOARDRUNTIME_WIFI_SETTINGS` straight to NVM with no dependency on `APPLY` having run.
- **`LAN:ENAbled` writes `isEnabled` into that same struct and restarts nothing**, so it moves ahead of the save (to be persisted) and ahead of the apply (the firmware only fires a REINIT when `isEnabled` is set).
- **The restart is asynchronous and the save is link-independent** — `APPLY` enqueues a REINIT event, and `SaveToNvm` is a local flash write. Once the command reaches the device, persistence completes on-device regardless of the connection.
- **Bare `APPLY` never writes NVM**, so applying after saving cannot clobber what was saved.

## Bench validation

On an Nq1 (WINC1500 fw 19.7.7), over USB:

| Test | Result |
|---|---|
| Stage SSID + `SAVE`, **no `APPLY` at all**, cold boot | Persisted |
| Full new sequence with a **successful** `APPLY` (every command `0,"No error"`), reboot | Persisted through a real module REINIT + power cycle |
| Device restored to original configuration afterwards | Verified field-by-field |

One note for anyone reproducing: `APPLY` returns `-200` when the device is in standby (`SYSTem:POWer:STATe? -> 0`) because the radio isn't initialized. Power up first. That is unrelated to this change — but it does reinforce the ordering, since `APPLY` is the step that can fail and it no longer has the save riding behind it.

## Behavior change

Reconfiguration over WiFi/TCP now works instead of being rejected. Over WiFi the control connection is **expected to drop** when the target network changes; the config is already in NVM, so the device returns on the new network with settings intact. Documented on both `INetworkConfigurable` and the implementation so callers reconnect rather than treat the drop as an error. **Over USB the observable sequence is unchanged apart from the ordering.**

## Tests

Three ordering regressions — save-before-apply over USB, the same over a WiFi transport, and apply-is-the-final-command (guards against a future trailing command being appended into the restart window). **All three fail against the old ordering**, with the diagnostic showing `SAVE` at index 7 behind `APPLY` at index 4.

`_OverWifi_StillReEnablesLan` from #347 is kept and still passes — #376 had to delete it.

Full suite **1838 passed / 2 skipped** on net9.0 + net10.0; 0-warning Release on both TFMs.

## Note

Opened for review, not merging. If this approach is preferred, #376 should be closed as superseded — the two are mutually exclusive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)