### PR TITLE
fix(sdcard): run the SD→LAN restore inside the exchange lock, not after it (closes #407)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Capabilities/DaqifiDeviceCapabilityDocumentTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Capabilities/DaqifiDeviceCapabilityDocumentTests.cs
@@ -244,20 +244,33 @@ public class DaqifiDeviceCapabilityDocumentTests
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
-            Func<CancellationToken, Task>? prepareAsync = null)
+            Func<CancellationToken, Task>? prepareAsync = null,
+            Func<Task>? finalizeAsync = null)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Honor the exchange's prepare phase the way the real device does: it runs first,
-            // before anything this exchange sends (#396).
-            if (prepareAsync != null)
+            try
             {
-                await prepareAsync(cancellationToken).ConfigureAwait(false);
-            }
+                cancellationToken.ThrowIfCancellationRequested();
 
-            var before = SentCommands.Count;
-            setupAction();
-            return ResponsesSince(before);
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                var before = SentCommands.Count;
+                setupAction();
+                return ResponsesSince(before);
+            }
+            finally
+            {
+                // Honor the exchange's finalize phase the way the real device does: it runs
+                // however the exchange ended, still inside the exchange (#407).
+                if (finalizeAsync != null)
+                {
+                    await finalizeAsync().ConfigureAwait(false);
+                }
+            }
         }
 
         protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceDrainErrorQueueTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceDrainErrorQueueTests.cs
@@ -208,20 +208,33 @@ namespace Daqifi.Core.Tests.Device
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
-                Func<CancellationToken, Task>? prepareAsync = null)
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
             {
-                // Honor the exchange's prepare phase the way the real device does: it runs first,
-                // before anything this exchange sends (#396).
-                if (prepareAsync != null)
+                try
                 {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
-                }
+                    // Honor the exchange's prepare phase the way the real device does: it runs first,
+                    // before anything this exchange sends (#396).
+                    if (prepareAsync != null)
+                    {
+                        await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    }
 
-                cancellationToken.ThrowIfCancellationRequested();
-                setupAction();
-                ExecuteTextCommandCallCount++;
-                var reply = Replies.Count > 0 ? Replies.Dequeue() : Array.Empty<string>();
-                return reply;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    setupAction();
+                    ExecuteTextCommandCallCount++;
+                    var reply = Replies.Count > 0 ? Replies.Dequeue() : Array.Empty<string>();
+                    return reply;
+                }
+                finally
+                {
+                    // Honor the exchange's finalize phase the way the real device does: it runs
+                    // however the exchange ended, still inside the exchange (#407).
+                    if (finalizeAsync != null)
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
+                }
             }
         }
     }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -433,25 +433,38 @@ namespace Daqifi.Core.Tests.Device
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
-                Func<CancellationToken, Task>? prepareAsync = null)
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
             {
-                // Honor the exchange's prepare phase the way the real device does: it runs first,
-                // before anything this exchange sends (#396).
-                if (prepareAsync != null)
+                try
                 {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    // Honor the exchange's prepare phase the way the real device does: it runs first,
+                    // before anything this exchange sends (#396).
+                    if (prepareAsync != null)
+                    {
+                        await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    // Run the setup action so that Send() calls inside it are captured
+                    setupAction();
+                    TextCommandAttemptCount++;
+
+                    if (_failFirstAttempt && TextCommandAttemptCount == 1)
+                    {
+                        return new[] { "**ERROR: -200, \"Execution error\"\r\n" };
+                    }
+
+                    return _textCommandResponse;
                 }
-
-                // Run the setup action so that Send() calls inside it are captured
-                setupAction();
-                TextCommandAttemptCount++;
-
-                if (_failFirstAttempt && TextCommandAttemptCount == 1)
+                finally
                 {
-                    return new[] { "**ERROR: -200, \"Execution error\"\r\n" };
+                    // Honor the exchange's finalize phase the way the real device does: it runs
+                    // however the exchange ended, still inside the exchange (#407).
+                    if (finalizeAsync != null)
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
                 }
-
-                return _textCommandResponse;
             }
         }
 
@@ -513,40 +526,53 @@ namespace Daqifi.Core.Tests.Device
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
-                Func<CancellationToken, Task>? prepareAsync = null)
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
             {
-                // Honor the exchange's prepare phase the way the real device does: it runs first,
-                // before anything this exchange sends (#396).
-                if (prepareAsync != null)
+                try
                 {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
-                }
-
-                var before = _sent.Count;
-                setupAction();
-                var sentThisCall = _sent.Skip(before).ToList();
-                var isUsbStep = sentThisCall.Any(d => d.Contains("STReam:INTerface"));
-
-                if (isUsbStep)
-                {
-                    UsbStepAttemptCount++;
-
-                    switch (_usbStepBehavior)
+                    // Honor the exchange's prepare phase the way the real device does: it runs first,
+                    // before anything this exchange sends (#396).
+                    if (prepareAsync != null)
                     {
-                        case UsbStepBehavior.ScpiError:
-                            return new[] { "**ERROR: -200, \"Execution error\"\r\n" };
-                        case UsbStepBehavior.ScpiErrorThenSucceed:
-                            if (UsbStepAttemptCount == 1)
-                            {
+                        await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    var before = _sent.Count;
+                    setupAction();
+                    var sentThisCall = _sent.Skip(before).ToList();
+                    var isUsbStep = sentThisCall.Any(d => d.Contains("STReam:INTerface"));
+
+                    if (isUsbStep)
+                    {
+                        UsbStepAttemptCount++;
+
+                        switch (_usbStepBehavior)
+                        {
+                            case UsbStepBehavior.ScpiError:
                                 return new[] { "**ERROR: -200, \"Execution error\"\r\n" };
-                            }
-                            break;
-                        case UsbStepBehavior.Cancel:
-                            throw new OperationCanceledException();
+                            case UsbStepBehavior.ScpiErrorThenSucceed:
+                                if (UsbStepAttemptCount == 1)
+                                {
+                                    return new[] { "**ERROR: -200, \"Execution error\"\r\n" };
+                                }
+                                break;
+                            case UsbStepBehavior.Cancel:
+                                throw new OperationCanceledException();
+                        }
+                    }
+
+                    return Array.Empty<string>();
+                }
+                finally
+                {
+                    // Honor the exchange's finalize phase the way the real device does: it runs
+                    // however the exchange ended, still inside the exchange (#407).
+                    if (finalizeAsync != null)
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
                     }
                 }
-
-                return Array.Empty<string>();
             }
         }
     }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -122,6 +122,230 @@ public class DaqifiDeviceStaleTextLineTests
         device.Disconnect();
     }
 
+    // ── Finalize phase (#407) — the mirror of the prepare phase above. An exchange that
+    // switches shared device state on the way in has to switch it back before anything else
+    // runs, or only half the pairing is serialized. ─────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteTextCommandWithFinalize_RunsFinalizeAfterTheSetupAction()
+    {
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Finalized Device", transport);
+
+        device.Connect();
+
+        var order = new List<string>();
+        await device.CallWithFinalizeAsync(
+            () => order.Add("setup"),
+            () => { order.Add("finalize"); return Task.CompletedTask; },
+            prepareAsync: _ => { order.Add("prepare"); return Task.CompletedTask; });
+
+        Assert.Equal(new[] { "prepare", "setup", "finalize" }, order);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommandWithFinalize_RunsFinalizeInsideTheExchange()
+    {
+        // The property #407 is about: the finalize phase holds the same lock acquisition the
+        // prepare phase does, so nothing can run between this exchange's commands and the state
+        // it restores. Asserted through the exchange's own re-entrancy guard rather than by
+        // racing threads — a nested exchange started from the finalize must be refused, and if
+        // the restore were back outside the lock this would quietly succeed instead.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Nested Finalize Device", transport);
+
+        device.Connect();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => device.CallWithFinalizeAsync(
+                () => { },
+                async () => await device.CallExecuteTextCommandAsync(() => { })));
+
+        Assert.Contains("not re-entrant", ex.Message);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommandWithFinalize_RunsFinalizeWhenTheExchangeThrows()
+    {
+        // The reason the finalize is a phase the exchange owns rather than "another prepare at
+        // the end": a failed exchange is exactly when the device most needs putting back.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Failing Device", transport);
+
+        device.Connect();
+
+        var finalized = false;
+
+        var ex = await Assert.ThrowsAsync<InvalidTimeZoneException>(
+            () => device.CallWithFinalizeAsync(
+                () => throw new InvalidTimeZoneException("the exchange failed"),
+                () => { finalized = true; return Task.CompletedTask; }));
+
+        Assert.Equal("the exchange failed", ex.Message);
+        Assert.True(finalized, "The finalize phase did not run for a failed exchange.");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommandWithFinalize_WhenBothFail_SurfacesTheExchangeFailure()
+    {
+        // A cleanup failure must never hide the failure that caused the cleanup: the caller
+        // needs the original to diagnose anything at all.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Doubly Failing Device", transport);
+
+        device.Connect();
+
+        var ex = await Assert.ThrowsAsync<InvalidTimeZoneException>(
+            () => device.CallWithFinalizeAsync(
+                () => throw new InvalidTimeZoneException("the exchange failed"),
+                () => throw new NotSupportedException("the restore failed too")));
+
+        Assert.Equal("the exchange failed", ex.Message);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommandWithFinalize_WhenOnlyTheFinalizeFails_SurfacesThatFailure()
+    {
+        // The complement, so "never throw from the finalize" isn't the rule: with nothing else
+        // unwinding, a failed restore is the only failure there is, and reporting success would
+        // hand the caller a device left in the prepared state.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Failing Restore Device", transport);
+
+        device.Connect();
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => device.CallWithFinalizeAsync(
+                () => { },
+                () => throw new NotSupportedException("the restore failed")));
+
+        Assert.Equal("the restore failed", ex.Message);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommandWithFinalize_WhenTheFinalizeFails_TheExchangeLockIsStillReleased()
+    {
+        // The finalize runs from the exchange's own finally, so a failure raised straight out of
+        // it would abandon the rest of that finally — the lock included — and every later exchange
+        // on the device would hang forever. Both outcomes are checked because they take different
+        // routes out: the restore failing alone, and the restore failing on top of a failed
+        // exchange.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Leaky Restore Device", transport);
+
+        device.Connect();
+
+        var restoreFailed = device.CallWithFinalizeAsync(
+            () => { },
+            () => throw new NotSupportedException("the restore failed"));
+        await AssertCompletesAsync(restoreFailed);
+        await Assert.ThrowsAsync<NotSupportedException>(() => restoreFailed);
+
+        var bothFailed = device.CallWithFinalizeAsync(
+            () => throw new InvalidTimeZoneException("the exchange failed"),
+            () => throw new NotSupportedException("the restore failed too"));
+        await AssertCompletesAsync(bothFailed);
+        await Assert.ThrowsAsync<InvalidTimeZoneException>(() => bothFailed);
+
+        var next = device.CallExecuteTextCommandAsync(() => { });
+        await AssertCompletesAsync(next);
+        await next;
+
+        device.Disconnect();
+    }
+
+    /// <summary>
+    /// Waits for a call with a bound, so a leaked exchange lock fails the test that is looking for
+    /// it instead of hanging the whole run.
+    /// </summary>
+    private static async Task AssertCompletesAsync(Task call)
+    {
+        var winner = await Task.WhenAny(call, Task.Delay(TimeSpan.FromSeconds(15)));
+        Assert.Same(call, winner);
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommandWithFinalize_NoOtherExchangeRunsBeforeTheFinalize()
+    {
+        // The race from #407 stated directly: a competing exchange must not be able to run
+        // between one exchange's commands and its restore. The second call is launched as soon
+        // as the first has sent, and the first's finalize then dawdles — plenty of room for the
+        // second to slip in if the restore were outside the lock.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Serialized Device", transport);
+
+        device.Connect();
+
+        var order = new List<string>();
+        var gate = new object();
+        void Record(string step)
+        {
+            lock (gate)
+            {
+                order.Add(step);
+            }
+        }
+
+        using var firstHasSent = new ManualResetEventSlim(false);
+
+        // The finalize dawdles on purpose. Recording a start and an end around the wait is what
+        // makes this a regression detector rather than a coincidence: with the restore outside
+        // the lock, the second exchange acquires it the moment the first exchange returns and its
+        // setup lands INSIDE that window.
+        var first = device.CallWithFinalizeAsync(
+            () => { Record("first.setup"); firstHasSent.Set(); },
+            async () =>
+            {
+                Record("first.finalize.start");
+                await Task.Delay(300);
+                Record("first.finalize.end");
+            });
+
+        Assert.True(firstHasSent.Wait(TimeSpan.FromSeconds(10)), "The first exchange never sent.");
+
+        var second = Task.Run(() => device.CallExecuteTextCommandAsync(() => Record("second.setup")));
+
+        await Task.WhenAll(first, second);
+
+        lock (gate)
+        {
+            Assert.Equal(
+                new[] { "first.setup", "first.finalize.start", "first.finalize.end", "second.setup" },
+                order);
+        }
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommandWithFinalize_WhenValidationRefusesTheExchange_DoesNotRunFinalize()
+    {
+        // The one case the finalize is skipped: the exchange never got past validation, so it
+        // never touched the device and there is nothing to put back. Running it here would only
+        // add a second failure on a device that is already gone.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Unconnected Device", transport);
+
+        var finalized = false;
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => device.CallWithFinalizeAsync(
+                () => { },
+                () => { finalized = true; return Task.CompletedTask; }));
+
+        Assert.False(finalized, "The finalize phase ran for an exchange that never started.");
+    }
+
     /// <summary>
     /// Stands in for a downstream subclass or test double that intercepts the text exchange —
     /// the case the single-seam design protects.
@@ -140,17 +364,30 @@ public class DaqifiDeviceStaleTextLineTests
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
-            Func<CancellationToken, Task>? prepareAsync = null)
+            Func<CancellationToken, Task>? prepareAsync = null,
+            Func<Task>? finalizeAsync = null)
         {
-            Intercepted = true;
-
-            if (prepareAsync != null)
+            try
             {
-                await prepareAsync(cancellationToken).ConfigureAwait(false);
-            }
+                Intercepted = true;
 
-            setupAction();
-            return new List<string> { "from the override" };
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                setupAction();
+                return new List<string> { "from the override" };
+            }
+            finally
+            {
+                // Honor the exchange's finalize phase the way the real device does: it runs
+                // however the exchange ended, still inside the exchange (#407).
+                if (finalizeAsync != null)
+                {
+                    await finalizeAsync().ConfigureAwait(false);
+                }
+            }
         }
     }
 
@@ -176,6 +413,19 @@ public class DaqifiDeviceStaleTextLineTests
                 responseTimeoutMs: 500,
                 completionTimeoutMs: 150,
                 prepareAsync: prepareAsync);
+        }
+
+        public Task<IReadOnlyList<string>> CallWithFinalizeAsync(
+            Action setupAction,
+            Func<Task> finalizeAsync,
+            Func<CancellationToken, Task>? prepareAsync = null)
+        {
+            return ExecuteTextCommandAsync(
+                setupAction,
+                responseTimeoutMs: 500,
+                completionTimeoutMs: 150,
+                prepareAsync: prepareAsync,
+                finalizeAsync: finalizeAsync);
         }
     }
 

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
@@ -307,18 +307,31 @@ public class DeviceDiagnosticsTests
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
-            Func<CancellationToken, Task>? prepareAsync = null)
+            Func<CancellationToken, Task>? prepareAsync = null,
+            Func<Task>? finalizeAsync = null)
         {
-            // Honor the exchange's prepare phase the way the real device does: it runs first,
-            // before anything this exchange sends (#396).
-            if (prepareAsync != null)
+            try
             {
-                await prepareAsync(cancellationToken).ConfigureAwait(false);
-            }
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
 
-            cancellationToken.ThrowIfCancellationRequested();
-            setupAction();
-            return CannedTextResponse.ToList();
+                cancellationToken.ThrowIfCancellationRequested();
+                setupAction();
+                return CannedTextResponse.ToList();
+            }
+            finally
+            {
+                // Honor the exchange's finalize phase the way the real device does: it runs
+                // however the exchange ended, still inside the exchange (#407).
+                if (finalizeAsync != null)
+                {
+                    await finalizeAsync().ConfigureAwait(false);
+                }
+            }
         }
 
         protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(

--- a/src/Daqifi.Core.Tests/Device/GetLanChipInfoAsyncTests.cs
+++ b/src/Daqifi.Core.Tests/Device/GetLanChipInfoAsyncTests.cs
@@ -95,18 +95,31 @@ public class GetLanChipInfoAsyncTests
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
-            Func<CancellationToken, Task>? prepareAsync = null)
+            Func<CancellationToken, Task>? prepareAsync = null,
+            Func<Task>? finalizeAsync = null)
         {
-            // Honor the exchange's prepare phase the way the real device does: it runs first,
-            // before anything this exchange sends (#396).
-            if (prepareAsync != null)
+            try
             {
-                await prepareAsync(cancellationToken).ConfigureAwait(false);
-            }
+                // Honor the exchange's prepare phase the way the real device does: it runs first,
+                // before anything this exchange sends (#396).
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                }
 
-            cancellationToken.ThrowIfCancellationRequested();
-            setupAction();
-            return CannedTextResponse.ToList();
+                cancellationToken.ThrowIfCancellationRequested();
+                setupAction();
+                return CannedTextResponse.ToList();
+            }
+            finally
+            {
+                // Honor the exchange's finalize phase the way the real device does: it runs
+                // however the exchange ended, still inside the exchange (#407).
+                if (finalizeAsync != null)
+                {
+                    await finalizeAsync().ConfigureAwait(false);
+                }
+            }
         }
 
         protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -257,6 +257,28 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task GetSdCardFilesAsync_WhenCancelledDuringTheSettleDelay_StillRestoresTheLanInterface()
+        {
+            // By the time the settle wait is cancelled the prepare phase has already switched the
+            // bus, so the exchange unwinds with the device sitting on the SD card. The restore has
+            // to happen anyway — which is why it is a phase the exchange owns and runs from its own
+            // try/finally, rather than a step tacked on to the end of a successful exchange (#407).
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "Daqifi/test.bin" };
+            device.Connect();
+
+            using var cts = new CancellationTokenSource();
+            var opTask = device.GetSdCardFilesAsync(cts.Token);
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => opTask);
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:STORage:SD:ENAble 0", sentCommands);       // DisableStorageSd
+            Assert.Contains("SYSTem:COMMunicate:LAN:ENAbled 1", sentCommands); // EnableNetworkLan
+        }
+
+        [Fact]
         public async Task DeleteSdCardFileAsync_HonorsCancellationDuringSettleDelay()
         {
             // Regression for #221 — symmetric with GetSdCardFilesAsync above.
@@ -1649,6 +1671,41 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Contains("SYSTem:COMMunicate:LAN:ENAbled 1", sent); // EnableNetworkLan (restore)
         }
 
+        [Fact]
+        public async Task SdCardTextOperations_HandTheLanRestoreToTheExchangeAsItsFinalizePhase()
+        {
+            // #407: the restore has to travel through the exchange's finalize phase, because that
+            // is what puts it under the same lock acquisition as the matching switch. This device
+            // drops the finalize phase on the floor — so if any restore still reaches the wire, it
+            // came from a caller-side finally running after the lock was already released, which is
+            // the defect. Every SD text operation is checked, since they share the pairing.
+            var device = new FinalizeDroppingSdCardDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "Daqifi/log.bin" };
+            device.Connect();
+
+            await device.GetSdCardFilesAsync();
+            await device.DeleteSdCardFileAsync("log.bin");
+
+            device.CannedTextResponse = new List<string> { "1024,4096" };
+            await device.GetSdCardStorageAsync();
+
+            var sent = device.SentMessages.Select(m => m.Data).ToList();
+
+            // The switch still happened — this is not a device that simply sent nothing.
+            Assert.Contains("SYSTem:COMMunicate:LAN:ENAbled 0", sent); // DisableNetworkLan
+            Assert.Contains("SYSTem:STORage:SD:ENAble 1", sent);       // EnableStorageSd
+
+            // And the restore did not, because the only route to it was the phase this device
+            // discarded.
+            Assert.DoesNotContain("SYSTem:COMMunicate:LAN:ENAbled 1", sent); // EnableNetworkLan
+            Assert.DoesNotContain("SYSTem:STORage:SD:ENAble 0", sent);       // DisableStorageSd
+
+            // Three operations, each of which offered the exchange a finalize phase (the listing
+            // and the delete send one exchange apiece here; storage the same).
+            Assert.Equal(3, device.ExchangesOfferedAFinalizePhase);
+            Assert.Equal(0, device.ExchangesWithoutAFinalizePhase);
+        }
+
         [Theory]
         [InlineData("3.6.3")]
         [InlineData("3.5.0")]
@@ -2168,6 +2225,54 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task DownloadSdCardFileAsync_WhenTheTransferIsAbandoned_DoesNotRestoreTheLanInterface()
+        {
+            // #407 / #399: an abandoned transfer is still running and still owns the transport —
+            // that is why the download gate stays held until it unwinds. Sending the LAN restore
+            // now would put commands onto a link that transfer is still reading from, on a device
+            // that has already stopped answering. The caller is told to reconnect or power-cycle,
+            // and both re-establish the interface anyway.
+            var device = new ParkedDownloadDevice(ParkMode.Asynchronous, TimeSpan.FromMilliseconds(300));
+            device.Connect();
+            using var destinationStream = new MemoryStream();
+
+            try
+            {
+                var opTask = device.DownloadSdCardFileAsync("data.bin", destinationStream);
+
+                var winner = await Task.WhenAny(opTask, Task.Delay(TimeSpan.FromSeconds(30)));
+                Assert.Same((Task)opTask, winner);
+                await Assert.ThrowsAsync<TimeoutException>(() => opTask);
+
+                var sent = device.SentCommandsSnapshot();
+                Assert.Contains("SYSTem:StopStreamData", sent); // the pre-flight stop did happen
+                Assert.DoesNotContain("SYSTem:STORage:SD:ENAble 0", sent);       // DisableStorageSd
+                Assert.DoesNotContain("SYSTem:COMMunicate:LAN:ENAbled 1", sent); // EnableNetworkLan
+            }
+            finally
+            {
+                device.Release();
+            }
+        }
+
+        [Fact]
+        public async Task DownloadSdCardFileAsync_WhenTheTransferCompletes_StillRestoresTheLanInterface()
+        {
+            // The complement, so skipping the restore for an abandoned transfer cannot quietly
+            // become "the download never restores the interface".
+            var device = new TestableDownloadDevice("TestDevice");
+            device.CannedFileData = Encoding.ASCII.GetBytes("hello sd card");
+            device.Connect();
+            using var destinationStream = new MemoryStream();
+
+            await device.DownloadSdCardFileAsync("data.bin", destinationStream);
+
+            var sent = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Contains("SYSTem:STORage:SD:ENAble 0", sent);       // DisableStorageSd
+            Assert.Contains("SYSTem:COMMunicate:LAN:ENAbled 1", sent); // EnableNetworkLan
+        }
+
+        [Fact]
         public async Task DownloadSdCardFileAsync_WhenTransferParksIgnoringItsToken_CallerCancellationStillEndsTheCall()
         {
             // The consumer-side stall watchdog described in #399: it cancels its token at 90s and
@@ -2366,23 +2471,36 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
-                Func<CancellationToken, Task>? prepareAsync = null)
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
             {
-                // Honor the exchange's prepare phase the way the real device does: it runs first,
-                // before anything this exchange sends (#396).
-                if (prepareAsync != null)
+                try
                 {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
-                }
+                    // Honor the exchange's prepare phase the way the real device does: it runs first,
+                    // before anything this exchange sends (#396).
+                    if (prepareAsync != null)
+                    {
+                        await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    }
 
-                var sentBefore = SentMessages.Count;
-                setupAction();
-                ExecuteTextCommandCallCount++;
-                var response = ResponseSequence.Count > 0
-                    ? ResponseSequence.Dequeue()
-                    : new List<string>();
-                return SdCardTestResponses.AnswerErrorQuery(
-                    response, SentMessages, sentBefore, ExecuteTextCommandCallCount, UnterminatedAttempts);
+                    var sentBefore = SentMessages.Count;
+                    setupAction();
+                    ExecuteTextCommandCallCount++;
+                    var response = ResponseSequence.Count > 0
+                        ? ResponseSequence.Dequeue()
+                        : new List<string>();
+                    return SdCardTestResponses.AnswerErrorQuery(
+                        response, SentMessages, sentBefore, ExecuteTextCommandCallCount, UnterminatedAttempts);
+                }
+                finally
+                {
+                    // Honor the exchange's finalize phase the way the real device does: it runs
+                    // however the exchange ended, still inside the exchange (#407).
+                    if (finalizeAsync != null)
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
+                }
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2494,22 +2612,35 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
-                Func<CancellationToken, Task>? prepareAsync = null)
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
             {
-                // Honor the exchange's prepare phase the way the real device does: it runs first,
-                // before anything this exchange sends (#396).
-                if (prepareAsync != null)
+                try
                 {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    // Honor the exchange's prepare phase the way the real device does: it runs first,
+                    // before anything this exchange sends (#396).
+                    if (prepareAsync != null)
+                    {
+                        await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    var sentBefore = SentMessages.Count;
+
+                    // Execute the setup action so we can capture the SCPI commands
+                    setupAction();
+                    _executeTextCommandCallCount++;
+                    return SdCardTestResponses.AnswerErrorQuery(
+                        CannedTextResponse, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts);
                 }
-
-                var sentBefore = SentMessages.Count;
-
-                // Execute the setup action so we can capture the SCPI commands
-                setupAction();
-                _executeTextCommandCallCount++;
-                return SdCardTestResponses.AnswerErrorQuery(
-                    CannedTextResponse, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts);
+                finally
+                {
+                    // Honor the exchange's finalize phase the way the real device does: it runs
+                    // however the exchange ended, still inside the exchange (#407).
+                    if (finalizeAsync != null)
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
+                }
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2523,6 +2654,49 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 _executeTextCommandCallCount++;
                 return SdCardTestResponses.AnswerErrorQuery(
                     CannedTextResponse, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts);
+            }
+        }
+
+        /// <summary>
+        /// Records how many exchanges were handed a finalize phase and then discards it, so a test
+        /// can tell a restore that arrived through the exchange seam (#407) from one that arrived
+        /// from a caller's own <c>finally</c> after the lock was released.
+        /// </summary>
+        private sealed class FinalizeDroppingSdCardDevice : TestableSdCardStreamingDevice
+        {
+            public FinalizeDroppingSdCardDevice(string name, IPAddress? ipAddress = null)
+                : base(name, ipAddress)
+            {
+            }
+
+            public int ExchangesOfferedAFinalizePhase { get; private set; }
+
+            public int ExchangesWithoutAFinalizePhase { get; private set; }
+
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+                Action setupAction,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
+            {
+                if (finalizeAsync != null)
+                {
+                    ExchangesOfferedAFinalizePhase++;
+                }
+                else
+                {
+                    ExchangesWithoutAFinalizePhase++;
+                }
+
+                return base.ExecuteTextCommandAsync(
+                    setupAction,
+                    responseTimeoutMs,
+                    completionTimeoutMs,
+                    cancellationToken,
+                    prepareAsync,
+                    finalizeAsync: null);
             }
         }
 
@@ -2558,17 +2732,30 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
-                Func<CancellationToken, Task>? prepareAsync = null)
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
             {
-                // Honor the exchange's prepare phase the way the real device does: it runs first,
-                // before anything this exchange sends (#396).
-                if (prepareAsync != null)
+                try
                 {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
-                }
+                    // Honor the exchange's prepare phase the way the real device does: it runs first,
+                    // before anything this exchange sends (#396).
+                    if (prepareAsync != null)
+                    {
+                        await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    }
 
-                setupAction();
-                return CannedTextResponse;
+                    setupAction();
+                    return CannedTextResponse;
+                }
+                finally
+                {
+                    // Honor the exchange's finalize phase the way the real device does: it runs
+                    // however the exchange ended, still inside the exchange (#407).
+                    if (finalizeAsync != null)
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
+                }
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2721,26 +2908,39 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
-                Func<CancellationToken, Task>? prepareAsync = null)
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
             {
-                // Honor the exchange's prepare phase the way the real device does: it runs first,
-                // before anything this exchange sends (#396).
-                if (prepareAsync != null)
+                try
                 {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    // Honor the exchange's prepare phase the way the real device does: it runs first,
+                    // before anything this exchange sends (#396).
+                    if (prepareAsync != null)
+                    {
+                        await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    var sentBefore = SentMessages.Count;
+
+                    setupAction();
+                    _executeTextCommandCallCount++;
+
+                    // GetSdCardFilesAsync drives the listing through THIS overload (the SPI switch is
+                    // the exchange's prepareAsync phase, #406), and terminates it with SYSTem:ERRor?
+                    // (#396) — so the listing has to be served here and terminated the same way
+                    // TestableSdCardStreamingDevice does, or Core reads it as incomplete.
+                    return SdCardTestResponses.AnswerErrorQuery(
+                        ListingLines, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts);
                 }
-
-                var sentBefore = SentMessages.Count;
-
-                setupAction();
-                _executeTextCommandCallCount++;
-
-                // GetSdCardFilesAsync drives the listing through THIS overload (the SPI switch is
-                // the exchange's prepareAsync phase, #406), and terminates it with SYSTem:ERRor?
-                // (#396) — so the listing has to be served here and terminated the same way
-                // TestableSdCardStreamingDevice does, or Core reads it as incomplete.
-                return SdCardTestResponses.AnswerErrorQuery(
-                    ListingLines, SentMessages, sentBefore, _executeTextCommandCallCount, UnterminatedAttempts);
+                finally
+                {
+                    // Honor the exchange's finalize phase the way the real device does: it runs
+                    // however the exchange ended, still inside the exchange (#407).
+                    if (finalizeAsync != null)
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
+                }
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
@@ -2810,12 +3010,32 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             internal override TimeSpan SdCardDownloadTimeout => _budget;
 
+            /// <summary>Commands this device was asked to send, in order.</summary>
+            public List<string> SentCommands { get; } = new();
+
             public override void Send<T>(IOutboundMessage<T> message)
             {
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    lock (SentCommands)
+                    {
+                        SentCommands.Add(stringMessage.Data);
+                    }
+                }
+
                 // Otherwise swallowed: this device never gets as far as exchanging commands.
                 var cancelSource = CancelOnNextSend;
                 CancelOnNextSend = null;
                 cancelSource?.Cancel();
+            }
+
+            /// <summary>Snapshot of <see cref="SentCommands"/>, safe to read while the abandoned worker runs.</summary>
+            public IReadOnlyList<string> SentCommandsSnapshot()
+            {
+                lock (SentCommands)
+                {
+                    return SentCommands.ToList();
+                }
             }
 
             protected override async Task ExecuteRawCaptureAsync(
@@ -2990,19 +3210,32 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
-                Func<CancellationToken, Task>? prepareAsync = null)
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
             {
-                // Honor the exchange's prepare phase the way the real device does: it runs first,
-                // before anything this exchange sends (#396).
-                if (prepareAsync != null)
+                try
                 {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
-                }
+                    // Honor the exchange's prepare phase the way the real device does: it runs first,
+                    // before anything this exchange sends (#396).
+                    if (prepareAsync != null)
+                    {
+                        await prepareAsync(cancellationToken).ConfigureAwait(false);
+                    }
 
-                var sentBefore = SentMessages.Count;
-                setupAction();
-                return SdCardTestResponses.AnswerErrorQuery(
-                    CannedTextResponse, SentMessages, sentBefore, attemptNumber: 1, unterminatedAttempts: 0);
+                    var sentBefore = SentMessages.Count;
+                    setupAction();
+                    return SdCardTestResponses.AnswerErrorQuery(
+                        CannedTextResponse, SentMessages, sentBefore, attemptNumber: 1, unterminatedAttempts: 0);
+                }
+                finally
+                {
+                    // Honor the exchange's finalize phase the way the real device does: it runs
+                    // however the exchange ended, still inside the exchange (#407).
+                    if (finalizeAsync != null)
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
+                }
             }
 
             protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -558,7 +559,7 @@ namespace Daqifi.Core.Device
         /// <remarks>
         /// Waits up to 10 seconds to acquire <c>_textExchangeLock</c> before
         /// tearing down the consumer / producer / transport. This prevents
-        /// a race where an in-flight <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task})"/>
+        /// a race where an in-flight <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
         /// is mid-swap (text consumer running on the stream, protobuf
         /// consumer not yet restarted) and Disconnect rips the transport
         /// out from under it. If the wait times out, Disconnect proceeds
@@ -807,6 +808,28 @@ namespace Daqifi.Core.Device
         /// it did before this exchange began.
         /// </para>
         /// </param>
+        /// <param name="finalizeAsync">
+        /// Optional phase that undoes what <paramref name="prepareAsync"/> established — the SD card
+        /// operations use it to hand the shared SPI bus back to the LAN interface.
+        /// <para>
+        /// It is the mirror of the prepare phase and runs under the <b>same</b> lock acquisition, so
+        /// nothing can interleave between this exchange's commands and the state it restores (#407).
+        /// It runs after the protobuf consumer has been restarted, mirroring the prepare phase
+        /// running before the consumer was swapped out.
+        /// </para>
+        /// <para>
+        /// It runs whether the exchange succeeds or fails, so the device is never left in the
+        /// prepared state. It takes no cancellation token on purpose: it is cleanup, and a cancelled
+        /// or timed-out exchange still has to put the device back. Keep it short and non-blocking —
+        /// it holds the lock while it runs.
+        /// </para>
+        /// <para>
+        /// If the exchange failed and the finalize phase then fails too, the finalize failure is
+        /// logged and dropped and the exchange's original failure is what the caller sees — a
+        /// cleanup failure must never hide the failure that caused the cleanup. If the exchange
+        /// succeeded, a finalize failure is the only failure there is, and it propagates.
+        /// </para>
+        /// </param>
         /// <returns>
         /// A list of text lines received from the device. Lines that were already in flight when the
         /// exchange opened — late replies to earlier commands — are excluded: only what arrived once
@@ -820,10 +843,10 @@ namespace Daqifi.Core.Device
         /// <exception cref="InvalidOperationException">Thrown when the device has no transport-based connection.</exception>
         /// <exception cref="TransportNotConnectedException">Thrown when the underlying transport has dropped.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
-        // prepareAsync is added AFTER cancellationToken (technically violating CA1068
-        // "CancellationToken should be last") to keep existing positional callers working, matching
-        // the convention established in IFirmwareUpdateService for the same reason. It is a
-        // parameter on this seam rather than a second virtual method deliberately: a parallel
+        // prepareAsync and finalizeAsync are added AFTER cancellationToken (technically violating
+        // CA1068 "CancellationToken should be last") to keep existing positional callers working,
+        // matching the convention established in IFirmwareUpdateService for the same reason. They
+        // are parameters on this seam rather than separate virtual methods deliberately: a parallel
         // method would be bypassed silently by any subclass that overrides only this one, which for
         // an instrumented device or a test double means the override quietly stops intercepting SD
         // operations with nothing to indicate it. Overriders must widen their signature — a compile
@@ -834,10 +857,12 @@ namespace Daqifi.Core.Device
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
-            Func<CancellationToken, Task>? prepareAsync = null)
+            Func<CancellationToken, Task>? prepareAsync = null,
+            Func<Task>? finalizeAsync = null)
         {
             return ExecuteTextCommandCoreAsync(
                 prepareAsync,
+                finalizeAsync,
                 _ => { setupAction(); return Task.CompletedTask; },
                 responseTimeoutMs,
                 completionTimeoutMs,
@@ -846,7 +871,7 @@ namespace Daqifi.Core.Device
 #pragma warning restore CA1068
 
         /// <summary>
-        /// Async overload of <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task})"/>
+        /// Async overload of <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
         /// that accepts an async setup action so callers can <c>await</c> cancellable operations
         /// (e.g. <see cref="Task.Delay(int, CancellationToken)"/>) between SCPI commands without
         /// blocking the thread-pool thread.
@@ -872,6 +897,7 @@ namespace Daqifi.Core.Device
         {
             return ExecuteTextCommandCoreAsync(
                 prepareAsync: null,
+                finalizeAsync: null,
                 setupActionAsync,
                 responseTimeoutMs,
                 completionTimeoutMs,
@@ -880,6 +906,7 @@ namespace Daqifi.Core.Device
 
         private async Task<IReadOnlyList<string>> ExecuteTextCommandCoreAsync(
             Func<CancellationToken, Task>? prepareAsync,
+            Func<Task>? finalizeAsync,
             Func<CancellationToken, Task> setupActionAsync,
             int responseTimeoutMs,
             int completionTimeoutMs,
@@ -924,6 +951,12 @@ namespace Daqifi.Core.Device
             }
 
             _isInsideTextExchange.Value = true;
+
+            // Whether the exchange got past validation and so owes its finalize phase, and whether
+            // it is on its way out normally rather than with an exception unwinding. Both are read
+            // only by the finalize block in the outer finally below.
+            var exchangeStarted = false;
+            var completedNormally = false;
             try
             {
                 // All validation runs INSIDE the lock so a competing thread
@@ -960,6 +993,11 @@ namespace Daqifi.Core.Device
                     throw new TransportNotConnectedException(
                         "Device transport is no longer connected.");
                 }
+
+                // Past validation: from here on the exchange acts on the device, so its finalize
+                // phase (if any) is owed however this ends — including a prepare phase that failed
+                // part-way and left the device half-way into the state it was establishing.
+                exchangeStarted = true;
 
                 var sw = Stopwatch.StartNew();
 
@@ -1124,12 +1162,36 @@ namespace Daqifi.Core.Device
 
                 // The text consumer is stopped by this point, so the list is no longer being
                 // appended to concurrently and can be re-projected safely.
-                return staleLineCount > 0
+                var result = staleLineCount > 0
                     ? collectedLines.Skip(staleLineCount).ToList()
                     : collectedLines;
+
+                completedNormally = true;
+                return result;
             }
             finally
             {
+                // Finalize phase, if any — the mirror of the prepare phase above, and deliberately
+                // still inside the lock: an exchange that switches shared device state on the way in
+                // has to switch it back before anything else can run, or the pairing is only half
+                // serialized (#407). It runs after the protobuf consumer has been restarted, just as
+                // the prepare phase ran before the consumer was swapped out.
+                // A failure here is never thrown from this point: doing so would abandon the rest of
+                // the finally, leaking the lock this exchange holds. It is held until after the
+                // release below and dealt with there.
+                Exception? finalizeFailure = null;
+                if (exchangeStarted && finalizeAsync != null)
+                {
+                    try
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        finalizeFailure = ex;
+                    }
+                }
+
                 _isInsideTextExchange.Value = false;
                 // Release can race with Dispose() — Dispose acquires the lock
                 // before disposing it, but if that acquisition timed out and
@@ -1143,6 +1205,29 @@ namespace Daqifi.Core.Device
                 }
                 catch (ObjectDisposedException)
                 {
+                }
+
+                if (finalizeFailure != null)
+                {
+                    if (completedNormally)
+                    {
+                        // Nothing else is unwinding, so a failed restore is the only failure there
+                        // is. Surface it rather than report a success the device never got back
+                        // from — the caller's next command would run against the wrong state.
+                        // Rethrown only now, with the lock already released, so a failed restore
+                        // cannot also wedge the device.
+                        ExceptionDispatchInfo.Capture(finalizeFailure).Throw();
+                    }
+
+                    // Otherwise an exception is already on its way to the caller, and it is the one
+                    // that explains what went wrong. Replacing it with this one would lose the
+                    // diagnosis, so the cleanup failure is logged instead: cleanup never hides the
+                    // failure that caused the cleanup.
+                    SafeLog(() => _logger.LogError(
+                        finalizeFailure,
+                        "The text exchange's finalize phase failed while another failure was already "
+                        + "unwinding. The original failure is being surfaced to the caller; the device "
+                        + "may be left in the state the prepare phase established."));
                 }
             }
         }
@@ -1166,7 +1251,7 @@ namespace Daqifi.Core.Device
         /// on hardware faults, or discard them if known-stale.
         /// </para>
         /// <para>
-        /// Each iteration uses <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task})"/>, which
+        /// Each iteration uses <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>, which
         /// pauses the protobuf consumer for the duration of the text exchange.
         /// Avoid calling this during active streaming or concurrently with
         /// other text commands.

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1698,9 +1698,9 @@ namespace Daqifi.Core.Device
         /// <para>
         /// The terminator is only meaningful if it cannot be confused with a late reply to an
         /// earlier command, so two things guard that boundary: the text exchange discards whatever
-        /// was already in flight when it opened, and this method does its SPI-bus switch and settle
-        /// delay before the exchange rather than inside it, leaving the exchange with no internal
-        /// gap for a stale reply to slip into.
+        /// was already in flight when it opened, and this method's SPI-bus switch and settle delay
+        /// run as the exchange's prepare phase, ahead of that boundary, leaving the exchange with no
+        /// internal gap for a stale reply to slip into.
         /// </para>
         /// <para>
         /// The terminator's error code is used only as a liveness marker, never for classification:
@@ -1730,55 +1730,51 @@ namespace Daqifi.Core.Device
             IReadOnlyList<string> lines = Array.Empty<string>();
             IReadOnlyList<string> listing = Array.Empty<string>();
             var isComplete = false;
-            try
+
+            // Attempt 0 plus SD_LIST_MAX_RETRIES retries. A SCPI error here is often a transient
+            // timing issue, and an unterminated response can be a one-off stall, so both are
+            // retried once after an additional settle delay before being surfaced.
+            for (var attempt = 0; attempt <= SD_LIST_MAX_RETRIES; attempt++)
             {
-                // Attempt 0 plus SD_LIST_MAX_RETRIES retries. A SCPI error here is often a transient
-                // timing issue, and an unterminated response can be a one-off stall, so both are
-                // retried once after an additional settle delay before being surfaced.
-                for (var attempt = 0; attempt <= SD_LIST_MAX_RETRIES; attempt++)
+                if (attempt > 0)
                 {
-                    if (attempt > 0)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
-                    }
-
-                    // The SPI bus switch and its settle wait run as the exchange's prepare phase:
-                    // inside the exchange lock, so a competing text exchange cannot restore the LAN
-                    // interface between the switch and the LIST, and ahead of the stale-line
-                    // boundary, so the settle wait does not become a window in which a late reply to
-                    // an earlier command could pass for this listing's terminator. Querying the card
-                    // too soon after the switch makes the device answer -200 (Execution error), so
-                    // the wait itself is not optional.
-                    lines = await ExecuteTextCommandAsync(
-                        () =>
-                        {
-                            Send(ScpiMessageProducer.GetSdFileList);
-
-                            // End-of-listing terminator — see this method's remarks. Sent inside
-                            // the same text exchange so the ordering guarantee holds.
-                            Send(ScpiMessageProducer.GetSystemError);
-                        },
-                        responseTimeoutMs: 3000,
-                        completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
-                        cancellationToken: cancellationToken,
-                        prepareAsync: PrepareSdInterfaceAndSettleAsync);
-
-                    isComplete = TrySplitAtSdListTerminator(lines, out listing);
-
-                    if (isComplete && !ContainsScpiError(listing))
-                    {
-                        break;
-                    }
+                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
                 }
-            }
-            finally
-            {
-                // Restore LAN interface regardless of outcome
-                if (IsConnected)
+
+                // The SPI bus switch and its settle wait run as the exchange's prepare phase, and
+                // the restore as its finalize phase: both inside the exchange lock, so a competing
+                // text exchange can neither restore the LAN interface between the switch and the
+                // LIST nor slip in between the LIST and the restore. The prepare also sits ahead of
+                // the stale-line boundary, so its settle wait does not become a window in which a
+                // late reply to an earlier command could pass for this listing's terminator.
+                // Querying the card too soon after the switch makes the device answer -200
+                // (Execution error), so the wait itself is not optional.
+                //
+                // Each attempt therefore leaves the bus back on LAN, including across the retry
+                // delay above — the pairing is per exchange rather than per call so that gap, which
+                // is outside the lock, is not one in which the device sits switched to the card.
+                lines = await ExecuteTextCommandAsync(
+                    () =>
+                    {
+                        Send(ScpiMessageProducer.GetSdFileList);
+
+                        // End-of-listing terminator — see this method's remarks. Sent inside
+                        // the same text exchange so the ordering guarantee holds.
+                        Send(ScpiMessageProducer.GetSystemError);
+                    },
+                    responseTimeoutMs: 3000,
+                    completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
+                    cancellationToken: cancellationToken,
+                    prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                    finalizeAsync: RestoreLanInterfaceAsync);
+
+                isComplete = TrySplitAtSdListTerminator(lines, out listing);
+
+                if (isComplete && !ContainsScpiError(listing))
                 {
-                    PrepareLanInterface();
+                    break;
                 }
             }
 
@@ -1800,7 +1796,7 @@ namespace Daqifi.Core.Device
         /// </summary>
         /// <remarks>
         /// Passed as the <c>prepareAsync</c> phase of
-        /// <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task})"/>
+        /// <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
         /// rather than run
         /// inline, so it executes inside the text-exchange lock — a competing exchange restoring the
         /// LAN interface between the switch and the commands that depend on it would leave them
@@ -1814,6 +1810,33 @@ namespace Daqifi.Core.Device
             // Querying the card too soon after the switch makes the device answer -200
             // (Execution error), so this wait is not optional.
             await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Finalize phase shared by the SD card text exchanges: hands the shared SPI bus back to the
+        /// LAN interface. The mirror of <see cref="PrepareSdInterfaceAndSettleAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// Passed as the <c>finalizeAsync</c> phase of
+        /// <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
+        /// rather than run from the caller's own <c>finally</c>, so it holds the same lock
+        /// acquisition the matching prepare phase does. Restoring from outside the lock leaves a
+        /// window in which a competing exchange runs between this operation's commands and its
+        /// restore — the switch serialized, the restore not (#407).
+        /// <para>
+        /// The connection check keeps a restore off a device that dropped mid-operation, where the
+        /// sends would only throw <see cref="DeviceNotConnectedException"/> over the top of whatever
+        /// actually failed. Nothing to restore in that case: the link is gone.
+        /// </para>
+        /// </remarks>
+        private Task RestoreLanInterfaceAsync()
+        {
+            if (IsConnected)
+            {
+                PrepareLanInterface();
+            }
+
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -1913,51 +1936,40 @@ namespace Daqifi.Core.Device
             Send(ScpiMessageProducer.StopStreaming);
             IsStreaming = false;
 
-            IReadOnlyList<string> lines;
-            try
+            // Same prepare/finalize pairing as GetSdCardFilesAsync: the SPI bus switch and its
+            // settle wait are the exchange's prepare phase and the LAN restore is its finalize
+            // phase, so both halves are held by the one lock acquisition rather than only the
+            // switch (#407). The settle wait also moves ahead of the exchange's stale-line
+            // boundary instead of blocking a thread inside it.
+            var lines = await ExecuteTextCommandAsync(
+                () => Send(ScpiMessageProducer.GetSdSpace),
+                responseTimeoutMs: 3000,
+                cancellationToken: cancellationToken,
+                prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                finalizeAsync: RestoreLanInterfaceAsync);
+
+            // Only retry transient SCPI errors. A "No SD Card Detected" line
+            // is non-transient — retrying just delays the typed exception and
+            // risks misclassification if the marker isn't repeated on retry.
+            if (ContainsScpiError(lines) && !ContainsNoSdCardMarker(lines))
             {
-                lines = await ExecuteTextCommandAsync(() =>
+                for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
                 {
-                    PrepareSdInterface();
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                    // Allow the device firmware to complete the SPI bus switch
-                    // before querying the SD card. Without this delay, the device
-                    // can return SCPI error -200 (Execution error).
-                    Thread.Sleep(SD_INTERFACE_SETTLE_DELAY_MS);
+                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
 
-                    Send(ScpiMessageProducer.GetSdSpace);
-                }, responseTimeoutMs: 3000, cancellationToken: cancellationToken);
+                    lines = await ExecuteTextCommandAsync(
+                        () => Send(ScpiMessageProducer.GetSdSpace),
+                        responseTimeoutMs: 3000,
+                        cancellationToken: cancellationToken,
+                        prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                        finalizeAsync: RestoreLanInterfaceAsync);
 
-                // Only retry transient SCPI errors. A "No SD Card Detected" line
-                // is non-transient — retrying just delays the typed exception and
-                // risks misclassification if the marker isn't repeated on retry.
-                if (ContainsScpiError(lines) && !ContainsNoSdCardMarker(lines))
-                {
-                    for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
+                    if (!ContainsScpiError(lines) || ContainsNoSdCardMarker(lines))
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken);
-
-                        lines = await ExecuteTextCommandAsync(() =>
-                        {
-                            PrepareSdInterface();
-                            Thread.Sleep(SD_INTERFACE_SETTLE_DELAY_MS);
-                            Send(ScpiMessageProducer.GetSdSpace);
-                        }, responseTimeoutMs: 3000, cancellationToken: cancellationToken);
-
-                        if (!ContainsScpiError(lines) || ContainsNoSdCardMarker(lines))
-                        {
-                            break;
-                        }
+                        break;
                     }
-                }
-            }
-            finally
-            {
-                if (IsConnected)
-                {
-                    PrepareLanInterface();
                 }
             }
 
@@ -2221,54 +2233,47 @@ namespace Daqifi.Core.Device
             Send(ScpiMessageProducer.StopStreaming);
             IsStreaming = false;
 
-            IReadOnlyList<string> lines;
-            try
-            {
-                // Same prepare-phase treatment as GetSdCardFilesAsync, for the same two reasons —
-                // the SPI switch stays serialized against competing text exchanges, and its settle
-                // wait stays outside the stale-line boundary. The consequence of a stale line is
-                // milder here (delete keys off ContainsScpiError, so it would mean a pointless
-                // delete-and-relist retry rather than a bad listing) but it is the same defect.
-                lines = await ExecuteTextCommandAsync(
-                    () =>
-                    {
-                        Send(ScpiMessageProducer.DeleteSdFile(fileName));
-                        Send(ScpiMessageProducer.GetSdFileList);
-                    },
-                    responseTimeoutMs: 3000,
-                    cancellationToken: cancellationToken,
-                    prepareAsync: PrepareSdInterfaceAndSettleAsync);
-
-                if (ContainsScpiError(lines))
+            // Same prepare/finalize treatment as GetSdCardFilesAsync, for the same reasons — the
+            // SPI switch stays serialized against competing text exchanges, its settle wait stays
+            // outside the stale-line boundary, and the restore stays under the same lock as the
+            // switch instead of running from a finally after the lock has been dropped. The
+            // consequence of a stale line is milder here (delete keys off ContainsScpiError, so it
+            // would mean a pointless delete-and-relist retry rather than a bad listing) but it is
+            // the same defect.
+            var lines = await ExecuteTextCommandAsync(
+                () =>
                 {
-                    for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
+                    Send(ScpiMessageProducer.DeleteSdFile(fileName));
+                    Send(ScpiMessageProducer.GetSdFileList);
+                },
+                responseTimeoutMs: 3000,
+                cancellationToken: cancellationToken,
+                prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                finalizeAsync: RestoreLanInterfaceAsync);
 
-                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+            if (ContainsScpiError(lines))
+            {
+                for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                        lines = await ExecuteTextCommandAsync(
-                            () =>
-                            {
-                                Send(ScpiMessageProducer.DeleteSdFile(fileName));
-                                Send(ScpiMessageProducer.GetSdFileList);
-                            },
-                            responseTimeoutMs: 3000,
-                            cancellationToken: cancellationToken,
-                            prepareAsync: PrepareSdInterfaceAndSettleAsync);
+                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
 
-                        if (!ContainsScpiError(lines))
+                    lines = await ExecuteTextCommandAsync(
+                        () =>
                         {
-                            break;
-                        }
+                            Send(ScpiMessageProducer.DeleteSdFile(fileName));
+                            Send(ScpiMessageProducer.GetSdFileList);
+                        },
+                        responseTimeoutMs: 3000,
+                        cancellationToken: cancellationToken,
+                        prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                        finalizeAsync: RestoreLanInterfaceAsync);
+
+                    if (!ContainsScpiError(lines))
+                    {
+                        break;
                     }
-                }
-            }
-            finally
-            {
-                if (IsConnected)
-                {
-                    PrepareLanInterface();
                 }
             }
 
@@ -2345,6 +2350,13 @@ namespace Daqifi.Core.Device
         /// protobuf consumer stopped, so reconnecting (or power-cycling, if its SD subsystem is
         /// genuinely wedged) is the reliable way to resume normal operation.
         /// <para>
+        /// The LAN interface is deliberately <b>not</b> restored in that case: the abandoned
+        /// transfer still owns the transport, and putting the restore commands onto a link it is
+        /// still reading would only add traffic to a device that has already stopped answering. The
+        /// reconnect the caller needs anyway re-establishes the interface. On every other outcome —
+        /// success, a stall, a cancellation the transfer did observe — the restore runs as before.
+        /// </para>
+        /// <para>
         /// Until an abandoned transfer unwinds it still owns the transport, so a further download
         /// on the same device fails fast with <see cref="InvalidOperationException"/> rather than
         /// putting a second reader on the same stream. A caller looping over many files against a
@@ -2390,6 +2402,10 @@ namespace Daqifi.Core.Device
             var stopwatch = Stopwatch.StartNew();
             long fileSize = 0;
             var budget = SdCardDownloadTimeout;
+
+            // Set when the transfer was given up on and left running (#399/#401). Read only by the
+            // restore below, on this same async flow.
+            var workerAbandoned = false;
 
             try
             {
@@ -2443,12 +2459,21 @@ namespace Daqifi.Core.Device
 
                         fileSize = bytesReceived;
                     }, token).ConfigureAwait(false);
-                }, budget, fileName, cancellationToken).ConfigureAwait(false);
+                },
+                budget,
+                fileName,
+                cancellationToken,
+                onWorkerAbandoned: () => workerAbandoned = true).ConfigureAwait(false);
             }
             finally
             {
-                // Restore LAN interface
-                if (IsConnected)
+                // Restore the LAN interface — but NOT when the transfer was abandoned. An abandoned
+                // worker is still alive and still owns the transport (that is why the download gate
+                // is not released until it finally unwinds), so sending the restore now would put
+                // SCPI commands onto a link a transfer is still reading, on top of a device that has
+                // already stopped answering. There is nothing to gain: the caller is told to
+                // reconnect or power-cycle, and both re-establish the interface anyway (#399/#401).
+                if (!workerAbandoned && IsConnected)
                 {
                     try
                     {
@@ -2584,6 +2609,11 @@ namespace Daqifi.Core.Device
         /// <param name="budget">The cooperative budget; the hard deadline is <see cref="HardDeadlineFor"/> of it.</param>
         /// <param name="fileName">Used only in the <see cref="TimeoutException"/> message.</param>
         /// <param name="cancellationToken">The caller's token, observed by the race itself and not only by the worker.</param>
+        /// <param name="onWorkerAbandoned">
+        /// Invoked, before this method throws, when the worker is given up on while still running.
+        /// Lets the caller skip any cleanup that would touch the transport the abandoned worker
+        /// still owns.
+        /// </param>
         /// <exception cref="InvalidOperationException">
         /// Thrown when a previous download still owns <see cref="_sdDownloadGate"/> — it is either
         /// genuinely in flight or was abandoned and is still parked on the transport.
@@ -2592,7 +2622,8 @@ namespace Daqifi.Core.Device
             Func<CancellationToken, Task> operation,
             TimeSpan budget,
             string fileName,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            Action? onWorkerAbandoned = null)
         {
             // Checked before taking the gate so a cancelled caller neither acquires it nor gets an
             // answer about some other transfer.
@@ -2672,6 +2703,10 @@ namespace Daqifi.Core.Device
                 // it below honors that result instead of discarding it.
                 if (winner != workerTask && !workerTask.IsCompleted)
                 {
+                    // Tell the caller before unwinding: the worker keeps running and keeps the
+                    // transport, so any cleanup that would write to it has to be skipped.
+                    onWorkerAbandoned?.Invoke();
+
                     // Cancel explicitly instead of relying on the deadline timer having fired: the
                     // delay above and hardDeadlineCts are two separate timers of the same duration,
                     // so the delay can win by a hair and leave a late-returning worker running one

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -202,7 +202,9 @@ namespace Daqifi.Core.Device.SdCard
         /// Thrown when the transfer does not finish within the implementation's download deadline.
         /// The deadline is enforced by the download itself, so it holds even when the transfer is
         /// parked in a call that cannot observe a cancellation token; the in-flight transfer is
-        /// then abandoned rather than awaited (#399).
+        /// then abandoned rather than awaited (#399). An abandoned transfer still owns the
+        /// transport, so the interface it switched is left as-is rather than restored over the top
+        /// of it — reconnect before using the device again.
         /// </exception>
         Task<SdCardDownloadResult> DownloadSdCardFileAsync(
             string fileName,


### PR DESCRIPTION
## Why

The SD card operations turn a switch on the way in and turn it back off on the way out. The DAQiFi hardware shares one SPI bus between the SD card and the network interface, so before Core can talk to the card it has to hand the bus over, and afterwards it has to hand it back.

#406 made the hand-over safe: it now happens while the operation holds the device's text-command lock, so nothing else can run in the middle of it. The hand-back was left where it was — in each method's own cleanup block, which runs *after* the lock has already been let go. So half the pair was protected and half was not, and another command could slip in between an SD operation and its own hand-back, or run while it was happening.

## What

The text exchange gained a matching "finalize" step, so the hand-back now runs under the same lock as the hand-over. The listing, the delete, and the storage-space query all use it. Nothing about the commands sent to the device changes on the normal path.

Two decisions worth stating plainly:

- **If the restore fails while something else has already gone wrong, the original problem is what you see.** The restore failure is written to the log and dropped, because a cleanup failure that hides the real failure leaves you with nothing to diagnose. If the operation itself went fine, a failed restore is the only thing that went wrong, so it is reported normally.
- **A download that was given up on does not get a restore.** When a download blows through its deadline, Core stops waiting for it but the transfer is still running and still holding the connection (#399/#401). Sending it more commands would just add traffic to a device that has already stopped answering, and the caller is told to reconnect anyway — which puts the interface right. Every other outcome still restores as before.

## How

`ExecuteTextCommandAsync` takes an optional finalize step alongside the prepare step added in #406. The exchange wraps the caller's work in a try/finally around it, so the finalize runs whether the work succeeded or blew up, and always before the lock is released. Anything the finalize throws is held until after the lock is released and only then reported, so a bad restore can't also wedge the device — that one bit me while writing this, and there's a test for it.

Subclasses that override `ExecuteTextCommandAsync` have to widen their signature by one parameter, exactly as in #406, and for the same reason: a compile error beats an override that quietly stops seeing SD traffic.

Side effects worth knowing about:

- The storage-space query's bus switch moved into the prepare step to match its siblings, which also removes a blocking sleep from an async path. Same commands, same order.
- On a **retry**, the bus is now handed back and re-taken between attempts instead of staying on the card across the gap. That gap is outside the lock, so leaving the device switched over during it was the same defect in miniature. The device already sees this exact enable/disable pattern between any two back-to-back SD calls, so it is not a new sequence for the firmware — but it is a real change on the retry path, and the retry path is rare enough that the bench cannot exercise it on demand.

## Tests

Full suite green on **net9.0 and net10.0** (2203 passed, 2 skipped each), plus the MCP project (23), build clean with 0 warnings.

New coverage, each checked to fail with its fix disabled:

- the restore runs inside the exchange (proved through the exchange's own re-entrancy guard, so it is deterministic rather than a thread race);
- no competing exchange can run between an operation's commands and its restore (the restore deliberately dawdles, so a competitor would land inside the window);
- the restore still runs when the exchange throws — at the exchange level and end-to-end through `GetSdCardFilesAsync`;
- a failed restore does not replace a failure already unwinding, and does surface when it is the only failure;
- a failed restore still releases the lock (this one hung the run before the fix, which is how I found it);
- the SD operations hand the restore to the exchange rather than doing it themselves — a device that discards the finalize step sees no restore commands at all;
- an abandoned download sends no restore, and a completed one still does.

## Bench

DAQiFi Nyquist 1, firmware 3.7.2, example CLI built against this branch. Nothing destructive — no format, delete, download, flash, reboot or WiFi reconfiguration.

- USB `--sd-list`: 32 files. `--sd-storage`: 7.44 GiB total, parsed fine — that is the query whose prepare step moved.
- USB streaming right after the SD work: 50 Hz, two channels, clean.
- **The real proof — WiFi.** The SD operations disable the LAN interface over USB, so if the restore had not run the device would have dropped off the network. It streamed over `192.168.1.30` immediately afterwards, and a final USB listing returned all 32 files again.

Refs #406, #396, #399. Narrower than #342 by design — this is one asymmetry inside a path that already has a lock, and does not settle whether Core should serialize all mutating operations per device.

closes #407

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)