### PR TITLE
fix(sdcard): run the SD bus switch as a prepare phase inside the exchange lock

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceDrainErrorQueueTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceDrainErrorQueueTests.cs
@@ -203,17 +203,25 @@ namespace Daqifi.Core.Tests.Device
                 }
             }
 
-            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null)
             {
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 cancellationToken.ThrowIfCancellationRequested();
                 setupAction();
                 ExecuteTextCommandCallCount++;
                 var reply = Replies.Count > 0 ? Replies.Dequeue() : Array.Empty<string>();
-                return Task.FromResult(reply);
+                return reply;
             }
         }
     }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -428,23 +428,30 @@ namespace Daqifi.Core.Tests.Device
                 }
             }
 
-            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null)
             {
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 // Run the setup action so that Send() calls inside it are captured
                 setupAction();
                 TextCommandAttemptCount++;
 
                 if (_failFirstAttempt && TextCommandAttemptCount == 1)
                 {
-                    return Task.FromResult<IReadOnlyList<string>>(
-                        new[] { "**ERROR: -200, \"Execution error\"\r\n" });
+                    return new[] { "**ERROR: -200, \"Execution error\"\r\n" };
                 }
 
-                return Task.FromResult(_textCommandResponse);
+                return _textCommandResponse;
             }
         }
 
@@ -501,12 +508,20 @@ namespace Daqifi.Core.Tests.Device
                 }
             }
 
-            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null)
             {
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 var before = _sent.Count;
                 setupAction();
                 var sentThisCall = _sent.Skip(before).ToList();
@@ -519,13 +534,11 @@ namespace Daqifi.Core.Tests.Device
                     switch (_usbStepBehavior)
                     {
                         case UsbStepBehavior.ScpiError:
-                            return Task.FromResult<IReadOnlyList<string>>(
-                                new[] { "**ERROR: -200, \"Execution error\"\r\n" });
+                            return new[] { "**ERROR: -200, \"Execution error\"\r\n" };
                         case UsbStepBehavior.ScpiErrorThenSucceed:
                             if (UsbStepAttemptCount == 1)
                             {
-                                return Task.FromResult<IReadOnlyList<string>>(
-                                    new[] { "**ERROR: -200, \"Execution error\"\r\n" });
+                                return new[] { "**ERROR: -200, \"Execution error\"\r\n" };
                             }
                             break;
                         case UsbStepBehavior.Cancel:
@@ -533,7 +546,7 @@ namespace Daqifi.Core.Tests.Device
                     }
                 }
 
-                return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+                return Array.Empty<string>();
             }
         }
     }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -97,6 +97,63 @@ public class DaqifiDeviceStaleTextLineTests
         device.Disconnect();
     }
 
+    [Fact]
+    public async Task ExecuteTextCommand_CarryingAPreparePhase_IsStillCaughtByASubclassOverride()
+    {
+        // The prepare phase is a parameter on the existing virtual rather than a second virtual
+        // method, so a subclass that overrides ExecuteTextCommandAsync keeps intercepting the SD
+        // operations that use it. A parallel seam would route past such an override with no compile
+        // error and no runtime signal — an instrumented device or test double would simply stop
+        // seeing SD traffic. If this ever regresses to a sibling method, this test fails.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new InterceptingTestableDevice("Intercepting Device", transport);
+
+        device.Connect();
+
+        var prepared = false;
+        var lines = await device.CallWithPrepareAsync(
+            _ => { prepared = true; return Task.CompletedTask; },
+            () => { });
+
+        Assert.True(device.Intercepted, "The subclass override did not see the call.");
+        Assert.True(prepared, "The override was handed the prepare phase and ran it.");
+        Assert.Equal(new[] { "from the override" }, lines);
+
+        device.Disconnect();
+    }
+
+    /// <summary>
+    /// Stands in for a downstream subclass or test double that intercepts the text exchange —
+    /// the case the single-seam design protects.
+    /// </summary>
+    private sealed class InterceptingTestableDevice : StaleLineTestableDevice
+    {
+        public InterceptingTestableDevice(string name, IStreamTransport transport)
+            : base(name, transport)
+        {
+        }
+
+        public bool Intercepted { get; private set; }
+
+        protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            Action setupAction,
+            int responseTimeoutMs = 1000,
+            int completionTimeoutMs = 250,
+            CancellationToken cancellationToken = default,
+            Func<CancellationToken, Task>? prepareAsync = null)
+        {
+            Intercepted = true;
+
+            if (prepareAsync != null)
+            {
+                await prepareAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            setupAction();
+            return new List<string> { "from the override" };
+        }
+    }
+
     /// <summary>Exposes the protected text-exchange entry points.</summary>
     private class StaleLineTestableDevice : DaqifiDevice
     {
@@ -114,8 +171,11 @@ public class DaqifiDeviceStaleTextLineTests
             Func<CancellationToken, Task> prepareAsync,
             Action setupAction)
         {
-            return ExecuteTextCommandWithPrepareAsync(
-                prepareAsync, setupAction, responseTimeoutMs: 500, completionTimeoutMs: 150);
+            return ExecuteTextCommandAsync(
+                setupAction,
+                responseTimeoutMs: 500,
+                completionTimeoutMs: 150,
+                prepareAsync: prepareAsync);
         }
     }
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -55,7 +55,49 @@ public class DaqifiDeviceStaleTextLineTests
         device.Disconnect();
     }
 
-    /// <summary>Exposes the protected text-exchange entry point.</summary>
+    [Fact]
+    public async Task ExecuteTextCommandWithPrepare_RunsPrepareBeforeTheSetupAction()
+    {
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Prepared Device", transport);
+
+        device.Connect();
+
+        var order = new List<string>();
+        await device.CallWithPrepareAsync(
+            _ => { order.Add("prepare"); return Task.CompletedTask; },
+            () => order.Add("setup"));
+
+        Assert.Equal(new[] { "prepare", "setup" }, order);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommandWithPrepare_RunsPrepareInsideTheExchange()
+    {
+        // The property that matters for the SD card operations: the prepare phase holds the
+        // device-wide text-exchange lock, so no competing exchange can interleave between the SPI
+        // bus switch it performs and the commands that depend on it. Asserted through the
+        // exchange's own re-entrancy guard rather than by racing two threads — if prepare runs
+        // inside the critical section, a nested exchange must be refused, and if it had been
+        // hoisted back outside the lock this would silently succeed instead.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Nested Device", transport);
+
+        device.Connect();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => device.CallWithPrepareAsync(
+                async _ => await device.CallExecuteTextCommandAsync(() => { }),
+                () => { }));
+
+        Assert.Contains("not re-entrant", ex.Message);
+
+        device.Disconnect();
+    }
+
+    /// <summary>Exposes the protected text-exchange entry points.</summary>
     private class StaleLineTestableDevice : DaqifiDevice
     {
         public StaleLineTestableDevice(string name, IStreamTransport transport)
@@ -66,6 +108,14 @@ public class DaqifiDeviceStaleTextLineTests
         public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(Action setupAction)
         {
             return ExecuteTextCommandAsync(setupAction, responseTimeoutMs: 500, completionTimeoutMs: 150);
+        }
+
+        public Task<IReadOnlyList<string>> CallWithPrepareAsync(
+            Func<CancellationToken, Task> prepareAsync,
+            Action setupAction)
+        {
+            return ExecuteTextCommandWithPrepareAsync(
+                prepareAsync, setupAction, responseTimeoutMs: 500, completionTimeoutMs: 150);
         }
     }
 

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
@@ -302,15 +302,23 @@ public class DeviceDiagnosticsTests
             }
         }
 
-        protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+        protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
             Action setupAction,
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            Func<CancellationToken, Task>? prepareAsync = null)
         {
+            // Honor the exchange's prepare phase the way the real device does: it runs first,
+            // before anything this exchange sends (#396).
+            if (prepareAsync != null)
+            {
+                await prepareAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
             setupAction();
-            return Task.FromResult<IReadOnlyList<string>>(CannedTextResponse.ToList());
+            return CannedTextResponse.ToList();
         }
 
         protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(

--- a/src/Daqifi.Core.Tests/Device/GetLanChipInfoAsyncTests.cs
+++ b/src/Daqifi.Core.Tests/Device/GetLanChipInfoAsyncTests.cs
@@ -90,15 +90,23 @@ public class GetLanChipInfoAsyncTests
             }
         }
 
-        protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+        protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
             Action setupAction,
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            Func<CancellationToken, Task>? prepareAsync = null)
         {
+            // Honor the exchange's prepare phase the way the real device does: it runs first,
+            // before anything this exchange sends (#396).
+            if (prepareAsync != null)
+            {
+                await prepareAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
             setupAction();
-            return Task.FromResult<IReadOnlyList<string>>(CannedTextResponse.ToList());
+            return CannedTextResponse.ToList();
         }
 
         protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -1982,6 +1982,22 @@ namespace Daqifi.Core.Tests.Device.SdCard
                     response, SentMessages, sentBefore, ExecuteTextCommandCallCount, UnterminatedAttempts));
             }
 
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandWithPrepareAsync(
+                Func<CancellationToken, Task> prepareAsync,
+                Action setupAction,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default)
+            {
+                // The prepare phase precedes the exchange proper, so its commands are outside the
+                // window whose replies belong to this response — mirroring the real device, where
+                // it runs before the consumer swap.
+                await prepareAsync(cancellationToken).ConfigureAwait(false);
+
+                return await ExecuteTextCommandAsync(
+                    setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken).ConfigureAwait(false);
+            }
+
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Func<CancellationToken, Task> setupActionAsync,
                 int responseTimeoutMs = 1000,
@@ -2099,6 +2115,19 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 _executeTextCommandCallCount++;
                 return Task.FromResult(SdCardTestResponses.AnswerErrorQuery(
                     CannedTextResponse, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts));
+            }
+
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandWithPrepareAsync(
+                Func<CancellationToken, Task> prepareAsync,
+                Action setupAction,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default)
+            {
+                await prepareAsync(cancellationToken).ConfigureAwait(false);
+
+                return await ExecuteTextCommandAsync(
+                    setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken).ConfigureAwait(false);
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2366,6 +2395,19 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 setupAction();
                 return Task.FromResult(SdCardTestResponses.AnswerErrorQuery(
                     CannedTextResponse, SentMessages, sentBefore, attemptNumber: 1, unterminatedAttempts: 0));
+            }
+
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandWithPrepareAsync(
+                Func<CancellationToken, Task> prepareAsync,
+                Action setupAction,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default)
+            {
+                await prepareAsync(cancellationToken).ConfigureAwait(false);
+
+                return await ExecuteTextCommandAsync(
+                    setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken).ConfigureAwait(false);
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -1966,36 +1966,28 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 }
             }
 
-            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null)
             {
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 var sentBefore = SentMessages.Count;
                 setupAction();
                 ExecuteTextCommandCallCount++;
                 var response = ResponseSequence.Count > 0
                     ? ResponseSequence.Dequeue()
                     : new List<string>();
-                return Task.FromResult(SdCardTestResponses.AnswerErrorQuery(
-                    response, SentMessages, sentBefore, ExecuteTextCommandCallCount, UnterminatedAttempts));
-            }
-
-            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandWithPrepareAsync(
-                Func<CancellationToken, Task> prepareAsync,
-                Action setupAction,
-                int responseTimeoutMs = 1000,
-                int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
-            {
-                // The prepare phase precedes the exchange proper, so its commands are outside the
-                // window whose replies belong to this response — mirroring the real device, where
-                // it runs before the consumer swap.
-                await prepareAsync(cancellationToken).ConfigureAwait(false);
-
-                return await ExecuteTextCommandAsync(
-                    setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken).ConfigureAwait(false);
+                return SdCardTestResponses.AnswerErrorQuery(
+                    response, SentMessages, sentBefore, ExecuteTextCommandCallCount, UnterminatedAttempts);
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2102,32 +2094,27 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 }
             }
 
-            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null)
             {
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 var sentBefore = SentMessages.Count;
 
                 // Execute the setup action so we can capture the SCPI commands
                 setupAction();
                 _executeTextCommandCallCount++;
-                return Task.FromResult(SdCardTestResponses.AnswerErrorQuery(
-                    CannedTextResponse, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts));
-            }
-
-            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandWithPrepareAsync(
-                Func<CancellationToken, Task> prepareAsync,
-                Action setupAction,
-                int responseTimeoutMs = 1000,
-                int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
-            {
-                await prepareAsync(cancellationToken).ConfigureAwait(false);
-
-                return await ExecuteTextCommandAsync(
-                    setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken).ConfigureAwait(false);
+                return SdCardTestResponses.AnswerErrorQuery(
+                    CannedTextResponse, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts);
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2171,14 +2158,22 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 }
             }
 
-            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null)
             {
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 setupAction();
-                return Task.FromResult<IReadOnlyList<string>>(CannedTextResponse);
+                return CannedTextResponse;
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2310,14 +2305,22 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 }
             }
 
-            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null)
             {
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 setupAction();
-                return Task.FromResult<IReadOnlyList<string>>(new List<string>());
+                return new List<string>();
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2385,29 +2388,24 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 }
             }
 
-            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null)
             {
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 var sentBefore = SentMessages.Count;
                 setupAction();
-                return Task.FromResult(SdCardTestResponses.AnswerErrorQuery(
-                    CannedTextResponse, SentMessages, sentBefore, attemptNumber: 1, unterminatedAttempts: 0));
-            }
-
-            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandWithPrepareAsync(
-                Func<CancellationToken, Task> prepareAsync,
-                Action setupAction,
-                int responseTimeoutMs = 1000,
-                int completionTimeoutMs = 250,
-                CancellationToken cancellationToken = default)
-            {
-                await prepareAsync(cancellationToken).ConfigureAwait(false);
-
-                return await ExecuteTextCommandAsync(
-                    setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken).ConfigureAwait(false);
+                return SdCardTestResponses.AnswerErrorQuery(
+                    CannedTextResponse, SentMessages, sentBefore, attemptNumber: 1, unterminatedAttempts: 0);
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -509,7 +509,7 @@ namespace Daqifi.Core.Device
         /// <remarks>
         /// Waits up to 10 seconds to acquire <c>_textExchangeLock</c> before
         /// tearing down the consumer / producer / transport. This prevents
-        /// a race where an in-flight <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken)"/>
+        /// a race where an in-flight <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task})"/>
         /// is mid-swap (text consumer running on the stream, protobuf
         /// consumer not yet restarted) and Disconnect rips the transport
         /// out from under it. If the wait times out, Disconnect proceeds
@@ -738,6 +738,20 @@ namespace Daqifi.Core.Device
         /// <param name="responseTimeoutMs">The time in milliseconds to wait for the first text response after sending commands.</param>
         /// <param name="completionTimeoutMs">The time in milliseconds of inactivity after the first response before considering the response complete. Defaults to 250ms.</param>
         /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <param name="prepareAsync">
+        /// Optional phase that puts the device into the state the commands require, for callers that
+        /// need one — the SD card operations use it to switch the shared SPI bus over to the card and
+        /// wait for the firmware to settle.
+        /// <para>
+        /// It runs inside the device-wide text-exchange lock, so no competing exchange can interleave
+        /// between it and <paramref name="setupAction"/> and undo what it established. It also runs
+        /// before the consumer swap, and therefore before the stale-line boundary below: a settle
+        /// wait placed inside <paramref name="setupAction"/> would widen that boundary into a window
+        /// where a late reply to an earlier command could be captured as part of this response
+        /// (#396). Anything the device emits in reply to it goes to the protobuf consumer, exactly as
+        /// it did before this exchange began.
+        /// </para>
+        /// </param>
         /// <returns>
         /// A list of text lines received from the device. Lines that were already in flight when the
         /// exchange opened — late replies to earlier commands — are excluded: only what arrived once
@@ -745,56 +759,21 @@ namespace Daqifi.Core.Device
         /// </returns>
         /// <exception cref="InvalidOperationException">Thrown when the device is not connected or has no transport.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        // prepareAsync is added AFTER cancellationToken (technically violating CA1068
+        // "CancellationToken should be last") to keep existing positional callers working, matching
+        // the convention established in IFirmwareUpdateService for the same reason. It is a
+        // parameter on this seam rather than a second virtual method deliberately: a parallel
+        // method would be bypassed silently by any subclass that overrides only this one, which for
+        // an instrumented device or a test double means the override quietly stops intercepting SD
+        // operations with nothing to indicate it. Overriders must widen their signature — a compile
+        // error, which is the point.
+#pragma warning disable CA1068
         protected virtual Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
             Action setupAction,
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
-            CancellationToken cancellationToken = default)
-        {
-            return ExecuteTextCommandCoreAsync(
-                prepareAsync: null,
-                _ => { setupAction(); return Task.CompletedTask; },
-                responseTimeoutMs,
-                completionTimeoutMs,
-                cancellationToken);
-        }
-
-        /// <summary>
-        /// Variant of <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken)"/> that
-        /// first runs a <paramref name="prepareAsync"/> phase, for callers that must put the device
-        /// into a particular state before the commands they are about to send will work.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The prepare phase runs inside the device-wide text-exchange lock, so no other text
-        /// exchange can interleave between it and <paramref name="setupAction"/>. That is the whole
-        /// point of the seam: the SD card operations switch the shared SPI bus over to the card and
-        /// wait for the firmware to settle, and a competing exchange restoring the LAN interface in
-        /// that gap would leave their commands running against the wrong interface.
-        /// </para>
-        /// <para>
-        /// It also runs BEFORE the consumer swap and therefore before the stale-line boundary is
-        /// taken, which is the second reason the phases are split: the settle wait a prepare phase
-        /// needs would, if it sat inside <paramref name="setupAction"/>, widen that boundary into a
-        /// window where a late reply to an earlier command could be captured as part of this
-        /// response (#396). Anything the device emits in reply to the prepare phase is consumed by
-        /// the protobuf consumer, exactly as it was before this exchange began.
-        /// </para>
-        /// </remarks>
-        /// <param name="prepareAsync">An async function that puts the device into the required state. Receives the operation's cancellation token.</param>
-        /// <param name="setupAction">An action that sends SCPI commands to the device while the text consumer is active.</param>
-        /// <param name="responseTimeoutMs">The time in milliseconds to wait for the first text response after sending commands.</param>
-        /// <param name="completionTimeoutMs">The time in milliseconds of inactivity after the first response before considering the response complete. Defaults to 250ms.</param>
-        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
-        /// <returns>A list of text lines received from the device, excluding anything already in flight when the exchange opened.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the device is not connected or has no transport.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
-        protected virtual Task<IReadOnlyList<string>> ExecuteTextCommandWithPrepareAsync(
-            Func<CancellationToken, Task> prepareAsync,
-            Action setupAction,
-            int responseTimeoutMs = 1000,
-            int completionTimeoutMs = 250,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            Func<CancellationToken, Task>? prepareAsync = null)
         {
             return ExecuteTextCommandCoreAsync(
                 prepareAsync,
@@ -803,9 +782,10 @@ namespace Daqifi.Core.Device
                 completionTimeoutMs,
                 cancellationToken);
         }
+#pragma warning restore CA1068
 
         /// <summary>
-        /// Async overload of <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken)"/>
+        /// Async overload of <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task})"/>
         /// that accepts an async setup action so callers can <c>await</c> cancellable operations
         /// (e.g. <see cref="Task.Delay(int, CancellationToken)"/>) between SCPI commands without
         /// blocking the thread-pool thread.
@@ -1114,7 +1094,7 @@ namespace Daqifi.Core.Device
         /// on hardware faults, or discard them if known-stale.
         /// </para>
         /// <para>
-        /// Each iteration uses <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken)"/>, which
+        /// Each iteration uses <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task})"/>, which
         /// pauses the protobuf consumer for the duration of the text exchange.
         /// Avoid calling this during active streaming or concurrently with
         /// other text commands.

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -752,6 +752,52 @@ namespace Daqifi.Core.Device
             CancellationToken cancellationToken = default)
         {
             return ExecuteTextCommandCoreAsync(
+                prepareAsync: null,
+                _ => { setupAction(); return Task.CompletedTask; },
+                responseTimeoutMs,
+                completionTimeoutMs,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Variant of <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken)"/> that
+        /// first runs a <paramref name="prepareAsync"/> phase, for callers that must put the device
+        /// into a particular state before the commands they are about to send will work.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The prepare phase runs inside the device-wide text-exchange lock, so no other text
+        /// exchange can interleave between it and <paramref name="setupAction"/>. That is the whole
+        /// point of the seam: the SD card operations switch the shared SPI bus over to the card and
+        /// wait for the firmware to settle, and a competing exchange restoring the LAN interface in
+        /// that gap would leave their commands running against the wrong interface.
+        /// </para>
+        /// <para>
+        /// It also runs BEFORE the consumer swap and therefore before the stale-line boundary is
+        /// taken, which is the second reason the phases are split: the settle wait a prepare phase
+        /// needs would, if it sat inside <paramref name="setupAction"/>, widen that boundary into a
+        /// window where a late reply to an earlier command could be captured as part of this
+        /// response (#396). Anything the device emits in reply to the prepare phase is consumed by
+        /// the protobuf consumer, exactly as it was before this exchange began.
+        /// </para>
+        /// </remarks>
+        /// <param name="prepareAsync">An async function that puts the device into the required state. Receives the operation's cancellation token.</param>
+        /// <param name="setupAction">An action that sends SCPI commands to the device while the text consumer is active.</param>
+        /// <param name="responseTimeoutMs">The time in milliseconds to wait for the first text response after sending commands.</param>
+        /// <param name="completionTimeoutMs">The time in milliseconds of inactivity after the first response before considering the response complete. Defaults to 250ms.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>A list of text lines received from the device, excluding anything already in flight when the exchange opened.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the device is not connected or has no transport.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        protected virtual Task<IReadOnlyList<string>> ExecuteTextCommandWithPrepareAsync(
+            Func<CancellationToken, Task> prepareAsync,
+            Action setupAction,
+            int responseTimeoutMs = 1000,
+            int completionTimeoutMs = 250,
+            CancellationToken cancellationToken = default)
+        {
+            return ExecuteTextCommandCoreAsync(
+                prepareAsync,
                 _ => { setupAction(); return Task.CompletedTask; },
                 responseTimeoutMs,
                 completionTimeoutMs,
@@ -778,6 +824,7 @@ namespace Daqifi.Core.Device
             CancellationToken cancellationToken = default)
         {
             return ExecuteTextCommandCoreAsync(
+                prepareAsync: null,
                 setupActionAsync,
                 responseTimeoutMs,
                 completionTimeoutMs,
@@ -785,6 +832,7 @@ namespace Daqifi.Core.Device
         }
 
         private async Task<IReadOnlyList<string>> ExecuteTextCommandCoreAsync(
+            Func<CancellationToken, Task>? prepareAsync,
             Func<CancellationToken, Task> setupActionAsync,
             int responseTimeoutMs,
             int completionTimeoutMs,
@@ -863,6 +911,19 @@ namespace Daqifi.Core.Device
                 }
 
                 var sw = Stopwatch.StartNew();
+
+                // Prepare phase, if any. Deliberately here: inside the lock, so no competing text
+                // exchange can interleave between it and the setup action below and undo the state
+                // it establishes; and before the consumer swap, so the wait it typically needs
+                // cannot widen the stale-line boundary taken further down. Any device output it
+                // provokes goes to the protobuf consumer, which is still running at this point.
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+
+                    SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Prepare phase completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));
+                }
+
                 var collectedLines = new List<string>();
                 var stream = _transport.Stream;
                 int? originalReadTimeout = null;

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1668,8 +1668,7 @@ namespace Daqifi.Core.Device
                     // an earlier command could pass for this listing's terminator. Querying the card
                     // too soon after the switch makes the device answer -200 (Execution error), so
                     // the wait itself is not optional.
-                    lines = await ExecuteTextCommandWithPrepareAsync(
-                        PrepareSdInterfaceAndSettleAsync,
+                    lines = await ExecuteTextCommandAsync(
                         () =>
                         {
                             Send(ScpiMessageProducer.GetSdFileList);
@@ -1680,7 +1679,8 @@ namespace Daqifi.Core.Device
                         },
                         responseTimeoutMs: 3000,
                         completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
-                        cancellationToken: cancellationToken);
+                        cancellationToken: cancellationToken,
+                        prepareAsync: PrepareSdInterfaceAndSettleAsync);
 
                     isComplete = TrySplitAtSdListTerminator(lines, out listing);
 
@@ -1716,7 +1716,9 @@ namespace Daqifi.Core.Device
         /// the card and waits for the firmware to complete the switch.
         /// </summary>
         /// <remarks>
-        /// Passed to <see cref="DaqifiDevice.ExecuteTextCommandWithPrepareAsync"/> rather than run
+        /// Passed as the <c>prepareAsync</c> phase of
+        /// <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task})"/>
+        /// rather than run
         /// inline, so it executes inside the text-exchange lock — a competing exchange restoring the
         /// LAN interface between the switch and the commands that depend on it would leave them
         /// running against the wrong interface — and ahead of the exchange's stale-line boundary, so
@@ -2142,15 +2144,15 @@ namespace Daqifi.Core.Device
                 // wait stays outside the stale-line boundary. The consequence of a stale line is
                 // milder here (delete keys off ContainsScpiError, so it would mean a pointless
                 // delete-and-relist retry rather than a bad listing) but it is the same defect.
-                lines = await ExecuteTextCommandWithPrepareAsync(
-                    PrepareSdInterfaceAndSettleAsync,
+                lines = await ExecuteTextCommandAsync(
                     () =>
                     {
                         Send(ScpiMessageProducer.DeleteSdFile(fileName));
                         Send(ScpiMessageProducer.GetSdFileList);
                     },
                     responseTimeoutMs: 3000,
-                    cancellationToken: cancellationToken);
+                    cancellationToken: cancellationToken,
+                    prepareAsync: PrepareSdInterfaceAndSettleAsync);
 
                 if (ContainsScpiError(lines))
                 {
@@ -2160,15 +2162,15 @@ namespace Daqifi.Core.Device
 
                         await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
 
-                        lines = await ExecuteTextCommandWithPrepareAsync(
-                            PrepareSdInterfaceAndSettleAsync,
+                        lines = await ExecuteTextCommandAsync(
                             () =>
                             {
                                 Send(ScpiMessageProducer.DeleteSdFile(fileName));
                                 Send(ScpiMessageProducer.GetSdFileList);
                             },
                             responseTimeoutMs: 3000,
-                            cancellationToken: cancellationToken);
+                            cancellationToken: cancellationToken,
+                            prepareAsync: PrepareSdInterfaceAndSettleAsync);
 
                         if (!ContainsScpiError(lines))
                         {

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1661,20 +1661,15 @@ namespace Daqifi.Core.Device
                         await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
                     }
 
-                    // Switch the shared SPI bus over to the SD card and let the firmware settle
-                    // BEFORE opening the text exchange. Querying the card too soon after the switch
-                    // makes the device answer -200 (Execution error), so the delay itself is not
-                    // optional — but running it outside the exchange leaves the exchange with no
-                    // internal gap at all, so its very first act is the LIST query. That matters for
-                    // the terminator: the exchange discards anything received before its setup
-                    // action sends, and a gap inside the action would widen that boundary into a
-                    // window where a late reply to an earlier command could still be mistaken for
-                    // this listing's terminator. The delay is unchanged from the device's point of
-                    // view — if anything longer, since the consumer swap now follows it.
-                    PrepareSdInterface();
-                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
-
-                    lines = await ExecuteTextCommandAsync(
+                    // The SPI bus switch and its settle wait run as the exchange's prepare phase:
+                    // inside the exchange lock, so a competing text exchange cannot restore the LAN
+                    // interface between the switch and the LIST, and ahead of the stale-line
+                    // boundary, so the settle wait does not become a window in which a late reply to
+                    // an earlier command could pass for this listing's terminator. Querying the card
+                    // too soon after the switch makes the device answer -200 (Execution error), so
+                    // the wait itself is not optional.
+                    lines = await ExecuteTextCommandWithPrepareAsync(
+                        PrepareSdInterfaceAndSettleAsync,
                         () =>
                         {
                             Send(ScpiMessageProducer.GetSdFileList);
@@ -1714,6 +1709,26 @@ namespace Daqifi.Core.Device
             var files = SdCardFileListParser.ParseFileList(listing);
             _sdCardFiles = files;
             return files;
+        }
+
+        /// <summary>
+        /// Prepare phase shared by the SD card text exchanges: switches the shared SPI bus over to
+        /// the card and waits for the firmware to complete the switch.
+        /// </summary>
+        /// <remarks>
+        /// Passed to <see cref="DaqifiDevice.ExecuteTextCommandWithPrepareAsync"/> rather than run
+        /// inline, so it executes inside the text-exchange lock — a competing exchange restoring the
+        /// LAN interface between the switch and the commands that depend on it would leave them
+        /// running against the wrong interface — and ahead of the exchange's stale-line boundary, so
+        /// the settle wait cannot be mistaken for a window in which the device was answering.
+        /// </remarks>
+        private async Task PrepareSdInterfaceAndSettleAsync(CancellationToken cancellationToken)
+        {
+            PrepareSdInterface();
+
+            // Querying the card too soon after the switch makes the device answer -200
+            // (Execution error), so this wait is not optional.
+            await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -2122,16 +2137,13 @@ namespace Daqifi.Core.Device
             IReadOnlyList<string> lines;
             try
             {
-                // Switch the shared SPI bus to the SD card and settle BEFORE opening the text
-                // exchange, for the same reason as GetSdCardFilesAsync: a gap inside the setup
-                // action is a window in which a late reply to an earlier command can be captured
-                // as part of this response. Here that would mean a stale error line triggering a
-                // pointless delete-and-relist retry rather than a bad listing, but it is the same
-                // defect, so it gets the same treatment.
-                PrepareSdInterface();
-                await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
-
-                lines = await ExecuteTextCommandAsync(
+                // Same prepare-phase treatment as GetSdCardFilesAsync, for the same two reasons —
+                // the SPI switch stays serialized against competing text exchanges, and its settle
+                // wait stays outside the stale-line boundary. The consequence of a stale line is
+                // milder here (delete keys off ContainsScpiError, so it would mean a pointless
+                // delete-and-relist retry rather than a bad listing) but it is the same defect.
+                lines = await ExecuteTextCommandWithPrepareAsync(
+                    PrepareSdInterfaceAndSettleAsync,
                     () =>
                     {
                         Send(ScpiMessageProducer.DeleteSdFile(fileName));
@@ -2148,10 +2160,8 @@ namespace Daqifi.Core.Device
 
                         await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
 
-                        PrepareSdInterface();
-                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
-
-                        lines = await ExecuteTextCommandAsync(
+                        lines = await ExecuteTextCommandWithPrepareAsync(
+                            PrepareSdInterfaceAndSettleAsync,
                             () =>
                             {
                                 Send(ScpiMessageProducer.DeleteSdFile(fileName));


### PR DESCRIPTION
Follow-up to #400 (merged as c2d5da8). This fix was ready minutes after that merge landed, so it needs its own PR.

## The problem this fixes

#400 went through several review rounds on where the SD card's SPI bus switch should happen relative to the text exchange. The last move — hoisting `PrepareSdInterface()` and its settle delay *above* `ExecuteTextCommandAsync` — closed a stale-terminator window but opened a different one, and that is what merged.

`ExecuteTextCommandCoreAsync` runs its setup action while holding the device-wide `_textExchangeLock`. The bus switch used to run inside that lock, because it lived inside the setup action. Hoisting it moved it outside:

```
thread A: PrepareSdInterface()                 <- outside the lock now
thread B: acquires _textExchangeLock, runs some other text exchange,
          whose finally calls PrepareLanInterface()
thread A: acquires the lock, sends LIST        <- now running against LAN interface state
```

The device answers a LIST it cannot service, and the listing fails or retries for no reason. Concurrent text operations are an expected scenario — `_textExchangeLock` exists precisely because of #186 — so this is reachable, not theoretical.

## Why not just move it back

Moving the switch back inside the setup action reinstates the window #400 spent two rounds closing: the settle wait between the switch and the LIST sits *after* the exchange's stale-line boundary, so a late reply to an earlier command arriving during it is captured as part of this response — and for the listing that means a stale `SYSTem:ERRor?` reply can pass for the end-of-listing terminator, letting a silent device read as a healthy empty card. That is the original #396 bug.

Both properties are wanted, so this splits the setup instead of choosing between them.

## The fix

The existing virtual `ExecuteTextCommandAsync` gains an optional `prepareAsync` phase that runs **inside the lock** and **before the consumer swap**:

```
acquire lock -> validate -> prepare (SPI switch + settle) -> consumer swap -> stale-line boundary -> sends
```

- Inside the lock, so no competing exchange can interleave between the switch and the sends.
- Ahead of the boundary, so the settle wait is not a window in which the device appears to be answering. The setup action stays gap-free — two `Send()` calls, no awaits.
- Before the consumer swap, so anything the device emits in reply to the prepare phase goes to the protobuf consumer, exactly as it did before the exchange began.

`GetSdCardFilesAsync` and both `DeleteSdCardFileAsync` call sites share one `PrepareSdInterfaceAndSettleAsync`.

## Subclassing impact — this one does break overrides, on purpose

The first version of this PR added a parallel `ExecuteTextCommandWithPrepareAsync` and claimed nothing broke. That was wrong, and Qodo caught it: the parallel method called the core directly, so a subclass overriding `ExecuteTextCommandAsync` silently stopped intercepting SD LIST and DELETE — no compile error, no runtime signal. The three extra overrides my own test fakes suddenly needed were the tell; anything outside this repo would just have stopped seeing SD traffic.

So there is one seam, and the honest statement of the cost:

- **Callers** are unaffected. `prepareAsync` is optional and sits after `cancellationToken` (CA1068 suppressed, matching the convention in `IFirmwareUpdateService`), so existing positional calls still compile.
- **Overriders must widen their signature.** C# requires an override to match the full parameter list, so every existing `ExecuteTextCommandAsync(Action, int, int, CancellationToken)` override fails with CS0115 until `Func<CancellationToken, Task>? prepareAsync = null` is appended. Ten in this repo; any downstream subclass — desktop, the Avalonia port, consumer test doubles — will hit the same.

That break is the point. A compile error that says "add this parameter" is strictly better than an override that quietly stops intercepting, which is the defect class this whole series has been retiring. An override that accepts the parameter and ignores it is still correct for a fake, since there is no real SPI bus to switch.

Only the `Action` overload takes the parameter. The `Func<CancellationToken, Task>` overload has no caller needing a prepare phase, and adding it there would break another eight overrides for no benefit.

## Known gap, deliberately not addressed here

The *restore* side is still unsynchronized: `PrepareLanInterface()` runs in each SD method's `finally`, outside the lock, so a competing exchange's restore can still fire during another exchange. That predates #400 — it is on `main` today and is not something these changes introduced. Fixing it needs a symmetric finalize seam that still runs when the exchange itself throws, which is a larger change than belongs in a follow-up. Flagging it explicitly rather than leaving it implied; happy to file it separately.

## Tests

Full suite green on **net9.0 and net10.0** (1961 passed, 0 failed), build clean with 0 warnings.

Three new tests in `DaqifiDeviceStaleTextLineTests`:
- prepare runs before the setup action;
- prepare runs *inside* the exchange — asserted through the exchange's own re-entrancy guard, so it is deterministic rather than a thread race: a nested exchange started from within prepare must be refused, and if the phase were ever hoisted back outside the lock this test would silently start passing for the wrong reason, so it is written to fail in that case;
- a call carrying a prepare phase is still caught by a subclass override, which fails if the seam ever splits into two virtuals again.

Every test double now honors the prepare phase rather than ignoring the argument.

## Bench

DAQiFi Nyquist 1, firmware 3.7.2, `/dev/cu.usbmodem1101`, example CLI built against this branch: listing returns all 31 files across repeated runs; `--sd-storage` and a 10 Hz two-channel stream unaffected. Nothing destructive — no format, delete, flash, reboot or WiFi change.

The delete path is deliberately not bench-verified: confirming it on hardware means deleting a file from the shared bench card. Its prepare phase is the identical helper the listing uses.

Refs #396. Follow-up to #400.

**Not merging — opened for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
