### PR TITLE
fix(sd): make SD card operations work over the TCP/WiFi transport (closes #327)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
@@ -642,6 +642,19 @@ public class SdCardFileReceiverTests
         Assert.Null(ex.Timeout);
     }
 
+    [Fact]
+    public void Ctor_OriginalTwoParameterSignature_StillExistsForCompiledCallers()
+    {
+        // Optional arguments are compile-time only: adding parameters to the (Stream, int)
+        // constructor would have kept every source caller compiling while leaving already-built
+        // consumers of the Daqifi.Core package calling a CLR signature that no longer exists.
+        // Assert on the metadata, not on a call, because a source-level call would bind happily
+        // to a widened constructor and prove nothing.
+        var ctor = typeof(SdCardFileReceiver).GetConstructor(new[] { typeof(Stream), typeof(int) });
+
+        Assert.NotNull(ctor);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
@@ -650,7 +663,8 @@ public class SdCardFileReceiverTests
         using var sourceStream = new MemoryStream();
 
         Assert.Throws<ArgumentOutOfRangeException>(
-            () => new SdCardFileReceiver(sourceStream, idleTimeout: TimeSpan.FromSeconds(seconds)));
+            () => new SdCardFileReceiver(
+                sourceStream, zeroLengthReadMeansClosed: false, idleTimeout: TimeSpan.FromSeconds(seconds)));
     }
 
     #endregion

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
@@ -511,6 +511,150 @@ public class SdCardFileReceiverTests
 
     #endregion
 
+    #region WiFi/TCP transport (#327)
+
+    [Fact]
+    public async Task ReceiveAsync_TcpSizedChunks_ReceivesTheWholeFile()
+    {
+        // The firmware clamps every SD reply chunk it writes to the TCP buffer at 1024 bytes
+        // (#599), so a WiFi download arrives as a long run of short reads no matter how large the
+        // receive buffer is.
+        var fileData = new byte[50_000];
+        new Random(1327).NextBytes(fileData);
+        using var sourceStream = new ChunkedMemoryStream(Combine(fileData, EofMarker), chunkSize: 1024);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream, zeroLengthReadMeansClosed: true);
+
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "wifi.bin");
+
+        Assert.Equal(fileData.Length, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(7)]
+    [InlineData(13)]
+    [InlineData(14)]
+    public async Task ReceiveAsync_EofMarkerSplitAtAnyOffsetOfATcpChunk_DetectedCorrectly(int bytesOfMarkerInFirstChunk)
+    {
+        // The 1024-byte clamp lands wherever the file's length puts it, so the terminator can be
+        // cut at any offset. Size the file so the chunk boundary falls that many bytes into the
+        // marker, and check the split is invisible to the caller.
+        var fileLength = 1024 - bytesOfMarkerInFirstChunk + 1024;
+        var fileData = new byte[fileLength];
+        new Random(bytesOfMarkerInFirstChunk).NextBytes(fileData);
+
+        using var sourceStream = new ChunkedMemoryStream(Combine(fileData, EofMarker), chunkSize: 1024);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream, zeroLengthReadMeansClosed: true);
+
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "wifi.bin");
+
+        Assert.Equal(fileLength, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_ThrottledTcpDelivery_KeepsGoingWhileChunksArrive()
+    {
+        // The firmware's SD task and the WiFi task that drains the TCP buffer run at different
+        // priorities, so chunks arrive with gaps. The inactivity window must be a per-gap budget
+        // that each chunk resets, not a total the whole transfer has to fit inside.
+        var fileData = Encoding.ASCII.GetBytes(new string('x', 40));
+        using var sourceStream = new ThrottledStream(
+            Combine(fileData, EofMarker), chunkSize: 8, gap: TimeSpan.FromMilliseconds(30));
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(
+            sourceStream, zeroLengthReadMeansClosed: true, idleTimeout: TimeSpan.FromSeconds(2));
+
+        var bytesReceived = await receiver.ReceiveAsync(destinationStream, "wifi.bin");
+
+        Assert.Equal(fileData.Length, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_TransportGoesSilentWithoutReturningZero_StallsOnTheIdleWindow()
+    {
+        // A socket never reports silence: NetworkStream.ReadAsync ignores Socket.ReceiveTimeout, so
+        // a device that stops answering mid-file leaves the read parked. Without the inactivity
+        // window the transfer would sit there for the caller's whole download budget.
+        using var sourceStream = new NeverEndingStream();
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(
+            sourceStream, zeroLengthReadMeansClosed: true, idleTimeout: TimeSpan.FromMilliseconds(200));
+
+        var ex = await Assert.ThrowsAsync<SdCardTransferStalledException>(
+            () => receiver.ReceiveAsync(
+                destinationStream, "wifi.bin", timeout: TimeSpan.FromMinutes(30)));
+
+        Assert.Equal(SdCardTransferStallReason.NoDataReceived, ex.Reason);
+        Assert.Equal(TimeSpan.FromMilliseconds(200), ex.Timeout);
+        Assert.Contains("stopped feeding the transfer", ex.Message);
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_IdleWindowDisabled_LeavesTheOverallDeadlineInCharge()
+    {
+        using var sourceStream = new NeverEndingStream();
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(
+            sourceStream, zeroLengthReadMeansClosed: true, idleTimeout: Timeout.InfiniteTimeSpan);
+
+        var ex = await Assert.ThrowsAsync<SdCardTransferStalledException>(
+            () => receiver.ReceiveAsync(
+                destinationStream, "wifi.bin", timeout: TimeSpan.FromMilliseconds(150)));
+
+        Assert.Equal(SdCardTransferStallReason.TransferTimeout, ex.Reason);
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_ZeroLengthReadOnANetworkTransport_ReportsTransportClosed()
+    {
+        // NetworkStream.CanRead stays true after the peer's FIN, so the stream cannot be asked what
+        // an empty read means — only the caller knows. On a socket it can mean one thing.
+        using var sourceStream = new TokenIgnoringSilentStream();
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream, zeroLengthReadMeansClosed: true);
+
+        var ex = await Assert.ThrowsAsync<SdCardTransferStalledException>(
+            () => receiver.ReceiveAsync(destinationStream, "wifi.bin", timeout: TimeSpan.FromSeconds(5)));
+
+        Assert.Equal(SdCardTransferStallReason.TransportClosed, ex.Reason);
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_ZeroLengthReadOnSerial_StillReportsNoDataReceived()
+    {
+        // Regression guard for the USB path: there an empty read is the ordinary per-read timeout
+        // on a quiet device, and calling that a closed transport would tell callers not to retry
+        // something that is entirely retryable (#398 gap 1).
+        using var sourceStream = new TokenIgnoringSilentStream();
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream, zeroLengthReadMeansClosed: false);
+
+        var ex = await Assert.ThrowsAsync<SdCardTransferStalledException>(
+            () => receiver.ReceiveAsync(destinationStream, "usb.bin", timeout: TimeSpan.FromSeconds(5)));
+
+        Assert.Equal(SdCardTransferStallReason.NoDataReceived, ex.Reason);
+        Assert.Null(ex.Timeout);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Ctor_NonPositiveIdleTimeout_Throws(int seconds)
+    {
+        using var sourceStream = new MemoryStream();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new SdCardFileReceiver(sourceStream, idleTimeout: TimeSpan.FromSeconds(seconds)));
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static byte[] Combine(params byte[][] arrays)
@@ -658,6 +802,60 @@ public class SdCardFileReceiverTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(Read(buffer, offset, count));
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A stream that hands out small chunks with a pause between them and never returns an empty
+    /// read, the way a socket delivers a throttled SD reply.
+    /// </summary>
+    private sealed class ThrottledStream : Stream
+    {
+        private readonly byte[] _data;
+        private readonly int _chunkSize;
+        private readonly TimeSpan _gap;
+        private int _position;
+
+        public ThrottledStream(byte[] data, int chunkSize, TimeSpan gap)
+        {
+            _data = data;
+            _chunkSize = chunkSize;
+            _gap = gap;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _data.Length;
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => ReadAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(_gap, cancellationToken);
+
+            var available = _data.Length - _position;
+            if (available <= 0)
+            {
+                // Past the payload the device simply says nothing more, as a socket would.
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            var toRead = Math.Min(Math.Min(count, _chunkSize), available);
+            Array.Copy(_data, _position, buffer, offset, toRead);
+            _position += toRead;
+            return toRead;
         }
 
         public override void Flush() { }

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -653,6 +654,55 @@ public class SdCardFileReceiverTests
         var ctor = typeof(SdCardFileReceiver).GetConstructor(new[] { typeof(Stream), typeof(int) });
 
         Assert.NotNull(ctor);
+    }
+
+    [Fact]
+    public async Task Ctor_OriginalSignature_LeavesTheCallersDeadlineInCharge()
+    {
+        // Restoring the CLR signature is only half of what an old caller is owed. The other half is
+        // that it still DOES what it did: before the inactivity window existed, a transport that
+        // went quiet without returning zero bytes ran until the caller's own deadline. Delegating
+        // with the new default would have switched on a 20-second window nobody asked for and
+        // started abandoning those transfers — a silent change, and precisely to the callers this
+        // overload exists to protect.
+        using var sourceStream = new NeverEndingStream();
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        var ex = await Assert.ThrowsAsync<SdCardTransferStalledException>(
+            () => receiver.ReceiveAsync(
+                destinationStream, "legacy.bin", timeout: TimeSpan.FromMilliseconds(400)));
+
+        // The caller's deadline ended it, not an idle window: an active window shorter than 400 ms
+        // would report NoDataReceived and its own duration instead.
+        Assert.Equal(SdCardTransferStallReason.TransferTimeout, ex.Reason);
+        Assert.Equal(TimeSpan.FromMilliseconds(400), ex.Timeout);
+    }
+
+    [Fact]
+    public void Ctor_OriginalSignature_LeavesTheInactivityWindowOff()
+    {
+        // The behavioral test above can only rule out a window shorter than its own deadline, and
+        // the default is 20 seconds — too long to wait out in a unit test. So assert the state
+        // directly, the same way the signature test asserts on metadata: a null window is "off",
+        // and this fails for ANY window, not just a short one.
+        using var stream = new MemoryStream();
+
+        Assert.Null(IdleTimeoutOf(new SdCardFileReceiver(stream)));
+
+        // Control: the opt-in overload does get the default, so this is pinning the difference
+        // between the two constructors rather than asserting the feature is simply never on.
+        Assert.Equal(
+            SdCardFileReceiver.DefaultIdleTimeout,
+            IdleTimeoutOf(new SdCardFileReceiver(stream, zeroLengthReadMeansClosed: true)));
+    }
+
+    private static TimeSpan? IdleTimeoutOf(SdCardFileReceiver receiver)
+    {
+        var field = typeof(SdCardFileReceiver).GetField(
+            "_idleTimeout", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return (TimeSpan?)field!.GetValue(receiver);
     }
 
     [Theory]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -1801,6 +1801,62 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.DoesNotContain("SYSTem:STORage:SD:SPACe?", device.SentMessages.Select(m => m.Data));
         }
 
+        [Fact]
+        public async Task DownloadSdCardFileAsync_OverWifi_ChunkedAndThrottledDelivery_ReceivesTheWholeFile()
+        {
+            // The end-to-end shape of a WiFi download: the firmware clamps every chunk it writes to
+            // the TCP buffer at 1024 bytes (#599) and the chunks arrive with gaps, so the terminator
+            // lands split across reads and the file is reassembled from a long run of short ones.
+            var fileData = new byte[5_000];
+            new Random(599).NextBytes(fileData);
+
+            var device = new ChunkedWifiDownloadDevice("TestDevice", fileData, chunkSize: 1024);
+            device.Metadata.FirmwareVersion = "3.7.2";
+            device.Connect();
+            using var destination = new MemoryStream();
+
+            var result = await device.DownloadSdCardFileAsync("wifi.bin", destination);
+
+            Assert.Equal(fileData.Length, result.FileSize);
+            Assert.Equal(fileData, destination.ToArray());
+        }
+
+        [Fact]
+        public async Task DownloadSdCardFileAsync_OverWifi_DeviceGoesSilent_StallsOnTheIdleWindow()
+        {
+            // A socket never surfaces silence of its own accord, so before the inactivity window
+            // this sat on the read until the 30-minute download budget expired. It has to give up
+            // in the window instead — and say the device stopped feeding it, not that time ran out.
+            var device = new SilentWifiDownloadDevice("TestDevice")
+            {
+                IdleTimeoutOverride = TimeSpan.FromMilliseconds(200)
+            };
+            device.Metadata.FirmwareVersion = "3.7.2";
+            device.Connect();
+            using var destination = new MemoryStream();
+
+            var ex = await Assert.ThrowsAsync<SdCardTransferStalledException>(
+                () => device.DownloadSdCardFileAsync("wifi.bin", destination));
+
+            Assert.Equal(SdCardTransferStallReason.NoDataReceived, ex.Reason);
+            Assert.Equal(TimeSpan.FromMilliseconds(200), ex.Timeout);
+        }
+
+        [Fact]
+        public async Task StopSdCardLoggingAsync_OverWifi_DoesNotReEnableLan()
+        {
+            // LAN:ENAbled 1 re-initializes the WiFi module, which would drop the very connection
+            // this command arrived on. Nothing disabled the LAN over WiFi in the first place, so
+            // there is nothing to restore — the mirror of PrepareLanInterface's transport check.
+            var device = new TestableNonUsbSdCardStreamingDevice("TestDevice");
+            device.Connect();
+
+            await device.StopSdCardLoggingAsync();
+
+            var sentCommands = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Equal(new[] { "SYSTem:StopStreamData", "SYSTem:STORage:SD:ENAble 0" }, sentCommands);
+        }
+
         #endregion
 
         [Theory]
@@ -3260,6 +3316,98 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
                 using var fakeStream = new MemoryStream(data);
                 await rawAction(fakeStream, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// A WiFi/TCP device whose SD reply arrives the way the firmware actually writes it: in
+        /// chunks no larger than the TCP clamp (#599), with a pause between them, and with no
+        /// zero-length read to mark the end — a socket that has run out of data simply waits.
+        /// </summary>
+        private sealed class ChunkedWifiDownloadDevice : DaqifiStreamingDevice
+        {
+            private readonly byte[] _fileData;
+            private readonly int _chunkSize;
+
+            public ChunkedWifiDownloadDevice(string name, byte[] fileData, int chunkSize)
+                : base(name)
+            {
+                _fileData = fileData;
+                _chunkSize = chunkSize;
+            }
+
+            public override bool IsUsbConnection => false;
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+            }
+
+            protected override async Task ExecuteRawCaptureAsync(
+                Func<Stream, CancellationToken, Task> rawAction,
+                CancellationToken cancellationToken = default)
+            {
+                using var fakeStream = new SlowChunkStream(_fileData, _chunkSize, TimeSpan.FromMilliseconds(1));
+                await rawAction(fakeStream, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// A WiFi/TCP device that acknowledges the GET and then never sends anything, and — like a
+        /// socket — never returns an empty read to say so.
+        /// </summary>
+        private sealed class SilentWifiDownloadDevice : DaqifiStreamingDevice
+        {
+            public SilentWifiDownloadDevice(string name)
+                : base(name)
+            {
+            }
+
+            public TimeSpan IdleTimeoutOverride { get; init; } = TimeSpan.FromMilliseconds(200);
+
+            public override bool IsUsbConnection => false;
+
+            internal override TimeSpan SdCardTransferIdleTimeout => IdleTimeoutOverride;
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+            }
+
+            protected override async Task ExecuteRawCaptureAsync(
+                Func<Stream, CancellationToken, Task> rawAction,
+                CancellationToken cancellationToken = default)
+            {
+                using var fakeStream = new SilentStream();
+                await rawAction(fakeStream, cancellationToken);
+            }
+
+            private sealed class SilentStream : Stream
+            {
+                public override bool CanRead => true;
+                public override bool CanSeek => false;
+                public override bool CanWrite => false;
+                public override long Length => throw new NotSupportedException();
+                public override long Position
+                {
+                    get => throw new NotSupportedException();
+                    set => throw new NotSupportedException();
+                }
+
+                public override int Read(byte[] buffer, int offset, int count)
+                {
+                    Thread.Sleep(Timeout.Infinite);
+                    return 0;
+                }
+
+                public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                {
+                    await Task.Delay(Timeout.Infinite, cancellationToken);
+                    return 0;
+                }
+
+                public override void Flush() { }
+                public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+                public override void SetLength(long value) => throw new NotSupportedException();
+                public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
             }
         }
     }

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -216,7 +216,9 @@ namespace Daqifi.Core.Device
 
         /// <summary>
         /// Gets a value indicating whether the device is connected over USB (serial transport).
-        /// SD card file downloads require a USB connection because the SD card and WiFi/LAN share the SPI bus.
+        /// The SD card and the WiFi/LAN module share one SPI bus, so this decides how every SD
+        /// operation prepares that bus, what a silent transport means to a file transfer, and
+        /// whether SD logging can be started at all.
         /// </summary>
         public virtual bool IsUsbConnection => Transport is SerialStreamTransport;
 
@@ -2520,8 +2522,11 @@ namespace Daqifi.Core.Device
             if (!IsUsbConnection)
             {
                 throw new InvalidOperationException(
-                    "SD card logging requires a USB/serial connection. " +
-                    "The SD card and WiFi/LAN share the SPI bus, so SD operations cannot be performed over a network connection.");
+                    "SD card logging requires a USB/serial connection. Starting a logging session " +
+                    "disables the LAN interface to give the SD card the shared SPI bus, which over " +
+                    "a network connection would drop the very link the command arrived on. " +
+                    "Listing, downloading and deleting SD files do work over WiFi on firmware " +
+                    "v3.7.0 and later.");
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -2600,11 +2605,18 @@ namespace Daqifi.Core.Device
             if (IsUsbConnection)
             {
                 Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.Usb));
-            }
 
-            // Re-enable LAN interface. StartSdCardLoggingAsync disables LAN because
-            // the SD card and WiFi/LAN share the SPI bus on the hardware.
-            Send(ScpiMessageProducer.EnableNetworkLan);
+                // Re-enable LAN interface. StartSdCardLoggingAsync disables LAN because
+                // the SD card and WiFi/LAN share the SPI bus on the hardware.
+                //
+                // Only over USB, and for the same reason PrepareLanInterface() is transport-aware:
+                // over WiFi/TCP the LAN was never disabled (nothing can disable it from the other
+                // end of the connection it carries), and LAN:ENAbled 1 re-initializes the WiFi
+                // module — which would drop the very link this command arrived on. A session that
+                // logged over USB, disconnected, and came back over WiFi could otherwise call this
+                // and cut itself off (#327).
+                Send(ScpiMessageProducer.EnableNetworkLan);
+            }
 
             _isLoggingToSdCard = false;
 
@@ -2728,7 +2740,7 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
-        /// Downloads a file from the device's SD card over USB.
+        /// Downloads a file from the device's SD card, over USB or over WiFi/TCP.
         /// </summary>
         /// <param name="fileName">The name of the file to download.</param>
         /// <param name="destinationStream">The stream to write file contents to.</param>
@@ -2745,7 +2757,9 @@ namespace Daqifi.Core.Device
         /// listing reports as 0 bytes downloads successfully as a legitimate empty file.
         /// </exception>
         /// <exception cref="SdCardTransferStalledException">
-        /// Thrown when the transfer stops making progress before the end-of-file marker arrives.
+        /// Thrown when the transfer stops making progress before the end-of-file marker arrives:
+        /// the transport returned an empty read, closed, or — the only signal a socket gives —
+        /// went quiet for longer than <see cref="SdCardTransferIdleTimeout"/>.
         /// </exception>
         /// <exception cref="TimeoutException">
         /// Thrown when the download does not finish within <see cref="SdCardDownloadTimeout"/>.
@@ -2828,11 +2842,14 @@ namespace Daqifi.Core.Device
                 {
                     await ExecuteRawCaptureAsync(async (stream, ct) =>
                     {
-                        // Prepare SD card interface
+                        // Prepare SD card interface. Transport-aware: over USB it hands the shared
+                        // SPI bus to the card, over WiFi/TCP it leaves the LAN up because the reply
+                        // comes back over that very connection (#598/#599).
                         PrepareSdInterface();
 
-                        // Small delay to let the interface switch settle
-                        await Task.Delay(50, ct).ConfigureAwait(false);
+                        // Let the interface switch settle before the card is asked for anything —
+                        // the same wait the LIST/DELETE/space exchanges take for the same reason.
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, ct).ConfigureAwait(false);
 
                         // Send the SCPI command to request the file
                         Send(ScpiMessageProducer.GetSdFile(fileName));
@@ -2844,7 +2861,17 @@ namespace Daqifi.Core.Device
                         // bounded number of times before giving up (see #264). Passing the listed
                         // size keeps that retry off a genuinely 0-byte file, which is a legitimate
                         // empty download rather than a wedged subsystem (#398 gap 2).
-                        var receiver = new SdCardFileReceiver(stream);
+                        // The receiver is told what its transport's silence means. Over USB serial a
+                        // zero-length read is the per-read ReadTimeout firing on a device that is
+                        // merely quiet; over TCP it is the peer's FIN and nothing else, and the
+                        // socket keeps reporting itself readable either way. Over TCP the socket
+                        // also never surfaces silence at all — ReadAsync ignores the receive
+                        // timeout — so the inactivity window is the only thing standing between a
+                        // device that stopped answering and the full 30-minute budget (#327).
+                        var receiver = new SdCardFileReceiver(
+                            stream,
+                            zeroLengthReadMeansClosed: !IsUsbConnection,
+                            idleTimeout: SdCardTransferIdleTimeout);
                         var listedFileSizeBytes = TryGetListedFileSize(fileName);
                         long bytesReceived;
                         var attempt = 0;
@@ -2944,7 +2971,7 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
-        /// Downloads a file from the device's SD card over USB to a temporary file.
+        /// Downloads a file from the device's SD card, over USB or over WiFi/TCP, to a temporary file.
         /// </summary>
         /// <param name="fileName">The name of the file to download.</param>
         /// <param name="progress">Optional progress reporting.</param>
@@ -2992,6 +3019,14 @@ namespace Daqifi.Core.Device
         /// </summary>
         /// <remarks>Virtual only as a test seam — a 30-minute budget is not unit-testable.</remarks>
         internal virtual TimeSpan SdCardDownloadTimeout => TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// How long a download may go without receiving a single byte before it is declared
+        /// stalled. Bounds a WiFi/TCP transfer whose device stopped answering, which the socket
+        /// itself never reports (see <see cref="SdCardFileReceiver.DefaultIdleTimeout"/>).
+        /// </summary>
+        /// <remarks>Virtual only as a test seam — a 20-second window is not unit-testable.</remarks>
+        internal virtual TimeSpan SdCardTransferIdleTimeout => SdCardFileReceiver.DefaultIdleTimeout;
 
         /// <summary>
         /// The part of <paramref name="budget"/> not yet consumed, floored at zero (a negative

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -178,7 +178,7 @@ namespace Daqifi.Core.Device.SdCard
         Task FormatSdCardAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Downloads a file from the device's SD card over USB.
+        /// Downloads a file from the device's SD card, over USB or over WiFi/TCP.
         /// </summary>
         /// <param name="fileName">The name of the file to download.</param>
         /// <param name="destinationStream">The stream to write file contents to.</param>
@@ -213,7 +213,7 @@ namespace Daqifi.Core.Device.SdCard
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Downloads a file from the device's SD card over USB to a temporary file.
+        /// Downloads a file from the device's SD card, over USB or over WiFi/TCP, to a temporary file.
         /// </summary>
         /// <param name="fileName">The name of the file to download.</param>
         /// <param name="progress">Optional progress reporting.</param>

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
@@ -43,10 +43,36 @@ public sealed class SdCardFileReceiver
     private readonly TimeSpan? _idleTimeout;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SdCardFileReceiver"/> class.
+    /// Default read buffer size, in bytes.
+    /// </summary>
+    private const int DefaultBufferSize = 16384;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SdCardFileReceiver"/> class for a transport
+    /// that reports silence with a zero-length read — USB serial, where the port's own read
+    /// timeout provides that signal.
     /// </summary>
     /// <param name="sourceStream">The transport stream to read raw bytes from.</param>
     /// <param name="bufferSize">Read buffer size in bytes. Defaults to 16384 (16 KB).</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="bufferSize"/> is not positive.
+    /// </exception>
+    /// <remarks>
+    /// Kept with its original signature rather than folded into the overload below as optional
+    /// parameters: optional arguments are a compile-time convenience, so adding parameters here
+    /// would change the CLR signature and leave already-compiled consumers of the
+    /// <c>Daqifi.Core</c> package calling a constructor that no longer exists.
+    /// </remarks>
+    public SdCardFileReceiver(Stream sourceStream, int bufferSize = DefaultBufferSize)
+        : this(sourceStream, zeroLengthReadMeansClosed: false, idleTimeout: null, bufferSize: bufferSize)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SdCardFileReceiver"/> class, stating what the
+    /// transport's silence means.
+    /// </summary>
+    /// <param name="sourceStream">The transport stream to read raw bytes from.</param>
     /// <param name="zeroLengthReadMeansClosed">
     /// Whether a zero-length read means the peer closed the connection. True for a stream-oriented
     /// network transport, where that is the only thing zero bytes can mean; false for USB serial,
@@ -60,6 +86,7 @@ public sealed class SdCardFileReceiver
     /// to <see cref="DefaultIdleTimeout"/>; pass <see cref="Timeout.InfiniteTimeSpan"/>
     /// to disable the window and rely solely on the overall transfer deadline.
     /// </param>
+    /// <param name="bufferSize">Read buffer size in bytes. Defaults to 16384 (16 KB).</param>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="bufferSize"/> is not positive, or when
     /// <paramref name="idleTimeout"/> is neither positive nor
@@ -67,9 +94,9 @@ public sealed class SdCardFileReceiver
     /// </exception>
     public SdCardFileReceiver(
         Stream sourceStream,
-        int bufferSize = 16384,
-        bool zeroLengthReadMeansClosed = false,
-        TimeSpan? idleTimeout = null)
+        bool zeroLengthReadMeansClosed,
+        TimeSpan? idleTimeout = null,
+        int bufferSize = DefaultBufferSize)
     {
         _sourceStream = sourceStream ?? throw new ArgumentNullException(nameof(sourceStream));
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
@@ -48,9 +48,10 @@ public sealed class SdCardFileReceiver
     private const int DefaultBufferSize = 16384;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SdCardFileReceiver"/> class for a transport
-    /// that reports silence with a zero-length read — USB serial, where the port's own read
-    /// timeout provides that signal.
+    /// Initializes a new instance of the <see cref="SdCardFileReceiver"/> class with the behavior
+    /// it had before the inactivity window existed: silence is reported by a zero-length read (USB
+    /// serial, where the port's own read timeout provides that signal), and the only thing that
+    /// ends a quiet transfer is the caller's own deadline or cancellation.
     /// </summary>
     /// <param name="sourceStream">The transport stream to read raw bytes from.</param>
     /// <param name="bufferSize">Read buffer size in bytes. Defaults to 16384 (16 KB).</param>
@@ -58,13 +59,25 @@ public sealed class SdCardFileReceiver
     /// Thrown when <paramref name="bufferSize"/> is not positive.
     /// </exception>
     /// <remarks>
-    /// Kept with its original signature rather than folded into the overload below as optional
-    /// parameters: optional arguments are a compile-time convenience, so adding parameters here
-    /// would change the CLR signature and leave already-compiled consumers of the
-    /// <c>Daqifi.Core</c> package calling a constructor that no longer exists.
+    /// This overload exists for consumers compiled against an earlier <c>Daqifi.Core</c>, so it
+    /// preserves what they were compiled against on <b>both</b> axes. Keeping the signature is the
+    /// obvious half: optional arguments are a compile-time convenience, so adding parameters to it
+    /// would change the CLR signature and leave those consumers calling a constructor that no
+    /// longer exists. Keeping the semantics is the half that is easy to lose — delegating with the
+    /// new default would switch on a 20-second inactivity window that no such caller ever asked
+    /// for, and any transport that can go quiet without returning zero bytes would start being
+    /// abandoned mid-transfer. A silent behavior change is worse than the loud binary break this
+    /// overload exists to prevent, so the window is explicitly off here.
+    /// <para>
+    /// Use the overload below to opt into it.
+    /// </para>
     /// </remarks>
     public SdCardFileReceiver(Stream sourceStream, int bufferSize = DefaultBufferSize)
-        : this(sourceStream, zeroLengthReadMeansClosed: false, idleTimeout: null, bufferSize: bufferSize)
+        : this(
+            sourceStream,
+            zeroLengthReadMeansClosed: false,
+            idleTimeout: Timeout.InfiniteTimeSpan,
+            bufferSize: bufferSize)
     {
     }
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
@@ -19,15 +19,57 @@ public sealed class SdCardFileReceiver
     internal static readonly byte[] EndOfFileMarker =
         Encoding.ASCII.GetBytes("__END_OF_FILE__");
 
+    /// <summary>
+    /// How long the transfer may go without receiving a single byte before it is declared stalled,
+    /// when the caller does not specify a window of its own.
+    /// </summary>
+    /// <remarks>
+    /// Only a network transport actually needs this. On USB serial the port has a per-read
+    /// <c>ReadTimeout</c> and <c>SerialStream.ReadAsync</c> returns 0 bytes when it elapses, so
+    /// silence is noticed within half a second by the zero-length-read path below. A socket has no
+    /// equivalent: <c>NetworkStream.ReadAsync</c> ignores <c>Socket.ReceiveTimeout</c> and simply
+    /// waits, so without this window a device that stopped answering mid-file would keep the
+    /// transfer parked until the caller's whole (30-minute) download budget expired.
+    /// <para>
+    /// The value is well clear of the longest legitimate gap the firmware can produce: its SD
+    /// reply writer retries a full TCP buffer for up to ten seconds before it gives up on a chunk.
+    /// </para>
+    /// </remarks>
+    internal static readonly TimeSpan DefaultIdleTimeout = TimeSpan.FromSeconds(20);
+
     private readonly Stream _sourceStream;
     private readonly int _bufferSize;
+    private readonly bool _zeroLengthReadMeansClosed;
+    private readonly TimeSpan? _idleTimeout;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SdCardFileReceiver"/> class.
     /// </summary>
     /// <param name="sourceStream">The transport stream to read raw bytes from.</param>
     /// <param name="bufferSize">Read buffer size in bytes. Defaults to 16384 (16 KB).</param>
-    public SdCardFileReceiver(Stream sourceStream, int bufferSize = 16384)
+    /// <param name="zeroLengthReadMeansClosed">
+    /// Whether a zero-length read means the peer closed the connection. True for a stream-oriented
+    /// network transport, where that is the only thing zero bytes can mean; false for USB serial,
+    /// where it is the ordinary per-read-timeout signal from a device that is merely quiet. It
+    /// selects between <see cref="SdCardTransferStallReason.TransportClosed"/> and
+    /// <see cref="SdCardTransferStallReason.NoDataReceived"/> — the stream itself cannot tell them
+    /// apart, because <c>NetworkStream.CanRead</c> stays true after the peer's FIN.
+    /// </param>
+    /// <param name="idleTimeout">
+    /// How long to wait without receiving a byte before declaring the transfer stalled. Defaults
+    /// to <see cref="DefaultIdleTimeout"/>; pass <see cref="Timeout.InfiniteTimeSpan"/>
+    /// to disable the window and rely solely on the overall transfer deadline.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="bufferSize"/> is not positive, or when
+    /// <paramref name="idleTimeout"/> is neither positive nor
+    /// <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    public SdCardFileReceiver(
+        Stream sourceStream,
+        int bufferSize = 16384,
+        bool zeroLengthReadMeansClosed = false,
+        TimeSpan? idleTimeout = null)
     {
         _sourceStream = sourceStream ?? throw new ArgumentNullException(nameof(sourceStream));
 
@@ -36,7 +78,20 @@ public sealed class SdCardFileReceiver
             throw new ArgumentOutOfRangeException(nameof(bufferSize), "Buffer size must be greater than zero.");
         }
 
+        var effectiveIdleTimeout = idleTimeout ?? DefaultIdleTimeout;
+        if (effectiveIdleTimeout != Timeout.InfiniteTimeSpan && effectiveIdleTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(idleTimeout),
+                effectiveIdleTimeout,
+                "Idle timeout must be positive, or Timeout.InfiniteTimeSpan to disable it.");
+        }
+
         _bufferSize = bufferSize;
+        _zeroLengthReadMeansClosed = zeroLengthReadMeansClosed;
+        _idleTimeout = effectiveIdleTimeout == Timeout.InfiniteTimeSpan
+            ? null
+            : effectiveIdleTimeout;
     }
 
     /// <summary>
@@ -120,9 +175,19 @@ public sealed class SdCardFileReceiver
             while (true)
             {
                 int bytesRead;
+
+                // One inactivity window per read. Allocated per iteration rather than reset in
+                // place because a CancellationTokenSource cannot be un-cancelled: reusing one
+                // would turn a byte that arrived at the exact instant the window closed into a
+                // permanently dead token for every read after it.
+                using var idleCts = _idleTimeout is null
+                    ? null
+                    : CancellationTokenSource.CreateLinkedTokenSource(token);
+                idleCts?.CancelAfter(_idleTimeout!.Value);
+
                 try
                 {
-                    bytesRead = await _sourceStream.ReadAsync(buffer, 0, buffer.Length, token)
+                    bytesRead = await _sourceStream.ReadAsync(buffer, 0, buffer.Length, idleCts?.Token ?? token)
                         .ConfigureAwait(false);
                 }
                 catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
@@ -132,6 +197,19 @@ public sealed class SdCardFileReceiver
                         totalBytesReceived,
                         SdCardTransferStallReason.TransferTimeout,
                         effectiveTimeout,
+                        ex);
+                }
+                catch (OperationCanceledException ex) when (idleCts is { IsCancellationRequested: true } && !token.IsCancellationRequested)
+                {
+                    // Nothing arrived for the whole window while neither the caller nor the overall
+                    // deadline had anything to say — the device stopped feeding the transfer. This
+                    // is the only stall signal a socket gives (see DefaultIdleTimeout); on serial
+                    // the zero-length-read path below gets there first and this never fires.
+                    throw new SdCardTransferStalledException(
+                        fileName,
+                        totalBytesReceived,
+                        SdCardTransferStallReason.NoDataReceived,
+                        _idleTimeout,
                         ex);
                 }
 
@@ -145,15 +223,17 @@ public sealed class SdCardFileReceiver
 
                 if (bytesRead == 0)
                 {
-                    // A zero-byte read is NOT proof the stream closed. Over USB serial — the
-                    // transport SD download runs on — Core sets a per-read SerialPort.ReadTimeout
-                    // and .NET's SerialStream.ReadAsync returns 0 on that timeout instead of
-                    // throwing, so zero bytes is the ORDINARY stall signal there. Only an
-                    // unreadable stream is genuinely closed; report the two distinctly so a
-                    // caller can retry a stall and give up on a closed transport (#398 gap 1).
-                    var reason = _sourceStream.CanRead
-                        ? SdCardTransferStallReason.NoDataReceived
-                        : SdCardTransferStallReason.TransportClosed;
+                    // A zero-byte read is NOT proof the stream closed on every transport. Over USB
+                    // serial Core sets a per-read SerialPort.ReadTimeout and .NET's
+                    // SerialStream.ReadAsync returns 0 on that timeout instead of throwing, so zero
+                    // bytes is the ORDINARY stall signal there (#398 gap 1). On a socket it is the
+                    // opposite: zero bytes is the peer's FIN and nothing else, and the stream will
+                    // not admit it — NetworkStream.CanRead stays true until the stream is disposed,
+                    // so the CanRead probe alone would report a closed connection as merely quiet.
+                    // The caller, which knows its transport, settles it (#327).
+                    var reason = _zeroLengthReadMeansClosed || !_sourceStream.CanRead
+                        ? SdCardTransferStallReason.TransportClosed
+                        : SdCardTransferStallReason.NoDataReceived;
 
                     throw new SdCardTransferStalledException(fileName, totalBytesReceived, reason);
                 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardTransferStalledException.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTransferStalledException.cs
@@ -30,9 +30,11 @@ namespace Daqifi.Core.Device.SdCard
         public SdCardTransferStallReason Reason { get; }
 
         /// <summary>
-        /// Gets the overall transfer deadline that elapsed, when
-        /// <see cref="Reason"/> is <see cref="SdCardTransferStallReason.TransferTimeout"/>;
-        /// otherwise <c>null</c>.
+        /// Gets the window that elapsed without progress: the overall transfer deadline when
+        /// <see cref="Reason"/> is <see cref="SdCardTransferStallReason.TransferTimeout"/>, or the
+        /// inactivity window when <see cref="Reason"/> is
+        /// <see cref="SdCardTransferStallReason.NoDataReceived"/> because the transport simply went
+        /// silent rather than returning an empty read. <c>null</c> otherwise.
         /// </summary>
         public TimeSpan? Timeout { get; }
 
@@ -43,8 +45,10 @@ namespace Daqifi.Core.Device.SdCard
         /// <param name="bytesReceived">File bytes received before the stall.</param>
         /// <param name="reason">Why the transfer stalled.</param>
         /// <param name="timeout">
-        /// The elapsed transfer deadline, for
-        /// <see cref="SdCardTransferStallReason.TransferTimeout"/>.
+        /// The window that elapsed without progress — the transfer deadline for
+        /// <see cref="SdCardTransferStallReason.TransferTimeout"/>, or the inactivity window for a
+        /// <see cref="SdCardTransferStallReason.NoDataReceived"/> stall on a transport that goes
+        /// silent instead of returning an empty read.
         /// </param>
         /// <param name="innerException">Optional inner exception.</param>
         public SdCardTransferStalledException(
@@ -88,6 +92,15 @@ namespace Daqifi.Core.Device.SdCard
                         "the EOF marker. {2}",
                         fileName,
                         (timeout ?? TimeSpan.Zero).TotalSeconds,
+                        received),
+                _ when timeout.HasValue =>
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "No data arrived for SD card file '{0}' for {1:F0} seconds, so the transfer "
+                        + "was abandoned before the EOF marker. {2} The device stopped feeding the "
+                        + "transfer; retry the download.",
+                        fileName,
+                        timeout.Value.TotalSeconds,
                         received),
                 _ =>
                     $"No data arrived for SD card file '{fileName}' before the EOF marker. {received} " +


### PR DESCRIPTION
## Why

The firmware has served SD card listings and file reads over WiFi since v3.7.0, and desktop apps want to offer SD offload without asking people to plug in a USB cable. Issue #327 asked us to confirm Core can do that.

Most of it already could. The interface prep and the firmware-version gate were made transport-aware in earlier work. What was left was the part nobody had run over a network: the file transfer itself, which was written against a serial port and quietly assumed one.

## What

Three things a socket does differently from a serial port, each of which the download got wrong:

**A stalled transfer used to hang for half an hour.** A serial port has a per-read timeout, so if the device goes quiet the read comes back empty within half a second and we notice. A socket has nothing like that — `NetworkStream.ReadAsync` ignores the receive timeout and just waits. So a device that stopped part-way through a file left the download parked until the caller's whole 30-minute budget ran out. The receiver now watches for inactivity and gives up after 20 seconds with a message that says what happened and how many bytes made it.

**A closed connection was reported as "the device is just quiet".** The old code asked the stream whether it was still readable and inferred the rest. A socket keeps reporting itself readable after the other end hangs up, so a dropped connection looked retryable when it wasn't. The download now tells the receiver which transport it is on, because that is the only place the answer exists.

**Stopping an SD logging session cut the WiFi link.** It re-enabled the LAN interface unconditionally, which restarts the WiFi module. Over USB that is correct and necessary; over WiFi it drops the very connection the command arrived on. It is now USB-only, matching what the interface-restore helper already did.

Plus some tidying found along the way: the download's settle wait now uses the same constant as the other SD operations instead of its own shorter one, and the docs and the logging-start error no longer claim SD operations are impossible over a network.

Nothing public was removed and no existing signature changed. `SdCardFileReceiver` keeps its original `(Stream, int)` constructor untouched — it now delegates to a new overload that carries the transport semantics. That distinction matters because Core ships as a NuGet package: adding optional parameters to the existing constructor would have kept every source caller compiling while breaking already-built consumers at runtime. A reflection test pins the old signature, mutation-verified to fail if it is ever widened.

## How it was checked

16 new unit tests cover the network cases: 1024-byte chunked delivery, the end-of-file terminator split at every offset of a chunk boundary, throttled delivery, the inactivity window, the zero-length-read classification on both transports, and a full download over a simulated WiFi device. Full suite green — 2,354 tests on net9.0 and net10.0.

### Bench: Nyquist 1, firmware 3.7.2

**Over USB — everything works, byte for byte.**

| | result |
|---|---|
| LIST | 33 files with sizes and dates |
| Storage query | free 7,799,930,880 / total 7,800,356,864 |
| Download | 2,551 bytes, exactly the listed size, `sha256[0:16]=9DD0AE41B7FCF5C4`, 0.63 s |
| Content | parsed to 232 log entries; end-of-file marker correctly stripped |
| DELETE | file gone, confirmed by re-listing |

**Over WiFi (192.168.1.30) — the transport works; this firmware build does not finish the job.**

- Storage query returns exactly the same numbers as USB, so SCPI reaches the card and the shared SPI bus is arbitrated correctly with the LAN up.
- LIST works but comes back short: 16 entries where USB sees 33.
- Download **starts** — 51 real file bytes arrive over TCP, so the firmware's reply routing is doing its job — and then the device stops feeding it. Reproduced exactly, twice, including after a reboot with a fresh buffer pool.
- DELETE returned without error but the file was still there when checked over USB afterwards.

The truncation and the starved transfer are both the known firmware limitation on 3.7.2: the TCP write buffer can shrink to ~1400 B after a streaming session re-partitions the pool, and the SD reply writer gives up on a chunk rather than reporting it. Both are fixed on the firmware main branch after this release (#748 bounds the drains by the runtime buffer size, #750 makes the reply timeout terminal). They are not something Core can paper over.

**What this PR does change about that experience:** before, the starved WiFi download was a 30-minute freeze with nothing to show for it. Now it is a 20-second, clearly worded failure that reports the 51 bytes it did receive. That is what makes the firmware problem visible instead of looking like a hung app.

### Answering the issue's fourth question

Sequencing while a WiFi stream is or was active is already correct and needs no `SYSTem:STReam:INTerface` handling. The firmware picks where an SD reply goes from the interface the command arrived on (`wifi_tcp_server_ContextIsTcp`), not from the stream-interface setting, so the two are independent. All four SD operations already stop streaming first. The end-of-listing probe is also safe over TCP: SCPI replies and SD replies go into the same TCP buffer, and the listing command blocks until the listing has been handed over, so the terminator cannot overtake it.

## Deliberately left out

- **SD logging over WiFi** still refuses. Starting a session disables the LAN to give the card the bus, which cannot work from the other end of a network connection. Only the stop path needed fixing.
- **`FormatSdCardAsync`** has no transport gate. It is destructive and untestable on the bench, and it does not prepare the SD interface on either transport today — worth its own look.
- **The first SD command of every WiFi session answers "No SD Card Detected"**, then the next command a second later reads the card fine. I tried making the listing retry it and the bench showed it did not help, so that change was dropped rather than shipped unverified. Worth filing against the firmware; the mount clearly loses a race to the shared bus when the LAN stays up.
- **The stream interface is never normalized over WiFi** (device init returns early for non-USB). Unrelated to SD reply routing, so out of scope here.

