### PR TITLE
fix(sdcard): distinguish a timed-out SD LIST from an empty card (closes #396)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -1,0 +1,203 @@
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using System.Text;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Coverage for the stale-line boundary in the text exchange (raised while fixing #396).
+/// </summary>
+/// <remarks>
+/// A late reply to an EARLIER command can still be in flight when the next text exchange opens
+/// its consumer, and would otherwise be returned as part of the new exchange's response. That is
+/// wrong for every caller, but it is actively dangerous for one that infers device liveness from
+/// response content: the SD listing accepts a <c>SYSTem:ERRor?</c> reply as proof that the device
+/// answered and that the listing before it is complete. A stale line satisfying that check would
+/// let a silent device pass as a healthy empty SD card — the exact bug #396 is about.
+/// </remarks>
+public class DaqifiDeviceStaleTextLineTests
+{
+    [Fact]
+    public async Task ExecuteTextCommand_DropsLinesThatArrivedBeforeTheExchangeSentAnything()
+    {
+        // The stale line is released into the stream at the moment the exchange binds its text
+        // consumer — after the protobuf consumer has been stopped, and before the setup action
+        // has sent anything. That is exactly the window a late reply to an earlier command can
+        // land in. The device then stays silent, as one that has stopped answering would.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Preloaded Device", transport);
+
+        device.Connect();
+        transport.ReleaseOnStreamAccess(2); // 2nd access inside the exchange = text-consumer bind
+
+        var lines = await device.CallExecuteTextCommandAsync(() => { });
+
+        // The exchange sent nothing, so nothing in it can legitimately have been answered.
+        Assert.Empty(lines);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_KeepsLinesThatArriveAfterTheExchangeSentSomething()
+    {
+        // The complement, so the fix cannot be "drop everything": a reply that arrives once the
+        // setup action has sent its command must still be returned.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Answering Device", transport);
+
+        device.Connect();
+
+        var lines = await device.CallExecuteTextCommandAsync(() => transport.Release());
+
+        Assert.Contains(lines, l => l.Contains("No error"));
+
+        device.Disconnect();
+    }
+
+    /// <summary>Exposes the protected text-exchange entry point.</summary>
+    private class StaleLineTestableDevice : DaqifiDevice
+    {
+        public StaleLineTestableDevice(string name, IStreamTransport transport)
+            : base(name, transport)
+        {
+        }
+
+        public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(Action setupAction)
+        {
+            return ExecuteTextCommandAsync(setupAction, responseTimeoutMs: 500, completionTimeoutMs: 150);
+        }
+    }
+
+    /// <summary>
+    /// Transport whose stream withholds one canned line until released, and which can arm that
+    /// release on the Nth access of its <see cref="Stream"/> property.
+    /// </summary>
+    /// <remarks>
+    /// Keying off the property access — rather than a delay — makes the timing deterministic:
+    /// the text exchange reads <c>Stream</c> once up front and again when it binds the temporary
+    /// text consumer, and that second access happens after the protobuf consumer has been stopped
+    /// (so it cannot swallow the line first) and before the setup action runs.
+    /// </remarks>
+    private sealed class ReleaseOnStreamAccessMockTransport : IStreamTransport
+    {
+        private readonly WithheldLineStream _stream;
+        private int _streamAccessCount;
+        private int _releaseOnAccess = -1;
+        private bool _isConnected;
+        private bool _disposed;
+
+        public ReleaseOnStreamAccessMockTransport(string line)
+        {
+            _stream = new WithheldLineStream(line);
+        }
+
+        public Stream Stream
+        {
+            get
+            {
+                if (_disposed) throw new ObjectDisposedException(nameof(ReleaseOnStreamAccessMockTransport));
+
+                var access = Interlocked.Increment(ref _streamAccessCount);
+                if (_releaseOnAccess > 0 && access == _releaseOnAccess)
+                {
+                    _stream.Release();
+                }
+
+                return _stream;
+            }
+        }
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "Withheld: Connected" : "Withheld: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        /// <summary>Arms the release for the Nth subsequent access of <see cref="Stream"/>.</summary>
+        public void ReleaseOnStreamAccess(int accessNumber)
+        {
+            Interlocked.Exchange(ref _streamAccessCount, 0);
+            _releaseOnAccess = accessNumber;
+        }
+
+        /// <summary>Releases the withheld line immediately.</summary>
+        public void Release() => _stream.Release();
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(ReleaseOnStreamAccessMockTransport));
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().Wait();
+
+        public void Disconnect() => DisconnectAsync().Wait();
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _isConnected = false;
+            _disposed = true;
+        }
+
+        private sealed class WithheldLineStream : Stream
+        {
+            private readonly byte[] _line;
+            private readonly object _gate = new();
+            private bool _released;
+            private int _position;
+
+            public WithheldLineStream(string line) => _line = Encoding.ASCII.GetBytes(line);
+
+            public void Release()
+            {
+                lock (_gate)
+                {
+                    _released = true;
+                }
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                lock (_gate)
+                {
+                    if (_released && _position < _line.Length)
+                    {
+                        var toCopy = Math.Min(count, _line.Length - _position);
+                        Array.Copy(_line, _position, buffer, offset, toCopy);
+                        _position += toCopy;
+                        return toCopy;
+                    }
+                }
+
+                // Idle link: nothing to hand over, and no busy-spin in the reader thread.
+                Thread.Sleep(10);
+                return 0;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) { }
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
@@ -55,5 +55,34 @@ namespace Daqifi.Core.Tests.Device
             Assert.False(ScpiResponseClassifier.TryExtractErrorCode(line, out var code));
             Assert.Equal(0, code);
         }
+
+        [Theory]
+        [InlineData("0,\"No error\"")]                    // clean queue — the common case
+        [InlineData("-200,\"Execution error\"")]
+        [InlineData("+0,\"No error\"")]                   // explicit positive sign
+        [InlineData("-420, \"Query UNTERMINATED\"")]      // space after the comma
+        [InlineData("  0,\"No error\"  \r\n")]            // leading/trailing whitespace + CRLF
+        [InlineData("0,\"\"")]                            // empty message
+        public void IsSystemErrorReplyLine_MatchesErrorQueueReplies(string line)
+        {
+            Assert.True(ScpiResponseClassifier.IsSystemErrorReplyLine(line));
+        }
+
+        [Theory]
+        [InlineData("Daqifi/log_20240115_103000.bin 1024")]  // SD listing entry
+        [InlineData("Daqifi/log_20240115_103000.bin")]       // listing entry with no size
+        [InlineData("0,\"No error\" 1024")]                  // reply shape but with a trailing size
+        [InlineData("**ERROR: -200, \"Execution error\"")]   // ERROR-prefixed, not a query reply
+        [InlineData("Error !! No SD Card Detected")]
+        [InlineData("0 1024")]                               // no comma
+        [InlineData("0,No error")]                           // unquoted message
+        [InlineData("0,\"")]                                 // unterminated quote
+        [InlineData("-,\"No error\"")]                       // sign with no digits
+        [InlineData("[Error:3]Failed to open directory")]
+        [InlineData("")]
+        public void IsSystemErrorReplyLine_DoesNotMatchListingOrOtherText(string line)
+        {
+            Assert.False(ScpiResponseClassifier.IsSystemErrorReplyLine(line));
+        }
     }
 }

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -871,8 +871,9 @@ namespace Daqifi.Core.Tests.Device.SdCard
         [Fact]
         public async Task GetSdCardFilesAsync_WithEmptyDirectory_ReturnsEmptyList()
         {
-            // Arrange - device returns no lines (empty directory, no errors). This is
-            // the legitimate "0 files" case and must keep its existing behavior.
+            // Arrange - device returns no listing lines (empty directory, no errors) but does
+            // answer the terminator query. This is the legitimate "0 files" case and must keep
+            // its existing behavior: an empty list, no exception (#396).
             var device = new RetryableSdCardStreamingDevice("TestDevice");
             device.ResponseSequence.Enqueue(new List<string>());
             device.Connect();
@@ -884,6 +885,150 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Empty(files);
             Assert.Equal(1, device.ExecuteTextCommandCallCount);
         }
+
+        #region Timed-out vs. empty listing (issue #396)
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_SendsTerminatorQueryAfterListCommand()
+        {
+            // The terminator only proves the listing is complete if it is requested AFTER the
+            // listing itself, in the same exchange — the transport is ordered, so its reply
+            // cannot overtake listing lines the device had already written.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "Daqifi/log_20240115_103000.bin" };
+            device.Connect();
+
+            await device.GetSdCardFilesAsync();
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            var listIndex = sentCommands.IndexOf("SYSTem:STORage:SD:LIST?");
+            var terminatorIndex = sentCommands.IndexOf("SYSTem:ERRor?");
+            Assert.True(listIndex >= 0, "The file-list query was not sent.");
+            Assert.True(terminatorIndex > listIndex, "The terminator query must be sent after the file-list query.");
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_TerminatorReplyIsNotParsedAsAFile()
+        {
+            // The terminator is a protocol artifact, not directory content: it must never reach
+            // the file parser and show up as a phantom SD card file.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "Daqifi/log_20240115_103000.bin" };
+            device.Connect();
+
+            var files = await device.GetSdCardFilesAsync();
+
+            Assert.Single(files);
+            Assert.Equal("log_20240115_103000.bin", files[0].FileName);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WhenDeviceNeverAnswers_ThrowsInsteadOfReturningEmptyList()
+        {
+            // The bug in #396: a device that never answered produced the exact same empty list as
+            // a healthy empty card, so downstream rendered "SD card OK - 0 files" for an
+            // unreachable device holding data. Both attempts go unanswered here.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "Daqifi/log_20240115_103000.bin" };
+            device.Connect();
+
+            // A first, healthy listing populates the cache...
+            Assert.Single(await device.GetSdCardFilesAsync());
+
+            // ...then the device goes silent.
+            device.CannedTextResponse = new List<string>();
+            device.UnterminatedAttempts = int.MaxValue;
+
+            await Assert.ThrowsAsync<SdCardListIncompleteException>(
+                () => device.GetSdCardFilesAsync());
+
+            // The cache must not be overwritten with a listing we never actually received.
+            Assert.Single(device.SdCardFiles);
+            Assert.Equal("log_20240115_103000.bin", device.SdCardFiles[0].FileName);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WhenListingIsTruncated_ThrowsRatherThanReturningAShortList()
+        {
+            // The case no downstream mitigation can reach: the device answered, but stopped
+            // part-way through the listing. Corroborating with a later query (as the Avalonia port
+            // does) cannot detect this — only the missing terminator can.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "Daqifi/log_20240115_103000.bin",
+                "Daqifi/log_20240115_1030",
+            };
+            device.UnterminatedAttempts = int.MaxValue;
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<SdCardListIncompleteException>(
+                () => device.GetSdCardFilesAsync());
+
+            // The partial response is preserved for diagnostics rather than silently returned.
+            Assert.Equal(2, ex.RawDeviceResponse.Count);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WithStaleTerminatorAheadOfTheListing_StillReturnsTheFiles()
+        {
+            // A terminator reply from a previous, timed-out exchange can still be in the transport
+            // buffer and lead this response. Splitting at the FIRST match would discard the real
+            // listing behind it and report an empty card — the very failure #396 is about.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "-200,\"Execution error\"",   // stale reply left over from an earlier exchange
+                "Daqifi/log_20240115_103000.bin",
+                "Daqifi/data.bin",
+            };
+            device.Connect();
+
+            var files = await device.GetSdCardFilesAsync();
+
+            // Both files survive, and the stale reply is not parsed as a phantom file.
+            Assert.Equal(2, files.Count);
+            Assert.Equal("log_20240115_103000.bin", files[0].FileName);
+            Assert.Equal("data.bin", files[1].FileName);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WhenTerminatorMissingOnFirstAttemptOnly_RetriesAndSucceeds()
+        {
+            // A one-off stall is retried on the same terms as a transient SCPI error, so a single
+            // dropped reply does not become a user-visible failure.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            device.ResponseSequence.Enqueue(new List<string>());
+            device.ResponseSequence.Enqueue(new List<string> { "Daqifi/log_20240115_103000.bin" });
+            device.UnterminatedAttempts = 1;
+            device.Connect();
+
+            var files = await device.GetSdCardFilesAsync();
+
+            Assert.Single(files);
+            Assert.Equal("log_20240115_103000.bin", files[0].FileName);
+            Assert.Equal(2, device.ExecuteTextCommandCallCount);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WhenDeviceNeverAnswers_RestoresLanInterface()
+        {
+            // The throw must not skip the interface restore — the SD subsystem would be left
+            // enabled and the LAN disabled for every later command.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>();
+            device.UnterminatedAttempts = int.MaxValue;
+            device.Connect();
+
+            await Assert.ThrowsAsync<SdCardListIncompleteException>(
+                () => device.GetSdCardFilesAsync());
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:STORage:SD:ENAble 0", sentCommands); // DisableStorageSd
+            Assert.Contains("SYSTem:COMMunicate:LAN:ENAbled 1", sentCommands); // EnableNetworkLan
+        }
+
+        #endregion
 
         [Fact]
         public async Task GetSdCardFilesAsync_LastScpiError_ContainsOnlyScpiFormattedLine()
@@ -1799,6 +1944,9 @@ namespace Daqifi.Core.Tests.Device.SdCard
             public Queue<List<string>> ResponseSequence { get; } = new();
             public int ExecuteTextCommandCallCount { get; private set; }
 
+            /// <inheritdoc cref="TestableSdCardStreamingDevice.UnterminatedAttempts"/>
+            public int UnterminatedAttempts { get; set; }
+
             public RetryableSdCardStreamingDevice(string name, IPAddress? ipAddress = null)
                 : base(name, ipAddress)
             {
@@ -1824,12 +1972,14 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default)
             {
+                var sentBefore = SentMessages.Count;
                 setupAction();
                 ExecuteTextCommandCallCount++;
                 var response = ResponseSequence.Count > 0
                     ? ResponseSequence.Dequeue()
                     : new List<string>();
-                return Task.FromResult<IReadOnlyList<string>>(response);
+                return Task.FromResult(SdCardTestResponses.AnswerErrorQuery(
+                    response, SentMessages, sentBefore, ExecuteTextCommandCallCount, UnterminatedAttempts));
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -1838,12 +1988,63 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default)
             {
+                var sentBefore = SentMessages.Count;
                 await setupActionAsync(cancellationToken).ConfigureAwait(false);
                 ExecuteTextCommandCallCount++;
                 var response = ResponseSequence.Count > 0
                     ? ResponseSequence.Dequeue()
                     : new List<string>();
-                return response;
+                return SdCardTestResponses.AnswerErrorQuery(
+                    response, SentMessages, sentBefore, ExecuteTextCommandCallCount, UnterminatedAttempts);
+            }
+        }
+
+        /// <summary>
+        /// Shared device-behavior helper for the SD card fakes: models the way a live device
+        /// answers the <c>SYSTem:ERRor?</c> query that <c>GetSdCardFilesAsync</c> appends to the
+        /// listing exchange as an end-of-listing terminator (#396).
+        /// </summary>
+        private static class SdCardTestResponses
+        {
+            /// <summary>The reply a healthy device gives to <c>SYSTem:ERRor?</c> with a clean queue.</summary>
+            public const string NoErrorReply = "0,\"No error\"";
+
+            /// <summary>
+            /// Appends the <c>SYSTem:ERRor?</c> reply to <paramref name="response"/> when the
+            /// exchange actually asked for it and this attempt is not one of the
+            /// <paramref name="unterminatedAttempts"/> leading attempts being simulated as
+            /// unanswered.
+            /// </summary>
+            public static IReadOnlyList<string> AnswerErrorQuery(
+                IReadOnlyList<string> response,
+                IReadOnlyList<IOutboundMessage<string>> sentMessages,
+                int sentBefore,
+                int attemptNumber,
+                int unterminatedAttempts)
+            {
+                if (attemptNumber <= unterminatedAttempts)
+                {
+                    return response;
+                }
+
+                var errorQuery = ScpiMessageProducer.GetSystemError.Data;
+                var askedForError = false;
+                for (var i = sentBefore; i < sentMessages.Count; i++)
+                {
+                    if (sentMessages[i].Data == errorQuery)
+                    {
+                        askedForError = true;
+                        break;
+                    }
+                }
+
+                if (!askedForError)
+                {
+                    return response;
+                }
+
+                var withTerminator = new List<string>(response) { NoErrorReply };
+                return withTerminator;
             }
         }
 
@@ -1853,8 +2054,19 @@ namespace Daqifi.Core.Tests.Device.SdCard
         /// </summary>
         private class TestableSdCardStreamingDevice : DaqifiStreamingDevice
         {
+            private int _executeTextCommandCallCount;
+
             public List<IOutboundMessage<string>> SentMessages { get; } = new();
             public List<string> CannedTextResponse { get; set; } = new();
+
+            /// <summary>
+            /// Number of leading text exchanges to answer WITHOUT the <c>SYSTem:ERRor?</c> reply
+            /// that <c>GetSdCardFilesAsync</c> uses as its end-of-listing terminator (#396) — i.e.
+            /// how many attempts simulate a device that never answered, or stopped answering
+            /// part-way through the listing. Defaults to 0, so the fake behaves like a healthy
+            /// device and always terminates its listing.
+            /// </summary>
+            public int UnterminatedAttempts { get; set; }
 
             /// <summary>
             /// Simulates a USB connection so SD card operations are allowed.
@@ -1880,9 +2092,13 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default)
             {
+                var sentBefore = SentMessages.Count;
+
                 // Execute the setup action so we can capture the SCPI commands
                 setupAction();
-                return Task.FromResult<IReadOnlyList<string>>(CannedTextResponse);
+                _executeTextCommandCallCount++;
+                return Task.FromResult(SdCardTestResponses.AnswerErrorQuery(
+                    CannedTextResponse, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts));
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -1891,8 +2107,11 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default)
             {
+                var sentBefore = SentMessages.Count;
                 await setupActionAsync(cancellationToken).ConfigureAwait(false);
-                return CannedTextResponse;
+                _executeTextCommandCallCount++;
+                return SdCardTestResponses.AnswerErrorQuery(
+                    CannedTextResponse, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts);
             }
         }
 
@@ -2143,8 +2362,10 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default)
             {
+                var sentBefore = SentMessages.Count;
                 setupAction();
-                return Task.FromResult<IReadOnlyList<string>>(CannedTextResponse);
+                return Task.FromResult(SdCardTestResponses.AnswerErrorQuery(
+                    CannedTextResponse, SentMessages, sentBefore, attemptNumber: 1, unterminatedAttempts: 0));
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2153,8 +2374,10 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default)
             {
+                var sentBefore = SentMessages.Count;
                 await setupActionAsync(cancellationToken).ConfigureAwait(false);
-                return CannedTextResponse;
+                return SdCardTestResponses.AnswerErrorQuery(
+                    CannedTextResponse, SentMessages, sentBefore, attemptNumber: 1, unterminatedAttempts: 0);
             }
 
             protected override async Task ExecuteRawCaptureAsync(

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -738,7 +738,11 @@ namespace Daqifi.Core.Device
         /// <param name="responseTimeoutMs">The time in milliseconds to wait for the first text response after sending commands.</param>
         /// <param name="completionTimeoutMs">The time in milliseconds of inactivity after the first response before considering the response complete. Defaults to 250ms.</param>
         /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
-        /// <returns>A list of text lines received from the device.</returns>
+        /// <returns>
+        /// A list of text lines received from the device. Lines that were already in flight when the
+        /// exchange opened — late replies to earlier commands — are excluded: only what arrived once
+        /// <paramref name="setupAction"/> had begun sending is returned.
+        /// </returns>
         /// <exception cref="InvalidOperationException">Thrown when the device is not connected or has no transport.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
         protected virtual Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -863,6 +867,10 @@ namespace Daqifi.Core.Device
                 var stream = _transport.Stream;
                 int? originalReadTimeout = null;
 
+                // Number of lines that were already in flight when this exchange opened — see the
+                // note at the point it is captured, below.
+                var staleLineCount = 0;
+
                 try
                 {
                     if (stream.CanTimeout)
@@ -910,6 +918,23 @@ namespace Daqifi.Core.Device
                     await Task.Delay(50, cancellationToken).ConfigureAwait(false);
 
                     SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Text consumer started at {ElapsedMs}ms", sw.ElapsedMilliseconds));
+
+                    // Mark the boundary between "already in flight" and "answers to this exchange".
+                    // Anything captured before the setup action has sent anything is a late reply to
+                    // an EARLIER command, or line noise — never a response to a command this exchange
+                    // has yet to send. Those lines are dropped from the result below.
+                    //
+                    // Position matters as much as content: a caller that keys off response content —
+                    // e.g. the SD listing's end-of-listing terminator (#396) — would otherwise accept
+                    // a stale line as proof that the device answered a query it never even received,
+                    // and report a complete listing for a device that has gone silent.
+                    staleLineCount = collectedLines.Count;
+                    if (staleLineCount > 0)
+                    {
+                        SafeLog(() => _logger.LogDebug(
+                            "[ExecuteTextCommandAsync] Discarding {StaleLineCount} line(s) received before this exchange sent anything",
+                            staleLineCount));
+                    }
 
                     // Execute the setup action (sends SCPI commands). ConfigureAwait(false)
                     // matches the surrounding lock-protected awaits.
@@ -984,7 +1009,11 @@ namespace Daqifi.Core.Device
                     SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Total elapsed: {ElapsedMs}ms", sw.ElapsedMilliseconds));
                 }
 
-                return collectedLines;
+                // The text consumer is stopped by this point, so the list is no longer being
+                // appended to concurrently and can be re-projected safely.
+                return staleLineCount > 0
+                    ? collectedLines.Skip(staleLineCount).ToList()
+                    : collectedLines;
             }
             finally
             {

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -49,6 +49,19 @@ namespace Daqifi.Core.Device
         private const int SD_LIST_MAX_RETRIES = 1;
 
         /// <summary>
+        /// Inactivity window that ends the SD listing text exchange, in milliseconds.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately longer than the 250ms default. The listing is only accepted once its
+        /// end-of-listing terminator has been seen (see <see cref="GetSdCardFilesAsync"/>), and the
+        /// terminator can trail the last listing line by more than the default window — the firmware
+        /// walks the directory tree between chunks, and a congested WiFi link adds its own gaps. With
+        /// the default, a merely-slow terminator would read as a missing one and fail a listing that
+        /// was about to complete.
+        /// </remarks>
+        private const int SD_LIST_COMPLETION_TIMEOUT_MS = 1000;
+
+        /// <summary>
         /// Maximum number of retry attempts for the USB stream-interface command sent during
         /// <see cref="OnDeviceInitializingAsync"/> when the device returns a transient SCPI error
         /// (e.g. because the firmware still has the interface set from a prior WiFi session).
@@ -1655,7 +1668,10 @@ namespace Daqifi.Core.Device
                         // End-of-listing terminator — see this method's remarks. Sent inside the
                         // same text exchange so the ordering guarantee holds.
                         Send(ScpiMessageProducer.GetSystemError);
-                    }, responseTimeoutMs: 3000, cancellationToken: cancellationToken);
+                    },
+                    responseTimeoutMs: 3000,
+                    completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
+                    cancellationToken: cancellationToken);
 
                     isComplete = TrySplitAtSdListTerminator(lines, out listing);
 

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1613,6 +1613,13 @@ namespace Daqifi.Core.Device
         /// a plausible-looking empty list.
         /// </para>
         /// <para>
+        /// The terminator is only meaningful if it cannot be confused with a late reply to an
+        /// earlier command, so two things guard that boundary: the text exchange discards whatever
+        /// was already in flight when it opened, and this method does its SPI-bus switch and settle
+        /// delay before the exchange rather than inside it, leaving the exchange with no internal
+        /// gap for a stale reply to slip into.
+        /// </para>
+        /// <para>
         /// The terminator's error code is used only as a liveness marker, never for classification:
         /// the queue it pops can hold entries left by earlier commands, so attributing the code to
         /// this listing would misreport stale failures. SD errors continue to be classified from the
@@ -1654,24 +1661,31 @@ namespace Daqifi.Core.Device
                         await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken);
                     }
 
-                    lines = await ExecuteTextCommandAsync(async ct =>
-                    {
-                        PrepareSdInterface();
+                    // Switch the shared SPI bus over to the SD card and let the firmware settle
+                    // BEFORE opening the text exchange. Querying the card too soon after the switch
+                    // makes the device answer -200 (Execution error), so the delay itself is not
+                    // optional — but running it outside the exchange leaves the exchange with no
+                    // internal gap at all, so its very first act is the LIST query. That matters for
+                    // the terminator: the exchange discards anything received before its setup
+                    // action sends, and a gap inside the action would widen that boundary into a
+                    // window where a late reply to an earlier command could still be mistaken for
+                    // this listing's terminator. The delay is unchanged from the device's point of
+                    // view — if anything longer, since the consumer swap now follows it.
+                    PrepareSdInterface();
+                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken);
 
-                        // Allow the device firmware to complete the SPI bus switch
-                        // before querying the SD card. Without this delay, the device
-                        // can return SCPI error -200 (Execution error).
-                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, ct).ConfigureAwait(false);
+                    lines = await ExecuteTextCommandAsync(
+                        () =>
+                        {
+                            Send(ScpiMessageProducer.GetSdFileList);
 
-                        Send(ScpiMessageProducer.GetSdFileList);
-
-                        // End-of-listing terminator — see this method's remarks. Sent inside the
-                        // same text exchange so the ordering guarantee holds.
-                        Send(ScpiMessageProducer.GetSystemError);
-                    },
-                    responseTimeoutMs: 3000,
-                    completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
-                    cancellationToken: cancellationToken);
+                            // End-of-listing terminator — see this method's remarks. Sent inside
+                            // the same text exchange so the ordering guarantee holds.
+                            Send(ScpiMessageProducer.GetSystemError);
+                        },
+                        responseTimeoutMs: 3000,
+                        completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
+                        cancellationToken: cancellationToken);
 
                     isComplete = TrySplitAtSdListTerminator(lines, out listing);
 

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1583,6 +1583,32 @@ namespace Daqifi.Core.Device
         /// <exception cref="SdCardNotPresentException">Thrown when no SD card is installed in the device.</exception>
         /// <exception cref="SdCardFilesystemException">Thrown when the SD card filesystem cannot satisfy the request (corrupt card, unreadable directory).</exception>
         /// <exception cref="SdCardOperationException">Thrown when the device returned an SCPI error that did not match a more specific condition. Empty directories return an empty list rather than throwing.</exception>
+        /// <exception cref="SdCardListIncompleteException">
+        /// Thrown when the listing did not arrive in full — the device never answered, or stopped
+        /// answering part-way through. Distinguishing this from a genuinely empty card is the whole
+        /// point of the terminator probe described in the remarks (closes #396).
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// The firmware emits no end-of-listing marker, and for an empty directory it writes nothing
+        /// at all, so a lost or truncated reply is byte-for-byte indistinguishable from a healthy
+        /// empty card. Core closes that gap by appending a <c>SYSTem:ERRor?</c> query to the same
+        /// text exchange: the transport delivers in order and the firmware does not process the
+        /// next command until the listing has been handed to the output, so receiving the reply
+        /// proves both that the device is answering and that the listing ahead of it is complete.
+        /// Its absence means the response is incomplete, and the caller gets an exception instead of
+        /// a plausible-looking empty list.
+        /// </para>
+        /// <para>
+        /// The terminator's error code is used only as a liveness marker, never for classification:
+        /// the queue it pops can hold entries left by earlier commands, so attributing the code to
+        /// this listing would misreport stale failures. SD errors continue to be classified from the
+        /// listing lines themselves. Note the side effect this implies — each listing consumes one
+        /// entry from the device's SCPI error queue, so a
+        /// <see cref="DaqifiDevice.DrainErrorQueueAsync"/> run afterwards will not see the entry
+        /// this listing generated.
+        /// </para>
+        /// </remarks>
         public async Task<IReadOnlyList<SdCardFileInfo>> GetSdCardFilesAsync(CancellationToken cancellationToken = default)
         {
             if (!IsConnected)
@@ -1598,42 +1624,44 @@ namespace Daqifi.Core.Device
             Send(ScpiMessageProducer.StopStreaming);
             IsStreaming = false;
 
-            IReadOnlyList<string> lines;
+            IReadOnlyList<string> lines = Array.Empty<string>();
+            IReadOnlyList<string> listing = Array.Empty<string>();
+            var isComplete = false;
             try
             {
-                lines = await ExecuteTextCommandAsync(async ct =>
+                // Attempt 0 plus SD_LIST_MAX_RETRIES retries. A SCPI error here is often a transient
+                // timing issue, and an unterminated response can be a one-off stall, so both are
+                // retried once after an additional settle delay before being surfaced.
+                for (var attempt = 0; attempt <= SD_LIST_MAX_RETRIES; attempt++)
                 {
-                    PrepareSdInterface();
-
-                    // Allow the device firmware to complete the SPI bus switch
-                    // before querying the SD card. Without this delay, the device
-                    // can return SCPI error -200 (Execution error).
-                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, ct).ConfigureAwait(false);
-
-                    Send(ScpiMessageProducer.GetSdFileList);
-                }, responseTimeoutMs: 3000, cancellationToken: cancellationToken);
-
-                // If the response contains a SCPI error (transient timing issue),
-                // retry once after an additional settle delay.
-                if (ContainsScpiError(lines))
-                {
-                    for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
+                    if (attempt > 0)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
                         await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken);
+                    }
 
-                        lines = await ExecuteTextCommandAsync(async ct =>
-                        {
-                            PrepareSdInterface();
-                            await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, ct).ConfigureAwait(false);
-                            Send(ScpiMessageProducer.GetSdFileList);
-                        }, responseTimeoutMs: 3000, cancellationToken: cancellationToken);
+                    lines = await ExecuteTextCommandAsync(async ct =>
+                    {
+                        PrepareSdInterface();
 
-                        if (!ContainsScpiError(lines))
-                        {
-                            break;
-                        }
+                        // Allow the device firmware to complete the SPI bus switch
+                        // before querying the SD card. Without this delay, the device
+                        // can return SCPI error -200 (Execution error).
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, ct).ConfigureAwait(false);
+
+                        Send(ScpiMessageProducer.GetSdFileList);
+
+                        // End-of-listing terminator — see this method's remarks. Sent inside the
+                        // same text exchange so the ordering guarantee holds.
+                        Send(ScpiMessageProducer.GetSystemError);
+                    }, responseTimeoutMs: 3000, cancellationToken: cancellationToken);
+
+                    isComplete = TrySplitAtSdListTerminator(lines, out listing);
+
+                    if (isComplete && !ContainsScpiError(listing))
+                    {
+                        break;
                     }
                 }
             }
@@ -1646,11 +1674,71 @@ namespace Daqifi.Core.Device
                 }
             }
 
-            ThrowIfSdCardListError(lines);
+            if (!isComplete)
+            {
+                throw new SdCardListIncompleteException(lines);
+            }
 
-            var files = SdCardFileListParser.ParseFileList(lines);
+            ThrowIfSdCardListError(listing);
+
+            var files = SdCardFileListParser.ParseFileList(listing);
             _sdCardFiles = files;
             return files;
+        }
+
+        /// <summary>
+        /// Splits a raw SD listing response at the <c>SYSTem:ERRor?</c> terminator reply that
+        /// <see cref="GetSdCardFilesAsync"/> appends to the exchange.
+        /// </summary>
+        /// <param name="lines">The raw response lines captured from the device.</param>
+        /// <param name="listingLines">
+        /// The lines that precede the terminator — the directory listing proper — when the method
+        /// returns <c>true</c>; otherwise the unmodified input.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> when the terminator was present, meaning the response is complete;
+        /// <c>false</c> when it never arrived, meaning the response is missing or truncated.
+        /// </returns>
+        private static bool TrySplitAtSdListTerminator(
+            IReadOnlyList<string> lines,
+            out IReadOnlyList<string> listingLines)
+        {
+            // Scan from the end. A terminator reply from a PREVIOUS, timed-out exchange can still
+            // be sitting in the transport buffer and lead this response; splitting at the first
+            // match would then discard the listing that follows it and report an empty card —
+            // exactly the failure this terminator exists to prevent.
+            var terminatorIndex = -1;
+            for (var i = lines.Count - 1; i >= 0; i--)
+            {
+                if (ScpiResponseClassifier.IsSystemErrorReplyLine(lines[i]))
+                {
+                    terminatorIndex = i;
+                    break;
+                }
+            }
+
+            if (terminatorIndex < 0)
+            {
+                listingLines = lines;
+                return false;
+            }
+
+            var listing = new List<string>(terminatorIndex);
+            for (var j = 0; j < terminatorIndex; j++)
+            {
+                // Any other terminator-shaped line is a stale reply of the same kind, not
+                // directory content — no firmware listing entry can match that shape, since
+                // entries are always "<path> <size>".
+                if (ScpiResponseClassifier.IsSystemErrorReplyLine(lines[j]))
+                {
+                    continue;
+                }
+
+                listing.Add(lines[j]);
+            }
+
+            listingLines = listing;
+            return true;
         }
 
         /// <summary>
@@ -2331,6 +2419,8 @@ namespace Daqifi.Core.Device
             }
 
             // No error lines and no content lines — empty directory. Caller continues.
+            // Safe to treat as empty rather than as a lost reply: GetSdCardFilesAsync only reaches
+            // this point once the device has answered the end-of-listing terminator (#396).
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1658,7 +1658,7 @@ namespace Daqifi.Core.Device
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken);
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
                     }
 
                     // Switch the shared SPI bus over to the SD card and let the firmware settle
@@ -1672,7 +1672,7 @@ namespace Daqifi.Core.Device
                     // this listing's terminator. The delay is unchanged from the device's point of
                     // view — if anything longer, since the consumer swap now follows it.
                     PrepareSdInterface();
-                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken);
+                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
 
                     lines = await ExecuteTextCommandAsync(
                         () =>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -2122,13 +2122,23 @@ namespace Daqifi.Core.Device
             IReadOnlyList<string> lines;
             try
             {
-                lines = await ExecuteTextCommandAsync(async ct =>
-                {
-                    PrepareSdInterface();
-                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, ct).ConfigureAwait(false);
-                    Send(ScpiMessageProducer.DeleteSdFile(fileName));
-                    Send(ScpiMessageProducer.GetSdFileList);
-                }, responseTimeoutMs: 3000, cancellationToken: cancellationToken);
+                // Switch the shared SPI bus to the SD card and settle BEFORE opening the text
+                // exchange, for the same reason as GetSdCardFilesAsync: a gap inside the setup
+                // action is a window in which a late reply to an earlier command can be captured
+                // as part of this response. Here that would mean a stale error line triggering a
+                // pointless delete-and-relist retry rather than a bad listing, but it is the same
+                // defect, so it gets the same treatment.
+                PrepareSdInterface();
+                await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+
+                lines = await ExecuteTextCommandAsync(
+                    () =>
+                    {
+                        Send(ScpiMessageProducer.DeleteSdFile(fileName));
+                        Send(ScpiMessageProducer.GetSdFileList);
+                    },
+                    responseTimeoutMs: 3000,
+                    cancellationToken: cancellationToken);
 
                 if (ContainsScpiError(lines))
                 {
@@ -2136,15 +2146,19 @@ namespace Daqifi.Core.Device
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken);
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
 
-                        lines = await ExecuteTextCommandAsync(async ct =>
-                        {
-                            PrepareSdInterface();
-                            await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, ct).ConfigureAwait(false);
-                            Send(ScpiMessageProducer.DeleteSdFile(fileName));
-                            Send(ScpiMessageProducer.GetSdFileList);
-                        }, responseTimeoutMs: 3000, cancellationToken: cancellationToken);
+                        PrepareSdInterface();
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+
+                        lines = await ExecuteTextCommandAsync(
+                            () =>
+                            {
+                                Send(ScpiMessageProducer.DeleteSdFile(fileName));
+                                Send(ScpiMessageProducer.GetSdFileList);
+                            },
+                            responseTimeoutMs: 3000,
+                            cancellationToken: cancellationToken);
 
                         if (!ContainsScpiError(lines))
                         {

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -52,6 +52,67 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
+        /// Returns true if the line is the reply to a <c>SYSTem:ERRor?</c> query — the IEEE 488.2
+        /// error-queue format <c>&lt;code&gt;,"&lt;message&gt;"</c>, e.g. <c>0,"No error"</c> or
+        /// <c>-200,"Execution error"</c>. Deliberately narrow: the code must be the first thing on
+        /// the line and the quoted message must run to the end of it, so a device-emitted SD listing
+        /// entry (always <c>&lt;path&gt; &lt;size&gt;</c>, space-separated, per the firmware's
+        /// <c>"%s %u\r\n"</c> format) can never match. Unlike <see cref="IsScpiErrorLine"/> this does
+        /// not require an <c>ERROR</c> token — the query reply carries the bare code.
+        /// </summary>
+        /// <remarks>
+        /// Used as the end-of-response marker for the SD card directory listing (closes #396): the
+        /// firmware emits no terminator of its own and writes nothing at all for an empty directory,
+        /// so Core appends a <c>SYSTem:ERRor?</c> query to the same text exchange and treats its
+        /// reply as proof that everything the device had to say about the listing has arrived.
+        /// </remarks>
+        internal static bool IsSystemErrorReplyLine(string line)
+        {
+            var trimmed = line.Trim();
+
+            var index = 0;
+            if (index < trimmed.Length && (trimmed[index] == '+' || trimmed[index] == '-'))
+            {
+                index++;
+            }
+
+            var digitStart = index;
+            while (index < trimmed.Length && trimmed[index] >= '0' && trimmed[index] <= '9')
+            {
+                index++;
+            }
+
+            if (index == digitStart)
+            {
+                return false;
+            }
+
+            index = SkipSpaces(trimmed, index);
+
+            if (index >= trimmed.Length || trimmed[index] != ',')
+            {
+                return false;
+            }
+
+            index = SkipSpaces(trimmed, index + 1);
+
+            // Require an opening quote and a distinct closing quote at end-of-line.
+            return index < trimmed.Length - 1
+                   && trimmed[index] == '"'
+                   && trimmed[trimmed.Length - 1] == '"';
+        }
+
+        private static int SkipSpaces(string value, int index)
+        {
+            while (index < value.Length && (value[index] == ' ' || value[index] == '\t'))
+            {
+                index++;
+            }
+
+            return index;
+        }
+
+        /// <summary>
         /// Extracts the numeric error code from a SCPI error line — e.g. <c>-200</c> from
         /// <c>**ERROR: -200,"Execution error"</c>, <c>ERROR -113,"Undefined header"</c>, or
         /// <c>**ERROR\t-113,...</c>. The delimiter between the <c>ERROR</c>/<c>**ERROR</c> token and

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -40,6 +40,11 @@ namespace Daqifi.Core.Device.SdCard
         /// <exception cref="SdCardNotPresentException">Thrown when no SD card is installed in the device.</exception>
         /// <exception cref="SdCardFilesystemException">Thrown when the SD card filesystem cannot satisfy the request (e.g. corrupt card, unreadable directory).</exception>
         /// <exception cref="SdCardOperationException">Thrown when the device returned an SCPI error that did not match a more specific condition. An empty directory returns an empty list rather than throwing.</exception>
+        /// <exception cref="SdCardListIncompleteException">
+        /// Thrown when the device did not answer the listing query, or stopped answering part-way
+        /// through it. An empty result therefore always means an empty card — never an unreachable
+        /// device — so callers can render it as such (closes #396).
+        /// </exception>
         Task<IReadOnlyList<SdCardFileInfo>> GetSdCardFilesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardListIncompleteException.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardListIncompleteException.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// Thrown when an SD card directory listing did not arrive in full: the device either never
+    /// answered the <c>SYSTem:STORage:SD:LISt?</c> query, or stopped answering part-way through it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The firmware emits no end-of-listing marker and writes nothing at all for an empty directory,
+    /// so "no bytes received" is byte-for-byte identical to a healthy empty card on the wire. Core
+    /// therefore appends a <c>SYSTem:ERRor?</c> query to the same text exchange and uses its reply as
+    /// a terminator: the transport is ordered, so a terminator reply proves both that the device is
+    /// answering and that everything it had to say about the listing arrived first. This exception
+    /// is raised when that terminator never came back — which previously surfaced as a healthy-looking
+    /// "empty SD card" (closes #396).
+    /// </para>
+    /// <para>
+    /// A caller seeing this should treat the listing as unknown, not empty. Typical causes are a
+    /// silently dropped link, a device that is wedged or powered down, or congestion severe enough
+    /// to push the reply past the response window. Retrying once the link is known good is
+    /// reasonable; rendering "0 files" is not.
+    /// </para>
+    /// </remarks>
+    public class SdCardListIncompleteException : SdCardOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SdCardListIncompleteException"/> class.
+        /// </summary>
+        /// <param name="rawDeviceResponse">The raw response lines captured from the device, if any.</param>
+        public SdCardListIncompleteException(IReadOnlyList<string> rawDeviceResponse)
+            : base(
+                "The SD card directory listing did not complete: the device did not finish "
+                + "answering the file-list query, so the listing may be missing entries or be "
+                + "absent entirely. This is not an empty SD card — check the connection and retry.",
+                rawDeviceResponse)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`GetSdCardFilesAsync` returned an empty list both when the SD card was genuinely empty and when the device never answered, so an unreachable device holding data rendered downstream as "SD card OK · 0 files" ([daqifi-avalonia#2](https://github.com/daqifi/daqifi-avalonia/pull/2)).

## Which option, and why none of the three worked as written

The issue offered three options. Checking them against the firmware source (`daqifi-nyquist-firmware`, `sd_card_manager.c` / `SCPIStorageSD.c`) changed the answer:

**Options 1 and 2 as stated are wrong** — they would make a genuinely empty card throw. `ListFilesInDirectoryChunked` only calls `sendChunk` when `strBuffIndex > 0`, so an empty directory produces **zero bytes**, and `SCPI_StorageSDListDir` writes no SCPI result of its own. A phase-1 timeout with zero lines collected is therefore *exactly* what a healthy empty card looks like. "The device never answered" and "the card is empty" are byte-for-byte identical on the wire, and no amount of timeout bookkeeping inside `ExecuteTextCommandCoreAsync` can separate them.

**Option 3 as stated is also out** — the firmware emits no end-of-listing marker. Verified on the bench (raw SCPI probe below): the listing simply stops.

**What shipped: option 3, with Core supplying the terminator the firmware lacks.** `GetSdCardFilesAsync` appends a `SYSTem:ERRor?` query to the *same* text exchange, right after `SYSTem:STORage:SD:LIST?`, and treats its reply as the end-of-listing marker. The transport is ordered and `SCPI_StorageSDListDir` blocks in `sd_card_manager_WaitForCompletion` until every chunk has been handed to the output, so the reply arriving proves **both** that the device is answering **and** that the listing ahead of it arrived in full. Its absence raises the new `SdCardListIncompleteException` instead of a plausible-looking empty list.

That also fixes the **truncation** case the issue calls out as unreachable by any downstream mitigation: corroborating with a later `GetSdCardStorageAsync` proves the device answered a *subsequent* request, never that *this* listing was complete. A missing terminator does.

The terminator's error code is used only as a liveness marker, never for classification — the queue it pops can hold entries from earlier commands. Documented side effect: each listing now consumes one SCPI error-queue entry.

## Caller audit of the text path

The blast radius is deliberately narrow. In particular the *empty-reply contract* of `ExecuteTextCommandCoreAsync` is untouched, which matters because that is a genuinely unsafe thing to change globally — several callers depend on an empty reply being the *success* case:

| Caller | Zero lines means | Impact |
| --- | --- | --- |
| `DaqifiDevice.InitializeAsync` (echo off / stop / power on / protobuf format) | success — these are commands, not queries | a blanket throw would break every device init |
| `DaqifiStreamingDevice.OnDeviceInitializingAsync` (`SetStreamInterface`) | success — command, not query | same |
| `DaqifiDevice.DrainErrorQueueAsync` | already handled explicitly: "Empty reply means timeout or unresponsive device… terminate rather than spin" | would become a throw |
| `GetSdCardStorageAsync`, `GetLanChipInfoAsync`, and the other query helpers | parser failure → already typed exceptions | unaffected |
| `DeleteSdCardFileAsync` (delete + LIST) | refreshes `_sdCardFiles` | unchanged; see below |
| **`GetSdCardFilesAsync`** | **the bug** | **fixed** |

`src/Daqifi.Mcp` does not call `GetSdCardFilesAsync`, and no doc depends on empty-on-timeout.

Review round 1 did add one shared change to `ExecuteTextCommandCoreAsync` — dropping lines that predate the exchange's own commands (see below). That is additive for every caller in the table: none of them can want a reply to a command they had not yet sent, and all of the above were re-benched afterwards.

**Deliberate scope boundary:** `DeleteSdCardFileAsync` re-lists to refresh the cache and has the same latent ambiguity, but resolving it means deciding what a lost reply says about whether the *delete* succeeded — a different question — and it cannot be bench-verified non-destructively on the shared board. Left exactly as it is on `main`; no regression either way.

## Bench evidence — DAQiFi Nyquist 1, firmware 3.7.2, `/dev/cu.usbmodem1101`

Example CLI built against this worktree's `Daqifi.Core`.

Real listing still returns in full and does **not** throw — 31 files, and the terminator is not parsed as a phantom entry:

```
$ ... --sd-list
Listing SD card files...
  log_20260623_143217.bin  2026-06-23 14:32:17  [Protobuf]
  ... (29 more)
  log_20260728_190448.bin  2026-07-28 19:04:48  [Protobuf]
Total: 31 file(s)
```

Raw SCPI probe (read-only; SD enable → list → LAN restore) confirming both halves of the design:

```
=== Probe 1: LIST alone ===
last 3 lines:
  'DAQiFi/log_20260728_104156.bin 13791'
  'DAQiFi/log_20260728_190448.bin 0'
  'DAQIFI> '
--> no end-of-listing marker of any kind

=== Probe 2: LIST followed by SYSTem:ERRor? ===
last 3 lines:
  'DAQIFI> SYSTem:ERRor?'
  '0,"No error"'
  'DAQIFI> '
--> terminator arrives last, after every listing line
```

The reply is the bare `<code>,"<message>"` form the matcher expects, and it lands after every listing line. Also re-ran `--sd-storage` (unchanged) and a 10 Hz / 2-channel stream (5 messages, clean stop), then `--sd-list` again — still 31 files. Nothing destructive: no format, delete, flash, reboot or WiFi change.

The silent-device and truncated-listing paths are covered by unit tests rather than the bench — provoking them on real hardware needs an unplug mid-transfer.

## Tests

`src/Daqifi.Core.Tests`, full suite green on **net9.0 and net10.0** (1958 passed, 0 failed), build clean with 0 warnings.

- genuinely empty card → empty list, no throw
- device never answers → `SdCardListIncompleteException`, and the previously-cached listing is **not** overwritten
- truncated listing → throws rather than returning a short list, partial response preserved in `RawDeviceResponse`
- terminator sent *after* the LIST, and never parsed as a file
- a stale terminator *ahead* of the listing (late reply from a previous timed-out exchange) still yields the full listing — the split scans from the end for exactly this reason
- missing terminator on the first attempt only → retried, succeeds
- the throw still restores the LAN interface
- `ScpiResponseClassifier.IsSystemErrorReplyLine` match/non-match table, including `<path> <size>` listing entries and `**ERROR:`-prefixed lines
- a line that arrived before the exchange sent anything is dropped, and one that arrives after is kept (`DaqifiDeviceStaleTextLineTests`)

The SD test doubles now model the device rather than replaying canned lines verbatim: they answer `SYSTem:ERRor?` when the exchange asked for it, with an `UnterminatedAttempts` knob to simulate a device that went silent.

## Siblings

Companion to #394 / #395 / #398, worked in parallel. No semantic overlap: #395 owns the typed connectivity guards at the top of `ExecuteTextCommandCoreAsync`, #398 owns the GET-side empty-transfer ambiguity in `SdCardFileReceiver`. This PR touches neither: the only change inside `ExecuteTextCommandCoreAsync` is to the timeout/return semantics of its body (the stale-line boundary from review round 1), not to the connectivity guards at its top. Textual conflicts in `DaqifiStreamingDevice.cs` are possible.

## Review round 1 (Qodo)

Two bugs found, both valid, both fixed in `918c32c`.

**Stale terminator could false-complete.** Content alone cannot separate a stale terminator-shaped line from a fresh one — that is the same ambiguity this PR is about, one level up. What separates them is *position relative to our own commands*, so `ExecuteTextCommandCoreAsync` now marks the boundary: it snapshots the collected-line count immediately before the setup action runs and drops those lines from the result. A line captured before the exchange sent anything cannot be a response to a command that had not yet gone out, so this is right for every caller, not just the listing — and it needs no signature change. Covered by `DaqifiDeviceStaleTextLineTests`, which releases the stale line at the exact moment the exchange binds its text consumer (keyed off the `Stream` property access, so no timing dependence); verified to fail without the fix.

This is the one place the change reaches outside `GetSdCardFilesAsync`, and it is the timeout/return semantics of the exchange body rather than the connectivity guards at its top — still disjoint from #395.

**Terminator could be missed by the completion window.** Requiring a reply while keeping the 250ms inactivity default was the wrong trade — the firmware walks the directory tree between chunks. The listing exchange now uses a dedicated `SD_LIST_COMPLETION_TIMEOUT_MS = 1000`; other text queries keep the default, having no terminator to wait for.

Re-benched after both fixes: listing still returns all 31 files, and `--sd-storage`, `--lan-chip-info` and a 10 Hz two-channel stream all still pass — the last three specifically to prove the shared-exchange change did not regress the non-SD text paths. Full suite green on net9.0 and net10.0 (1958 passed), 0 warnings.


## Review round 2 (Qodo)

One bug, valid, fixed in `a82c3af`.

**Stale lines could still leak through a gap inside the setup action.** The round-1 boundary only rules out lines that predate the setup action, not ones arriving during a gap *within* it — for the listing, the 100ms SPI settle delay. `PrepareSdInterface()` and that delay now run before the exchange opens, so the exchange has no internal gap and its first act is the LIST query; the boundary collapses from a timed wait to thread scheduling. From the device's side the delay is unchanged, if anything longer, since the consumer swap now follows it.

I did not take the suggested `Send()`-based gate: it flips on the first outbound write, and the listing setup action *starts* by sending the prep commands, so it would already be true before the settle delay — leaving the exact window it was meant to close. Details on the thread.

Re-benched: 31 files on three consecutive listings, `--sd-storage` and a 10 Hz two-channel stream unaffected.


## Review rounds 3-4 (Qodo)

**Round 3** — the settle delay lost its `ConfigureAwait(false)` when round 2 moved it out of the setup action lambda. Restored in `2d7952f`, and applied to the retry-gap delay in the same loop.

**Round 4** — Qodo re-raised the stale-line finding, but its quoted evidence ("the setup action ... `await`s a settle delay before sending the LIST + terminator") no longer matches the code: that has not been true since `a82c3af`. Verified and explained on the thread.

The general point was still live elsewhere, though. Grepping every `ExecuteTextCommandAsync` call site turned up the identical pattern in `DeleteSdCardFileAsync`, at both its first-attempt and retry sites — the last two `async ct =>` setup actions in the file. Fixed the same way in `0c2f9c0`; every call site is now a synchronous lambda with no internal gap. The consequence there was milder than the listing's: delete keys off `ContainsScpiError` rather than a terminator, so a stale error line would have caused a spurious delete-and-relist retry rather than an incomplete listing being accepted.

This supersedes the scope note above: the delete path's *gap* is now fixed. What is still deliberately left alone there is the terminator itself, for the reason given — a lost reply's meaning for whether the *delete* succeeded is a separate question.

The delete path is deliberately not bench-verified: confirming it on hardware means actually deleting a file from the shared bench card. The reorder is byte-identical to the one validated on the listing path against real firmware.

closes #396

**Not merging — opened for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
