### PR TITLE
fix(device): make background failures visible and stop the last silent read-loop spin (closes #377, #394, #378)

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -50,6 +50,7 @@ The base interface for all DAQiFi devices, providing fundamental connection and 
 - `Send<T>(IOutboundMessage<T>)` - Send commands to device
 - `StatusChanged` event - Connection status notifications
 - `MessageReceived` event - Incoming data notifications
+- `ErrorOccurred` event - Background read/parse/decode failures (see [Error Surface](#error-surface))
 
 ### IStreamingDevice
 
@@ -490,6 +491,10 @@ device.StatusChanged += (_, e) =>
 Custom transports can opt into the same escalation by implementing `ITransportHealthSink`; the
 reader and writer loops report every read/write outcome to a transport that does.
 
+The failures that feed this escalation are also reported individually, as they happen, on
+`IDevice.ErrorOccurred` — see [Error Surface](#error-surface). That event is diagnostics only;
+`ConnectionStatus.Lost` remains the single signal that means "the connection is over".
+
 ### Working with Device Metadata
 
 After initialization, device metadata is populated:
@@ -770,6 +775,77 @@ device.SendFailed += (_, e) =>
 A single failed write does not stop the queue: the producer keeps draining the remaining
 messages regardless of whether anything observes the failure.
 
+## Error Surface
+
+Reading from the device and decoding its frames both happen on background threads, where an
+exception has nobody to throw to. Those failures used to be invisible: a stream that could not be
+read and a stream that could not be decoded both looked exactly like a device sending nothing.
+`IDevice.ErrorOccurred` is the one place to answer *"why am I getting no samples"*.
+
+```csharp
+device.ErrorOccurred += (_, e) =>
+{
+    Console.WriteLine($"[{e.Source}] {e.Error.Message}");
+    if (e.SuppressedCount > 0)
+    {
+        Console.WriteLine($"  ...and {e.SuppressedCount} more like it since the last report");
+    }
+};
+```
+
+`DeviceErrorEventArgs.Source` says which stage failed:
+
+| Source | What it means |
+|---|---|
+| `MessageConsumer` | A read from the transport stream failed, a frame could not be parsed, or a `MessageReceived` subscriber threw |
+| `StreamDecode` | A streaming frame could not be decoded into channel samples. That frame is dropped; the stream continues |
+
+### Observational, never escalating
+
+Raising this event changes nothing about what the device does. There is no tear-down, no retry, no
+`Status` change, and per-frame isolation is unchanged — a single malformed frame is still dropped on
+its own without disturbing the stream. Deciding that a link is genuinely dead is a separate
+mechanism with its own signal: `ConnectionStatus.Lost` on `StatusChanged` (see
+[Detecting a dropped connection](#detecting-a-dropped-connection)). The two often fire together on a
+real drop — the same failing reads feed both — but neither implies the other, and an `ErrorOccurred`
+on its own is not a reason to reconnect.
+
+Every error is also written to the device's `ILogger` at warning level, so it stays visible with no
+subscriber attached.
+
+### Throttle policy
+
+A systematic failure repeats at the frame rate, so raises are collapsed per **bucket**, where a
+bucket is (`Source`, exception type):
+
+- The **first** occurrence in a bucket is always raised, immediately.
+- After that, a bucket raises **at most once every five seconds**. Occurrences in between are
+  counted and reported as `SuppressedCount` on the next raise — so a storm shows up as a number
+  rather than as thousands of events.
+- Buckets are independent: a *new* kind of failure is raised at once even while another kind is
+  being collapsed.
+- Connecting resets the throttle, so a reconnect reports its first failure immediately.
+
+### Decode failure counter
+
+`DaqifiStreamingDevice.DecodeFailureCount` is the always-on companion to the event: the number of
+frames whose decode threw and was discarded during the current streaming session. It is reset by
+`StartStreaming()`, and a healthy stream leaves it at zero — so a non-zero value while samples are
+missing is the fastest confirmation that frames are arriving but not decoding.
+
+```csharp
+device.StartStreaming();
+// ...
+if (device.DecodeFailureCount > 0)
+{
+    Console.WriteLine($"{device.DecodeFailureCount} frame(s) failed to decode this session");
+}
+```
+
+`ErrorOccurred` is raised on a background thread, so handlers should do the minimum and push real
+work elsewhere. A handler that throws is caught and ignored — it can never disturb reading or
+streaming.
+
 ## Features
 
 - **Simple Factory API**: Single-call connection with `DaqifiDeviceFactory`
@@ -777,6 +853,8 @@ messages regardless of whether anything observes the failure.
   unit connected over two transports
 - **Clean Abstraction**: Hardware details hidden behind well-defined interfaces
 - **Event-Driven**: Status changes and messages handled via events
+- **Observable Failures**: Background read and decode errors surface on `ErrorOccurred` instead of
+  failing silently
 - **Type Safety**: Generic message types provide compile-time safety
 - **Retry Support**: Built-in connection retry with exponential backoff
 - **Thread-Safe Sending**: Background message queue for thread-safe command sending

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBackoffTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBackoffTests.cs
@@ -1,0 +1,275 @@
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Transport;
+
+namespace Daqifi.Core.Tests.Communication.Consumers;
+
+/// <summary>
+/// No failure mode in the reader loop may spin without progress. A failure that repeats every
+/// iteration must be backed off, and a failure that is genuinely I/O against the stream must reach
+/// the transport so a dead link can still be escalated (issues #377, #378).
+/// </summary>
+public class StreamMessageConsumerBackoffTests
+{
+    /// <summary>
+    /// Window over which raise counts are sampled. With the loop's 100 ms error back-off this
+    /// bounds a repeating failure to a handful of raises; without one it is limited only by how
+    /// fast the thread can spin.
+    /// </summary>
+    private static readonly TimeSpan SampleWindow = TimeSpan.FromMilliseconds(700);
+
+    /// <summary>
+    /// Generous ceiling for "backed off" over <see cref="SampleWindow"/>. The unbacked-off loop
+    /// produces tens of thousands in the same window, so the separation is not marginal.
+    /// </summary>
+    private const int BackedOffCeiling = 25;
+
+    [Fact]
+    public void WhenTheCanReadProbeThrows_ItIsTreatedAsAStreamFaultAndReportedToTheTransport()
+    {
+        // Probing readability touches the same handle a read does, and on a half-torn-down stream
+        // the getter itself can throw. That is the link failing, so it has to reach the transport —
+        // otherwise this one failure mode silently bypasses connection-loss escalation.
+        using var stream = new ThrowingCanReadStream();
+        var sink = new RecordingHealthSink();
+        var errors = 0;
+
+        using var consumer = new StreamMessageConsumer<string>(
+            stream, new LineBasedMessageParser(), healthSink: sink);
+        consumer.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        consumer.Start();
+
+        Assert.True(
+            WaitUntil(() => sink.FaultCount >= TransportConnectionWatchdog.ConsecutiveFaultThreshold,
+                TimeSpan.FromSeconds(10)),
+            $"a throwing CanRead must be reported to the transport, saw {sink.FaultCount} fault(s)");
+
+        Assert.True(Volatile.Read(ref errors) >= 1, "it must also be visible as a consumer error");
+
+        consumer.StopSafely(timeoutMs: 2000);
+    }
+
+    [Fact]
+    public void WhenTheCanReadProbeThrows_TheLoopBacksOffInsteadOfSpinning()
+    {
+        using var stream = new ThrowingCanReadStream();
+        var errors = 0;
+
+        using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+        consumer.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        consumer.Start();
+        Thread.Sleep(SampleWindow);
+        consumer.StopSafely(timeoutMs: 2000);
+
+        var raised = Volatile.Read(ref errors);
+        Assert.True(raised >= 1, "the failure must be reported at all");
+        Assert.True(raised <= BackedOffCeiling, $"expected a backed-off cadence, saw {raised} raises");
+    }
+
+    [Fact]
+    public void WhenParsingThrowsOnEveryIteration_TheLoopBacksOffInsteadOfSpinning()
+    {
+        // A parser that throws on the bytes it holds will throw on exactly the same bytes next time
+        // round, so retrying at full speed makes no progress and burns a core while raising errors
+        // as fast as the thread can go.
+        using var stream = new AlwaysReadableStream();
+        var sink = new RecordingHealthSink();
+        var errors = 0;
+
+        using var consumer = new StreamMessageConsumer<string>(
+            stream, new AlwaysThrowingParser(), healthSink: sink);
+        consumer.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        consumer.Start();
+        Thread.Sleep(SampleWindow);
+        consumer.StopSafely(timeoutMs: 2000);
+
+        var raised = Volatile.Read(ref errors);
+        Assert.True(raised >= 1, "the parse failure must be reported at all");
+        Assert.True(raised <= BackedOffCeiling, $"expected a backed-off cadence, saw {raised} raises");
+    }
+
+    [Fact]
+    public void AParseFailure_IsNeverReportedToTheTransportAsAnIoFault()
+    {
+        // The counterpart to the back-off: a parse failure means the bytes were bad, not that the
+        // link is gone. Escalating it would disconnect a perfectly healthy device over malformed
+        // data — the reads themselves are succeeding.
+        using var stream = new AlwaysReadableStream();
+        var sink = new RecordingHealthSink();
+
+        using var consumer = new StreamMessageConsumer<string>(
+            stream, new AlwaysThrowingParser(), healthSink: sink);
+
+        consumer.Start();
+        Thread.Sleep(SampleWindow);
+        consumer.StopSafely(timeoutMs: 2000);
+
+        Assert.Equal(0, sink.FaultCount);
+        Assert.True(sink.SuccessCount >= 1, "the reads themselves were fine and must be reported as such");
+    }
+
+    [Fact]
+    public void AFailureThatLandsWhileStopping_IsSwallowedRatherThanKillingTheProcess()
+    {
+        // The reader loop runs on a background thread, so an exception that escapes its catch does
+        // not just end the loop — it terminates the host process. A stop that lands while the try
+        // body is mid-flight used to do exactly that, because the catch filter stopped matching the
+        // moment the running flag cleared.
+        //
+        // Reaching the end of this test at all is the assertion: if the exception escapes, the test
+        // host dies and the whole run aborts.
+        using var stream = new AlwaysReadableStream();
+        var parser = new GatedThrowingParser();
+        var errors = 0;
+
+        using var consumer = new StreamMessageConsumer<string>(stream, parser);
+        consumer.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        consumer.Start();
+
+        Assert.True(parser.Entered.Wait(TimeSpan.FromSeconds(10)), "the parser was never reached");
+
+        // Clear the running flag while the parser is parked inside the try body, then let it throw.
+        var stopper = new Thread(() => consumer.StopSafely(timeoutMs: 5000)) { IsBackground = true };
+        stopper.Start();
+        Assert.True(WaitUntil(() => !consumer.IsRunning, TimeSpan.FromSeconds(10)));
+        parser.Release.Set();
+
+        Assert.True(stopper.Join(TimeSpan.FromSeconds(10)), "the consumer never stopped");
+        Assert.False(consumer.IsRunning);
+
+        // The failure arrived during teardown, so it says nothing about the device and is not
+        // reported as a device-visible error.
+        Assert.Equal(0, Volatile.Read(ref errors));
+    }
+
+    private static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            Thread.Sleep(10);
+        }
+
+        return condition();
+    }
+
+    private sealed class RecordingHealthSink : ITransportHealthSink
+    {
+        private int _faultCount;
+        private int _successCount;
+
+        public int FaultCount => Volatile.Read(ref _faultCount);
+
+        public int SuccessCount => Volatile.Read(ref _successCount);
+
+        public void ReportIoFault(Exception error) => Interlocked.Increment(ref _faultCount);
+
+        public void ReportIoSuccess() => Interlocked.Increment(ref _successCount);
+    }
+
+    /// <summary>
+    /// A parser that fails on everything it is handed, standing in for a systematic parse failure.
+    /// </summary>
+    private sealed class AlwaysThrowingParser : IMessageParser<string>
+    {
+        public IEnumerable<IInboundMessage<string>> ParseMessages(byte[] data, out int consumedBytes)
+        {
+            consumedBytes = 0;
+            throw new FormatException("this parser cannot handle anything");
+        }
+    }
+
+    /// <summary>
+    /// A parser that parks inside <see cref="ParseMessages"/> until released, then throws — so a
+    /// stop can be made to land precisely while the reader is inside its try body.
+    /// </summary>
+    private sealed class GatedThrowingParser : IMessageParser<string>
+    {
+        public ManualResetEventSlim Entered { get; } = new(false);
+
+        public ManualResetEventSlim Release { get; } = new(false);
+
+        public IEnumerable<IInboundMessage<string>> ParseMessages(byte[] data, out int consumedBytes)
+        {
+            consumedBytes = 0;
+            Entered.Set();
+            Release.Wait(TimeSpan.FromSeconds(30));
+            throw new FormatException("failing after the stop landed");
+        }
+    }
+
+    /// <summary>
+    /// A readable stream that always yields a byte, so the loop reaches the parse stage every
+    /// iteration.
+    /// </summary>
+    private sealed class AlwaysReadableStream : Stream
+    {
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            buffer[offset] = (byte)'x';
+            return 1;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A stream whose readability probe itself fails, as a handle torn down underneath the reader
+    /// can.
+    /// </summary>
+    private sealed class ThrowingCanReadStream : Stream
+    {
+        public override bool CanRead => throw new ObjectDisposedException(nameof(ThrowingCanReadStream));
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new ObjectDisposedException(nameof(ThrowingCanReadStream));
+
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBackoffTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBackoffTests.cs
@@ -146,6 +146,66 @@ public class StreamMessageConsumerBackoffTests
         Assert.Equal(0, Volatile.Read(ref errors));
     }
 
+    [Fact]
+    public void AStopThatLandsDuringTheReadabilityProbe_ReportsNothing()
+    {
+        // Closing a handle is *supposed* to make the reader fail, and the stream going unreadable is
+        // exactly what a deliberate Disconnect looks like from inside the loop. Reporting that would
+        // put a phantom "the connection died" into the transport's health sink and into consumer
+        // diagnostics on every intentional teardown.
+        using var stream = new GatedUnreadableStream();
+        var sink = new RecordingHealthSink();
+        var errors = 0;
+
+        using var consumer = new StreamMessageConsumer<string>(
+            stream, new LineBasedMessageParser(), healthSink: sink);
+        consumer.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        consumer.Start();
+
+        Assert.True(stream.ProbeEntered.Wait(TimeSpan.FromSeconds(10)), "the probe was never reached");
+
+        // Clear the running flag while the reader is parked inside the probe, then let the stream
+        // report itself unreadable — the shape of a handle closed underneath an in-flight read.
+        var stopper = new Thread(() => consumer.StopSafely(timeoutMs: 5000)) { IsBackground = true };
+        stopper.Start();
+        Assert.True(WaitUntil(() => !consumer.IsRunning, TimeSpan.FromSeconds(10)));
+        stream.ReleaseProbe.Set();
+
+        Assert.True(stopper.Join(TimeSpan.FromSeconds(10)), "the consumer never stopped");
+
+        Assert.Equal(0, sink.FaultCount);
+        Assert.Equal(0, Volatile.Read(ref errors));
+    }
+
+    [Fact]
+    public void AStopThatLandsDuringAReadFailure_ReportsNothing()
+    {
+        // Same rule for the read itself, which is the path a real teardown almost always takes:
+        // the handle is closed, and the in-flight Read throws because of it.
+        using var stream = new GatedThrowingReadStream();
+        var sink = new RecordingHealthSink();
+        var errors = 0;
+
+        using var consumer = new StreamMessageConsumer<string>(
+            stream, new LineBasedMessageParser(), healthSink: sink);
+        consumer.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        consumer.Start();
+
+        Assert.True(stream.ReadEntered.Wait(TimeSpan.FromSeconds(10)), "the read was never reached");
+
+        var stopper = new Thread(() => consumer.StopSafely(timeoutMs: 5000)) { IsBackground = true };
+        stopper.Start();
+        Assert.True(WaitUntil(() => !consumer.IsRunning, TimeSpan.FromSeconds(10)));
+        stream.ReleaseRead.Set();
+
+        Assert.True(stopper.Join(TimeSpan.FromSeconds(10)), "the consumer never stopped");
+
+        Assert.Equal(0, sink.FaultCount);
+        Assert.Equal(0, Volatile.Read(ref errors));
+    }
+
     private static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -217,6 +277,96 @@ public class StreamMessageConsumerBackoffTests
         {
             buffer[offset] = (byte)'x';
             return 1;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A stream whose readability probe parks until released and then reports the stream
+    /// unreadable, so a stop can be made to land precisely while the reader is inside the probe.
+    /// </summary>
+    private sealed class GatedUnreadableStream : Stream
+    {
+        private int _probeCount;
+
+        public ManualResetEventSlim ProbeEntered { get; } = new(false);
+
+        public ManualResetEventSlim ReleaseProbe { get; } = new(false);
+
+        public override bool CanRead
+        {
+            get
+            {
+                // Only gate the first probe; later ones (e.g. from PerformClear) answer at once.
+                if (Interlocked.Increment(ref _probeCount) != 1)
+                {
+                    return false;
+                }
+
+                ProbeEntered.Set();
+                ReleaseProbe.Wait(TimeSpan.FromSeconds(30));
+                return false;
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => 0;
+
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A stream whose read parks until released and then fails, reproducing the in-flight read that
+    /// a closing handle breaks.
+    /// </summary>
+    private sealed class GatedThrowingReadStream : Stream
+    {
+        public ManualResetEventSlim ReadEntered { get; } = new(false);
+
+        public ManualResetEventSlim ReleaseRead { get; } = new(false);
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ReadEntered.Set();
+            ReleaseRead.Wait(TimeSpan.FromSeconds(30));
+            throw new IOException("the handle was closed underneath this read");
         }
 
         public override bool CanRead => true;

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBackoffTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBackoffTests.cs
@@ -206,6 +206,92 @@ public class StreamMessageConsumerBackoffTests
         Assert.Equal(0, Volatile.Read(ref errors));
     }
 
+    [Fact]
+    public void AThrowingErrorSubscriber_DoesNotStopMessageConsumption()
+    {
+        // The reader loop is the top of a background thread, so a callback that throws out of it
+        // does not merely stop consumption — it terminates the process. The route is two hops: the
+        // handler throws on the fault path, the outer catch reports the failure by calling that
+        // same handler, and the second throw is inside a catch block with nothing above it.
+        using var stream = new RecoveringStream();
+        var errors = 0;
+        var received = new List<string>();
+
+        using var consumer = new StreamMessageConsumer<string>(stream, new LineBasedMessageParser());
+        consumer.MessageReceived += (_, e) =>
+        {
+            lock (received)
+            {
+                received.Add(e.Message.Data);
+            }
+        };
+        consumer.ErrorOccurred += (_, _) =>
+        {
+            Interlocked.Increment(ref errors);
+            throw new InvalidOperationException("a subscriber that throws on every error");
+        };
+
+        consumer.Start();
+
+        // Let the failing phase drive the fault path through the throwing subscriber.
+        Assert.True(WaitUntil(() => Volatile.Read(ref errors) >= 2, TimeSpan.FromSeconds(10)),
+            "the fault path never ran");
+
+        // The link recovers. The reader must still be alive and still consuming — this is the
+        // assertion that matters, not merely that no exception surfaced in the test.
+        stream.Recover("$DAQiFi\r\n");
+
+        Assert.True(WaitUntil(() =>
+        {
+            lock (received)
+            {
+                return received.Count >= 1;
+            }
+        }, TimeSpan.FromSeconds(10)), "the reader stopped consuming after a subscriber threw");
+
+        Assert.True(consumer.IsRunning);
+        consumer.StopSafely(timeoutMs: 2000);
+    }
+
+    [Fact]
+    public void AThrowingHealthSink_DoesNotStopMessageConsumption()
+    {
+        // Same guarantee for the transport side: ITransportHealthSink is implemented by consumers
+        // of this library, so it is exactly as untrusted as an event subscriber.
+        using var stream = new RecoveringStream();
+        var sink = new ThrowingHealthSink();
+        var received = new List<string>();
+
+        using var consumer = new StreamMessageConsumer<string>(
+            stream, new LineBasedMessageParser(), healthSink: sink);
+        consumer.MessageReceived += (_, e) =>
+        {
+            lock (received)
+            {
+                received.Add(e.Message.Data);
+            }
+        };
+
+        consumer.Start();
+
+        Assert.True(WaitUntil(() => sink.FaultCalls >= 2, TimeSpan.FromSeconds(10)),
+            "the fault path never ran");
+
+        stream.Recover("$DAQiFi\r\n");
+
+        Assert.True(WaitUntil(() =>
+        {
+            lock (received)
+            {
+                return received.Count >= 1;
+            }
+        }, TimeSpan.FromSeconds(10)), "the reader stopped consuming after the health sink threw");
+
+        Assert.True(sink.SuccessCalls >= 1, "the success path must have been exercised too");
+        Assert.True(consumer.IsRunning);
+        consumer.StopSafely(timeoutMs: 2000);
+    }
+
     private static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -220,6 +306,88 @@ public class StreamMessageConsumerBackoffTests
         }
 
         return condition();
+    }
+
+    /// <summary>
+    /// A health sink that fails every callback, standing in for a consumer-supplied transport with
+    /// a bug in it.
+    /// </summary>
+    private sealed class ThrowingHealthSink : ITransportHealthSink
+    {
+        private int _faultCalls;
+        private int _successCalls;
+
+        public int FaultCalls => Volatile.Read(ref _faultCalls);
+
+        public int SuccessCalls => Volatile.Read(ref _successCalls);
+
+        public void ReportIoFault(Exception error)
+        {
+            Interlocked.Increment(ref _faultCalls);
+            throw new InvalidOperationException("a health sink that throws");
+        }
+
+        public void ReportIoSuccess()
+        {
+            Interlocked.Increment(ref _successCalls);
+            throw new InvalidOperationException("a health sink that throws");
+        }
+    }
+
+    /// <summary>
+    /// A stream that fails its reads until told to recover, then delivers a line — so "the reader is
+    /// still consuming" can be asserted directly rather than inferred.
+    /// </summary>
+    private sealed class RecoveringStream : Stream
+    {
+        private readonly object _gate = new();
+        private byte[]? _pending;
+
+        public void Recover(string text)
+        {
+            lock (_gate)
+            {
+                _pending = System.Text.Encoding.UTF8.GetBytes(text);
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            lock (_gate)
+            {
+                if (_pending == null)
+                {
+                    Thread.Sleep(5);
+                    throw new IOException("the link is down");
+                }
+
+                var length = Math.Min(_pending.Length, count);
+                Array.Copy(_pending, 0, buffer, offset, length);
+                _pending = null;
+                return length;
+            }
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     private sealed class RecordingHealthSink : ITransportHealthSink

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBackoffTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBackoffTests.cs
@@ -292,6 +292,45 @@ public class StreamMessageConsumerBackoffTests
         consumer.StopSafely(timeoutMs: 2000);
     }
 
+    [Fact]
+    public void TheRecoveringStreamHelper_DeliversAWholePayloadAcrossPartialReads()
+    {
+        // Guards the harness the two tests above depend on. Driven with a one-byte read buffer, so
+        // the payload can only arrive if the helper retains what a read did not take — a helper
+        // that dropped the unread suffix would deliver "$" and never complete the line, and those
+        // tests would then be asserting nothing.
+        using var stream = new RecoveringStream();
+        var received = new List<string>();
+
+        using var consumer = new StreamMessageConsumer<string>(
+            stream, new LineBasedMessageParser(), bufferSize: 1);
+        consumer.MessageReceived += (_, e) =>
+        {
+            lock (received)
+            {
+                received.Add(e.Message.Data);
+            }
+        };
+
+        consumer.Start();
+        stream.Recover("$DAQiFi\r\n");
+
+        Assert.True(WaitUntil(() =>
+        {
+            lock (received)
+            {
+                return received.Count >= 1;
+            }
+        }, TimeSpan.FromSeconds(10)), "the payload never arrived in full");
+
+        lock (received)
+        {
+            Assert.Equal("$DAQiFi", received[0]);
+        }
+
+        consumer.StopSafely(timeoutMs: 2000);
+    }
+
     private static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -342,12 +381,14 @@ public class StreamMessageConsumerBackoffTests
     {
         private readonly object _gate = new();
         private byte[]? _pending;
+        private int _pendingOffset;
 
         public void Recover(string text)
         {
             lock (_gate)
             {
                 _pending = System.Text.Encoding.UTF8.GetBytes(text);
+                _pendingOffset = 0;
             }
         }
 
@@ -361,9 +402,21 @@ public class StreamMessageConsumerBackoffTests
                     throw new IOException("the link is down");
                 }
 
-                var length = Math.Min(_pending.Length, count);
-                Array.Copy(_pending, 0, buffer, offset, length);
-                _pending = null;
+                // Honor Stream.Read's contract: hand back at most count bytes and keep the
+                // remainder for the next call. Copying min(payload, count) and then dropping the
+                // rest would silently couple these tests to the consumer's read buffer being larger
+                // than the payload — the test would keep passing for a reason unrelated to the code
+                // under test, and would start failing on an unrelated bufferSize change.
+                var length = Math.Min(_pending.Length - _pendingOffset, count);
+                Array.Copy(_pending, _pendingOffset, buffer, offset, length);
+                _pendingOffset += length;
+
+                if (_pendingOffset == _pending.Length)
+                {
+                    _pending = null;
+                    _pendingOffset = 0;
+                }
+
                 return length;
             }
         }

--- a/src/Daqifi.Core.Tests/Communication/Transport/ConnectionLossEscalationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/ConnectionLossEscalationTests.cs
@@ -1,0 +1,355 @@
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Core.Tests.Communication.Transport;
+
+/// <summary>
+/// Issues #377 and #394: a connection that dies mid-stream must reach the device as
+/// <see cref="ConnectionStatus.Lost"/> rather than leaving it reporting <c>Connected</c> forever,
+/// and an intentional disconnect must never be mistaken for one.
+/// </summary>
+/// <remarks>
+/// The TCP half — a peer that closes the socket, driven over a real loopback connection — lives in
+/// <see cref="TcpStreamTransportDropDetectionTests"/>. These cover the serial-shaped path (a read
+/// that starts throwing) end to end through a device, and the one remaining place the reader loop
+/// could still spin silently forever: a stream that has stopped being readable at all.
+/// </remarks>
+public class ConnectionLossEscalationTests
+{
+    [Fact]
+    public void AMidStreamReadFailure_TransitionsTheDeviceToLost()
+    {
+        // The serial-unplug shape: reads start throwing and never recover.
+        using var transport = new WatchedFailingTransport();
+        using var device = new DaqifiDevice("Unplugged Device", transport);
+
+        var lost = new ManualResetEventSlim(false);
+        device.StatusChanged += (_, e) =>
+        {
+            if (e.Status == ConnectionStatus.Lost)
+            {
+                lost.Set();
+            }
+        };
+
+        device.Connect();
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+
+        transport.FailingStream.FailReads = true;
+
+        Assert.True(lost.Wait(TimeSpan.FromSeconds(10)), "the device never reported ConnectionStatus.Lost");
+        Assert.Equal(ConnectionStatus.Lost, device.Status);
+        Assert.False(device.IsConnected);
+    }
+
+    [Fact]
+    public void AMidStreamReadFailure_AlsoReachesTheDeviceErrorSurface()
+    {
+        // #377 escalates; #378 explains. Both are fed by the same reader-loop failure.
+        using var transport = new WatchedFailingTransport();
+        using var device = new DaqifiDevice("Unplugged Device", transport);
+
+        var raised = new ManualResetEventSlim(false);
+        DeviceErrorEventArgs? captured = null;
+        device.ErrorOccurred += (_, e) =>
+        {
+            captured = e;
+            raised.Set();
+        };
+
+        device.Connect();
+        transport.FailingStream.FailReads = true;
+
+        Assert.True(raised.Wait(TimeSpan.FromSeconds(10)));
+        Assert.Equal(DeviceErrorSource.MessageConsumer, captured!.Source);
+    }
+
+    [Fact]
+    public void ASingleFailedRead_DoesNotReportLost()
+    {
+        using var transport = new WatchedFailingTransport();
+        using var device = new DaqifiDevice("Blipping Device", transport);
+
+        var statuses = new List<ConnectionStatus>();
+        device.StatusChanged += (_, e) =>
+        {
+            lock (statuses)
+            {
+                statuses.Add(e.Status);
+            }
+        };
+
+        device.Connect();
+
+        // One failure, then the stream goes back to idling — a glitch, not a disconnect. Escalation
+        // needs a run of five, so nothing may be reported. (That a *successful* read clears an
+        // accumulated run is covered by StreamMessageConsumerHealthReportingTests.)
+        transport.FailingStream.FailOnce();
+
+        Thread.Sleep(600);
+
+        lock (statuses)
+        {
+            Assert.DoesNotContain(ConnectionStatus.Lost, statuses);
+        }
+
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+    }
+
+    [Fact]
+    public void AnIntentionalDisconnect_NeverReportsLost_EvenThoughTeardownFailsTheReads()
+    {
+        using var transport = new WatchedFailingTransport();
+        using var device = new DaqifiDevice("Departing Device", transport);
+
+        device.Connect();
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+
+        var statuses = new List<ConnectionStatus>();
+        device.StatusChanged += (_, e) =>
+        {
+            lock (statuses)
+            {
+                statuses.Add(e.Status);
+            }
+        };
+
+        // Closing the handle is what makes the in-flight reads fail, exactly as a real transport
+        // teardown does. None of that may be reported as a loss.
+        device.Disconnect();
+
+        Thread.Sleep(600);
+
+        lock (statuses)
+        {
+            Assert.DoesNotContain(ConnectionStatus.Lost, statuses);
+            Assert.Contains(ConnectionStatus.Disconnected, statuses);
+        }
+
+        Assert.Equal(ConnectionStatus.Disconnected, device.Status);
+    }
+
+    [Fact]
+    public void AStreamThatIsNoLongerReadable_IsReportedInsteadOfSpunOnSilently()
+    {
+        // The last silent-spin path in the reader loop (issue #377): a stream that reports itself
+        // unreadable never becomes readable again, so backing off and looping forever produced no
+        // data, no error and no status change simultaneously.
+        using var stream = new UnreadableStream();
+        var sink = new RecordingHealthSink();
+        var errors = 0;
+
+        using var consumer = new StreamMessageConsumer<string>(
+            stream, new LineBasedMessageParser(), healthSink: sink);
+        consumer.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        consumer.Start();
+
+        Assert.True(WaitUntil(
+            () => sink.FaultCount >= TransportConnectionWatchdog.ConsecutiveFaultThreshold,
+            TimeSpan.FromSeconds(10)),
+            $"expected the unreadable stream to be escalated, saw {sink.FaultCount} fault(s)");
+        Assert.True(Volatile.Read(ref errors) >= 1);
+
+        consumer.StopSafely(timeoutMs: 2000);
+    }
+
+    private static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            Thread.Sleep(10);
+        }
+
+        return condition();
+    }
+
+    /// <summary>
+    /// Records what the reader loop reports, standing in for a real transport.
+    /// </summary>
+    private sealed class RecordingHealthSink : ITransportHealthSink
+    {
+        private int _faultCount;
+
+        public int FaultCount => Volatile.Read(ref _faultCount);
+
+        public void ReportIoFault(Exception error) => Interlocked.Increment(ref _faultCount);
+
+        public void ReportIoSuccess()
+        {
+        }
+    }
+
+    /// <summary>
+    /// A transport whose stream can be made to fail, wired to the same
+    /// <see cref="TransportConnectionWatchdog"/> the real serial and TCP transports use — so this
+    /// exercises the production escalation rules, not a test-only approximation of them.
+    /// </summary>
+    private sealed class WatchedFailingTransport : IStreamTransport, ITransportHealthSink
+    {
+        private readonly TransportConnectionWatchdog _watchdog;
+        private bool _isConnected;
+        private bool _disposed;
+
+        public WatchedFailingTransport()
+        {
+            _watchdog = new TransportConnectionWatchdog("Test transport", HandleConnectionLost);
+        }
+
+        public FailableStream FailingStream { get; } = new();
+
+        public Stream Stream => _disposed
+            ? throw new ObjectDisposedException(nameof(WatchedFailingTransport))
+            : FailingStream;
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => IsConnected ? "Test: Connected" : "Test: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            _watchdog.Arm();
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            // Disarm before tearing anything down, exactly as the real transports do: closing the
+            // handle makes in-flight reads fail, and none of that is a lost connection.
+            _watchdog.Disarm();
+
+            _isConnected = false;
+            FailingStream.FailReads = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().GetAwaiter().GetResult();
+
+        public void Disconnect() => DisconnectAsync().GetAwaiter().GetResult();
+
+        public void ReportIoFault(Exception error) => _watchdog.RecordFault(error);
+
+        public void ReportIoSuccess() => _watchdog.RecordSuccess();
+
+        private void HandleConnectionLost(Exception error)
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo, error));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _isConnected = false;
+            _watchdog.Dispose();
+            FailingStream.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// A stream that idles quietly until told to fail its reads.
+    /// </summary>
+    internal sealed class FailableStream : Stream
+    {
+        private int _failuresRemaining = -1;
+
+        public volatile bool FailReads;
+
+        /// <summary>
+        /// Fails exactly one read, then goes back to idling — a glitch rather than a disconnect.
+        /// </summary>
+        public void FailOnce() => Interlocked.Exchange(ref _failuresRemaining, 1);
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (FailReads)
+            {
+                Thread.Sleep(5);
+                throw new IOException("the device is gone");
+            }
+
+            if (Volatile.Read(ref _failuresRemaining) > 0)
+            {
+                Interlocked.Decrement(ref _failuresRemaining);
+                throw new IOException("a transient read glitch");
+            }
+
+            // Idle: the device has nothing to say right now. This is not a socket, so a zero-byte
+            // read is "nothing yet" and is never reported as a fault.
+            Thread.Sleep(20);
+            return 0;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A stream that is open but permanently unreadable — the shape a closed or disposed underlying
+    /// handle presents to the reader loop.
+    /// </summary>
+    private sealed class UnreadableStream : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/Daqifi.Core.Tests/Communication/Transport/ConnectionLossEscalationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/ConnectionLossEscalationTests.cs
@@ -115,6 +115,9 @@ public class ConnectionLossEscalationTests
             }
         };
 
+        var errors = 0;
+        device.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
         // Closing the handle is what makes the in-flight reads fail, exactly as a real transport
         // teardown does. None of that may be reported as a loss.
         device.Disconnect();
@@ -128,6 +131,10 @@ public class ConnectionLossEscalationTests
         }
 
         Assert.Equal(ConnectionStatus.Disconnected, device.Status);
+
+        // Teardown is also silent: an intentional disconnect is not a diagnostic event, and the
+        // failures its own handle-closing provokes must not be reported as device problems.
+        Assert.Equal(0, Volatile.Read(ref errors));
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/DeviceErrorSurfaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceErrorSurfaceTests.cs
@@ -515,8 +515,6 @@ public class DeviceErrorSurfaceTests
     /// </summary>
     internal sealed class ScriptedStream : Stream
     {
-        private readonly Queue<byte[]> _pending = new();
-        private readonly object _gate = new();
         private int _readCount;
 
         public volatile bool FailReads;
@@ -540,19 +538,10 @@ public class DeviceErrorSurfaceTests
                 throw new IOException("the device is gone");
             }
 
-            lock (_gate)
-            {
-                if (_pending.Count == 0)
-                {
-                    Thread.Sleep(5);
-                    return 0;
-                }
-
-                var chunk = _pending.Dequeue();
-                var length = Math.Min(chunk.Length, count);
-                Array.Copy(chunk, 0, buffer, offset, length);
-                return length;
-            }
+            // Idle. These tests drive the failure paths only, so this stream never delivers data —
+            // it deliberately has no payload queue to get the partial-read contract wrong with.
+            Thread.Sleep(5);
+            return 0;
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/src/Daqifi.Core.Tests/Device/DeviceErrorSurfaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceErrorSurfaceTests.cs
@@ -1,0 +1,429 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using System.Net;
+using System.Text;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Issue #378: background failures used to be invisible — the message consumer raised
+/// <c>ErrorOccurred</c> into an event with no subscribers, and a per-frame decode failure was
+/// swallowed by an empty catch. Both now reach <see cref="DaqifiDevice.ErrorOccurred"/> without
+/// changing anything about how the device behaves.
+/// </summary>
+public class DeviceErrorSurfaceTests
+{
+    #region Message consumer errors
+
+    [Fact]
+    public void AFailingReadLoop_ReachesAnErrorOccurredSubscriber()
+    {
+        using var transport = new ScriptedStreamTransport();
+        using var device = new DaqifiDevice("Erroring Device", transport);
+
+        var raised = new ManualResetEventSlim(false);
+        DeviceErrorEventArgs? captured = null;
+        device.ErrorOccurred += (_, e) =>
+        {
+            captured = e;
+            raised.Set();
+        };
+
+        device.Connect();
+        transport.ScriptedStream.FailReads = true;
+
+        Assert.True(raised.Wait(TimeSpan.FromSeconds(10)), "the read failure never reached a subscriber");
+        Assert.Equal(DeviceErrorSource.MessageConsumer, captured!.Source);
+        Assert.IsType<IOException>(captured.Error);
+    }
+
+    [Fact]
+    public void AHealthyIdleDevice_RaisesNoErrors()
+    {
+        // The bench case: a connected device that simply has nothing to say must stay quiet.
+        // A read timeout is what an idle device looks like, not a failure.
+        using var transport = new ScriptedStreamTransport();
+        using var device = new DaqifiDevice("Quiet Device", transport);
+
+        var errors = 0;
+        device.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        device.Connect();
+        transport.ScriptedStream.TimeoutReads = true;
+
+        Thread.Sleep(500);
+
+        Assert.Equal(0, Volatile.Read(ref errors));
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+    }
+
+    [Fact]
+    public void AThrowingErrorSubscriber_DoesNotDisturbTheReaderLoop()
+    {
+        using var transport = new ScriptedStreamTransport();
+        using var device = new DaqifiDevice("Erroring Device", transport);
+
+        var raised = new ManualResetEventSlim(false);
+        device.ErrorOccurred += (_, _) =>
+        {
+            raised.Set();
+            throw new InvalidOperationException("a badly behaved subscriber");
+        };
+
+        device.Connect();
+        transport.ScriptedStream.FailReads = true;
+        Assert.True(raised.Wait(TimeSpan.FromSeconds(10)));
+
+        // The reader survived the throwing handler: it is still issuing reads, and the device was
+        // not knocked out of Connected by it.
+        var readsSoFar = transport.ScriptedStream.ReadCount;
+        Assert.True(WaitUntil(() => transport.ScriptedStream.ReadCount > readsSoFar + 2, TimeSpan.FromSeconds(10)),
+            "the reader loop stopped issuing reads after a subscriber threw");
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+    }
+
+    [Fact]
+    public void AfterDisconnect_TheConsumerErrorSurfaceIsDetached()
+    {
+        using var transport = new ScriptedStreamTransport();
+        using var device = new DaqifiDevice("Erroring Device", transport);
+
+        var errors = 0;
+        device.ErrorOccurred += (_, _) => Interlocked.Increment(ref errors);
+
+        device.Connect();
+        device.Disconnect();
+
+        var afterDisconnect = Volatile.Read(ref errors);
+        transport.ScriptedStream.FailReads = true;
+        Thread.Sleep(400);
+
+        Assert.Equal(afterDisconnect, Volatile.Read(ref errors));
+    }
+
+    #endregion
+
+    #region Stream decode errors
+
+    [Fact]
+    public void ASystematicallyThrowingDecode_StaysObservableWhileTheStreamKeepsRunning()
+    {
+        var device = CreateStreamingDevice();
+        var channel = (IAnalogChannel)device.Channels.First(c => c.Type == ChannelType.Analog);
+        channel.IsEnabled = true;
+
+        // A subscriber that throws on every sample is the realistic shape of a decode that fails
+        // on every frame: it propagates out of the per-channel push and into the frame's catch.
+        channel.SampleReceived += (_, _) => throw new InvalidOperationException("decode consumer is broken");
+
+        var errors = new List<DeviceErrorEventArgs>();
+        device.ErrorOccurred += (_, e) =>
+        {
+            lock (errors)
+            {
+                errors.Add(e);
+            }
+        };
+
+        var rawFrames = 0;
+        device.StreamMessageReceived += _ => Interlocked.Increment(ref rawFrames);
+
+        device.StartStreaming();
+
+        const int frameCount = 200;
+        for (var i = 1; i <= frameCount; i++)
+        {
+            device.InvokeStreamMessage(AnalogFrame((uint)(i * 1000), 1.0f));
+        }
+
+        // Isolation is unchanged: every frame was still delivered, and the stream is still running.
+        Assert.Equal(frameCount, Volatile.Read(ref rawFrames));
+        Assert.True(device.IsStreaming);
+
+        // But the failure is no longer silent.
+        Assert.Equal(frameCount, device.DecodeFailureCount);
+
+        lock (errors)
+        {
+            var error = Assert.Single(errors);
+            Assert.Equal(DeviceErrorSource.StreamDecode, error.Source);
+            Assert.IsType<InvalidOperationException>(error.Error);
+        }
+    }
+
+    [Fact]
+    public void ADecodeStorm_IsBoundedByTheThrottle()
+    {
+        // The volume guarantee from the acceptance criteria: thousands of identical failures must
+        // not become thousands of events.
+        var device = CreateStreamingDevice();
+        var channel = (IAnalogChannel)device.Channels.First(c => c.Type == ChannelType.Analog);
+        channel.IsEnabled = true;
+        channel.SampleReceived += (_, _) => throw new InvalidOperationException("decode consumer is broken");
+
+        var raises = 0;
+        device.ErrorOccurred += (_, _) => Interlocked.Increment(ref raises);
+
+        device.StartStreaming();
+
+        const int frameCount = 5000;
+        for (var i = 1; i <= frameCount; i++)
+        {
+            device.InvokeStreamMessage(AnalogFrame((uint)(i * 1000), 1.0f));
+        }
+
+        Assert.Equal(frameCount, device.DecodeFailureCount);
+
+        // Bounded, not proportional. The policy allows one raise per five seconds per bucket, so a
+        // fast machine sees exactly one; the upper bound leaves room for a slow one without turning
+        // this into a timing test.
+        Assert.InRange(Volatile.Read(ref raises), 1, 3);
+    }
+
+    [Fact]
+    public void AHealthyDecode_LeavesTheFailureCounterAtZeroAndRaisesNothing()
+    {
+        var device = CreateStreamingDevice();
+        var channel = (IAnalogChannel)device.Channels.First(c => c.Type == ChannelType.Analog);
+        channel.IsEnabled = true;
+
+        var samples = 0;
+        channel.SampleReceived += (_, _) => Interlocked.Increment(ref samples);
+
+        var raises = 0;
+        device.ErrorOccurred += (_, _) => Interlocked.Increment(ref raises);
+
+        device.StartStreaming();
+        for (var i = 1; i <= 50; i++)
+        {
+            device.InvokeStreamMessage(AnalogFrame((uint)(i * 1000), 1.0f));
+        }
+
+        Assert.Equal(50, Volatile.Read(ref samples));
+        Assert.Equal(0, device.DecodeFailureCount);
+        Assert.Equal(0, Volatile.Read(ref raises));
+    }
+
+    [Fact]
+    public void TheDecodeFailureCounter_DescribesTheCurrentSession()
+    {
+        var device = CreateStreamingDevice();
+        var channel = (IAnalogChannel)device.Channels.First(c => c.Type == ChannelType.Analog);
+        channel.IsEnabled = true;
+        channel.SampleReceived += (_, _) => throw new InvalidOperationException("decode consumer is broken");
+
+        device.StartStreaming();
+        device.InvokeStreamMessage(AnalogFrame(1000, 1.0f));
+        device.InvokeStreamMessage(AnalogFrame(2000, 1.0f));
+        Assert.Equal(2, device.DecodeFailureCount);
+
+        device.StopStreaming();
+        device.StartStreaming();
+
+        Assert.Equal(0, device.DecodeFailureCount);
+    }
+
+    [Fact]
+    public void AFrameThatArrivesOutsideAStreamingSession_IsNotCountedAsADecodeFailure()
+    {
+        // Frames outside a session are re-raised but never decoded, so nothing can fail.
+        var device = CreateStreamingDevice();
+        var channel = (IAnalogChannel)device.Channels.First(c => c.Type == ChannelType.Analog);
+        channel.IsEnabled = true;
+        channel.SampleReceived += (_, _) => throw new InvalidOperationException("decode consumer is broken");
+
+        device.InvokeStreamMessage(AnalogFrame(1000, 1.0f));
+
+        Assert.Equal(0, device.DecodeFailureCount);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            Thread.Sleep(10);
+        }
+
+        return condition();
+    }
+
+    private static DecodableStreamingDevice CreateStreamingDevice()
+    {
+        var device = new DecodableStreamingDevice("Decode Device");
+        device.Connect();
+
+        var status = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 1,
+            AnalogInRes = 65535,
+        };
+        status.AnalogInPortRange.Add(1.0f);
+
+        device.PopulateChannelsFromStatus(status);
+        return device;
+    }
+
+    private static DaqifiOutMessage AnalogFrame(uint timestamp, float value)
+    {
+        var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+        frame.AnalogInDataFloat.Add(value);
+        return frame;
+    }
+
+    /// <summary>
+    /// A streaming device with no transport, exposing the protected stream handler so frames can be
+    /// injected directly and swallowing outbound SCPI.
+    /// </summary>
+    private sealed class DecodableStreamingDevice : DaqifiStreamingDevice
+    {
+        public DecodableStreamingDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)
+        {
+        }
+
+        public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+
+        public override void Send<T>(IOutboundMessage<T> message)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A transport over a stream whose reads can be made to fail or time out on demand, so a device
+    /// can be driven through a failing read loop without hardware.
+    /// </summary>
+    private sealed class ScriptedStreamTransport : IStreamTransport
+    {
+        private bool _isConnected;
+        private bool _disposed;
+
+        public ScriptedStream ScriptedStream { get; } = new();
+
+        public Stream Stream => _disposed
+            ? throw new ObjectDisposedException(nameof(ScriptedStreamTransport))
+            : ScriptedStream;
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "Scripted: Connected" : "Scripted: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().GetAwaiter().GetResult();
+
+        public void Disconnect() => DisconnectAsync().GetAwaiter().GetResult();
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _isConnected = false;
+            _disposed = true;
+            ScriptedStream.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// A stream whose reads can be switched between delivering scripted bytes, timing out (an idle
+    /// device), and failing (a device that has gone away).
+    /// </summary>
+    internal sealed class ScriptedStream : Stream
+    {
+        private readonly Queue<byte[]> _pending = new();
+        private readonly object _gate = new();
+        private int _readCount;
+
+        public volatile bool FailReads;
+        public volatile bool TimeoutReads;
+
+        public int ReadCount => Volatile.Read(ref _readCount);
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Interlocked.Increment(ref _readCount);
+
+            if (TimeoutReads)
+            {
+                Thread.Sleep(5);
+                throw new TimeoutException("no data within the read timeout");
+            }
+
+            if (FailReads)
+            {
+                Thread.Sleep(5);
+                throw new IOException("the device is gone");
+            }
+
+            lock (_gate)
+            {
+                if (_pending.Count == 0)
+                {
+                    Thread.Sleep(5);
+                    return 0;
+                }
+
+                var chunk = _pending.Dequeue();
+                var length = Math.Min(chunk.Length, count);
+                Array.Copy(chunk, 0, buffer, offset, length);
+                return length;
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            // Outbound SCPI goes nowhere; these tests only exercise the read side.
+            _ = Encoding.UTF8.GetString(buffer, offset, count);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core.Tests/Device/DeviceErrorSurfaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceErrorSurfaceTests.cs
@@ -103,6 +103,43 @@ public class DeviceErrorSurfaceTests
         Assert.Equal(afterDisconnect, Volatile.Read(ref errors));
     }
 
+    [Fact]
+    public async Task AStuckTextConsumerThatOutlivesItsExchange_CanNoLongerRaiseOnTheDevice()
+    {
+        // The text exchange binds a temporary consumer to the device's error surface. Stopping and
+        // disposing that consumer are both time-bounded, so a reader parked in an un-returning read
+        // outlives the exchange — and a still-subscribed zombie would both retain the device and
+        // report failures against an exchange (and a connection) that ended long ago.
+        using var stream = new StallingStream();
+        using var transport = new StreamBackedTransport(stream);
+        using var device = new TextCommandTestableDevice("Stalling Device", transport);
+
+        var stuckReaderErrors = 0;
+        device.ErrorOccurred += (_, e) =>
+        {
+            if (e.Error is EndOfStreamException)
+            {
+                Interlocked.Increment(ref stuckReaderErrors);
+            }
+        };
+
+        device.Connect();
+
+        // The setup action runs once the text consumer is reading, so this is what parks its
+        // in-flight read past the exchange's stop and dispose windows.
+        await device.CallTextCommandAsync(() => stream.StallThenFail());
+
+        // Detach the protobuf consumer too, so the only thing that could still report is the
+        // abandoned text reader.
+        device.Disconnect();
+
+        // Outlast the stalled read, which fails when it finally returns.
+        Thread.Sleep(StallingStream.StallDuration);
+        Thread.Sleep(TimeSpan.FromMilliseconds(750));
+
+        Assert.Equal(0, Volatile.Read(ref stuckReaderErrors));
+    }
+
     #endregion
 
     #region Stream decode errors
@@ -295,6 +332,125 @@ public class DeviceErrorSurfaceTests
         public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
 
         public override void Send<T>(IOutboundMessage<T> message)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="DaqifiStreamingDevice"/> exposing the protected text exchange, so the temporary
+    /// text consumer's lifetime can be exercised.
+    /// </summary>
+    private sealed class TextCommandTestableDevice : DaqifiStreamingDevice
+    {
+        public TextCommandTestableDevice(string name, IStreamTransport transport) : base(name, transport)
+        {
+        }
+
+        public Task<IReadOnlyList<string>> CallTextCommandAsync(Action setupAction) =>
+            ExecuteTextCommandAsync(setupAction, responseTimeoutMs: 200, completionTimeoutMs: 100);
+    }
+
+    /// <summary>
+    /// A transport that simply hands out a caller-supplied stream.
+    /// </summary>
+    private sealed class StreamBackedTransport : IStreamTransport
+    {
+        private readonly Stream _stream;
+        private bool _isConnected;
+        private bool _disposed;
+
+        public StreamBackedTransport(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        public Stream Stream => _disposed
+            ? throw new ObjectDisposedException(nameof(StreamBackedTransport))
+            : _stream;
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "Stream: Connected" : "Stream: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().GetAwaiter().GetResult();
+
+        public void Disconnect() => DisconnectAsync().GetAwaiter().GetResult();
+
+        public void Dispose()
+        {
+            _isConnected = false;
+            _disposed = true;
+        }
+    }
+
+    /// <summary>
+    /// A stream that idles quietly until told to stall, after which a read parks for
+    /// <see cref="StallDuration"/> — long enough to outlast the exchange's bounded stop and dispose
+    /// joins — and then fails. This reproduces the reader that is still alive after its consumer has
+    /// been disposed.
+    /// </summary>
+    internal sealed class StallingStream : Stream
+    {
+        /// <summary>
+        /// Comfortably longer than the text exchange's <c>StopSafely</c> join plus the consumer's
+        /// dispose-time grace (1 s each), so the reader provably outlives both.
+        /// </summary>
+        public static readonly TimeSpan StallDuration = TimeSpan.FromSeconds(3);
+
+        private volatile bool _stalling;
+
+        public void StallThenFail() => _stalling = true;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_stalling)
+            {
+                Thread.Sleep(StallDuration);
+                throw new EndOfStreamException("the stalled read finally gave up");
+            }
+
+            Thread.Sleep(5);
+            return 0;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
         {
         }
     }

--- a/src/Daqifi.Core.Tests/Device/DeviceErrorThrottleTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceErrorThrottleTests.cs
@@ -1,0 +1,179 @@
+using Daqifi.Core.Device;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Issue #378: the error surface has to stay useful under a systematic failure that repeats at the
+/// frame rate. These pin the documented policy — first occurrence always through, repeats collapsed
+/// per (source, exception type) with the collapsed count reported on the next raise.
+/// </summary>
+public class DeviceErrorThrottleTests
+{
+    private static readonly TimeSpan ShortInterval = TimeSpan.FromMilliseconds(150);
+
+    [Fact]
+    public void TheFirstOccurrence_IsAlwaysRaised()
+    {
+        var throttle = new DeviceErrorThrottle(ShortInterval);
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new InvalidOperationException(), out var suppressed));
+        Assert.Equal(0, suppressed);
+    }
+
+    [Fact]
+    public void RepeatsWithinTheInterval_AreCollapsed()
+    {
+        var throttle = new DeviceErrorThrottle(TimeSpan.FromMinutes(1));
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new InvalidOperationException(), out _));
+
+        for (var i = 0; i < 1000; i++)
+        {
+            Assert.False(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new InvalidOperationException(), out _));
+        }
+    }
+
+    [Fact]
+    public void TheNextRaiseAfterTheInterval_ReportsHowManyWereCollapsed()
+    {
+        var throttle = new DeviceErrorThrottle(ShortInterval);
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, new IOException(), out _));
+
+        const int collapsed = 25;
+        for (var i = 0; i < collapsed; i++)
+        {
+            Assert.False(throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, new IOException(), out _));
+        }
+
+        Thread.Sleep(ShortInterval + ShortInterval);
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, new IOException(), out var suppressed));
+        Assert.Equal(collapsed, suppressed);
+
+        // The count is consumed by the raise that reports it, not carried forward.
+        Thread.Sleep(ShortInterval + ShortInterval);
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, new IOException(), out var afterReport));
+        Assert.Equal(0, afterReport);
+    }
+
+    [Fact]
+    public void ADifferentExceptionType_IsNotDelayedBehindAnOngoingStorm()
+    {
+        // The whole point of bucketing: a new failure mode appearing during a storm of another one
+        // is exactly the thing an operator needs to see, and it must not wait for a window to open.
+        var throttle = new DeviceErrorThrottle(TimeSpan.FromMinutes(1));
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new InvalidOperationException(), out _));
+        Assert.False(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new InvalidOperationException(), out _));
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new IndexOutOfRangeException(), out _));
+    }
+
+    [Fact]
+    public void ADifferentSource_IsNotDelayedBehindAnOngoingStorm()
+    {
+        var throttle = new DeviceErrorThrottle(TimeSpan.FromMinutes(1));
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new IOException(), out _));
+        Assert.False(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new IOException(), out _));
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, new IOException(), out _));
+    }
+
+    [Fact]
+    public void AZeroInterval_DisablesCollapsingEntirely()
+    {
+        var throttle = new DeviceErrorThrottle(TimeSpan.Zero);
+
+        for (var i = 0; i < 100; i++)
+        {
+            Assert.True(throttle.ShouldRaise(DeviceErrorSource.StreamDecode, new IOException(), out var suppressed));
+            Assert.Equal(0, suppressed);
+        }
+    }
+
+    [Fact]
+    public void Reset_LetsTheNextOccurrenceThroughImmediately()
+    {
+        var throttle = new DeviceErrorThrottle(TimeSpan.FromMinutes(1));
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, new IOException(), out _));
+        Assert.False(throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, new IOException(), out _));
+
+        throttle.Reset();
+
+        Assert.True(throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, new IOException(), out _));
+    }
+
+    [Fact]
+    public void ManyDistinctFailureTypes_DoNotGrowTheBucketTableWithoutBound()
+    {
+        var throttle = new DeviceErrorThrottle(TimeSpan.FromMinutes(1));
+
+        // More distinct types than the cap, driven through twice: past the cap they share the
+        // overflow bucket, so the second pass must be collapsed rather than raised again.
+        var errors = BuildDistinctErrors();
+
+        foreach (var error in errors)
+        {
+            throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, error, out _);
+        }
+
+        var raisedOnSecondPass = errors.Count(e => throttle.ShouldRaise(DeviceErrorSource.MessageConsumer, e, out _));
+        Assert.Equal(0, raisedOnSecondPass);
+    }
+
+    /// <summary>
+    /// Builds a list of exceptions with distinct runtime types, so each would claim its own bucket.
+    /// </summary>
+    private static List<Exception> BuildDistinctErrors()
+    {
+        var errors = new List<Exception>
+        {
+            new IOException(),
+            new EndOfStreamException(),
+            new FileNotFoundException(),
+            new DirectoryNotFoundException(),
+            new PathTooLongException(),
+            new FileLoadException(),
+            new InvalidOperationException(),
+            new IndexOutOfRangeException(),
+            new FormatException(),
+            new NotSupportedException(),
+            new NotImplementedException(),
+            new TimeoutException(),
+            new ArgumentException(),
+            new ArgumentNullException(),
+            new ArgumentOutOfRangeException(),
+            new OverflowException(),
+            new ObjectDisposedException("stream"),
+            new NullReferenceException(),
+            new InvalidCastException(),
+            new RankException(),
+            new ArithmeticException(),
+            new DivideByZeroException(),
+            new KeyNotFoundException(),
+            new PlatformNotSupportedException(),
+            new UnauthorizedAccessException(),
+            new ApplicationException(),
+            new SystemException(),
+            new MissingFieldException(),
+            new MissingMethodException(),
+            new MissingMemberException(),
+            new BadImageFormatException(),
+            new TypeLoadException(),
+            new DataMisalignedException(),
+            new InsufficientMemoryException(),
+            new OutOfMemoryException(),
+            new AggregateException(),
+            new OperationCanceledException(),
+            new ArrayTypeMismatchException(),
+            new MethodAccessException(),
+            new FieldAccessException(),
+        };
+
+        Assert.True(errors.Count > DeviceErrorThrottle.MaxTrackedBuckets, "the fixture must exceed the cap");
+        return errors;
+    }
+}

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2915,6 +2915,7 @@ public class FirmwareUpdateServiceTests
         public bool IsStreaming { get; private set; }
         public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
+        public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred { add { } remove { } }
         public void Connect() => IsConnected = true;
         public void Disconnect() => IsConnected = false;
 
@@ -3019,6 +3020,7 @@ public class FirmwareUpdateServiceTests
         public bool IsStreaming { get; private set; }
         public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
+        public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred { add { } remove { } }
         public void Connect() => IsConnected = true;
         public void Disconnect() => IsConnected = false;
         public void Send<T>(IOutboundMessage<T> message) { }
@@ -3755,6 +3757,12 @@ public class FirmwareUpdateServiceTests
             remove { }
         }
 
+        public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred
+        {
+            add { }
+            remove { }
+        }
+
         public void Connect()
         {
             ConnectAttempts++;
@@ -3867,6 +3875,12 @@ public class FirmwareUpdateServiceTests
 
         public event EventHandler<DeviceStatusEventArgs>? StatusChanged;
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred
         {
             add { }
             remove { }

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -428,7 +428,7 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
 
                 // A successful read clears any run of failures the transport has accumulated, so
                 // a stream that glitches and recovers is never mistaken for a disconnected device.
-                _healthSink?.ReportIoSuccess();
+                SafeReportIoSuccess();
 
                 // Add received data to message buffer (guarded: a caller may be reading
                 // QueuedMessageCount and ClearBuffer's drain runs on this same thread).
@@ -459,7 +459,9 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                     break;
                 }
 
-                OnErrorOccurred(ex);
+                // Isolated: this is the last catch above a background thread's entry point, so a
+                // throwing subscriber here has nothing left to stop it (see SafeRaiseError).
+                SafeRaiseError(ex);
 
                 // Back off before the next iteration. What reaches here is a failure in the
                 // parse/dispatch half of the loop, and that half is deterministic with respect to
@@ -530,10 +532,74 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
             return false;
         }
 
-        _healthSink?.ReportIoFault(error);
-        OnErrorOccurred(error);
+        SafeReportIoFault(error);
+        SafeRaiseError(error);
         Thread.Sleep(backoffMs);
         return true;
+    }
+
+    /// <summary>
+    /// Reports a failed transfer to the transport, absorbing anything the sink throws.
+    /// </summary>
+    private void SafeReportIoFault(Exception error)
+    {
+        try
+        {
+            _healthSink?.ReportIoFault(error);
+        }
+        catch
+        {
+            // See SafeRaiseError.
+        }
+    }
+
+    /// <summary>
+    /// Reports a successful transfer to the transport, absorbing anything the sink throws.
+    /// </summary>
+    /// <remarks>
+    /// Runs once per successful read, so this is deliberately a plain method rather than a lambda
+    /// helper — no closure is allocated on the hot path.
+    /// </remarks>
+    private void SafeReportIoSuccess()
+    {
+        try
+        {
+            _healthSink?.ReportIoSuccess();
+        }
+        catch
+        {
+            // See SafeRaiseError.
+        }
+    }
+
+    /// <summary>
+    /// Raises <see cref="ErrorOccurred"/>, absorbing anything a subscriber throws.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every callback out of the reader loop — subscriber or transport health sink — is isolated,
+    /// because this loop is the top of a background thread: an exception that escapes it does not
+    /// merely stop message consumption, it terminates the process. The route is short and real. A
+    /// throwing handler here propagates into the loop's outer catch, which reports the failure by
+    /// calling this same handler; it throws again, and that second throw is inside a <c>catch</c>
+    /// block with nothing above it. Isolating the callback closes both hops at once.
+    /// </para>
+    /// <para>
+    /// Swallowed rather than logged, per the convention this class already follows for a throwing
+    /// <see cref="MessageReceived"/> subscriber: a consumer that breaks its own diagnostics is not
+    /// permitted to affect anyone else's data.
+    /// </para>
+    /// </remarks>
+    private void SafeRaiseError(Exception error, byte[]? rawData = null)
+    {
+        try
+        {
+            OnErrorOccurred(error, rawData);
+        }
+        catch
+        {
+            // A misbehaving subscriber must not stop message consumption or take down the process.
+        }
     }
 
     /// <summary>
@@ -582,7 +648,11 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
             }
             catch (Exception ex)
             {
-                OnErrorOccurred(ex);
+                // A throwing MessageReceived subscriber is reported rather than propagated, so one
+                // bad handler cannot starve the others of this batch. The report itself is isolated
+                // too: raising it from inside a catch block leaves nowhere for a second throw to go
+                // (see SafeRaiseError).
+                SafeRaiseError(ex);
             }
         }
     }

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -331,10 +331,18 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                     PerformClear();
                 }
 
-                // Check if data is available to avoid blocking
+                // A stream that reports itself unreadable never becomes readable again — that is a
+                // closed or disposed stream, not a momentary lull. Report it instead of spinning
+                // here forever producing no data, no error and no status change, which is the
+                // failure mode issue #377 was filed for. Backed off at the same cadence as a
+                // failing read so the escalation timing matches.
                 if (!_stream.CanRead)
                 {
-                    Thread.Sleep(10);
+                    var unreadable = new IOException(
+                        "The stream is no longer readable; the underlying connection has been closed.");
+                    _healthSink?.ReportIoFault(unreadable);
+                    OnErrorOccurred(unreadable);
+                    Thread.Sleep(100);
                     continue;
                 }
 

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -342,9 +342,11 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                 }
                 catch (Exception ex)
                 {
-                    _healthSink?.ReportIoFault(ex);
-                    OnErrorOccurred(ex);
-                    Thread.Sleep(100);
+                    if (!ReportStreamFault(ex))
+                    {
+                        break;
+                    }
+
                     continue;
                 }
 
@@ -357,9 +359,11 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                 {
                     var unreadable = new IOException(
                         "The stream is no longer readable; the underlying connection has been closed.");
-                    _healthSink?.ReportIoFault(unreadable);
-                    OnErrorOccurred(unreadable);
-                    Thread.Sleep(100);
+                    if (!ReportStreamFault(unreadable))
+                    {
+                        break;
+                    }
+
                     continue;
                 }
 
@@ -388,9 +392,11 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                     // throwing is how a physically disconnected device announces itself, and the
                     // transport is the only thing that can turn a run of them into a lost
                     // connection (issue #382). One failure escalates nothing.
-                    _healthSink?.ReportIoFault(ex);
-                    OnErrorOccurred(ex);
-                    Thread.Sleep(100); // Back off on error
+                    if (!ReportStreamFault(ex))
+                    {
+                        break;
+                    }
+
                     continue;
                 }
 
@@ -402,11 +408,21 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                     // legitimately return 0 for "nothing right now" and must not be escalated.
                     if (_stream is NetworkStream)
                     {
-                        _healthSink?.ReportIoFault(new EndOfStreamException(
-                            "The remote endpoint closed the connection (a socket read returned 0 bytes)."));
+                        // Same teardown rule as every other fault path, and the short back-off this
+                        // path has always used — an orderly peer shutdown is detected in tens of
+                        // milliseconds rather than half a second (issue #382).
+                        if (!ReportStreamFault(
+                                new EndOfStreamException(
+                                    "The remote endpoint closed the connection (a socket read returned 0 bytes)."),
+                                backoffMs: NoDataBackoffMs))
+                        {
+                            break;
+                        }
+
+                        continue;
                     }
 
-                    Thread.Sleep(10); // No data available, wait briefly
+                    Thread.Sleep(NoDataBackoffMs); // No data available, wait briefly
                     continue;
                 }
 
@@ -454,10 +470,70 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                 //
                 // Deliberately NOT reported to the health sink: a parse or dispatch failure is not
                 // evidence that the link is gone, and escalating it would disconnect a perfectly
-                // healthy device over malformed data. Only I/O against the stream does that.
-                Thread.Sleep(100);
+                // healthy device over malformed data. Only I/O against the stream does that — which
+                // is why this path does not go through ReportStreamFault.
+                Thread.Sleep(ErrorBackoffMs);
             }
         }
+    }
+
+    /// <summary>
+    /// Back-off applied after a reported failure, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// Whatever failed will almost certainly fail again immediately — a closed handle stays closed,
+    /// and a parser that rejects the bytes it holds rejects the same bytes next time — so retrying
+    /// at full speed makes no progress and burns a core. Also sets the escalation cadence: with the
+    /// transport's five-consecutive-failure threshold, a persistently failing stream is declared
+    /// lost after roughly half a second.
+    /// </remarks>
+    private const int ErrorBackoffMs = 100;
+
+    /// <summary>
+    /// Pause applied when a read returns no data, in milliseconds. Shorter than
+    /// <see cref="ErrorBackoffMs"/> because it is the idle path on most stream types.
+    /// </summary>
+    private const int NoDataBackoffMs = 10;
+
+    /// <summary>
+    /// Reports a stream-level failure to the transport and to subscribers, then backs off.
+    /// </summary>
+    /// <param name="error">The failure that was observed.</param>
+    /// <param name="backoffMs">How long to pause before the next iteration.</param>
+    /// <returns>
+    /// <c>true</c> to keep reading; <c>false</c> when a stop has already been requested, in which
+    /// case nothing was reported and the caller must leave the loop immediately.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Every fault path routes through here so the teardown rule is stated once. A failure observed
+    /// after <see cref="_isRunning"/> has been cleared is teardown, not a device problem: closing a
+    /// handle is <em>supposed</em> to make the in-flight read fail, and the stream going unreadable
+    /// is what a deliberate <c>Disconnect</c> looks like from in here. Reporting it would put a
+    /// phantom "the connection died" into a consumer's diagnostics and into the transport's health
+    /// sink on every intentional disconnect, and the back-off would delay this thread's exit —
+    /// making the stop's bounded join more likely to time out, which has its own knock-on effects.
+    /// </para>
+    /// <para>
+    /// This is the same rule the loop's outer catch follows; keeping the two consistent is the
+    /// point. Note it was never enough on its own to let a deliberate disconnect be reported as a
+    /// lost connection: a <c>continue</c> re-tests the loop condition, so at most one failure can
+    /// ever be reported after a stop, against an escalation threshold of five consecutive — and the
+    /// transports disarm their watchdog before they touch the handle. This closes the diagnostic
+    /// noise, not a hole in that guarantee.
+    /// </para>
+    /// </remarks>
+    private bool ReportStreamFault(Exception error, int backoffMs = ErrorBackoffMs)
+    {
+        if (!_isRunning)
+        {
+            return false;
+        }
+
+        _healthSink?.ReportIoFault(error);
+        OnErrorOccurred(error);
+        Thread.Sleep(backoffMs);
+        return true;
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -331,12 +331,29 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                     PerformClear();
                 }
 
+                // Probing readability is itself I/O against a handle that may be coming apart, and
+                // a CanRead getter is under no obligation not to throw on one. A throwing probe is
+                // a stream fault and is handled exactly like a failing read; letting it reach the
+                // outer catch instead would neither tell the transport nor back off.
+                bool canRead;
+                try
+                {
+                    canRead = _stream.CanRead;
+                }
+                catch (Exception ex)
+                {
+                    _healthSink?.ReportIoFault(ex);
+                    OnErrorOccurred(ex);
+                    Thread.Sleep(100);
+                    continue;
+                }
+
                 // A stream that reports itself unreadable never becomes readable again — that is a
                 // closed or disposed stream, not a momentary lull. Report it instead of spinning
                 // here forever producing no data, no error and no status change, which is the
                 // failure mode issue #377 was filed for. Backed off at the same cadence as a
                 // failing read so the escalation timing matches.
-                if (!_stream.CanRead)
+                if (!canRead)
                 {
                     var unreadable = new IOException(
                         "The stream is no longer readable; the underlying connection has been closed.");
@@ -410,10 +427,35 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
                 // Try to parse complete messages from buffer
                 ProcessMessageBuffer();
             }
-            catch (Exception ex) when (_isRunning)
+            catch (Exception ex)
             {
-                // Only report errors if we're still supposed to be running
+                // Caught unconditionally, on purpose. This is the top of a background thread, so an
+                // exception that escapes here does not merely end the loop — it terminates the
+                // whole process. The previous `when (_isRunning)` filter left exactly that hole: a
+                // concurrent Stop() clears the flag while the try body is mid-flight, the filter
+                // then declines to match, and a parse failure that would have been a logged
+                // diagnostic during normal running takes the host down instead. Only *reporting*
+                // was ever meant to be conditional.
+                if (!_isRunning)
+                {
+                    // Teardown noise: a failure seen while stopping says nothing about the device,
+                    // and the loop is about to exit anyway.
+                    break;
+                }
+
                 OnErrorOccurred(ex);
+
+                // Back off before the next iteration. What reaches here is a failure in the
+                // parse/dispatch half of the loop, and that half is deterministic with respect to
+                // the current buffer: a parser that throws on the bytes it holds will throw on
+                // exactly the same bytes next time round. Retrying at full speed is a hot spin that
+                // burns a core and raises errors as fast as the thread can go, which is the same
+                // no-progress-and-no-signal shape this class is being fixed for.
+                //
+                // Deliberately NOT reported to the health sink: a parse or dispatch failure is not
+                // evidence that the link is gone, and escalating it would disconnect a perfectly
+                // healthy device over malformed data. Only I/O against the stream does that.
+                Thread.Sleep(100);
             }
         }
     }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1090,7 +1090,16 @@ namespace Daqifi.Core.Device
                     // The protobuf consumer is stopped for the duration of this exchange, so
                     // without this a read failure during a text command (an unplug mid-SD-listing,
                     // say) would be the one background failure with nowhere to go (issue #378).
-                    textConsumer.ErrorOccurred += OnConsumerErrorOccurred;
+                    //
+                    // Scoped rather than a bare '+=' because this consumer can outlive the block:
+                    // its stop and dispose are both time-bounded and may return with the reader
+                    // thread still parked in an un-returning read. A live thread roots the consumer,
+                    // which would root this device through the handler — retaining the whole object
+                    // graph and, worse, letting a zombie reader keep raising errors on a device that
+                    // has since been disconnected. 'using' disposes in reverse declaration order, so
+                    // this detaches before textConsumer itself is disposed, on every exit path
+                    // including a cancellation or a throwing setup action.
+                    using var textConsumerErrors = new ConsumerErrorSubscription(this, textConsumer);
 
                     textConsumer.Start();
                     // ConfigureAwait(false): the lock is held, so resuming on a captured
@@ -1511,6 +1520,36 @@ namespace Daqifi.Core.Device
         private void OnConsumerErrorOccurred(object? sender, MessageConsumerErrorEventArgs e)
         {
             RaiseDeviceError(DeviceErrorSource.MessageConsumer, e.Error, e.RawData);
+        }
+
+        /// <summary>
+        /// Attaches a device's consumer-error forwarding to a short-lived
+        /// <see cref="IMessageConsumer{T}"/> for the duration of a scope, and detaches it again on
+        /// dispose.
+        /// </summary>
+        /// <remarks>
+        /// Exists so a temporary consumer can never end up permanently subscribed. Stopping and
+        /// disposing a consumer are both time-bounded and may return while its reader thread is
+        /// still alive; that thread roots the consumer, and a still-attached handler would root this
+        /// device through it. Detaching in a <c>finally</c> (which is what <c>using</c> compiles to)
+        /// makes the subscription's lifetime exactly the scope's, whatever way control leaves it.
+        /// </remarks>
+        private sealed class ConsumerErrorSubscription : IDisposable
+        {
+            private readonly DaqifiDevice _device;
+            private readonly IMessageConsumer<string> _consumer;
+
+            public ConsumerErrorSubscription(DaqifiDevice device, IMessageConsumer<string> consumer)
+            {
+                _device = device;
+                _consumer = consumer;
+                _consumer.ErrorOccurred += _device.OnConsumerErrorOccurred;
+            }
+
+            public void Dispose()
+            {
+                _consumer.ErrorOccurred -= _device.OnConsumerErrorOccurred;
+            }
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -454,6 +454,55 @@ namespace Daqifi.Core.Device
         public event EventHandler<MessageSendFailedEventArgs<string>>? SendFailed;
 
         /// <summary>
+        /// Occurs when something fails on one of the device's background threads: a read from the
+        /// transport stream, a parse, a dispatch to a subscriber, or the decode of a streaming frame.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Silence used to be the only symptom of these failures (issue #378) — a stream that cannot
+        /// be read and a stream that cannot be decoded both looked exactly like a device sending
+        /// nothing. This is the one place to answer "why am I getting no samples".
+        /// </para>
+        /// <para>
+        /// <b>Observational only.</b> Raising this never changes device behaviour: no tear-down, no
+        /// retry, no <see cref="Status"/> change, and a single bad frame is still isolated so the
+        /// stream survives it. Deciding that a link is actually dead is separate, and arrives as
+        /// <see cref="ConnectionStatus.Lost"/> on <see cref="StatusChanged"/> (issue #377). Every
+        /// error raised here is also written to the device's <c>ILogger</c>, so it stays visible with
+        /// no subscriber attached.
+        /// </para>
+        /// <para>
+        /// <b>Throttle policy.</b> A systematic failure repeats at the frame rate, so raises are
+        /// collapsed per bucket, where a bucket is
+        /// (<see cref="DeviceErrorEventArgs.Source"/>, exception type):
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>The first occurrence in a bucket is always raised, immediately.</description></item>
+        /// <item><description>
+        /// After that, a bucket raises at most once every five seconds. Occurrences in between are
+        /// counted and reported as <see cref="DeviceErrorEventArgs.SuppressedCount"/> on the next
+        /// raise, so a storm is visible as a number rather than as thousands of events.
+        /// </description></item>
+        /// <item><description>
+        /// Buckets are independent: a new kind of failure is raised at once even while another kind
+        /// is being collapsed.
+        /// </description></item>
+        /// </list>
+        /// <para>
+        /// Raised on a background thread (the reader loop, or whichever thread decoded the frame), so
+        /// handlers should do the minimum and push real work elsewhere. A handler that throws is
+        /// caught and ignored — it can never disturb reading or streaming.
+        /// </para>
+        /// </remarks>
+        public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred;
+
+        /// <summary>
+        /// Collapses repeated background failures so a systematic fault stays visible without
+        /// storming <see cref="ErrorOccurred"/>. See that event for the documented policy.
+        /// </summary>
+        private readonly DeviceErrorThrottle _errorThrottle = new();
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DaqifiDevice"/> class.
         /// </summary>
         /// <param name="name">The name of the device.</param>
@@ -510,6 +559,10 @@ namespace Daqifi.Core.Device
             Status = ConnectionStatus.Connecting;
             State = DeviceState.Connecting;
 
+            // A reconnect is a new session: its first background failure should be reported
+            // immediately rather than collapsed into a throttle window the previous session opened.
+            _errorThrottle.Reset();
+
             try
             {
                 // Connect transport if available
@@ -535,6 +588,14 @@ namespace Daqifi.Core.Device
                             new ProtobufMessageParser(),
                             healthSink: healthSink);
                     }
+
+                    // Read/parse/dispatch failures used to be raised into an event with no
+                    // subscribers (issue #378). Subscribe here rather than alongside
+                    // MessageReceived: that one is attached and detached around every consumer
+                    // swap, and error visibility must not have holes in it. '-=' first keeps a
+                    // reconnect on the same consumer instance from double-subscribing.
+                    _messageConsumer.ErrorOccurred -= OnConsumerErrorOccurred;
+                    _messageConsumer.ErrorOccurred += OnConsumerErrorOccurred;
                 }
 
                 // Start message producer and consumer if available
@@ -597,6 +658,7 @@ namespace Daqifi.Core.Device
                 if (_messageConsumer != null)
                 {
                     _messageConsumer.MessageReceived -= OnInboundMessageReceived;
+                    _messageConsumer.ErrorOccurred -= OnConsumerErrorOccurred;
                 }
 
                 if (_messageProducer != null)
@@ -1025,6 +1087,11 @@ namespace Daqifi.Core.Device
                         collectedLines.Add(e.Message.Data);
                     };
 
+                    // The protobuf consumer is stopped for the duration of this exchange, so
+                    // without this a read failure during a text command (an unplug mid-SD-listing,
+                    // say) would be the one background failure with nowhere to go (issue #378).
+                    textConsumer.ErrorOccurred += OnConsumerErrorOccurred;
+
                     textConsumer.Start();
                     // ConfigureAwait(false): the lock is held, so resuming on a captured
                     // sync context (e.g. UI thread) would deadlock if that thread calls Disconnect().
@@ -1429,6 +1496,64 @@ namespace Daqifi.Core.Device
             // A throwing subscriber must not be allowed to take down the producer's
             // background thread, so this goes through the same SafeLog guard as the logger above.
             SafeLog(() => SendFailed?.Invoke(this, e));
+        }
+
+        /// <summary>
+        /// Forwards a message-consumer failure (a failed read, a parse error, or a subscriber that
+        /// threw) to <see cref="ErrorOccurred"/>.
+        /// </summary>
+        /// <remarks>
+        /// Nothing in Core subscribed to <see cref="IMessageConsumer{T}.ErrorOccurred"/> before
+        /// issue #378, so these failures were raised into an empty event and lost. Forwarding them
+        /// is purely additive — the consumer's own back-off and the transport's drop escalation are
+        /// unchanged by whether anyone is listening here.
+        /// </remarks>
+        private void OnConsumerErrorOccurred(object? sender, MessageConsumerErrorEventArgs e)
+        {
+            RaiseDeviceError(DeviceErrorSource.MessageConsumer, e.Error, e.RawData);
+        }
+
+        /// <summary>
+        /// Logs a background failure and raises <see cref="ErrorOccurred"/> for it, subject to the
+        /// throttle policy documented on that event.
+        /// </summary>
+        /// <param name="source">The pipeline stage that failed.</param>
+        /// <param name="error">The exception that was caught.</param>
+        /// <param name="rawData">The bytes being processed at the time, if the stage had any.</param>
+        /// <remarks>
+        /// Never throws. It runs on background threads inside catch blocks whose entire purpose is
+        /// to keep reading and decoding alive, so neither a throwing logger nor a throwing
+        /// subscriber may escape — the same isolation <c>SendFailed</c> and the classified-event
+        /// raisers use.
+        /// </remarks>
+        protected void RaiseDeviceError(DeviceErrorSource source, Exception error, byte[]? rawData = null)
+        {
+            if (error == null)
+            {
+                return;
+            }
+
+            if (!_errorThrottle.ShouldRaise(source, error, out var suppressedCount))
+            {
+                return;
+            }
+
+            SafeLog(() => _logger.LogWarning(
+                error,
+                "[{Source}] Device '{DeviceName}' background failure ({SuppressedCount} like failure(s) suppressed since the last report).",
+                source,
+                Name,
+                suppressedCount));
+
+            var handler = ErrorOccurred;
+            if (handler == null)
+            {
+                return;
+            }
+
+            // Same guard as the logger above: a subscriber that throws must not take down the
+            // reader loop or the decode path this was raised from.
+            SafeLog(() => handler(this, new DeviceErrorEventArgs(source, error, suppressedCount, rawData)));
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -148,6 +148,30 @@ namespace Daqifi.Core.Device
         private int _suppressedWarmupFrameCount;
 
         /// <summary>
+        /// Backing counter for <see cref="DecodeFailureCount"/>.
+        /// </summary>
+        private long _decodeFailureCount;
+
+        /// <summary>
+        /// Gets the number of streaming frames whose decode threw and was discarded since the
+        /// current streaming session began.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Per-frame decoding is deliberately best-effort — a single malformed frame must never tear
+        /// down the stream — but that isolation used to be completely silent (issue #378): a decode
+        /// that failed on every frame produced zero samples and zero diagnostics, indistinguishable
+        /// from a device sending nothing. This counter is the cheap always-on version of that
+        /// signal; <see cref="DaqifiDevice.ErrorOccurred"/> carries the exception behind it.
+        /// </para>
+        /// <para>
+        /// Reset by <see cref="StartStreaming"/>, so it describes the current session. A healthy
+        /// stream leaves it at zero.
+        /// </para>
+        /// </remarks>
+        public long DecodeFailureCount => Interlocked.Read(ref _decodeFailureCount);
+
+        /// <summary>
         /// Gets a value indicating whether the device is currently streaming data.
         /// </summary>
         public bool IsStreaming { get; private set; }
@@ -358,6 +382,7 @@ namespace Daqifi.Core.Device
             // observed warmup frame).
             _awaitingFirstFullAnalogFrame = CountEnabledAnalogChannels(SnapshotChannels()) > 0;
             _suppressedWarmupFrameCount = 0;
+            Interlocked.Exchange(ref _decodeFailureCount, 0);
 
             IsStreaming = true;
             Send(ScpiMessageProducer.StartStreaming(StreamingFrequency));
@@ -484,10 +509,17 @@ namespace Daqifi.Core.Device
             {
                 DecodeStreamFrame(message);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // A single malformed frame must never tear down the stream or starve other
-                // consumers; decoding is best-effort per frame.
+                // consumers; decoding is best-effort per frame. That isolation stays exactly as it
+                // was — the frame is dropped and the loop continues — but it is no longer silent
+                // (issue #378): a decode that throws on every frame yields no samples, which used
+                // to be indistinguishable from a device sending nothing at all. Both the counter
+                // and the (throttled) event are observation only; neither changes what happens to
+                // this frame or the next one.
+                Interlocked.Increment(ref _decodeFailureCount);
+                RaiseDeviceError(DeviceErrorSource.StreamDecode, ex);
             }
         }
 

--- a/src/Daqifi.Core/Device/DeviceErrorEventArgs.cs
+++ b/src/Daqifi.Core/Device/DeviceErrorEventArgs.cs
@@ -1,0 +1,84 @@
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// Describes a failure that happened on one of a device's background threads — the message
+/// consumer's read loop, or the per-frame stream decoder.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Purely observational (issue #378). Raising this event never changes what the device does: no
+/// tear-down, no retry, no status change, and a single bad frame is still isolated so the stream
+/// survives it. Escalating a genuinely dead link to
+/// <see cref="ConnectionStatus.Lost"/> is the transports' job and is reported through
+/// <see cref="DaqifiDevice.StatusChanged"/>.
+/// </para>
+/// <para>
+/// Delivery is throttled per <see cref="Source"/> and exception type — see
+/// <see cref="DaqifiDevice.ErrorOccurred"/> for the policy — so <see cref="SuppressedCount"/> may be
+/// non-zero on the events that do get through.
+/// </para>
+/// </remarks>
+public class DeviceErrorEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeviceErrorEventArgs"/> class.
+    /// </summary>
+    /// <param name="source">Which part of the pipeline failed.</param>
+    /// <param name="error">The exception that was caught.</param>
+    /// <param name="suppressedCount">
+    /// How many like failures were collapsed by the throttle since the previous raise. Zero when
+    /// nothing was suppressed.
+    /// </param>
+    /// <param name="rawData">The raw bytes being processed when the failure occurred, if available.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="error"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="suppressedCount"/> is negative.</exception>
+    public DeviceErrorEventArgs(
+        DeviceErrorSource source,
+        Exception error,
+        int suppressedCount = 0,
+        byte[]? rawData = null)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        if (suppressedCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(suppressedCount), suppressedCount, "Suppressed count cannot be negative.");
+        }
+
+        Source = source;
+        Error = error;
+        SuppressedCount = suppressedCount;
+        RawData = rawData;
+        Timestamp = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Gets the part of the device pipeline that produced the failure.
+    /// </summary>
+    public DeviceErrorSource Source { get; }
+
+    /// <summary>
+    /// Gets the exception that was caught.
+    /// </summary>
+    public Exception Error { get; }
+
+    /// <summary>
+    /// Gets the number of like failures (same <see cref="Source"/>, same exception type) that the
+    /// throttle collapsed since the previous raise, or zero if none were.
+    /// </summary>
+    /// <remarks>
+    /// A large value is the signal that matters: it means the failure is systematic rather than a
+    /// one-off, which is exactly the case that used to be invisible.
+    /// </remarks>
+    public int SuppressedCount { get; }
+
+    /// <summary>
+    /// Gets the raw bytes being processed when the failure occurred, if the failing stage had any.
+    /// </summary>
+    public byte[]? RawData { get; }
+
+    /// <summary>
+    /// Gets the UTC time at which the failure was observed.
+    /// </summary>
+    public DateTime Timestamp { get; }
+}

--- a/src/Daqifi.Core/Device/DeviceErrorSource.cs
+++ b/src/Daqifi.Core/Device/DeviceErrorSource.cs
@@ -1,0 +1,35 @@
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// Identifies which part of a device's background pipeline produced a
+/// <see cref="DeviceErrorEventArgs"/>.
+/// </summary>
+/// <remarks>
+/// The source is the first thing a diagnostic needs: "no samples" caused by a stream that cannot be
+/// read is a different problem from a stream that reads fine but cannot be decoded, and before
+/// issue #378 both looked identical from outside the library (silence).
+/// </remarks>
+public enum DeviceErrorSource
+{
+    /// <summary>
+    /// The source could not be classified.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The background message consumer: a failed read from the transport stream, a parse failure,
+    /// or an exception thrown while dispatching a parsed message to subscribers.
+    /// </summary>
+    /// <remarks>
+    /// A persistent run of read failures is <em>also</em> what the transport escalates into
+    /// <see cref="ConnectionStatus.Lost"/> (issue #377). Seeing this source is therefore not by
+    /// itself proof the link is gone — watch <see cref="DaqifiDevice.StatusChanged"/> for that.
+    /// </remarks>
+    MessageConsumer = 1,
+
+    /// <summary>
+    /// Per-frame decoding of a streaming data frame into channel samples
+    /// (<see cref="DaqifiStreamingDevice"/>). The frame is dropped; the stream keeps running.
+    /// </summary>
+    StreamDecode = 2,
+}

--- a/src/Daqifi.Core/Device/DeviceErrorThrottle.cs
+++ b/src/Daqifi.Core/Device/DeviceErrorThrottle.cs
@@ -1,0 +1,172 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// Bounds how often a repeating background failure is raised as a
+/// <see cref="DeviceErrorEventArgs"/>, so a systematic failure stays visible without storming the
+/// subscriber (issue #378).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The failure this exists for is a decode that throws on <em>every</em> frame. At a few kHz that
+/// is thousands of raises per second — enough that a naive subscriber (a log sink, a UI marshal)
+/// becomes the bottleneck and the "observability" feature degrades the streaming it was added to
+/// explain. Collapsing repeats keeps the first report immediate and the rest cheap.
+/// </para>
+/// <para>
+/// The policy, per bucket (<see cref="DeviceErrorSource"/> + exception type):
+/// </para>
+/// <list type="bullet">
+/// <item><description>The first occurrence always passes, immediately.</description></item>
+/// <item><description>
+/// Later occurrences pass at most once per <see cref="Interval"/>; the ones in between are counted
+/// and reported as <see cref="DeviceErrorEventArgs.SuppressedCount"/> on the next one that passes.
+/// </description></item>
+/// <item><description>
+/// Buckets are per exception type, so a <em>new</em> kind of failure is never delayed behind an
+/// ongoing storm of a different one.
+/// </description></item>
+/// </list>
+/// <para>
+/// Bucket count is capped at <see cref="MaxTrackedBuckets"/>; everything past the cap shares a
+/// single overflow bucket. Exception types come from code rather than from the wire, so the cap is
+/// unreachable in practice — it exists so this can never grow without bound.
+/// </para>
+/// </remarks>
+internal sealed class DeviceErrorThrottle
+{
+    /// <summary>
+    /// Default minimum spacing between raises of the same bucket.
+    /// </summary>
+    /// <remarks>
+    /// Long enough that a per-frame failure at kHz rates collapses to a trickle, short enough that
+    /// a human watching a log still sees the problem is ongoing rather than a single stale line.
+    /// </remarks>
+    internal static readonly TimeSpan DefaultInterval = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Maximum number of distinct buckets tracked before everything else shares one.
+    /// </summary>
+    internal const int MaxTrackedBuckets = 32;
+
+    private const string OverflowKey = "<overflow>";
+
+    private readonly ConcurrentDictionary<string, Bucket> _buckets = new(StringComparer.Ordinal);
+    private readonly TimeSpan _interval;
+
+    /// <summary>
+    /// Initializes a new throttle.
+    /// </summary>
+    /// <param name="interval">
+    /// Minimum spacing between raises of the same bucket. Defaults to <see cref="DefaultInterval"/>.
+    /// <see cref="TimeSpan.Zero"/> disables collapsing entirely (every occurrence passes).
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="interval"/> is negative.</exception>
+    public DeviceErrorThrottle(TimeSpan? interval = null)
+    {
+        _interval = interval ?? DefaultInterval;
+        if (_interval < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(interval), _interval, "Throttle interval cannot be negative.");
+        }
+    }
+
+    /// <summary>
+    /// Gets the minimum spacing between raises of the same bucket.
+    /// </summary>
+    public TimeSpan Interval => _interval;
+
+    /// <summary>
+    /// Decides whether this occurrence should be raised.
+    /// </summary>
+    /// <param name="source">The pipeline stage that failed.</param>
+    /// <param name="error">The exception that was caught.</param>
+    /// <param name="suppressedCount">
+    /// When this returns <c>true</c>, the number of like occurrences collapsed since the previous
+    /// raise (zero if none). Meaningless when it returns <c>false</c>.
+    /// </param>
+    /// <returns><c>true</c> to raise, <c>false</c> to collapse this occurrence into the count.</returns>
+    public bool ShouldRaise(DeviceErrorSource source, Exception error, out int suppressedCount)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+
+        if (_interval == TimeSpan.Zero)
+        {
+            suppressedCount = 0;
+            return true;
+        }
+
+        var bucket = GetBucket($"{(int)source}:{error.GetType().FullName}");
+
+        lock (bucket)
+        {
+            var now = Stopwatch.GetTimestamp();
+
+            if (bucket.HasRaised && Stopwatch.GetElapsedTime(bucket.LastRaised, now) < _interval)
+            {
+                // Saturate rather than overflow: a run long enough to wrap int is already
+                // "enormous", and a negative count would be worse than an inexact one.
+                if (bucket.Suppressed < int.MaxValue)
+                {
+                    bucket.Suppressed++;
+                }
+
+                suppressedCount = 0;
+                return false;
+            }
+
+            suppressedCount = bucket.Suppressed;
+            bucket.Suppressed = 0;
+            bucket.LastRaised = now;
+            bucket.HasRaised = true;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Forgets all accumulated state, so the next occurrence of anything is raised immediately.
+    /// </summary>
+    /// <remarks>
+    /// Called when a device connects: a reconnect is a new session, and its first failure should be
+    /// reported at once rather than collapsed into a window opened by the previous session.
+    /// </remarks>
+    public void Reset() => _buckets.Clear();
+
+    /// <summary>
+    /// Resolves the bucket for a key, folding anything past <see cref="MaxTrackedBuckets"/> into a
+    /// shared overflow bucket.
+    /// </summary>
+    /// <remarks>
+    /// The count check is deliberately not atomic with the insert: racing callers may push the
+    /// table a few entries past the cap. That is harmless — the cap exists to stop unbounded
+    /// growth, not to be an exact quota — and paying for a lock on every background error to make
+    /// it exact would be the wrong trade.
+    /// </remarks>
+    private Bucket GetBucket(string key)
+    {
+        if (_buckets.TryGetValue(key, out var existing))
+        {
+            return existing;
+        }
+
+        if (_buckets.Count >= MaxTrackedBuckets)
+        {
+            key = OverflowKey;
+        }
+
+        return _buckets.GetOrAdd(key, _ => new Bucket());
+    }
+
+    /// <summary>
+    /// Per-key state. Mutated only under a lock on the instance itself.
+    /// </summary>
+    private sealed class Bucket
+    {
+        public long LastRaised;
+        public bool HasRaised;
+        public int Suppressed;
+    }
+}

--- a/src/Daqifi.Core/Device/IDevice.cs
+++ b/src/Daqifi.Core/Device/IDevice.cs
@@ -42,6 +42,17 @@ namespace Daqifi.Core.Device
         event EventHandler<MessageReceivedEventArgs> MessageReceived;
 
         /// <summary>
+        /// Occurs when something fails on one of the device's background threads — a read from the
+        /// transport stream, a parse, a dispatch to a subscriber, or the decode of a streaming frame.
+        /// </summary>
+        /// <remarks>
+        /// Observational only: it reports what went wrong and changes nothing about what the device
+        /// does (issue #378). Raises are throttled per source and exception type — see
+        /// <see cref="DaqifiDevice.ErrorOccurred"/> for the policy and the guarantees.
+        /// </remarks>
+        event EventHandler<DeviceErrorEventArgs> ErrorOccurred;
+
+        /// <summary>
         /// Connects to the device.
         /// </summary>
         void Connect();


### PR DESCRIPTION
## Why

When a DAQiFi device stops sending data, the library used to give you nothing to go on. A cable
pull, a dead WiFi link, or a decoder that fails on every frame all looked identical from the
outside: no samples, no error, no status change. Apps had no way to tell "the connection died"
from "the device is quiet", and no way to answer "why am I getting no samples".

Most of the *detection* landed in #403. This finishes the job by adding the missing piece — a place
for those failures to actually show up — and by closing the one path where the reader could still
spin forever in silence.

## What

- **A new `ErrorOccurred` event on every device.** Failures on the background threads — a failed
  read, an unparseable frame, a subscriber that threw, a frame that wouldn't decode — now reach
  your code, tagged with which stage failed. They also go to the logger, so they're visible even
  with nobody subscribed.
- **A decode-failure counter.** `DaqifiStreamingDevice.DecodeFailureCount` tells you how many
  frames were dropped in the current streaming session. Zero on a healthy stream.
- **No more silent spinning.** A stream that has gone permanently unreadable is now reported and
  escalated instead of being retried forever with nothing logged.
- Docs: a new "Error Surface" section in `docs/DEVICE_INTERFACES.md`.

The event is **diagnostics only**. It never tears anything down, never retries, and never changes
connection status. A single bad frame is still dropped on its own without disturbing the stream,
exactly as before. Declaring a connection actually dead stays the transports' job and still arrives
as `ConnectionStatus.Lost`.

## How

A broken thing usually breaks over and over — thousands of times a second at high sample rates — so
events are collapsed rather than fired for every occurrence. The first failure of a given kind is
reported immediately; after that, the same kind is reported at most once every five seconds, and
each report says how many were folded into it. A *different* kind of failure never waits behind an
ongoing storm. Reconnecting resets this, so a fresh session always reports its first problem right
away.

Handlers run on a background thread, and one that throws is caught and ignored — it can't disturb
reading or streaming.

### Note for implementers

`IDevice` gained an event, so anything implementing that interface directly (test doubles, mocks)
needs to add it. `DaqifiDevice` and its subclasses are unaffected.

### Testing

- Full suite green on net9.0 and net10.0 (2213 passing each), plus the MCP tests; Release build
  with zero warnings.
- New coverage: read failure reaching a subscriber, a decode that fails on every frame staying
  observable while the stream survives, the throttle under a 5000-failure storm, an unreadable
  stream being escalated, and an intentional disconnect still never reporting `Lost`.
- Bench (Nyquist 1, FW 3.7.2): 60 s USB stream and 45 s WiFi stream, both clean — zero error
  events, zero decode failures, no spurious `Lost`, and `Disconnect()` reporting `Disconnected`.
  TCP keep-alive did not disturb WiFi connect or streaming.

Still to verify by hand: a physical mid-stream cable pull (someone has to actually unplug it).

closes #377
closes #394
closes #378

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
