### PR TITLE
fix(producer): surface write failures via a SendFailed event

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -752,6 +752,24 @@ Parallel.For(0, 10, i =>
 
 However, for connection state changes (Connect/Disconnect), coordinate access from a single thread or use proper synchronization.
 
+## Delivery Failures
+
+`Send()` is fire-and-forget: it queues the message and returns before the background thread
+writes it, so delivery is not guaranteed. If the write fails — including a timeout, meaning the
+device isn't draining its receive buffer right now — `Send()` does not throw. `DaqifiDevice` logs
+a warning through its `ILogger` for every failed write, and code that needs to react to a
+delivery failure (not just read it from logs) can subscribe to `DaqifiDevice.SendFailed`:
+
+```csharp
+device.SendFailed += (_, e) =>
+{
+    Console.WriteLine($"Delivery failed (timeout: {e.IsTimeout}): {e.Error.Message}");
+};
+```
+
+A single failed write does not stop the queue: the producer keeps draining the remaining
+messages regardless of whether anything observes the failure.
+
 ## Features
 
 - **Simple Factory API**: Single-call connection with `DaqifiDeviceFactory`

--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
@@ -230,6 +230,94 @@ public class MessageProducerTests
     }
 
     [Fact]
+    public void MessageProducer_WhenWriteThrows_ShouldRaiseSendFailed()
+    {
+        // Arrange
+        using var stream = new ThrowOnWriteStream();
+        using var producer = new MessageProducer<string>(stream);
+        MessageSendFailedEventArgs<string>? captured = null;
+        producer.SendFailed += (_, e) => captured = e;
+        producer.Start();
+
+        // Act - the background thread will attempt to write and fail
+        var message = new ScpiMessage("TEST:COMMAND");
+        producer.Send(message);
+        var raised = SpinWait.SpinUntil(() => captured != null, TimeSpan.FromSeconds(2));
+        producer.StopSafely();
+
+        // Assert - the caller has a way to observe that this specific message was not delivered
+        Assert.True(raised, "Expected SendFailed to be raised when the stream write throws.");
+        Assert.Same(message, captured!.Message);
+        Assert.IsType<IOException>(captured.Error);
+        Assert.False(captured.IsTimeout);
+    }
+
+    [Fact]
+    public void MessageProducer_WhenWriteTimesOut_ShouldRaiseSendFailedWithIsTimeoutTrue()
+    {
+        // Arrange
+        using var stream = new ThrowOnWriteStream(new TimeoutException("Simulated write timeout."));
+        var logger = new CaptureLogger<MessageProducer<string>>();
+        using var producer = new MessageProducer<string>(stream, logger);
+        MessageSendFailedEventArgs<string>? captured = null;
+        producer.SendFailed += (_, e) => captured = e;
+        producer.Start();
+
+        // Act
+        producer.Send(new ScpiMessage("TEST:COMMAND"));
+        var raised = SpinWait.SpinUntil(() => captured != null, TimeSpan.FromSeconds(2));
+        producer.StopSafely();
+
+        // Assert - a timeout is distinguishable both on the event and in the log text, so the
+        // "device is busy" case can be told apart from any other delivery failure (issue #408).
+        Assert.True(raised, "Expected SendFailed to be raised when the stream write times out.");
+        Assert.True(captured!.IsTimeout);
+        var warning = logger.Entries.First(e => e.Level == LogLevel.Warning);
+        Assert.Contains("Timed out", warning.Message);
+    }
+
+    [Fact]
+    public void MessageProducer_WhenSendFailedSubscriberThrows_ShouldKeepDrainingAndStopCleanly()
+    {
+        // Arrange - a subscriber that throws must not be allowed to take down the background loop,
+        // mirroring the existing guarantee for a faulting ILogger.
+        using var stream = new ThrowOnWriteStream();
+        using var producer = new MessageProducer<string>(stream);
+        producer.SendFailed += (_, _) => throw new InvalidOperationException("Simulated subscriber failure.");
+        producer.Start();
+
+        // Act
+        for (var i = 0; i < 5; i++)
+        {
+            producer.Send(new ScpiMessage($"CMD{i}"));
+        }
+        var stopped = producer.StopSafely(2000);
+
+        // Assert
+        Assert.True(stopped, "StopSafely should not hang when a SendFailed subscriber throws.");
+        Assert.False(producer.IsRunning);
+        Assert.Equal(0, producer.QueuedMessageCount);
+    }
+
+    [Fact]
+    public void MessageProducer_Send_WhenSucceeding_ShouldNotRaiseSendFailed()
+    {
+        // Arrange
+        using var stream = new MemoryStream();
+        using var producer = new MessageProducer<string>(stream);
+        var raised = false;
+        producer.SendFailed += (_, _) => raised = true;
+        producer.Start();
+
+        // Act
+        producer.Send(new ScpiMessage("TEST:COMMAND"));
+        producer.StopSafely();
+
+        // Assert
+        Assert.False(raised);
+    }
+
+    [Fact]
     public void MessageProducer_WhenStoppedNormally_ShouldLogCleanExit()
     {
         // Arrange
@@ -323,6 +411,13 @@ public class MessageProducerTests
     /// </summary>
     private sealed class ThrowOnWriteStream : Stream
     {
+        private readonly Exception _exceptionToThrow;
+
+        public ThrowOnWriteStream(Exception? exceptionToThrow = null)
+        {
+            _exceptionToThrow = exceptionToThrow ?? new IOException("Simulated write failure for error-handling test.");
+        }
+
         public override bool CanRead => false;
         public override bool CanSeek => false;
         public override bool CanWrite => true;
@@ -337,7 +432,6 @@ public class MessageProducerTests
 
         public override void SetLength(long value) => throw new NotSupportedException();
 
-        public override void Write(byte[] buffer, int offset, int count) =>
-            throw new IOException("Simulated write failure for error-handling test.");
+        public override void Write(byte[] buffer, int offset, int count) => throw _exceptionToThrow;
     }
 }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceWithMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceWithMessageProducerTests.cs
@@ -1,6 +1,8 @@
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Device;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Text;
 
@@ -18,6 +20,52 @@ public class DaqifiDeviceWithMessageProducerTests
         }
 
         public byte[] GetBytes() => Data;
+    }
+
+    /// <summary>
+    /// A write-only stream whose <see cref="Write"/> always throws, used to exercise the
+    /// device's wiring of <see cref="IMessageProducer{T}.SendFailed"/> (issue #408).
+    /// </summary>
+    private sealed class ThrowOnWriteStream : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new IOException("Simulated write failure for error-handling test.");
+    }
+
+    /// <summary>
+    /// Captures log entries in-memory so tests can assert that the device logs as expected.
+    /// </summary>
+    private sealed class CaptureLogger : ILogger
+    {
+        private readonly ConcurrentQueue<(LogLevel Level, Exception? Exception, string Message)> _entries = new();
+
+        public IReadOnlyList<(LogLevel Level, Exception? Exception, string Message)> Entries => _entries.ToArray();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            _entries.Enqueue((logLevel, exception, formatter(state, exception)));
     }
 
     [Fact]
@@ -106,6 +154,49 @@ public class DaqifiDeviceWithMessageProducerTests
         // Act & Assert
         var ex = Assert.Throws<InvalidOperationException>(() => device.Send(ScpiMessageProducer.GetDeviceInfo));
         Assert.Contains("no transport or stream", ex.Message);
+    }
+
+    [Fact]
+    public void DaqifiDevice_SendMessage_WhenWriteFails_ShouldLogWarning()
+    {
+        // Arrange - a command that never reaches the device must not look delivered (issue #408);
+        // the device wires the producer's SendFailed event to its own logger so the failure is
+        // visible even though Send() itself never throws.
+        using var stream = new ThrowOnWriteStream();
+        var logger = new CaptureLogger();
+        using var device = new DaqifiDevice("Test Device", stream, logger: logger);
+        device.Connect();
+
+        // Act
+        device.Send(ScpiMessageProducer.GetDeviceInfo);
+        var warningLogged = SpinWait.SpinUntil(
+            () => logger.Entries.Any(e => e.Level == LogLevel.Warning),
+            TimeSpan.FromSeconds(2));
+
+        // Assert
+        Assert.True(warningLogged, "Expected a warning to be logged when a queued message fails to write.");
+        var warning = logger.Entries.First(e => e.Level == LogLevel.Warning);
+        Assert.IsType<IOException>(warning.Exception);
+    }
+
+    [Fact]
+    public void DaqifiDevice_SendMessage_WhenWriteFails_ShouldRaiseSendFailed()
+    {
+        // Arrange - DaqifiDevice.SendFailed is the only way a caller can react to a dropped
+        // command, since Send() itself never throws for a failed write (issue #408).
+        using var stream = new ThrowOnWriteStream();
+        using var device = new DaqifiDevice("Test Device", stream);
+        device.Connect();
+        MessageSendFailedEventArgs<string>? captured = null;
+        device.SendFailed += (_, e) => captured = e;
+
+        // Act
+        device.Send(ScpiMessageProducer.GetDeviceInfo);
+        var raised = SpinWait.SpinUntil(() => captured != null, TimeSpan.FromSeconds(2));
+
+        // Assert
+        Assert.True(raised, "Expected DaqifiDevice.SendFailed to be raised when a queued message fails to write.");
+        Assert.IsType<IOException>(captured!.Error);
     }
 
     [Fact]

--- a/src/Daqifi.Core/Communication/Producers/IMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/IMessageProducer.cs
@@ -28,8 +28,24 @@ public interface IMessageProducer<T> : IDisposable
     /// <summary>
     /// Queues a message for sending to the device.
     /// </summary>
+    /// <remarks>
+    /// This is fire-and-forget: the message is handed to a background thread and this call
+    /// returns before the write happens, so delivery is not guaranteed. A write that fails —
+    /// including one that never reaches the device — does not throw back to the caller; it is
+    /// only observable via <see cref="SendFailed"/> (issue #408).
+    /// </remarks>
     /// <param name="message">The message to send.</param>
     void Send(IOutboundMessage<T> message);
+
+    /// <summary>
+    /// Occurs when a queued message fails to write to the underlying stream.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Send"/> never throws for a failed write, so this is the only signal a caller
+    /// gets that a specific message was not delivered. Raised on the producer's background
+    /// thread; the producer keeps draining the remaining queue regardless of subscribers.
+    /// </remarks>
+    event EventHandler<MessageSendFailedEventArgs<T>>? SendFailed;
 
     /// <summary>
     /// Gets the number of messages currently queued for sending.

--- a/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
@@ -57,6 +57,9 @@ public class MessageProducer<T> : IMessageProducer<T>
     /// </summary>
     public bool IsRunning => _isRunning;
 
+    /// <inheritdoc />
+    public event EventHandler<MessageSendFailedEventArgs<T>>? SendFailed;
+
     /// <summary>
     /// Starts the message producer, beginning background message processing.
     /// </summary>
@@ -133,6 +136,11 @@ public class MessageProducer<T> : IMessageProducer<T>
     /// <summary>
     /// Queues a message for sending. The background thread will process it asynchronously.
     /// </summary>
+    /// <remarks>
+    /// This call returns before the write happens, so delivery is not guaranteed: a write that
+    /// fails on the background thread does not throw back here. Subscribe to
+    /// <see cref="SendFailed"/> if the caller needs to know a specific message was not delivered.
+    /// </remarks>
     /// <param name="message">The message to send.</param>
     /// <exception cref="ArgumentNullException">Thrown when message is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown when producer is not running.</exception>
@@ -188,12 +196,25 @@ public class MessageProducer<T> : IMessageProducer<T>
                             // that the link is gone. Treating it as evidence of a disconnect could
                             // tear down a healthy connection to a momentarily busy device — the
                             // same reason the reader loop treats a read timeout as benign.
-                            if (ex is not TimeoutException)
+                            var isTimeout = ex is TimeoutException;
+                            if (!isTimeout)
                             {
                                 _healthSink?.ReportIoFault(ex);
                             }
 
-                            SafeLog(() => _logger.LogWarning(ex, "Failed to write message to the stream; continuing with remaining queued messages."));
+                            // A timeout gets its own greppable message so "the write never
+                            // happened because the device isn't draining" (busy/flow-controlled)
+                            // can be told apart from any other write failure in the logs.
+                            var logMessage = isTimeout
+                                ? "Timed out writing message to the stream; continuing with remaining queued messages."
+                                : "Failed to write message to the stream; continuing with remaining queued messages.";
+                            SafeLog(() => _logger.LogWarning(ex, logMessage));
+
+                            // The only signal a caller gets that this specific message was not
+                            // delivered (issue #408). A throwing subscriber must not take down
+                            // the background loop, so this goes through the same SafeLog guard
+                            // used for the logger above.
+                            SafeLog(() => SendFailed?.Invoke(this, new MessageSendFailedEventArgs<T>(message, ex)));
                         }
                     }
                 }

--- a/src/Daqifi.Core/Communication/Producers/MessageSendFailedEventArgs.cs
+++ b/src/Daqifi.Core/Communication/Producers/MessageSendFailedEventArgs.cs
@@ -1,0 +1,57 @@
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Transport;
+
+namespace Daqifi.Core.Communication.Producers;
+
+/// <summary>
+/// Provides data for <see cref="IMessageProducer{T}.SendFailed"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="IMessageProducer{T}.Send"/> is fire-and-forget: the message is handed to a
+/// background thread and the call returns before the write happens. Without this event, a
+/// write that never reaches the device is indistinguishable to the caller from one that
+/// was delivered (issue #408). Raising it is purely observational — the producer still
+/// keeps draining the remaining queue exactly as it did before this event existed.
+/// </remarks>
+/// <typeparam name="T">The type of message data the producer sends.</typeparam>
+public sealed class MessageSendFailedEventArgs<T> : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageSendFailedEventArgs{T}"/> class.
+    /// </summary>
+    /// <param name="message">The message whose write failed.</param>
+    /// <param name="error">The exception the write threw.</param>
+    public MessageSendFailedEventArgs(IOutboundMessage<T> message, Exception error)
+    {
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+        Error = error ?? throw new ArgumentNullException(nameof(error));
+        IsTimeout = error is TimeoutException;
+        Timestamp = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Gets the message whose write failed.
+    /// </summary>
+    public IOutboundMessage<T> Message { get; }
+
+    /// <summary>
+    /// Gets the exception the write threw.
+    /// </summary>
+    public Exception Error { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Error"/> was a <see cref="TimeoutException"/>.
+    /// </summary>
+    /// <remarks>
+    /// A write timeout means the device is not draining its receive buffer right now (busy or
+    /// flow-controlled), not that the link is gone — the same reasoning <see cref="ITransportHealthSink"/>
+    /// reporting already applies. Subscribers that want to treat delivery failures differently
+    /// from a transient timeout can branch on this flag instead of inspecting <see cref="Error"/>'s type.
+    /// </remarks>
+    public bool IsTimeout { get; }
+
+    /// <summary>
+    /// Gets the UTC timestamp when the failure was recorded.
+    /// </summary>
+    public DateTime Timestamp { get; }
+}

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -593,10 +593,15 @@ namespace Daqifi.Core.Device
 
             try
             {
-                // Unsubscribe from message consumer events
+                // Unsubscribe from message consumer/producer events
                 if (_messageConsumer != null)
                 {
                     _messageConsumer.MessageReceived -= OnInboundMessageReceived;
+                }
+
+                if (_messageProducer != null)
+                {
+                    _messageProducer.SendFailed -= OnMessageSendFailed;
                 }
 
                 // Stop message consumer and producer safely if available

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -442,6 +442,18 @@ namespace Daqifi.Core.Device
         public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated;
 
         /// <summary>
+        /// Occurs when a message queued via <see cref="Send{T}"/> fails to write to the device.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Send{T}"/> is fire-and-forget, so this is the only way a caller can learn
+        /// that a specific command never reached the device (issue #408) — a warning is also
+        /// logged, but subscribing here lets a caller react (e.g. retry, surface a UI warning)
+        /// instead of only reading it from logs. Raised on the producer's background thread and
+        /// purely observational: it does not change <see cref="Status"/> or stop the queue.
+        /// </remarks>
+        public event EventHandler<MessageSendFailedEventArgs<string>>? SendFailed;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DaqifiDevice"/> class.
         /// </summary>
         /// <param name="name">The name of the device.</param>
@@ -469,6 +481,7 @@ namespace Daqifi.Core.Device
             _status = ConnectionStatus.Disconnected;
             _logger = logger ?? NullLogger.Instance;
             _messageProducer = new MessageProducer<string>(stream);
+            _messageProducer.SendFailed += OnMessageSendFailed;
             _directStream = stream;
         }
 
@@ -512,6 +525,7 @@ namespace Daqifi.Core.Device
                     if (_messageProducer == null)
                     {
                         _messageProducer = new MessageProducer<string>(_transport.Stream, healthSink: healthSink);
+                        _messageProducer.SendFailed += OnMessageSendFailed;
                     }
 
                     if (_messageConsumer == null)
@@ -1389,6 +1403,27 @@ namespace Daqifi.Core.Device
                     Status = ConnectionStatus.Lost;
                 }
             }
+        }
+
+        /// <summary>
+        /// Logs a message that the producer's background thread could not deliver.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="IMessageProducer{T}.Send"/> is fire-and-forget, so this is the device's only
+        /// visibility into a command that never reached the wire (issue #408). Purely observational:
+        /// it does not change <see cref="Status"/> or retry the message — the producer already keeps
+        /// draining the rest of the queue on its own.
+        /// </remarks>
+        private void OnMessageSendFailed(object? sender, MessageSendFailedEventArgs<string> e)
+        {
+            SafeLog(() => _logger.LogWarning(
+                e.Error,
+                "A queued message was not delivered to the device (timeout: {IsTimeout}).",
+                e.IsTimeout));
+
+            // A throwing subscriber must not be allowed to take down the producer's
+            // background thread, so this goes through the same SafeLog guard as the logger above.
+            SafeLog(() => SendFailed?.Invoke(this, e));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Closes #408.

`MessageProducer<T>.Send()` is fire-and-forget: the message goes onto a queue drained by a background thread, and if `stream.Write` fails, the failure was only logged at Warning. Nothing propagated to the caller, so a command that never reached the device looked identical, from the caller's point of view, to one that was delivered.

- Added `MessageSendFailedEventArgs<T>` and a `SendFailed` event on `IMessageProducer<T>`/`MessageProducer<T>`, raised (from the background thread, wrapped so a throwing subscriber can't kill the loop) for every failed write. Carries the failing message, the exception, and an `IsTimeout` flag.
- Added a forwarding `SendFailed` event on `DaqifiDevice` (mirroring the existing `ChannelsPopulated`-style concrete-class event), plus a log-warning subscriber wired at every place `DaqifiDevice` constructs a producer — so real device usage gets visibility today without needing #378's broader device-level error surface.
- Gave a write timeout its own log message text, distinct from other write failures, so "device is busy/flow-controlled" is greppable separately (per the issue's suggestion #3). Timeout classification for the health sink (#403) is unchanged — a timeout still isn't reported as an `ITransportHealthSink` fault.
- Documented on `Send()`/`IMessageProducer<T>.Send` that delivery is not guaranteed, and added a "Delivery Failures" section to `docs/DEVICE_INTERFACES.md`.

This is intentionally scoped to option 2/3 from the issue (something to observe, plus greppable logs) rather than #378's full device-level `ErrorOccurred` surface, since #378 is still open — `DaqifiDevice.SendFailed` gives real callers a signal today and can be superseded/wired into that broader surface later.

## Test plan
- [x] New unit tests: `SendFailed` raised on write failure (non-timeout and timeout), timeout gets distinct log text, a throwing `SendFailed` subscriber doesn't kill the background loop, no event on a successful write, and `DaqifiDevice.SendFailed`/log-warning wiring.
- [x] Full `Daqifi.Core.Tests` suite: 2191 passed, 2 skipped (pre-existing), 0 failed.
- [x] Bench-tested against a real Nyquist device (`/dev/cu.usbmodem1101`): connect → stream 3s @ 10 Hz on channels 0+1 → stop → disconnect, exit code 0, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)