### PR TITLE
fix(transport): name serial connect failures instead of calling them all access denials (closes #424)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialPortConnectExceptionTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialPortConnectExceptionTests.cs
@@ -1,0 +1,191 @@
+using Daqifi.Core.Communication.Transport;
+
+namespace Daqifi.Core.Tests.Communication.Transport;
+
+/// <summary>
+/// Pins the connect-failure translation added for #424: <see cref="SerialStreamTransport"/> no
+/// longer forwards the platform's exception for a failed open, because that exception cannot be
+/// classified. Measured on macOS with System.IO.Ports 10.0.10, a missing port and a port held by
+/// another process both produce
+/// <c>UnauthorizedAccessException("Access to the port 'X' is denied.")</c> wrapping an
+/// <c>IOException("Unknown error: 203")</c> — identical type, text, and HResult — so the reason has
+/// to come from evidence gathered around the failure instead.
+/// </summary>
+public class SerialPortConnectExceptionTests
+{
+    /// <summary>
+    /// The exact exception shape a failed open produces on macOS/Linux, for every cause.
+    /// </summary>
+    private static UnauthorizedAccessException PlatformDenied(string portName = "/dev/cu.fake") =>
+        new($"Access to the port '{portName}' is denied.", new IOException("Unknown error: 203"));
+
+    [Fact]
+    public void Classify_WhenPortIsAbsent_ReportsNotFound()
+    {
+        // The reported bug: a port that does not exist was called an access denial.
+        var reason = SerialPortConnectException.Classify(PlatformDenied(), portPresent: false,
+            permissionGateRuledOut: null);
+
+        Assert.Equal(SerialPortConnectFailure.NotFound, reason);
+    }
+
+    [Fact]
+    public void Classify_WhenPortIsAbsent_IgnoresThePermissionGate()
+    {
+        // Absence is conclusive; a device node that has already vanished cannot be a permission
+        // or an exclusivity problem, whatever the gate probe managed to say.
+        Assert.Equal(SerialPortConnectFailure.NotFound,
+            SerialPortConnectException.Classify(PlatformDenied(), false, permissionGateRuledOut: true));
+        Assert.Equal(SerialPortConnectFailure.NotFound,
+            SerialPortConnectException.Classify(PlatformDenied(), false, permissionGateRuledOut: false));
+    }
+
+    [Fact]
+    public void Classify_FileNotFoundException_ReportsNotFoundWithoutCorroboration()
+    {
+        // Windows names this case outright, so it needs no presence probe to agree with it.
+        var reason = SerialPortConnectException.Classify(
+            new FileNotFoundException("The port 'COM254' does not exist."),
+            portPresent: true,
+            permissionGateRuledOut: true);
+
+        Assert.Equal(SerialPortConnectFailure.NotFound, reason);
+    }
+
+    [Fact]
+    public void Classify_FileNotFoundExceptionNestedInside_ReportsNotFound()
+    {
+        var reason = SerialPortConnectException.Classify(
+            new UnauthorizedAccessException("wrapped", new FileNotFoundException("no such port")),
+            portPresent: true,
+            permissionGateRuledOut: true);
+
+        Assert.Equal(SerialPortConnectFailure.NotFound, reason);
+    }
+
+    [Fact]
+    public void Classify_PresentAndDeniedWhereNoPermissionGateCanApply_ReportsInUse()
+    {
+        // A macOS /dev/cu.* node is crw-rw-rw-, so nobody can be denied on permission grounds:
+        // the port exists and refuses to open because another process holds it.
+        var reason = SerialPortConnectException.Classify(PlatformDenied(), portPresent: true,
+            permissionGateRuledOut: true);
+
+        Assert.Equal(SerialPortConnectFailure.InUse, reason);
+    }
+
+    [Fact]
+    public void Classify_PresentAndDeniedWhereAPermissionGateCouldApply_ReportsAccessDenied()
+    {
+        // A Linux dialout-owned node at crw-rw---- is the genuine permission case.
+        var reason = SerialPortConnectException.Classify(PlatformDenied("/dev/ttyUSB0"),
+            portPresent: true, permissionGateRuledOut: false);
+
+        Assert.Equal(SerialPortConnectFailure.AccessDenied, reason);
+    }
+
+    [Fact]
+    public void Classify_WhenTheGateCannotBeDetermined_DegradesToAccessDenied()
+    {
+        // An unfamiliar platform keeps today's wording rather than asserting something false.
+        var reason = SerialPortConnectException.Classify(PlatformDenied(), portPresent: true,
+            permissionGateRuledOut: null);
+
+        Assert.Equal(SerialPortConnectFailure.AccessDenied, reason);
+    }
+
+    [Fact]
+    public void Classify_WhenPresenceCannotBeObserved_DoesNotInventAbsence()
+    {
+        // A probe that could not answer is not evidence the port is gone. Reporting NotFound here
+        // would turn any unrelated connect failure into a bogus "port was not found".
+        var reason = SerialPortConnectException.Classify(PlatformDenied(), portPresent: null,
+            permissionGateRuledOut: false);
+
+        Assert.Equal(SerialPortConnectFailure.AccessDenied, reason);
+    }
+
+    [Fact]
+    public void Classify_AnUnrecognizedIoFailure_StaysUnknown()
+    {
+        var reason = SerialPortConnectException.Classify(new IOException("the port hardware failed"),
+            portPresent: true, permissionGateRuledOut: true);
+
+        Assert.Equal(SerialPortConnectFailure.Unknown, reason);
+    }
+
+    [Fact]
+    public void Classify_NullError_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            SerialPortConnectException.Classify(null!, true, true));
+    }
+
+    [Theory]
+    [InlineData(SerialPortConnectFailure.NotFound, "was not found")]
+    [InlineData(SerialPortConnectFailure.InUse, "is in use")]
+    [InlineData(SerialPortConnectFailure.AccessDenied, "is denied")]
+    [InlineData(SerialPortConnectFailure.Unknown, "could not be opened")]
+    public void DescribeFailure_NamesThePortAndTheCause(SerialPortConnectFailure reason, string expected)
+    {
+        var message = SerialPortConnectException.DescribeFailure("/dev/cu.usbmodem1101", reason);
+
+        Assert.Contains("/dev/cu.usbmodem1101", message);
+        Assert.Contains(expected, message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DescribeFailure_AccessDenied_KeepsTheFrameworkWording()
+    {
+        // The one case the platform always got right; anything already keying on that phrasing for
+        // a real permission problem keeps matching.
+        Assert.Equal("Access to the port '/dev/ttyUSB0' is denied.",
+            SerialPortConnectException.DescribeFailure("/dev/ttyUSB0", SerialPortConnectFailure.AccessDenied));
+    }
+
+    [Fact]
+    public void FromOpenFailure_PreservesTheOriginalAsInnerException()
+    {
+        var original = PlatformDenied();
+
+        var ex = SerialPortConnectException.FromOpenFailure("/dev/cu.fake", original,
+            portPresent: false, permissionGateRuledOut: null);
+
+        Assert.Same(original, ex.InnerException);
+        Assert.Equal("/dev/cu.fake", ex.PortName);
+        Assert.Equal(SerialPortConnectFailure.NotFound, ex.Reason);
+        Assert.Contains("was not found", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(false, null, SerialPortConnectFailure.NotFound)]
+    [InlineData(true, true, SerialPortConnectFailure.InUse)]
+    [InlineData(true, false, SerialPortConnectFailure.AccessDenied)]
+    public void FromOpenFailure_KeepsTheInnerExceptionForEveryReason(
+        bool present, bool? gateRuledOut, SerialPortConnectFailure expected)
+    {
+        var original = PlatformDenied();
+
+        var ex = SerialPortConnectException.FromOpenFailure("/dev/cu.fake", original, present, gateRuledOut);
+
+        Assert.Equal(expected, ex.Reason);
+        Assert.Same(original, ex.InnerException);
+    }
+
+    [Fact]
+    public void SerialPortConnectException_IsAnIoException()
+    {
+        // Failing to open an I/O device is an I/O error, and Windows already reports a missing port
+        // as an IOException-derived type, so catch (IOException) around a connect keeps working.
+        var ex = new SerialPortConnectException("COM3", SerialPortConnectFailure.NotFound, "nope");
+
+        Assert.IsAssignableFrom<IOException>(ex);
+    }
+
+    [Fact]
+    public void SerialPortConnectException_RequiresAPortName()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new SerialPortConnectException(null!, SerialPortConnectFailure.NotFound, "nope"));
+    }
+}

--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
@@ -141,6 +141,91 @@ public class SerialStreamTransportTests
         Assert.False(transport.IsConnected);
     }
 
+    /// <summary>
+    /// A port name that resolves nowhere on the running platform, so the connect fails for the one
+    /// reason the test cares about.
+    /// </summary>
+    private static string NonexistentPort =>
+        OperatingSystem.IsWindows() ? "COM254" : "/dev/tty.daqifi-core-nonexistent-424";
+
+    [Fact]
+    public async Task SerialStreamTransport_ConnectAsync_WithMissingPort_ReportsPortNotFound()
+    {
+        // #424: SerialPort.Open reports a port that does not exist as "Access to the port '...' is
+        // denied.", sending users after a permissions problem for what is almost always a typo or
+        // a stale name (USB device nodes are renumbered across replugs).
+        using var transport = new SerialStreamTransport(NonexistentPort);
+
+        var ex = await Assert.ThrowsAsync<SerialPortConnectException>(() => transport.ConnectAsync());
+
+        Assert.Equal(SerialPortConnectFailure.NotFound, ex.Reason);
+        Assert.Equal(NonexistentPort, ex.PortName);
+        Assert.Contains(NonexistentPort, ex.Message);
+        Assert.Contains("was not found", ex.Message);
+        Assert.DoesNotContain("denied", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(transport.IsConnected);
+    }
+
+    [Fact]
+    public async Task SerialStreamTransport_ConnectAsync_WithMissingPort_KeepsThePlatformException()
+    {
+        // The translation adds a name for the failure; it must not throw the diagnosis away.
+        using var transport = new SerialStreamTransport(NonexistentPort);
+
+        var ex = await Assert.ThrowsAsync<SerialPortConnectException>(() => transport.ConnectAsync());
+
+        Assert.NotNull(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task SerialStreamTransport_ConnectAsync_WithMissingPort_StillCatchableAsIoException()
+    {
+        // The chosen base type: a caller bracketing a connect with catch (IOException) keeps working.
+        using var transport = new SerialStreamTransport(NonexistentPort);
+
+        var ex = await Assert.ThrowsAnyAsync<IOException>(() => transport.ConnectAsync());
+
+        Assert.IsType<SerialPortConnectException>(ex);
+    }
+
+    [Fact]
+    public async Task SerialStreamTransport_ConnectAsync_WithMissingPort_ReportsTheTypedErrorOnStatusChanged()
+    {
+        // The status event carries the same translated exception, so a subscriber classifying a
+        // failed connect sees the reason rather than the platform's guess.
+        using var transport = new SerialStreamTransport(NonexistentPort);
+        Exception? reported = null;
+        transport.StatusChanged += (_, e) => reported ??= e.Error;
+
+        await Assert.ThrowsAsync<SerialPortConnectException>(() => transport.ConnectAsync());
+
+        var typed = Assert.IsType<SerialPortConnectException>(reported);
+        Assert.Equal(SerialPortConnectFailure.NotFound, typed.Reason);
+    }
+
+    [Fact]
+    public async Task SerialStreamTransport_ConnectAsync_WithMissingPort_StillHonorsRetryPolicy()
+    {
+        // Translation happens inside a connect attempt, so it is still just a failed attempt: the
+        // retry loop runs the configured number of times and surfaces the typed exception at the end.
+        using var transport = new SerialStreamTransport(NonexistentPort);
+        var options = new ConnectionRetryOptions
+        {
+            Enabled = true,
+            MaxAttempts = 3,
+            InitialDelay = TimeSpan.Zero,
+            MaxDelay = TimeSpan.Zero
+        };
+        var failures = 0;
+        transport.StatusChanged += (_, e) => { if (!e.IsConnected) failures++; };
+
+        var ex = await Assert.ThrowsAsync<SerialPortConnectException>(
+            () => transport.ConnectAsync(options));
+
+        Assert.Equal(SerialPortConnectFailure.NotFound, ex.Reason);
+        Assert.Equal(3, failures);
+    }
+
     [Fact]
     public void SerialStreamTransport_Disconnect_WhenNotConnected_ShouldNotThrow()
     {

--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
@@ -142,11 +142,47 @@ public class SerialStreamTransportTests
     }
 
     /// <summary>
-    /// A port name that resolves nowhere on the running platform, so the connect fails for the one
-    /// reason the test cares about.
+    /// Produces a port name checked to be absent on the running host, so the missing-port tests
+    /// assert the <see cref="SerialPortConnectFailure.NotFound"/> translation and nothing else.
     /// </summary>
-    private static string NonexistentPort =>
-        OperatingSystem.IsWindows() ? "COM254" : "/dev/tty.daqifi-core-nonexistent-424";
+    /// <remarks>
+    /// Verified at runtime rather than hard-coded: a fixed name is only absent by assumption, and a
+    /// host that happens to have it — a virtual COM port, a leftover device node — would make these
+    /// tests either open real hardware or fail with a different error shape.
+    /// </remarks>
+    private static string CreateVerifiedAbsentPort()
+    {
+        var enumerated = new HashSet<string>(SerialPort.GetPortNames(), StringComparer.OrdinalIgnoreCase);
+
+        if (OperatingSystem.IsWindows())
+        {
+            // The Windows serial stack only accepts COM-prefixed names, so a random suffix is not
+            // an option; take the highest COM number the enumeration does not claim.
+            for (var number = 255; number >= 200; number--)
+            {
+                var candidate = $"COM{number}";
+                if (!enumerated.Contains(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new InvalidOperationException(
+                "No unused COM name available to exercise the missing-port path.");
+        }
+
+        for (var attempt = 0; attempt < 8; attempt++)
+        {
+            var candidate = $"/dev/tty.daqifi-core-absent-424-{Guid.NewGuid():N}";
+            if (!File.Exists(candidate) && !enumerated.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "Could not generate an absent device node path to exercise the missing-port path.");
+    }
 
     [Fact]
     public async Task SerialStreamTransport_ConnectAsync_WithMissingPort_ReportsPortNotFound()
@@ -154,13 +190,14 @@ public class SerialStreamTransportTests
         // #424: SerialPort.Open reports a port that does not exist as "Access to the port '...' is
         // denied.", sending users after a permissions problem for what is almost always a typo or
         // a stale name (USB device nodes are renumbered across replugs).
-        using var transport = new SerialStreamTransport(NonexistentPort);
+        var portName = CreateVerifiedAbsentPort();
+        using var transport = new SerialStreamTransport(portName);
 
         var ex = await Assert.ThrowsAsync<SerialPortConnectException>(() => transport.ConnectAsync());
 
         Assert.Equal(SerialPortConnectFailure.NotFound, ex.Reason);
-        Assert.Equal(NonexistentPort, ex.PortName);
-        Assert.Contains(NonexistentPort, ex.Message);
+        Assert.Equal(portName, ex.PortName);
+        Assert.Contains(portName, ex.Message);
         Assert.Contains("was not found", ex.Message);
         Assert.DoesNotContain("denied", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.False(transport.IsConnected);
@@ -170,7 +207,7 @@ public class SerialStreamTransportTests
     public async Task SerialStreamTransport_ConnectAsync_WithMissingPort_KeepsThePlatformException()
     {
         // The translation adds a name for the failure; it must not throw the diagnosis away.
-        using var transport = new SerialStreamTransport(NonexistentPort);
+        using var transport = new SerialStreamTransport(CreateVerifiedAbsentPort());
 
         var ex = await Assert.ThrowsAsync<SerialPortConnectException>(() => transport.ConnectAsync());
 
@@ -181,7 +218,7 @@ public class SerialStreamTransportTests
     public async Task SerialStreamTransport_ConnectAsync_WithMissingPort_StillCatchableAsIoException()
     {
         // The chosen base type: a caller bracketing a connect with catch (IOException) keeps working.
-        using var transport = new SerialStreamTransport(NonexistentPort);
+        using var transport = new SerialStreamTransport(CreateVerifiedAbsentPort());
 
         var ex = await Assert.ThrowsAnyAsync<IOException>(() => transport.ConnectAsync());
 
@@ -193,7 +230,7 @@ public class SerialStreamTransportTests
     {
         // The status event carries the same translated exception, so a subscriber classifying a
         // failed connect sees the reason rather than the platform's guess.
-        using var transport = new SerialStreamTransport(NonexistentPort);
+        using var transport = new SerialStreamTransport(CreateVerifiedAbsentPort());
         Exception? reported = null;
         transport.StatusChanged += (_, e) => reported ??= e.Error;
 
@@ -208,7 +245,7 @@ public class SerialStreamTransportTests
     {
         // Translation happens inside a connect attempt, so it is still just a failed attempt: the
         // retry loop runs the configured number of times and surfaces the typed exception at the end.
-        using var transport = new SerialStreamTransport(NonexistentPort);
+        using var transport = new SerialStreamTransport(CreateVerifiedAbsentPort());
         var options = new ConnectionRetryOptions
         {
             Enabled = true,

--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
@@ -152,7 +152,21 @@ public class SerialStreamTransportTests
     /// </remarks>
     private static string CreateVerifiedAbsentPort()
     {
-        var enumerated = new HashSet<string>(SerialPort.GetPortNames(), StringComparer.OrdinalIgnoreCase);
+        // SerialPort.GetPortNames() can itself throw (a container without /dev access, a
+        // locked-down host). It must not take the suite down from inside a test helper: that would
+        // surface as these tests failing, which reads exactly like the feature under test broke.
+        // An enumeration that cannot answer simply contributes no names — on Unix File.Exists
+        // still gives an independent absence check, and on Windows an unclaimed high COM number
+        // remains the best available answer.
+        HashSet<string> enumerated;
+        try
+        {
+            enumerated = new HashSet<string>(SerialPort.GetPortNames(), StringComparer.OrdinalIgnoreCase);
+        }
+        catch (Exception)
+        {
+            enumerated = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
 
         if (OperatingSystem.IsWindows())
         {
@@ -238,6 +252,25 @@ public class SerialStreamTransportTests
 
         var typed = Assert.IsType<SerialPortConnectException>(reported);
         Assert.Equal(SerialPortConnectFailure.NotFound, typed.Reason);
+    }
+
+    [Fact]
+    public async Task SerialStreamTransport_ConnectAsync_WhenThePresenceProbeThrows_DoesNotLeakIt()
+    {
+        // The production classification path calls SerialPort.GetPortNames(), which can throw on
+        // some hosts. That must degrade the reason, never replace the connect failure with the
+        // probe's own exception or escape as an unhandled error.
+        using var transport = new SerialStreamTransport(CreateVerifiedAbsentPort())
+        {
+            PortPresenceProbe = _ => throw new UnauthorizedAccessException("the probe could not run")
+        };
+
+        var ex = await Assert.ThrowsAsync<SerialPortConnectException>(() => transport.ConnectAsync());
+
+        // The caller still gets the real open failure, with the platform exception preserved, and
+        // no trace of the probe's failure anywhere in the chain.
+        Assert.NotNull(ex.InnerException);
+        Assert.DoesNotContain("the probe could not run", ex.ToString());
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
@@ -152,24 +152,42 @@ public class SerialStreamTransportTests
     /// </remarks>
     private static string CreateVerifiedAbsentPort()
     {
-        // SerialPort.GetPortNames() can itself throw (a container without /dev access, a
-        // locked-down host). It must not take the suite down from inside a test helper: that would
-        // surface as these tests failing, which reads exactly like the feature under test broke.
-        // An enumeration that cannot answer simply contributes no names — on Unix File.Exists
-        // still gives an independent absence check, and on Windows an unclaimed high COM number
-        // remains the best available answer.
+        // Whether the enumeration *answered* is tracked separately from what it returned, because
+        // the two failure modes are not equivalent and must not be collapsed. An empty result is a
+        // real answer — the host has no serial ports. A throw is no answer at all.
+        bool enumerationAnswered;
         HashSet<string> enumerated;
         try
         {
             enumerated = new HashSet<string>(SerialPort.GetPortNames(), StringComparer.OrdinalIgnoreCase);
+            enumerationAnswered = true;
         }
         catch (Exception)
         {
+            // Enumeration can throw on some hosts (a container without /dev access, a locked-down
+            // machine). It must not take the suite down from inside a test helper — that reads as
+            // the feature under test breaking rather than the environment.
             enumerated = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            enumerationAnswered = false;
         }
 
         if (OperatingSystem.IsWindows())
         {
+            // Windows has no absence check independent of the enumeration: a COM name is not a
+            // filesystem path, so there is no File.Exists equivalent, and the enumeration is itself
+            // the authority (it reads the HARDWARE\DEVICEMAP\SERIALCOMM registry map). That makes
+            // an answered enumeration sufficient — including an empty one, which positively means
+            // no COM ports exist — but leaves a *failed* enumeration with no evidence whatsoever.
+            // Choosing a name in that state would assert against an unverified port and could pass
+            // or fail for reasons unrelated to the translation being tested, so refuse instead.
+            if (!enumerationAnswered)
+            {
+                throw new InvalidOperationException(
+                    "Cannot verify an absent COM name: SerialPort.GetPortNames() failed and Windows " +
+                    "offers no independent check that a COM name is unused. Refusing to assert " +
+                    "against an unverified port.");
+            }
+
             // The Windows serial stack only accepts COM-prefixed names, so a random suffix is not
             // an option; take the highest COM number the enumeration does not claim.
             for (var number = 255; number >= 200; number--)
@@ -184,6 +202,9 @@ public class SerialStreamTransportTests
             throw new InvalidOperationException(
                 "No unused COM name available to exercise the missing-port path.");
         }
+
+        // Unix needs no such guard: the port name is a filesystem path, so File.Exists answers
+        // independently of the enumeration and a failed enumeration costs the check nothing.
 
         for (var attempt = 0; attempt < 8; attempt++)
         {

--- a/src/Daqifi.Core/Communication/Transport/SerialPortConnectException.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialPortConnectException.cs
@@ -32,6 +32,13 @@ namespace Daqifi.Core.Communication.Transport;
 /// as <see cref="Exception.InnerException"/>.
 /// </para>
 /// <para>
+/// <b>Migrating.</b> A connect that previously threw <see cref="UnauthorizedAccessException"/>
+/// now throws this instead, so <c>catch (UnauthorizedAccessException)</c> no longer matches.
+/// Replace it with <c>catch (SerialPortConnectException ex)</c> and switch on <see cref="Reason"/>
+/// — that distinction is the thing the old exception could not express, since on macOS a missing
+/// port and a busy port threw the very same exception.
+/// </para>
+/// <para>
 /// <b>Retries.</b> This type does not change retry behavior — a failed open is still one failed
 /// attempt under <see cref="ConnectionRetryOptions"/>. It does let a caller decide whether
 /// retrying is worthwhile: <see cref="SerialPortConnectFailure.InUse"/> can clear on its own,

--- a/src/Daqifi.Core/Communication/Transport/SerialPortConnectException.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialPortConnectException.cs
@@ -1,0 +1,180 @@
+namespace Daqifi.Core.Communication.Transport;
+
+/// <summary>
+/// Thrown when <see cref="SerialStreamTransport.ConnectAsync(ConnectionRetryOptions?, CancellationToken)"/>
+/// cannot open its serial port, carrying a stable <see cref="Reason"/> that says why.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What this replaces.</b> <see cref="System.IO.Ports.SerialPort.Open"/> reports a missing port
+/// on macOS and Linux as <c>UnauthorizedAccessException: Access to the port '...' is denied.</c>,
+/// which sends users looking for a permissions problem when the real cause is a wrong or stale
+/// port name — the common case, because USB serial device nodes are renumbered across replugs.
+/// This is the serial analog of the <see cref="TimeoutException"/> that
+/// <see cref="TcpStreamTransport"/> substitutes for a misleading <c>TaskCanceledException</c>
+/// (daqifi-desktop#517): the same failure, named accurately.
+/// </para>
+/// <para>
+/// <b>Why a typed reason.</b> The platform exception cannot be classified after the fact. Measured
+/// on macOS with System.IO.Ports 10.0.10, a missing port and a port held by another process
+/// produce byte-identical exceptions — same type, same message, and an inner
+/// <see cref="IOException"/> with the same text and the same (bogus, non-errno)
+/// <see cref="Exception.HResult"/>. Matching on message text or on the inner exception is
+/// therefore not merely unportable, it does not work at all. <see cref="Reason"/> is derived from
+/// evidence gathered around the failure instead — see
+/// <see cref="SerialStreamTransport.ConnectAsync(ConnectionRetryOptions?, CancellationToken)"/>.
+/// </para>
+/// <para>
+/// <b>Base type.</b> Derives from <see cref="IOException"/>: failing to open an I/O device is an
+/// I/O error, and on Windows a non-existent port already surfaces as an
+/// <see cref="IOException"/>-derived exception, so a caller that brackets a connect with
+/// <c>catch (IOException)</c> keeps working. The original platform exception is always preserved
+/// as <see cref="Exception.InnerException"/>.
+/// </para>
+/// <para>
+/// <b>Retries.</b> This type does not change retry behavior — a failed open is still one failed
+/// attempt under <see cref="ConnectionRetryOptions"/>. It does let a caller decide whether
+/// retrying is worthwhile: <see cref="SerialPortConnectFailure.InUse"/> can clear on its own,
+/// while <see cref="SerialPortConnectFailure.NotFound"/> and
+/// <see cref="SerialPortConnectFailure.AccessDenied"/> will not.
+/// </para>
+/// </remarks>
+public class SerialPortConnectException : IOException
+{
+    /// <summary>
+    /// Gets the name of the port that could not be opened (for example <c>COM3</c> or
+    /// <c>/dev/cu.usbmodem1101</c>).
+    /// </summary>
+    public string PortName { get; }
+
+    /// <summary>
+    /// Gets the classified reason the port could not be opened.
+    /// </summary>
+    public SerialPortConnectFailure Reason { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerialPortConnectException"/> class.
+    /// </summary>
+    /// <param name="portName">The port that could not be opened.</param>
+    /// <param name="reason">The classified reason for the failure.</param>
+    /// <param name="message">The message that describes the failure.</param>
+    /// <param name="innerException">
+    /// The platform exception that caused the failure, or <c>null</c>.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="portName"/> is null.</exception>
+    public SerialPortConnectException(
+        string portName,
+        SerialPortConnectFailure reason,
+        string message,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        PortName = portName ?? throw new ArgumentNullException(nameof(portName));
+        Reason = reason;
+    }
+
+    /// <summary>
+    /// Builds the translated exception for a failed <see cref="System.IO.Ports.SerialPort.Open"/>,
+    /// preserving <paramref name="error"/> as the inner exception.
+    /// </summary>
+    /// <param name="portName">The port that could not be opened.</param>
+    /// <param name="error">The platform exception the open threw.</param>
+    /// <param name="portPresent">
+    /// Whether the port is still visible to the system, or <c>null</c> if that could not be
+    /// observed. See <see cref="Classify"/>.
+    /// </param>
+    /// <param name="permissionGateRuledOut">
+    /// Whether a permission failure has been positively ruled out, or <c>null</c> if unknown.
+    /// See <see cref="Classify"/>.
+    /// </param>
+    internal static SerialPortConnectException FromOpenFailure(
+        string portName,
+        Exception error,
+        bool? portPresent,
+        bool? permissionGateRuledOut)
+    {
+        var reason = Classify(error, portPresent, permissionGateRuledOut);
+        return new SerialPortConnectException(portName, reason, DescribeFailure(portName, reason), error);
+    }
+
+    /// <summary>
+    /// Classifies a failed serial open from evidence collected around it, rather than from the
+    /// platform exception's type or text.
+    /// </summary>
+    /// <param name="error">The platform exception the open threw.</param>
+    /// <param name="portPresent">
+    /// <c>true</c> if the port is still enumerated (or its device node still exists),
+    /// <c>false</c> if it is definitely absent, <c>null</c> if the probe could not answer. A
+    /// failure to observe is never treated as absence.
+    /// </param>
+    /// <param name="permissionGateRuledOut">
+    /// <c>true</c> when the platform cannot be denying access on permission grounds — a Unix
+    /// device node that grants read and write to every user, or a Windows COM port, which has no
+    /// equivalent per-user gate. <c>false</c> when a permission failure is possible, <c>null</c>
+    /// when it could not be determined.
+    /// </param>
+    /// <returns>The classified reason.</returns>
+    /// <remarks>
+    /// <para>
+    /// The order matters. An explicit <see cref="FileNotFoundException"/> — what Windows reports
+    /// for a port that no longer exists — is conclusive on its own. Otherwise absence of the port
+    /// is the deciding signal, and it is the one that fixes the reported bug: it is portable, it
+    /// does not read any exception text, and it is the same probe the transport already trusts to
+    /// detect an unplug on an established connection.
+    /// </para>
+    /// <para>
+    /// Only once the port is known (or assumed) to exist does an access-denied exception have to be
+    /// split between "someone else has it" and "you may not have it", and that split is the one
+    /// piece the platform genuinely cannot answer on macOS. It is resolved from
+    /// <paramref name="permissionGateRuledOut"/>, and when that is unavailable the result stays
+    /// <see cref="SerialPortConnectFailure.AccessDenied"/> — the status-quo wording — so an
+    /// unfamiliar platform degrades to today's behavior instead of asserting something false.
+    /// </para>
+    /// </remarks>
+    internal static SerialPortConnectFailure Classify(
+        Exception error,
+        bool? portPresent,
+        bool? permissionGateRuledOut)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+
+        // Windows names the missing-port case outright. Checked before anything else, and through
+        // the inner exception too, because it needs no corroboration.
+        if (error is FileNotFoundException || error.InnerException is FileNotFoundException)
+        {
+            return SerialPortConnectFailure.NotFound;
+        }
+
+        // The port is definitely gone. This is the case the issue is about, and the only one where
+        // "access is denied" was actively misleading.
+        if (portPresent == false)
+        {
+            return SerialPortConnectFailure.NotFound;
+        }
+
+        if (error is UnauthorizedAccessException || error.InnerException is UnauthorizedAccessException)
+        {
+            return permissionGateRuledOut == true
+                ? SerialPortConnectFailure.InUse
+                : SerialPortConnectFailure.AccessDenied;
+        }
+
+        return SerialPortConnectFailure.Unknown;
+    }
+
+    /// <summary>
+    /// Produces the user-facing message for a classified failure.
+    /// </summary>
+    /// <param name="portName">The port that could not be opened.</param>
+    /// <param name="reason">The classified reason.</param>
+    /// <returns>A single-sentence description naming the port.</returns>
+    internal static string DescribeFailure(string portName, SerialPortConnectFailure reason) => reason switch
+    {
+        SerialPortConnectFailure.NotFound => $"Serial port '{portName}' was not found.",
+        SerialPortConnectFailure.InUse => $"Serial port '{portName}' is in use.",
+        // Deliberately the framework's own wording for the one case where it was always accurate,
+        // so anything already keying on that phrasing for a real permission problem still matches.
+        SerialPortConnectFailure.AccessDenied => $"Access to the port '{portName}' is denied.",
+        _ => $"Serial port '{portName}' could not be opened."
+    };
+}

--- a/src/Daqifi.Core/Communication/Transport/SerialPortConnectFailure.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialPortConnectFailure.cs
@@ -1,0 +1,42 @@
+namespace Daqifi.Core.Communication.Transport;
+
+/// <summary>
+/// Why a serial port could not be opened, as reported by
+/// <see cref="SerialPortConnectException.Reason"/>.
+/// </summary>
+/// <remarks>
+/// This is the stable, typed alternative to inspecting the platform exception a failed
+/// <see cref="System.IO.Ports.SerialPort.Open"/> produces. That exception carries no reliable
+/// classification of its own: on macOS a missing port and a busy port both surface as
+/// <see cref="UnauthorizedAccessException"/> ("Access to the port '...' is denied.") wrapping an
+/// <see cref="IOException"/> whose message and <see cref="Exception.HResult"/> are the same in
+/// both cases, so neither the type, the text, nor the errno can tell them apart.
+/// </remarks>
+public enum SerialPortConnectFailure
+{
+    /// <summary>
+    /// The reason could not be determined. The platform exception is still available as
+    /// <see cref="Exception.InnerException"/>.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The port does not exist. Usually a typo or a stale port name — USB serial device nodes are
+    /// renumbered across replugs, so a name captured earlier in a session may no longer resolve.
+    /// Retrying does not help; re-enumerate the available ports instead.
+    /// </summary>
+    NotFound,
+
+    /// <summary>
+    /// The port exists but another process already holds it open. Retrying can succeed once the
+    /// other process releases the port.
+    /// </summary>
+    InUse,
+
+    /// <summary>
+    /// The port exists but the current process is not permitted to open it — for example a Linux
+    /// device node owned by a group the user is not a member of (commonly <c>dialout</c>).
+    /// Retrying does not help until the permission is granted.
+    /// </summary>
+    AccessDenied
+}

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -226,6 +226,10 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     /// Establishes the serial connection asynchronously.
     /// </summary>
     /// <returns>A task representing the asynchronous connect operation.</returns>
+    /// <exception cref="SerialPortConnectException">
+    /// Thrown when the port cannot be opened, with <see cref="SerialPortConnectException.Reason"/>
+    /// naming the cause.
+    /// </exception>
     public async Task ConnectAsync()
     {
         await ConnectAsync(null);
@@ -236,6 +240,10 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     /// </summary>
     /// <param name="retryOptions">Configuration for retry behavior. If null, uses default single attempt.</param>
     /// <returns>A task representing the asynchronous connect operation.</returns>
+    /// <exception cref="SerialPortConnectException">
+    /// Thrown when the final attempt cannot open the port, with
+    /// <see cref="SerialPortConnectException.Reason"/> naming the cause.
+    /// </exception>
     public async Task ConnectAsync(ConnectionRetryOptions? retryOptions)
     {
         await ConnectAsync(retryOptions, CancellationToken.None);
@@ -249,12 +257,28 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
 
     /// <inheritdoc />
     /// <remarks>
+    /// <para>
     /// Cancellation is observed between attempts and while waiting out a backoff delay, and is
     /// checked immediately before each <see cref="SerialPort.Open"/>. It cannot interrupt the
     /// <c>Open</c> call itself — the framework offers no cancellable form of it — so on a port that
     /// hangs open, cancellation takes effect when that call returns. In practice opening a serial
     /// port either succeeds or fails quickly; the long wait worth cancelling is the retry loop.
+    /// </para>
+    /// <para>
+    /// A failed <see cref="SerialPort.Open"/> is reported as a
+    /// <see cref="SerialPortConnectException"/> naming the port and why it could not be opened,
+    /// rather than the platform's own exception, which on macOS and Linux calls every failure —
+    /// including a port that simply does not exist — an access denial (#424). The original is kept
+    /// as the inner exception. The reason is decided from what can be observed at the moment of
+    /// the failure: whether the port is still present, and whether the platform could be applying
+    /// a permission gate at all. Retry behavior is unchanged; a translated failure is still one
+    /// failed attempt.
+    /// </para>
     /// </remarks>
+    /// <exception cref="SerialPortConnectException">
+    /// Thrown when the final attempt cannot open the port, with
+    /// <see cref="SerialPortConnectException.Reason"/> naming the cause.
+    /// </exception>
     public async Task ConnectAsync(ConnectionRetryOptions? retryOptions, CancellationToken cancellationToken)
     {
         ThrowIfDisposed();
@@ -280,7 +304,21 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
                 // honor a cancel that arrived while the previous attempt was backing off.
                 attemptToken.ThrowIfCancellationRequested();
 
-                _serialPort.Open();
+                try
+                {
+                    _serialPort.Open();
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                {
+                    // Name the failure instead of forwarding the platform's guess at it (#424).
+                    // The evidence is gathered here, immediately after the failed open, because it
+                    // is only meaningful in that moment; the classification itself lives in
+                    // SerialPortConnectException.Classify. Argument and state exceptions are left
+                    // alone — a bad baud rate or an already-open port is a caller bug, not a port
+                    // that could not be opened.
+                    throw SerialPortConnectException.FromOpenFailure(
+                        _portName, ex, TryObservePortPresence(), TryRuleOutPermissionGate());
+                }
 
                 // After a successful open, swap the connect timeouts for the (shorter)
                 // operational ones — both directions, not just reads (#399).
@@ -439,6 +477,60 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
             IsPortPresent,
             $"Serial port {_portName} is no longer present; the device appears to have been disconnected.",
             _livenessCheckInterval);
+    }
+
+    /// <summary>
+    /// Observes whether the port exists, for classifying a failed open. Returns <c>null</c> when
+    /// the probe could not answer — a failure to observe is not evidence of absence, and reporting
+    /// it as absence would turn an unrelated connect failure into a bogus "port was not found".
+    /// </summary>
+    private bool? TryObservePortPresence()
+    {
+        try
+        {
+            return IsPortPresent();
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reports whether the platform can be ruled out as the source of an access-denied failure,
+    /// which is what separates a port held by another process from one the caller may not open.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when no per-user permission gate can apply, <c>false</c> when one could,
+    /// <c>null</c> when it could not be determined.
+    /// </returns>
+    /// <remarks>
+    /// A Unix device node that grants read and write to every user cannot produce a permission
+    /// failure for anybody, so a denial on such a node is exclusivity — the case macOS reports with
+    /// the same exception it uses for every other open failure, and <c>/dev/cu.*</c> nodes there are
+    /// <c>crw-rw-rw-</c>. A node that does not grant that (a Linux <c>dialout</c>-owned port at
+    /// <c>crw-rw----</c>, say) keeps the access-denied reading, so the genuine permission case is
+    /// still reported as one. Windows COM ports have no comparable gate: a port that exists and
+    /// refuses to open is one another process holds.
+    /// </remarks>
+    private bool? TryRuleOutPermissionGate()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        try
+        {
+            var mode = File.GetUnixFileMode(_portName);
+            return mode.HasFlag(UnixFileMode.OtherRead) && mode.HasFlag(UnixFileMode.OtherWrite);
+        }
+        catch (Exception)
+        {
+            // No stat (the port is gone, the name is not a path, or the platform will not say).
+            // Unknown, never a guess: the caller falls back to the access-denied wording.
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -274,6 +274,20 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     /// a permission gate at all. Retry behavior is unchanged; a translated failure is still one
     /// failed attempt.
     /// </para>
+    /// <para>
+    /// <b>Behavioral change for callers.</b> This method used to surface whatever
+    /// <see cref="SerialPort.Open"/> threw — on macOS and Linux always an
+    /// <see cref="UnauthorizedAccessException"/> whatever the real cause, on Windows a
+    /// <see cref="FileNotFoundException"/> or an <see cref="UnauthorizedAccessException"/>. Those
+    /// are now wrapped, so <c>catch (UnauthorizedAccessException)</c> around a connect no longer
+    /// matches and any branching on the platform exception's type has to move. Catch
+    /// <see cref="SerialPortConnectException"/> and switch on
+    /// <see cref="SerialPortConnectException.Reason"/>, which is the classification the platform
+    /// exception never reliably carried; <c>catch (IOException)</c> still matches for callers that
+    /// only need the broad case. The original exception remains available as
+    /// <see cref="Exception.InnerException"/>, so nothing is lost — only the type that arrives at
+    /// the catch site changes.
+    /// </para>
     /// </remarks>
     /// <exception cref="SerialPortConnectException">
     /// Thrown when the final attempt cannot open the port, with


### PR DESCRIPTION
## Why

Connecting to a serial port that doesn't exist reported `Access to the port '/dev/cu.doesnotexist' is denied.` — sending users off to check permissions and `dialout` group membership when the real problem was a wrong or stale port name. That's the common case, because USB serial device nodes get renumbered every time you replug. The TCP transport already avoids exactly this trap by translating a misleading `TaskCanceledException` into a real `TimeoutException`; serial had no equivalent.

## What

A failed serial connect now says what actually went wrong: "Serial port 'X' was not found.", "Serial port 'X' is in use.", or the original access-denied wording when it really is a permission problem. Callers who want to branch on it get a typed `SerialPortConnectException` with a `Reason` of `NotFound`, `InUse`, `AccessDenied`, or `Unknown`, instead of string-matching. The original platform exception is always kept as `InnerException`, so nothing is lost.

## How

The interesting part is that **the reason cannot be recovered from the platform exception at all**, which the issue's suggested fix assumed it could. On macOS a missing port and a port held by another process produce byte-identical exceptions — same type, same message, same inner `IOException`. Worse, that inner message wasn't even stable: on this machine, for the same port, one process reported `Unknown error: 203` and another reported `No such file or directory`. Its `HResult` is a stale errno, not a signal.

So the reason is derived from evidence gathered at the moment of the failure instead: whether the port is still present (the same probe the transport already trusts to detect an unplug), and whether a per-user permission gate could apply at all (a macOS `/dev/cu.*` node is `crw-rw-rw-`, so nobody can be denied on permission grounds — a denial there means someone else holds it; a Linux `dialout` port at `crw-rw----` keeps the access-denied reading). Anything that can't be determined degrades to today's wording rather than asserting something false. Retry behaviour is untouched — a translated failure is still just one failed attempt.

## Bench test

Real Nq1 (FW 3.7.2), macOS, example CLI built against this branch.

**USB/serial — the issue's own repro, before and after:**

```
BEFORE (raw SerialPort.Open — what Core used to forward)
  UnauthorizedAccessException: Access to the port '/dev/cu.doesnotexist' is denied.
   ---> IOException: Unknown error: 203 (HResult=203)

AFTER  $ Daqifi.Core.Cli.dll --serial /dev/cu.doesnotexist --duration 2
  Daqifi.Core.Communication.Transport.SerialPortConnectException:
      Serial port '/dev/cu.doesnotexist' was not found.
   ---> System.UnauthorizedAccessException: Access to the port '...' is denied.  (preserved)
```

**All three classifications against the real device:**

```
A. missing port      Reason = NotFound   "Serial port '/dev/cu.doesnotexist' was not found."
B. real port, held   Reason = InUse      "Serial port '/dev/cu.usbmodem1101' is in use."
C. real port, free   connected OK: Serial: /dev/cu.usbmodem1101 @ 9600 baud
```

**USB happy path not broken** — connect + SCPI init + clean disconnect still work, and discovery still identifies the unit:

```
Found: Nq1 (/dev/cu.usbmodem1101) SN:9090539562006014104 FW:3.7.2
```

**WiFi/TCP — no-regression check only** (this change is serial-only and touches zero TCP code). One consolidated connect to `192.168.1.30:9760`: the TCP transport connected fine and got through to `DaqifiDevice.InitializeAsync`, which then hit the known 8 s channel-config timeout this unit is currently in (SD low-heap / degraded state, power cycle being arranged). That is pre-existing and unrelated.

**Streaming, end to end on the real device** (after the unit was power cycled out of the channel-config window it had been stuck in):

```
$ Daqifi.Core.Cli.dll --serial /dev/cu.usbmodem1101 --channels 7 --rate 50 --duration 6
Connected to /dev/cu.usbmodem1101 @ 9600 baud
Streaming at 50 Hz...
ts=3192967391 analog=[3, 8, 0]
ts=3193807390 analog=[4, 8, 0]
...
ts=3389527390 analog=[4, 7, 0]
Streaming stopped.
Status: Disconnected                      exit 0
```

237 sample messages across the 6 s window on three analog channels, timestamps monotonic, clean stop. That is ~79% of the requested 50 Hz, which is the known rate behaviour of this bench unit (fw#716) and not a shortfall introduced here.

This closes the one gap left open earlier in review: the happy path is now proven to connect *and* stream, not just connect.

Full suite green: 2496 passed on both net9.0 and net10.0, Release build clean with 0 warnings.

## Note for daqifi-desktop

`SerialStreamTransport.ConnectAsync` now throws `SerialPortConnectException` (an `IOException`) where it previously threw the raw `UnauthorizedAccessException`. Desktop's `SerialStreamingDevice.LogConnectFailure` switches on `UnauthorizedAccessException` / `FileNotFoundException` to classify these as warnings rather than Sentry errors, so it will need one added case or those connect failures will start reporting as errors. Nothing inside Core regressed — serial discovery uses a raw `SerialPort` and has a catch-all fallback.

Closes #424


