### PR TITLE
fix(device): parse protobuf field 22 so analog IsEnabled tracks the device (closes #409)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
@@ -416,6 +416,127 @@ public class ChannelPopulationTests
         Assert.Equal(4095u, ((IAnalogChannel)newAnalog0).Resolution);
     }
 
+    [Fact]
+    public void PopulateChannelsFromStatus_WithAnalogInPortEnabled_SetsIsEnabledFromDevice()
+    {
+        // Arrange - device reports channels 0 and 2 enabled, 1 and 3 disabled via a bit-packed
+        // mask (byte 0b00000101 = 5): confirmed on the bench against a real Nq1 (fw 3.7.2),
+        // whose 16-channel status reported AnalogInPortEnabled as 2 bytes, [5,0], after enabling
+        // channels 0 and 2 — the same little-endian bit-per-channel layout Core sends outbound
+        // via EnableAdcChannels, not a byte-per-channel array (#409).
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 4,
+            AnalogInRes = 65535,
+            AnalogInPortEnabled = Google.Protobuf.ByteString.CopyFrom(0b0000_0101)
+        };
+
+        // Act
+        device.PopulateChannelsFromStatus(message);
+
+        // Assert
+        var analogChannels = device.Channels.Where(c => c.Type == ChannelType.Analog).ToList();
+        Assert.True(analogChannels[0].IsEnabled);
+        Assert.False(analogChannels[1].IsEnabled);
+        Assert.True(analogChannels[2].IsEnabled);
+        Assert.False(analogChannels[3].IsEnabled);
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_WithAnalogInPortEnabledSpanningMultipleBytes_SetsIsEnabledFromDevice()
+    {
+        // Arrange - a device with more than 8 analog channels packs the mask across multiple
+        // bytes; channel 9 is bit 1 of byte 1. Mirrors the bench-observed 2-byte mask for a
+        // 16-channel Nq1.
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 16,
+            AnalogInRes = 65535,
+            AnalogInPortEnabled = Google.Protobuf.ByteString.CopyFrom(0b0000_0000, 0b0000_0010)
+        };
+
+        // Act
+        device.PopulateChannelsFromStatus(message);
+
+        // Assert
+        var analogChannels = device.Channels.Where(c => c.Type == ChannelType.Analog).ToList();
+        Assert.False(analogChannels[0].IsEnabled);
+        Assert.True(analogChannels[9].IsEnabled);
+        Assert.False(analogChannels[10].IsEnabled);
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_WithoutAnalogInPortEnabled_DefaultsToDisabled()
+    {
+        // Arrange - older firmware never populates field 22; an empty byte string must not be
+        // read as "every channel disabled by the device" but simply "not reported".
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 2,
+            AnalogInRes = 65535
+        };
+
+        // Act
+        device.PopulateChannelsFromStatus(message);
+
+        // Assert
+        var analogChannels = device.Channels.Where(c => c.Type == ChannelType.Analog).ToList();
+        Assert.All(analogChannels, c => Assert.False(c.IsEnabled));
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_RepopulatingWithAnalogInPortEnabled_ResyncsExistingChannelFromDevice()
+    {
+        // A later status refresh must resync IsEnabled from the device's report rather than
+        // preserving whatever Core last set locally, so Core's view can't drift from the
+        // device's (#409).
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage { AnalogInPortNum = 2, AnalogInRes = 65535 };
+        device.PopulateChannelsFromStatus(message);
+
+        var analog0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+        analog0.IsEnabled = true; // Core enabled it locally.
+
+        // Act - the device reports channel 0 as actually disabled.
+        var refreshed = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 2,
+            AnalogInRes = 65535,
+            AnalogInPortEnabled = Google.Protobuf.ByteString.CopyFrom(0b0000_0000)
+        };
+        device.PopulateChannelsFromStatus(refreshed);
+
+        // Assert - same instance, reused, but IsEnabled now reflects the device.
+        var newAnalog0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+        Assert.Same(analog0, newAnalog0);
+        Assert.False(newAnalog0.IsEnabled);
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_WithShorterAnalogInPortEnabled_TreatsMissingByteAsDisabled()
+    {
+        // Arrange - device reports fewer enabled-mask bytes than channels need (e.g. a truncated
+        // frame): channels 8+ have no byte to read and must default to disabled rather than throw.
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 9,
+            AnalogInRes = 65535,
+            AnalogInPortEnabled = Google.Protobuf.ByteString.CopyFrom(0b0000_0001)
+        };
+
+        // Act
+        device.PopulateChannelsFromStatus(message);
+
+        // Assert
+        var analogChannels = device.Channels.Where(c => c.Type == ChannelType.Analog).ToList();
+        Assert.True(analogChannels[0].IsEnabled);
+        Assert.All(analogChannels.Skip(1), c => Assert.False(c.IsEnabled));
+    }
+
     #endregion
 
     #region Digital Channel Population

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
@@ -7,6 +7,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Daqifi.Core.Tests.Device
@@ -235,6 +237,58 @@ namespace Daqifi.Core.Tests.Device
 
             var sent = Assert.Single(device.SentMessages);
             Assert.Equal(ScpiMessageProducer.DisableDioPorts().Data, sent.Data);
+        }
+
+        #endregion
+
+        #region Concurrent status resync (#409)
+
+        [Fact]
+        public async Task EnableChannel_ConcurrentWithStatusResync_AlwaysSendsMaskIncludingJustEnabledChannel()
+        {
+            // Regression test for #409: PopulateChannelsFromStatus now resyncs analog IsEnabled
+            // from the device's reported mask on the consumer thread. Without a shared critical
+            // section, a status frame could interleave between EnableChannel's IsEnabled mutation
+            // and the ADC mask it computes and sends, silently dropping the just-enabled channel
+            // from the outbound mask. Hammer a concurrent status resync (reporting everything
+            // disabled) against repeated EnableChannel calls and assert the sent mask always
+            // reflects what was just requested.
+            var device = CreateConnectedDevice(analogChannels: 2, digitalChannels: 0);
+            var channel0 = AnalogChannelAt(device, 0);
+            var allDisabledStatus = new DaqifiOutMessage
+            {
+                AnalogInPortNum = 2,
+                AnalogInRes = 65535,
+                AnalogInPortEnabled = Google.Protobuf.ByteString.CopyFrom(0b0000_0000)
+            };
+
+            using var stop = new CancellationTokenSource();
+            var resyncTask = Task.Run(() =>
+            {
+                while (!stop.IsCancellationRequested)
+                {
+                    device.PopulateChannelsFromStatus(allDisabledStatus);
+                }
+            });
+
+            try
+            {
+                for (var i = 0; i < 500; i++)
+                {
+                    device.DisableAllChannels();
+                    device.SentMessages.Clear();
+
+                    device.EnableChannel(channel0);
+
+                    var sent = Assert.Single(device.SentMessages);
+                    Assert.Equal(ScpiMessageProducer.EnableAdcChannels("1").Data, sent.Data);
+                }
+            }
+            finally
+            {
+                stop.Cancel();
+                await resyncTask;
+            }
         }
 
         #endregion

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
@@ -300,7 +300,20 @@ namespace Daqifi.Core.Tests.Device
             finally
             {
                 stop.Cancel();
-                await resyncTask;
+
+                // The cancellation token only stops the loop between iterations — it can't
+                // interrupt a PopulateChannelsFromStatus call already in progress. If a
+                // reintroduced deadlock ever wedges that call, awaiting resyncTask unbounded would
+                // hang CI instead of failing the test. Bound the wait so a deadlock regression
+                // fails deterministically instead.
+                try
+                {
+                    await resyncTask.WaitAsync(TimeSpan.FromSeconds(5));
+                }
+                catch (TimeoutException)
+                {
+                    Assert.Fail("The status-resync worker did not stop within 5s of cancellation — possible deadlock regression.");
+                }
             }
         }
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
@@ -262,12 +262,25 @@ namespace Daqifi.Core.Tests.Device
                 AnalogInPortEnabled = Google.Protobuf.ByteString.CopyFrom(0b0000_0000)
             };
 
-            using var stop = new CancellationTokenSource();
+            // Safety net so a regression that reintroduces a deadlock fails the test instead of
+            // hanging CI indefinitely.
+            using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var resyncTask = Task.Run(() =>
             {
+                var iteration = 0;
                 while (!stop.IsCancellationRequested)
                 {
                     device.PopulateChannelsFromStatus(allDisabledStatus);
+                    // Yield periodically rather than every iteration — yielding every iteration
+                    // (e.g. via SpinWait.SpinOnce) spaces status frames out enough that this loop
+                    // stops reliably landing inside EnableChannel's now-much-shorter critical
+                    // section, silently defeating the regression coverage. Yielding every 64th
+                    // iteration keeps the interleaving pressure while still relinquishing the core
+                    // regularly enough to avoid pegging it.
+                    if (++iteration % 64 == 0)
+                    {
+                        Thread.Yield();
+                    }
                 }
             });
 

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -271,6 +271,35 @@ namespace Daqifi.Core.Device
         protected IReadOnlyList<IChannel> SnapshotChannels() => GetChannelsSnapshot();
 
         /// <summary>
+        /// Runs <paramref name="action"/> under the same lock that guards structural access to
+        /// <see cref="_channels"/> and the status-driven <c>IsEnabled</c> resync in
+        /// <see cref="PopulateChannelsFromStatus"/>. A subclass's channel-management API (e.g.
+        /// enable/disable) should mutate <see cref="IChannel.IsEnabled"/> and compute any derived
+        /// outbound state (an ADC/DIO enable mask) inside this critical section, so a concurrent
+        /// status frame on the consumer thread cannot interleave between the mutation and the
+        /// read that derives the mask — which would send a mask computed from a value the status
+        /// frame is about to overwrite (#409). Callers must perform blocking I/O (e.g. <c>Send</c>)
+        /// outside this method; the lock is reentrant, so calling <see cref="SnapshotChannels"/>
+        /// from within <paramref name="action"/> is safe.
+        /// </summary>
+        protected T WithChannelsLock<T>(Func<T> action)
+        {
+            lock (_channelsLock)
+            {
+                return action();
+            }
+        }
+
+        /// <inheritdoc cref="WithChannelsLock{T}"/>
+        protected void WithChannelsLock(Action action)
+        {
+            lock (_channelsLock)
+            {
+                action();
+            }
+        }
+
+        /// <summary>
         /// Gets the device's timestamp clock frequency in Hz.
         /// Populated from the <c>TimestampFreq</c> field of the status message.
         /// Used as the fallback frequency for SD card log file parsing when no

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1778,6 +1778,9 @@ namespace Daqifi.Core.Device
         /// For analog channels, calibration parameters (CalM, CalB, InternalScaleM, PortRange)
         /// are extracted from the message. If there's a mismatch between the declared channel
         /// count and the available calibration data, default values are used for missing parameters.
+        /// Analog channel <c>IsEnabled</c> is likewise taken from the device-reported enabled mask
+        /// (field 22, <c>analog_in_port_enabled</c>) when the message carries one, so it reflects
+        /// the device's own view rather than only what Core previously commanded.
         ///
         /// For digital channels, only the channel count is used to create instances.
         /// </remarks>
@@ -1805,8 +1808,11 @@ namespace Daqifi.Core.Device
             {
                 // Index existing channels by identity (type, number). Channels whose identity
                 // is unchanged are updated in place rather than replaced below, so consumer-held
-                // IChannel references — and the configuration on them (enable/direction/output/
-                // PWM state) — survive a routine status re-population untouched.
+                // IChannel references — and the configuration on them (direction/output/PWM
+                // state) — survive a routine status re-population untouched. IsEnabled is the
+                // exception: analog channels resync it from the device-reported enabled mask
+                // (field 22) whenever the device sends one, so Core's view cannot silently drift
+                // from the device's (#409).
                 var existingByKey = new Dictionary<(ChannelType, int), IChannel>();
                 foreach (var existing in _channels)
                 {
@@ -1857,6 +1863,12 @@ namespace Daqifi.Core.Device
             var analogInCalibrationMValues = message.AnalogInCalM;
             var analogInInternalScaleMValues = message.AnalogInIntScaleM;
             var analogInResolution = message.AnalogInRes;
+            var analogInPortEnabled = message.AnalogInPortEnabled;
+
+            // Firmware before v3.5.0 never populates this field, so an empty byte string is
+            // ambiguous between "no channels enabled" and "not reported". Only trust it as the
+            // source of truth for IsEnabled when the device actually sent something.
+            var enabledIsReported = analogInPortEnabled.Length > 0;
 
             var count = (int)message.AnalogInPortNum;
 
@@ -1894,6 +1906,10 @@ namespace Daqifi.Core.Device
                 if (existingByKey.TryGetValue((ChannelType.Analog, i), out var existing) && existing is AnalogChannel existingAnalog)
                 {
                     existingAnalog.UpdateScalingFromStatus(resolution, calibrationB, calibrationM, internalScaleM, portRange, resolutionIsAssumed);
+                    if (enabledIsReported)
+                    {
+                        existingAnalog.IsEnabled = IsChannelBitSet(analogInPortEnabled, i);
+                    }
                     destination.Add(existingAnalog);
                     continue;
                 }
@@ -1902,7 +1918,7 @@ namespace Daqifi.Core.Device
                 {
                     Name = $"AI{i}",
                     Direction = ChannelDirection.Input,
-                    IsEnabled = false,
+                    IsEnabled = enabledIsReported && IsChannelBitSet(analogInPortEnabled, i),
                     CalibrationB = calibrationB,
                     CalibrationM = calibrationM,
                     InternalScaleM = internalScaleM,
@@ -1992,6 +2008,19 @@ namespace Daqifi.Core.Device
             }
 
             return count;
+        }
+
+        /// <summary>
+        /// Reads bit <paramref name="channelNumber"/> from a device-reported per-channel enable
+        /// bitmask (analog_in_port_enabled, field 22 — confirmed bit-packed on the bench: 2 bytes
+        /// for 16 channels, little-endian, bit <c>n</c> = channel <c>n</c> — the same layout Core
+        /// sends outbound via <see cref="Communication.Producers.ScpiMessageProducer.EnableAdcChannels"/>).
+        /// Returns false when the channel number falls outside the bytes actually sent.
+        /// </summary>
+        private static bool IsChannelBitSet(Google.Protobuf.ByteString mask, int channelNumber)
+        {
+            var byteIndex = channelNumber / 8;
+            return byteIndex < mask.Length && (mask[byteIndex] & (1 << (channelNumber % 8))) != 0;
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -731,14 +731,34 @@ namespace Daqifi.Core.Device
                 throw new DeviceNotConnectedException();
             }
 
-            foreach (var channel in SnapshotChannels())
+            (bool HasChannels, uint Mask) adcMask = default;
+            (bool HasChannels, bool AnyEnabled) dioState = default;
+
+            // Mutate and derive the outbound masks in one critical section — see the matching
+            // comment in SetChannelsEnabled (#409) for why the gap matters.
+            WithChannelsLock(() =>
             {
-                channel.IsEnabled = false;
-            }
+                foreach (var channel in SnapshotChannels())
+                {
+                    channel.IsEnabled = false;
+                }
+
+                adcMask = ComputeAdcEnableMask();
+                dioState = ComputeDioEnableState();
+            });
 
             // Push the cleared state for whichever channel types this device actually has.
-            SendAdcEnableMask();
-            SendDioEnableState();
+            if (adcMask.HasChannels)
+            {
+                Send(ScpiMessageProducer.EnableAdcChannels(adcMask.Mask.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            if (dioState.HasChannels)
+            {
+                Send(dioState.AnyEnabled
+                    ? ScpiMessageProducer.EnableDioPorts()
+                    : ScpiMessageProducer.DisableDioPorts());
+            }
         }
 
         /// <inheritdoc />
@@ -1200,38 +1220,60 @@ namespace Daqifi.Core.Device
 
             var touchedAnalog = false;
             var touchedDigital = false;
+            var adcMask = (HasChannels: false, Mask: 0u);
+            var dioState = (HasChannels: false, AnyEnabled: false);
 
-            foreach (var channel in channels)
+            // Mutate IsEnabled and derive the outbound masks from it in one critical section, so
+            // a status frame resyncing analog IsEnabled from the device (#409) on the consumer
+            // thread cannot interleave between the mutation and the read that computes the mask —
+            // which would otherwise send a mask reflecting a value the status frame is about to
+            // overwrite, silently failing to apply the requested enable/disable on the device.
+            WithChannelsLock(() =>
             {
-                channel.IsEnabled = enabled;
+                foreach (var channel in channels)
+                {
+                    channel.IsEnabled = enabled;
 
-                if (channel.Type == ChannelType.Analog)
-                {
-                    touchedAnalog = true;
+                    if (channel.Type == ChannelType.Analog)
+                    {
+                        touchedAnalog = true;
+                    }
+                    else if (channel.Type == ChannelType.Digital)
+                    {
+                        touchedDigital = true;
+                    }
                 }
-                else if (channel.Type == ChannelType.Digital)
+
+                if (touchedAnalog)
                 {
-                    touchedDigital = true;
+                    adcMask = ComputeAdcEnableMask();
                 }
+
+                if (touchedDigital)
+                {
+                    dioState = ComputeDioEnableState();
+                }
+            });
+
+            if (touchedAnalog && adcMask.HasChannels)
+            {
+                Send(ScpiMessageProducer.EnableAdcChannels(adcMask.Mask.ToString(CultureInfo.InvariantCulture)));
             }
 
-            if (touchedAnalog)
+            if (touchedDigital && dioState.HasChannels)
             {
-                SendAdcEnableMask();
-            }
-
-            if (touchedDigital)
-            {
-                SendDioEnableState();
+                Send(dioState.AnyEnabled
+                    ? ScpiMessageProducer.EnableDioPorts()
+                    : ScpiMessageProducer.DisableDioPorts());
             }
         }
 
         /// <summary>
-        /// Recomputes the ADC enable bitmask over all currently-enabled analog channels and sends it.
-        /// Does nothing when the device has no analog channels. The firmware treats the value as a
-        /// set-replace, so the full mask of enabled analog channels is sent every time.
+        /// Computes the ADC enable bitmask over all currently-enabled analog channels. Must be
+        /// called under <see cref="DaqifiDevice.WithChannelsLock{T}"/> alongside any IsEnabled
+        /// mutation it should reflect (#409) — see <see cref="SetChannelsEnabled"/>.
         /// </summary>
-        private void SendAdcEnableMask()
+        private (bool HasChannels, uint Mask) ComputeAdcEnableMask()
         {
             uint mask = 0;
             var hasAnalogChannels = false;
@@ -1259,6 +1301,18 @@ namespace Daqifi.Core.Device
                 mask |= 1u << channel.ChannelNumber;
             }
 
+            return (hasAnalogChannels, mask);
+        }
+
+        /// <summary>
+        /// Recomputes the ADC enable bitmask over all currently-enabled analog channels and sends it.
+        /// Does nothing when the device has no analog channels. The firmware treats the value as a
+        /// set-replace, so the full mask of enabled analog channels is sent every time.
+        /// </summary>
+        private void SendAdcEnableMask()
+        {
+            var (hasAnalogChannels, mask) = WithChannelsLock(ComputeAdcEnableMask);
+
             if (!hasAnalogChannels)
             {
                 return;
@@ -1268,11 +1322,11 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
-        /// Sends the global DIO enable command reflecting whether any digital channel is enabled.
-        /// Does nothing when the device has no digital channels. The firmware exposes only a global
-        /// DIO enable, so per-channel digital enabling is collapsed to this aggregate state.
+        /// Computes whether any digital channel is enabled. Must be called under
+        /// <see cref="DaqifiDevice.WithChannelsLock{T}"/> alongside any IsEnabled mutation it
+        /// should reflect — see <see cref="SetChannelsEnabled"/>.
         /// </summary>
-        private void SendDioEnableState()
+        private (bool HasChannels, bool AnyEnabled) ComputeDioEnableState()
         {
             var hasDigitalChannels = false;
             var anyEnabled = false;
@@ -1291,6 +1345,18 @@ namespace Daqifi.Core.Device
                     anyEnabled = true;
                 }
             }
+
+            return (hasDigitalChannels, anyEnabled);
+        }
+
+        /// <summary>
+        /// Sends the global DIO enable command reflecting whether any digital channel is enabled.
+        /// Does nothing when the device has no digital channels. The firmware exposes only a global
+        /// DIO enable, so per-channel digital enabling is collapsed to this aggregate state.
+        /// </summary>
+        private void SendDioEnableState()
+        {
+            var (hasDigitalChannels, anyEnabled) = WithChannelsLock(ComputeDioEnableState);
 
             if (!hasDigitalChannels)
             {


### PR DESCRIPTION
## Summary

- Core previously never read `analog_in_port_enabled` (protobuf field 22) — analog channel `IsEnabled` was only ever set by Core's own `EnableChannel`/`DisableChannel` calls, so it could silently drift from the device's actual state (another session enabling a channel, state surviving a reconnect, a partially-applied command).
- `PopulateAnalogChannels` now parses field 22 and resyncs `IsEnabled` from it on every status frame that reports one — both for newly-created channels and for existing channel instances reused across a repopulation.
- Firmware that doesn't populate the field (pre-v3.5.0) sends an empty byte string, which is treated as "not reported" rather than "everything disabled" — existing/default behavior is preserved in that case.

This closes scope item 7 of #390, split out because #390 was closed by #404 with item 7 deliberately deferred. It directly addresses the staleness #404 introduced: `DeviceCapabilities.CurrentMaximumRateHz` is computed by the device from *its* enabled set, and Core's cached copy is only as good as Core's own view of that set.

## Bench verification

The issue explicitly flagged the wire encoding of field 22 as unverified, so I confirmed it against a real Nq1 (fw 3.7.2) before committing to an implementation:

- My first assumption (one byte per channel, matching sibling fields like `analog_in_port_type`) was **wrong**. The bench showed the real encoding is a **bit-packed mask**, same layout Core already sends outbound via `EnableAdcChannels`: enabling channels 0 and 2 on a 16-channel device produced `AnalogInPortEnabled = [5, 0]` (2 bytes, little-endian, bit *n* = channel *n*), not a 16-byte array.
- Verified the drift-resync path directly: forced Core's local channel 5 `IsEnabled = true` without telling the device (no SCPI sent), then requested a fresh status frame — Core's view snapped back to `false`, matching the device's real state.

## Test plan

- [x] `dotnet test` — full suite passes (2184 tests, 2 pre-existing skips)
- [x] New unit tests in `ChannelPopulationTests.cs` covering: single-byte mask, multi-byte mask (channel 9+), missing field 22 (old firmware) defaults to disabled, repopulation resyncs from device rather than preserving Core's stale value, truncated mask treats missing bytes as disabled
- [x] Bench-tested against a real DAQiFi Nq1 (fw 3.7.2) over USB/serial, per above

🤖 Generated with [Claude Code](https://claude.com/claude-code)