### PR TITLE
fix(channel): add CalB un-scaled by InternalScaleM, matching firmware (closes #387)

### DIFF
--- a/src/Daqifi.Core.Tests/Channel/AnalogChannelTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/AnalogChannelTests.cs
@@ -108,7 +108,7 @@ public class AnalogChannelTests
         var result = channel.GetScaledValue(32767); // Half of resolution
 
         // Assert
-        // Expected: (32767 / 65535) * 10.0 * 1.0 + 0.0) * 1.0 ≈ 5.0
+        // Expected: 32767 / 65535 * 10.0 * 1.0 * 1.0 + 0.0 ≈ 5.0
         Assert.Equal(5.0, result, precision: 2);
     }
 
@@ -128,7 +128,7 @@ public class AnalogChannelTests
         var result = channel.GetScaledValue(65535); // Max value
 
         // Assert
-        // Expected: (65535 / 65535) * 1.0 * 2.0 + 1.0 = 3.0
+        // Expected: 65535 / 65535 * 1.0 * 2.0 * 1.0 + 1.0 = 3.0
         Assert.Equal(3.0, result, precision: 6);
     }
 
@@ -148,8 +148,45 @@ public class AnalogChannelTests
         var result = channel.GetScaledValue(32767); // Half value
 
         // Assert
-        // Expected: ((32767 / 65535) * 1.0 * 1.0 + 0.0) * 10.0 ≈ 5.0
+        // Expected: 32767 / 65535 * 1.0 * 1.0 * 10.0 + 0.0 ≈ 5.0
         Assert.Equal(5.0, result, precision: 2);
+    }
+
+    [Fact]
+    public void GetScaledValue_WithInternalScaleAndOffset_DoesNotScaleTheOffset()
+    {
+        // Regression pin for daqifi-core#387: CalibrationB is an offset in volts and must be added
+        // after InternalScaleM is applied, matching the firmware's own conversion
+        // (MC12bADC.c: (range * scale * calM * raw) / resolution + calB, behind MEAS:VOLT:DC?).
+        // The old form multiplied CalibrationB by InternalScaleM, which diverged from the device
+        // whenever InternalScaleM != 1 and CalibrationB != 0.
+        var channel = new AnalogChannel(0, 65535)
+        {
+            PortRange = 10.0,
+            CalibrationM = 1.0,
+            CalibrationB = 0.25,
+            InternalScaleM = 2.0
+        };
+
+        // Correct:  65535 / 65535 * 10.0 * 1.0 * 2.0 + 0.25 = 20.25
+        // Old (bug): (65535 / 65535 * 10.0 * 1.0 + 0.25) * 2.0 = 20.50
+        Assert.Equal(20.25, channel.GetScaledValue(65535), precision: 6);
+    }
+
+    [Fact]
+    public void GetScaledValue_WithInternalScaleAndOffset_AtZeroRawReturnsTheOffsetUnscaled()
+    {
+        // At raw 0 the gain term vanishes, so the result is exactly CalibrationB — the cleanest
+        // statement that the offset is never multiplied by InternalScaleM (daqifi-core#387).
+        var channel = new AnalogChannel(0, 65535)
+        {
+            PortRange = 10.0,
+            CalibrationM = 1.0,
+            CalibrationB = -0.05,
+            InternalScaleM = 4.0
+        };
+
+        Assert.Equal(-0.05, channel.GetScaledValue(0), precision: 9);
     }
 
     [Fact]
@@ -428,8 +465,8 @@ public class AnalogChannelTests
     [Fact]
     public void GetScaledValue_WithNegativeRawAndOffset_AppliesOffsetAfterSignedGain()
     {
-        // Formula: (raw/Res * PortRange * M + B) * InternalScaleM.
-        // At -full scale with M=1, B=1: (-1 * 10 * 1 + 1) = -9.
+        // Formula: raw/Res * PortRange * M * InternalScaleM + B.
+        // At -full scale with M=1, InternalScaleM=1, B=1: (-1 * 10 * 1 * 1) + 1 = -9.
         var channel = new AnalogChannel(0, 262143)
         {
             PortRange = 10.0,

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
@@ -634,7 +634,9 @@ public sealed class SdCardCsvFileParserTests
     [Fact]
     public async Task ParseAsync_WithCalibrationOffsets_AppliesFullFormula()
     {
-        // Arrange — test the full scaling formula: (raw / resolution * portRange * calM + calB) * internalScaleM
+        // Arrange — test the full scaling formula: raw / resolution * portRange * calM * internalScaleM + calB
+        // calB is an offset in volts and is not scaled by internalScaleM (daqifi-core#387), so this
+        // case (internalScaleM=2, calB=-0.05) also pins the SD path against the live-channel path.
         await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
             "TestDevice", "SN001", 100u,
             (1000u, new[] { 32768.0 })  // half-scale on 16-bit ADC
@@ -661,9 +663,9 @@ public sealed class SdCardCsvFileParserTests
         var session = await parser.ParseAsync(stream, "test.csv", options);
         var samples = await ToListAsync(session.Samples);
 
-        // Expected: (32768 / 65535 * 10.0 * 1.02 + (-0.05)) * 2.0
+        // Expected: 32768 / 65535 * 10.0 * 1.02 * 2.0 + (-0.05)
         var normalized = 32768.0 / 65535.0;
-        var expected = (normalized * 10.0 * 1.02 + (-0.05)) * 2.0;
+        var expected = normalized * 10.0 * 1.02 * 2.0 + (-0.05);
         Assert.Single(samples);
         Assert.Equal(expected, samples[0].AnalogValues[0], precision: 5);
     }

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileParserTests.cs
@@ -599,11 +599,40 @@ public class SdCardFileParserTests
         Assert.Single(samples);
         Assert.Equal(2, samples[0].AnalogValues.Count);
 
-        // Channel 0: (32768/65535 * 1.0 * 1.0 + 0.0) * 1.0 ≈ 0.50001
+        // Channel 0: 32768/65535 * 1.0 * 1.0 * 1.0 + 0.0 ≈ 0.50001
         Assert.InRange(samples[0].AnalogValues[0], 0.499, 0.501);
 
-        // Channel 1: (32768/65535 * 1.0 * 2.0 + 0.1) * 1.0 ≈ 1.1000
+        // Channel 1: 32768/65535 * 1.0 * 2.0 * 1.0 + 0.1 ≈ 1.1000
         Assert.InRange(samples[0].AnalogValues[1], 1.099, 1.101);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithNonUnityIntScaleAndOffset_DoesNotScaleTheOffset()
+    {
+        // daqifi-core#387: calB is an offset in volts, added after the internal scale factor —
+        // the SD path must agree with AnalogChannel.GetScaledValue and with the firmware.
+        var statusMsg = SdCardTestFileBuilder.CreateStatusMessage();
+        statusMsg.AnalogInRes = 65535;
+        statusMsg.AnalogInPortRange.AddRange(new[] { 1.0f });
+        statusMsg.AnalogInIntScaleM.AddRange(new[] { 2.0f });
+        statusMsg.AnalogInCalM.AddRange(new[] { 1.0f });
+        statusMsg.AnalogInCalB.AddRange(new[] { 0.1f });
+
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(statusMsg)
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 1000,
+                analogIntValues: new[] { 32768 }));
+
+        using var stream = builder.Build();
+
+        var session = await _parser.ParseAsync(stream, "scaled-offset.bin");
+        var samples = await ToListAsync(session.Samples);
+
+        // Correct:  32768/65535 * 1.0 * 1.0 * 2.0 + 0.1 ≈ 1.10002
+        // Old (bug): (32768/65535 * 1.0 * 1.0 + 0.1) * 2.0 ≈ 1.20002
+        Assert.Single(samples);
+        Assert.InRange(samples[0].AnalogValues[0], 1.0999, 1.1001);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
@@ -387,6 +387,48 @@ public sealed class SdCardJsonFileParserTests
     }
 
     [Fact]
+    public async Task ParseAsync_WithNonUnityIntScaleAndOffset_DoesNotScaleTheOffset()
+    {
+        // daqifi-core#387: calB is an offset in volts, added after the internal scale factor —
+        // the SD path must agree with AnalogChannel.GetScaledValue and with the firmware.
+        await using var stream = SdCardTestJsonFileBuilder.BuildJsonFileWithIntegers(
+            (100u, new[] { 0, 32768, 0 }, "00")
+        );
+
+        var overrideConfig = new global::Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration(
+            AnalogPortCount: 3,
+            DigitalPortCount: 0,
+            TimestampFrequency: 100u,
+            DeviceSerialNumber: "SN001",
+            DevicePartNumber: "TestDevice",
+            FirmwareRevision: null,
+            CalibrationValues: new[] { (1.0, -0.05), (1.0, -0.05), (1.0, -0.05) },
+            Resolution: 65535,
+            PortRange: new[] { 10.0, 10.0, 10.0 },
+            InternalScaleM: new[] { 2.0, 2.0, 2.0 });
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardJsonFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            SessionStartTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            FallbackTimestampFrequency = 100,
+            ConfigurationOverride = overrideConfig
+        };
+
+        var session = await parser.ParseAsync(stream, "test.json", options);
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Single(samples);
+
+        // At raw 0 the gain term vanishes, so the result is exactly calB — never calB * intScale.
+        // Correct: -0.05.  Old (bug): -0.05 * 2.0 = -0.10.
+        Assert.Equal(-0.05, samples[0].AnalogValues[0], precision: 6);
+
+        // Correct:  32768 / 65535 * 10.0 * 1.0 * 2.0 + (-0.05)
+        Assert.Equal(32768.0 / 65535.0 * 10.0 * 2.0 - 0.05, samples[0].AnalogValues[1], precision: 5);
+    }
+
+    [Fact]
     public async Task ParseAsync_WithoutCalibrationConfig_ReturnsRawValues()
     {
         // Arrange — no config override → values pass through as-is

--- a/src/Daqifi.Core/Channel/AnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogChannel.cs
@@ -275,17 +275,20 @@ public class AnalogChannel : IAnalogChannel
 
     /// <summary>
     /// Converts a raw ADC value to a scaled value using the calibration parameters.
-    /// Formula: ScaledValue = (RawValue / Resolution * PortRange * CalibrationM + CalibrationB) * InternalScaleM
+    /// Formula: ScaledValue = RawValue / Resolution * PortRange * CalibrationM * InternalScaleM + CalibrationB
     /// </summary>
+    /// <remarks>
+    /// <see cref="CalibrationB"/> is an offset in volts and is added after <see cref="InternalScaleM"/>
+    /// is applied — it is not scaled by it. This matches the firmware's own on-device conversion, so a
+    /// value scaled here agrees with what the device reports for <c>MEASure:VOLTage:DC?</c>.
+    /// </remarks>
     /// <param name="rawValue">The raw ADC value from the device.</param>
     /// <returns>The scaled value.</returns>
     public double GetScaledValue(int rawValue)
     {
         lock (_lock)
         {
-            double normalized = (double)rawValue / Resolution;
-            double scaled = (normalized * _portRange * _calibrationM + _calibrationB) * _internalScaleM;
-            return scaled;
+            return AnalogScaling.Scale(rawValue, _resolution, _portRange, _calibrationM, _internalScaleM, _calibrationB);
         }
     }
 

--- a/src/Daqifi.Core/Channel/AnalogScaling.cs
+++ b/src/Daqifi.Core/Channel/AnalogScaling.cs
@@ -1,0 +1,52 @@
+namespace Daqifi.Core.Channel;
+
+/// <summary>
+/// The single implementation of the raw-ADC-count to volts conversion, shared by live channel
+/// scaling (<see cref="AnalogChannel.GetScaledValue"/>) and the SD-card log parsers so the two
+/// paths can never disagree about the same sample.
+/// </summary>
+internal static class AnalogScaling
+{
+    /// <summary>
+    /// Converts a raw ADC count to volts using the device's calibration parameters.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The formula mirrors the firmware's own on-device conversion (<c>MC12bADC.c</c>, the path
+    /// behind <c>MEASure:VOLTage:DC?</c>):
+    /// </para>
+    /// <code>
+    /// Volts = (raw / Resolution) * PortRange * CalibrationM * InternalScaleM + CalibrationB
+    /// </code>
+    /// <para>
+    /// <paramref name="calibrationB"/> is an offset in volts and is added <em>after</em>
+    /// <paramref name="internalScaleM"/> is applied — it is deliberately not scaled by it. Scaling
+    /// the offset makes host-side values diverge from the device's own <c>MEAS:VOLT:DC?</c> reading
+    /// whenever the internal scale factor is non-unity and the offset is non-zero.
+    /// </para>
+    /// </remarks>
+    /// <param name="rawValue">The raw ADC count.</param>
+    /// <param name="resolution">The ADC's maximum raw count (2^bits - 1). Must be non-zero.</param>
+    /// <param name="portRange">The channel's full-scale range, in volts.</param>
+    /// <param name="calibrationM">The calibration slope (gain).</param>
+    /// <param name="internalScaleM">The board's internal (front-end) scale factor.</param>
+    /// <param name="calibrationB">The calibration offset, in volts.</param>
+    /// <returns>The scaled value, in volts.</returns>
+    /// <remarks>
+    /// The parameters are ordered to match the formula left-to-right — the multiplicative terms in
+    /// order, then the additive offset last — so a call site reads as the formula does and the two
+    /// easily-transposed factors (<paramref name="internalScaleM"/> and
+    /// <paramref name="calibrationB"/>) are not interchangeable by eye.
+    /// </remarks>
+    internal static double Scale(
+        double rawValue,
+        double resolution,
+        double portRange,
+        double calibrationM,
+        double internalScaleM,
+        double calibrationB)
+    {
+        var normalized = rawValue / resolution;
+        return normalized * portRange * calibrationM * internalScaleM + calibrationB;
+    }
+}

--- a/src/Daqifi.Core/Channel/IAnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/IAnalogChannel.cs
@@ -58,8 +58,13 @@ public interface IAnalogChannel : IChannel
 
     /// <summary>
     /// Converts a raw ADC value to a scaled value using the calibration parameters.
-    /// Formula: ScaledValue = (RawValue / Resolution * PortRange * CalibrationM + CalibrationB) * InternalScaleM
+    /// Formula: ScaledValue = RawValue / Resolution * PortRange * CalibrationM * InternalScaleM + CalibrationB
     /// </summary>
+    /// <remarks>
+    /// <see cref="CalibrationB"/> is an offset in volts and is added after <see cref="InternalScaleM"/>
+    /// is applied — it is not scaled by it. This matches the firmware's own on-device conversion, so a
+    /// value scaled here agrees with what the device reports for <c>MEASure:VOLTage:DC?</c>.
+    /// </remarks>
     /// <param name="rawValue">The raw ADC value from the device.</param>
     /// <returns>The scaled value.</returns>
     double GetScaledValue(int rawValue);

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -438,7 +438,9 @@ public sealed class SdCardCsvFileParser
 
     /// <summary>
     /// Scales raw ADC values to real voltage using device calibration data.
-    /// Formula: (raw / resolution * portRange * calM + calB) * internalScaleM
+    /// Formula: <c>raw / resolution * portRange * calM * internalScaleM + calB</c>
+    /// (see <see cref="Channel.AnalogScaling"/> — <c>calB</c> is an offset in volts and is
+    /// deliberately not scaled by <c>internalScaleM</c>).
     /// </summary>
     private static IReadOnlyList<double> ScaleRawAnalogValues(
         IReadOnlyList<double> rawValues,
@@ -463,8 +465,7 @@ public sealed class SdCardCsvFileParser
             var range = portRange != null && ch < portRange.Count ? portRange[ch] : 1.0;
             var scaleM = intScale != null && ch < intScale.Count ? intScale[ch] : 1.0;
 
-            var normalized = rawValues[ch] / resolution;
-            result[ch] = (normalized * range * calM + calB) * scaleM;
+            result[ch] = Channel.AnalogScaling.Scale(rawValues[ch], resolution, range, calM, scaleM, calB);
         }
 
         return result;

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -337,7 +337,9 @@ public sealed class SdCardFileParser
 
     /// <summary>
     /// Scales raw ADC integer values using calibration parameters from the device config.
-    /// Formula: <c>(raw / resolution * portRange * calM + calB) * internalScaleM</c>
+    /// Formula: <c>raw / resolution * portRange * calM * internalScaleM + calB</c>
+    /// (see <see cref="Channel.AnalogScaling"/> — <c>calB</c> is an offset in volts and is
+    /// deliberately not scaled by <c>internalScaleM</c>).
     /// </summary>
     private static double[] ScaleRawAnalogValues(
         Google.Protobuf.Collections.RepeatedField<int> rawValues,
@@ -362,8 +364,7 @@ public sealed class SdCardFileParser
             var range = portRange != null && ch < portRange.Count ? portRange[ch] : 1.0;
             var scaleM = intScale != null && ch < intScale.Count ? intScale[ch] : 1.0;
 
-            var normalized = rawValues[ch] / resolution;
-            result[ch] = (normalized * range * calM + calB) * scaleM;
+            result[ch] = Channel.AnalogScaling.Scale(rawValues[ch], resolution, range, calM, scaleM, calB);
         }
 
         return result;

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -264,7 +264,9 @@ public sealed class SdCardJsonFileParser
 
     /// <summary>
     /// Scales raw ADC values to real voltage using device calibration data.
-    /// Formula: (raw / resolution * portRange * calM + calB) * internalScaleM
+    /// Formula: <c>raw / resolution * portRange * calM * internalScaleM + calB</c>
+    /// (see <see cref="Channel.AnalogScaling"/> — <c>calB</c> is an offset in volts and is
+    /// deliberately not scaled by <c>internalScaleM</c>).
     /// </summary>
     private static IReadOnlyList<double> ScaleRawAnalogValues(
         IReadOnlyList<double> rawValues,
@@ -289,8 +291,7 @@ public sealed class SdCardJsonFileParser
             var range = portRange != null && ch < portRange.Count ? portRange[ch] : 1.0;
             var scaleM = intScale != null && ch < intScale.Count ? intScale[ch] : 1.0;
 
-            var normalized = rawValues[ch] / resolution;
-            result[ch] = (normalized * range * calM + calB) * scaleM;
+            result[ch] = Channel.AnalogScaling.Scale(rawValues[ch], resolution, range, calM, scaleM, calB);
         }
 
         return result;


### PR DESCRIPTION
Closes #387.

## The bug

Core's host-side analog scaling multiplied the calibration offset `CalB` by `InternalScaleM`:

```
Volts = (raw/Res * PortRange * CalM + CalB) * InternalScaleM
```

The firmware's own on-device conversion — `MC12bADC.c`, the path behind `MEASure:VOLTage:DC?` — adds `CalB` un-scaled:

```
Volts = (Range * InternalScale * CalM * raw) / Res + CalB
```

So Core and the device disagreed about the same raw sample whenever `InternalScaleM != 1` **and** `CalB != 0`, and `MEAS:VOLT:DC?` would silently contradict what Core reported for that sample. The pre-Core desktop implementation matched the firmware form.

## Scope note — this fixes four call sites, not one

The issue names `AnalogChannel.GetScaledValue`, but the same formula was copy-pasted into the three SD-card parsers as well (`SdCardFileParser`, `SdCardCsvFileParser`, `SdCardJsonFileParser`). Fixing only the live path would have left Core disagreeing **with itself** — the same device, streamed live vs. downloaded from SD, would produce different volts.

All four now route through one internal `AnalogScaling.Scale` helper, so the live-streaming path and the SD-log path can't drift apart again.

## Bench verification

Ran against the bench Nq1 (HW 2.0.0, FW 3.7.2) over USB and dumped the per-channel scaling metadata the device actually reports:

| | value on all 16 AI channels |
|---|---|
| `Resolution` | 4096 |
| `PortRange` | 5.0 |
| `CalM` | 1.0 |
| `CalB` | **0.0** |
| `InternalScaleM` | **1.0** |
| old-form vs new-form delta | **0.0** |

So this is confirmed **latent on NQ1** — scaled output is bit-identical on this hardware. It bites any board/config with a non-unity internal scale and a non-zero offset. That's why there's no streaming bench run here: on this hardware the change is provably a no-op, so a stream comparison couldn't distinguish the two formulas.

## Release-notes item (behavior change)

> Analog scaling now matches the firmware's on-device formula: `CalibrationB` is added **after** `InternalScaleM` rather than being multiplied by it. Consumers with a non-unity `InternalScaleM` **and** a non-zero `CalibrationB` will see corrected (different) scaled values from `IAnalogChannel.GetScaledValue` and from SD-card log parsing. No change for any current NQ1 hardware, where `InternalScaleM = 1`.

## Tests

- Two new `AnalogChannel` tests: one pinning the corrected formula with `InternalScaleM = 2`, `CalB = 0.25`; one asserting that at `raw = 0` the result is exactly `CalB` (the cleanest statement that the offset is never scaled).
- New non-unity-scale + non-zero-offset tests for the protobuf and JSON SD parsers; the existing CSV test already used `InternalScaleM = 2`, `calB = -0.05` and had its expectation corrected.
- Regression check: reverting just the helper to the old formula fails exactly these 5 tests, so they would have caught it.
- Full suite green on net9.0 and net10.0 (1932 passed, 2 skipped). Release build 0 warnings under `TreatWarningsAsErrors`.

## Possible follow-up (not in this PR)

`AnalogScaling` is internal. The consumer that found this — the manufacturing calibration station ([daqifi/calibration#8](https://github.com/daqifi/calibration/issues/8), and #386 for the cal-write path) — does offline scaling of raw counts and would benefit from the canonical formula being public. That's an API decision worth its own ticket rather than a rider on a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)