### PR TITLE
fix(sd): use the device's own timestamp clock when parsing SD logs (closes #426)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardJsonFileParserTests.cs
@@ -185,8 +185,8 @@ public sealed class SdCardJsonFileParserTests
     public async Task ParseAsync_ConfigurationOverride_UsesProvidedConfig()
     {
         // Arrange — JSON has no metadata headers, so override fills in device info gaps.
-        // TimestampFrequency is inferred from FallbackTimestampFrequency (50MHz default),
-        // so the inferred value takes precedence over the override's value.
+        // JSON lines carry no frequency of their own, so the connected device's frequency is
+        // the best information available and must beat the FallbackTimestampFrequency guess.
         await using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
             (100u, new[] { 1.0, 2.0 }, "")
         );
@@ -217,8 +217,12 @@ public sealed class SdCardJsonFileParserTests
         Assert.Equal("NQ1", session.DeviceConfig.DevicePartNumber);
         Assert.Equal("1.0.0", session.DeviceConfig.FirmwareRevision);
         Assert.Equal(1, session.DeviceConfig.DigitalPortCount);
-        // Inferred frequency (from FallbackTimestampFrequency) takes precedence
-        Assert.Equal(50_000_000u, session.DeviceConfig.TimestampFrequency);
+        // The device's reported frequency beats the fallback guess, and says so.
+        Assert.Equal(1000u, session.DeviceConfig.TimestampFrequency);
+        Assert.Equal(1000u, session.TimestampFrequency);
+        Assert.Equal(
+            global::Daqifi.Core.Device.SdCard.SdCardTimestampSource.Device,
+            session.TimestampFrequencySource);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardTimestampFrequencyTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardTimestampFrequencyTests.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.SdCard;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+/// <summary>
+/// Tests for how an SD card log's timestamp clock frequency is chosen and reported (issue #426).
+/// </summary>
+/// <remarks>
+/// Firmware v3.7.2 and earlier write no <c>TimestampFreq</c> into SD card logs but do report one
+/// (42 MHz on the bench Nq1) in their live status message. Before the fix, the live figure was
+/// discarded and parsing fell back to 50 MHz, silently stretching every reconstructed timestamp
+/// by a factor of 50/42 ≈ 1.19.
+/// </remarks>
+public class SdCardTimestampFrequencyTests
+{
+    private const uint DeviceFrequencyHz = 42_000_000;
+
+    // 20 Hz at a 42 MHz counter: 42e6 / 20 = 2,100,000 ticks per sample. Measured on the bench.
+    private const uint TicksPerSampleAt20Hz = 2_100_000;
+
+    private readonly SdCardFileParser _parser = new();
+
+    #region SdCardDeviceConfiguration.FromDevice
+
+    [Fact]
+    public void FromDevice_WithDeviceReportedFrequency_PropagatesIt()
+    {
+        // Arrange — a device whose status message reported a real timestamp clock.
+        var device = new DaqifiDevice("TestDevice");
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage
+        {
+            AnalogInPortNum = 4,
+            DigitalPortNum = 2,
+            TimestampFreq = DeviceFrequencyHz
+        });
+
+        // Act
+        var config = SdCardDeviceConfiguration.FromDevice(device);
+
+        // Assert — the one field the live device is uniquely able to supply is carried across.
+        Assert.NotNull(config);
+        Assert.Equal(DeviceFrequencyHz, config.TimestampFrequency);
+    }
+
+    [Fact]
+    public void FromDevice_WhenDeviceReportedNoFrequency_KeepsZero()
+    {
+        // Arrange — status message with channel counts but no TimestampFreq.
+        var device = new DaqifiDevice("TestDevice");
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage
+        {
+            AnalogInPortNum = 4,
+            DigitalPortNum = 2
+        });
+
+        // Act
+        var config = SdCardDeviceConfiguration.FromDevice(device);
+
+        // Assert — zero means "unknown", which leaves the parser's fallback in charge.
+        Assert.NotNull(config);
+        Assert.Equal(0u, config.TimestampFrequency);
+    }
+
+    [Fact]
+    public void FromDevice_WithNoAnalogChannels_ReturnsNull()
+    {
+        // Arrange
+        var device = new DaqifiDevice("TestDevice");
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage
+        {
+            DigitalPortNum = 2,
+            TimestampFreq = DeviceFrequencyHz
+        });
+
+        // Act & Assert
+        Assert.Null(SdCardDeviceConfiguration.FromDevice(device));
+    }
+
+    #endregion
+
+    #region Resolver precedence
+
+    [Theory]
+    // File wins outright, even against a device and a fallback.
+    [InlineData(80_000_000u, 42_000_000u, 50_000_000u, 80_000_000u, SdCardTimestampSource.LogFile)]
+    // File silent: the device's real clock beats the fallback guess.
+    [InlineData(0u, 42_000_000u, 50_000_000u, 42_000_000u, SdCardTimestampSource.Device)]
+    // Nothing but the guess.
+    [InlineData(0u, 0u, 50_000_000u, 50_000_000u, SdCardTimestampSource.Fallback)]
+    // Guess disabled: no conversion at all rather than a wrong one.
+    [InlineData(0u, 0u, 0u, 0u, SdCardTimestampSource.None)]
+    // A device that reports nothing does not shadow the fallback.
+    [InlineData(0u, 0u, 1_000u, 1_000u, SdCardTimestampSource.Fallback)]
+    public void Resolve_FollowsFileThenDeviceThenFallback(
+        uint fileHz,
+        uint deviceHz,
+        uint fallbackHz,
+        uint expectedHz,
+        SdCardTimestampSource expectedSource)
+    {
+        var (frequencyHz, source) = SdCardTimestampFrequencyResolver.Resolve(fileHz, deviceHz, fallbackHz);
+
+        Assert.Equal(expectedHz, frequencyHz);
+        Assert.Equal(expectedSource, source);
+    }
+
+    #endregion
+
+    #region Parser reports which frequency it used
+
+    [Fact]
+    public async Task ParseAsync_WithFileEmbeddedFrequency_PrefersFileOverDevice()
+    {
+        // Arrange — the file states 80 MHz while a connected device claims 42 MHz.
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(
+                analogPortNum: 2,
+                digitalPortNum: 1,
+                timestampFreq: 80_000_000))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 1_000,
+                analogFloatValues: new[] { 1.0f, 2.0f }));
+
+        using var stream = builder.Build();
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "log_20240115_103000.bin", new SdCardParseOptions
+        {
+            ConfigurationOverride = DeviceOverride(DeviceFrequencyHz)
+        });
+
+        // Assert — a self-describing log is never overridden by a live device.
+        Assert.Equal(80_000_000u, session.TimestampFrequency);
+        Assert.Equal(SdCardTimestampSource.LogFile, session.TimestampFrequencySource);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WhenFileHasNoFrequency_UsesDeviceAndReportsIt()
+    {
+        // Arrange — a FW 3.7.2-shaped log: stream messages only, no TimestampFreq anywhere.
+        using var stream = BuildTwoSampleLogWithoutFrequency();
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "log_20240115_103000.bin", new SdCardParseOptions
+        {
+            ConfigurationOverride = DeviceOverride(DeviceFrequencyHz)
+        });
+
+        // Assert
+        Assert.Equal(DeviceFrequencyHz, session.TimestampFrequency);
+        Assert.Equal(SdCardTimestampSource.Device, session.TimestampFrequencySource);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WhenNothingSuppliesFrequency_SurfacesTheFallbackRatherThanHidingIt()
+    {
+        // Arrange — no file frequency, no connected device.
+        using var stream = BuildTwoSampleLogWithoutFrequency();
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "log_20240115_103000.bin", new SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 50_000_000
+        });
+
+        // Assert — the guess still happens, but the caller can now see that it did.
+        Assert.Equal(50_000_000u, session.TimestampFrequency);
+        Assert.Equal(SdCardTimestampSource.Fallback, session.TimestampFrequencySource);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithFallbackDisabled_ReportsNoFrequency()
+    {
+        // Arrange
+        using var stream = BuildTwoSampleLogWithoutFrequency();
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "log_20240115_103000.bin", new SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 0
+        });
+
+        // Assert
+        Assert.Equal(0u, session.TimestampFrequency);
+        Assert.Equal(SdCardTimestampSource.None, session.TimestampFrequencySource);
+    }
+
+    #endregion
+
+    #region Regression: the ~19% scaling error itself
+
+    [Fact]
+    public async Task ParseAsync_WithConnectedDevice_SpacesSamplesAtTheRecordedRate()
+    {
+        // Arrange — two samples one 20 Hz period apart on a 42 MHz counter, exactly as the
+        // bench Nq1 writes them.
+        using var stream = BuildTwoSampleLogWithoutFrequency();
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "log_20240115_103000.bin", new SdCardParseOptions
+        {
+            ConfigurationOverride = DeviceOverride(DeviceFrequencyHz)
+        });
+
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert — 50.0 ms apart, the rate the data was actually logged at. Falling back to
+        // 50 MHz would report 42.0 ms, an 8 ms (19%) error on every interval in the file.
+        Assert.Equal(2, samples.Count);
+        var spacing = (samples[1].Timestamp - samples[0].Timestamp).TotalMilliseconds;
+        Assert.Equal(50.0, spacing, precision: 3);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WithoutConnectedDevice_StillMisreportsButSaysSo()
+    {
+        // Arrange — the same file parsed offline, where the 50 MHz guess is all there is.
+        using var stream = BuildTwoSampleLogWithoutFrequency();
+
+        // Act
+        var session = await _parser.ParseAsync(stream, "log_20240115_103000.bin", new SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 50_000_000
+        });
+
+        var samples = await ToListAsync(session.Samples);
+
+        // Assert — this documents the residual limitation: with no device to ask, the spacing
+        // is still wrong. What changed is that TimestampFrequencySource now says the figure was
+        // a guess, so a caller can warn instead of silently trusting it.
+        var spacing = (samples[1].Timestamp - samples[0].Timestamp).TotalMilliseconds;
+        Assert.Equal(42.0, spacing, precision: 3);
+        Assert.Equal(SdCardTimestampSource.Fallback, session.TimestampFrequencySource);
+    }
+
+    #endregion
+
+    private static SdCardDeviceConfiguration DeviceOverride(uint timestampFrequencyHz) =>
+        new(
+            AnalogPortCount: 2,
+            DigitalPortCount: 1,
+            TimestampFrequency: timestampFrequencyHz,
+            DeviceSerialNumber: "TEST123",
+            DevicePartNumber: "Nq1",
+            FirmwareRevision: "3.7.2",
+            CalibrationValues: null);
+
+    private static System.IO.Stream BuildTwoSampleLogWithoutFrequency()
+    {
+        return new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 1_000_000,
+                analogFloatValues: new[] { 1.0f, 2.0f }))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: 1_000_000 + TicksPerSampleAt20Hz,
+                analogFloatValues: new[] { 3.0f, 4.0f }))
+            .Build();
+    }
+
+    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var list = new List<T>();
+        await foreach (var item in source)
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -73,6 +73,13 @@ public sealed class SdCardCsvFileParser
         var (headerConfig, columnLayout) = ParseHeader(lines, options);
         var config = MergeConfiguration(headerConfig, options.ConfigurationOverride);
 
+        var (timestampFrequency, timestampSource) = SdCardTimestampFrequencyResolver.Resolve(
+            headerConfig.TimestampFrequency,
+            options.ConfigurationOverride?.TimestampFrequency ?? 0u,
+            options.FallbackTimestampFrequency);
+
+        config = config with { TimestampFrequency = timestampFrequency };
+
         // Find the index of the first data row (after comments and column header)
         var dataStartIndex = FindDataStartIndex(lines);
 
@@ -83,7 +90,11 @@ public sealed class SdCardCsvFileParser
                 fileName,
                 fileCreatedDate,
                 config,
-                EmptySamples());
+                EmptySamples())
+            {
+                TimestampFrequency = timestampFrequency,
+                TimestampFrequencySource = timestampSource
+            };
         }
 
         var samples = ParseCsvLines(
@@ -94,7 +105,11 @@ public sealed class SdCardCsvFileParser
             fileCreatedDate,
             options);
 
-        return new SdCardLogSession(fileName, fileCreatedDate, config, samples);
+        return new SdCardLogSession(fileName, fileCreatedDate, config, samples)
+        {
+            TimestampFrequency = timestampFrequency,
+            TimestampFrequencySource = timestampSource
+        };
     }
 
     /// <summary>
@@ -138,7 +153,11 @@ public sealed class SdCardCsvFileParser
     {
         string? deviceName = null;
         string? serialNumber = null;
-        var timestampFreq = options.FallbackTimestampFrequency;
+
+        // File-stated frequency only. The device override and the caller's fallback are
+        // applied afterwards, in that order, so that a connected device's real clock beats a
+        // fallback guess instead of losing to it.
+        var timestampFreq = 0u;
         var analogChannelCount = 0;
         var digitalChannelCount = 0;
         var hasDigitalPair = false;

--- a/src/Daqifi.Core/Device/SdCard/SdCardDeviceConfiguration.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardDeviceConfiguration.cs
@@ -32,8 +32,17 @@ public sealed record SdCardDeviceConfiguration(
     /// <summary>
     /// Creates an <see cref="SdCardDeviceConfiguration"/> from a connected device's
     /// channel configuration. This captures the calibration, resolution, port range,
-    /// and internal scale values needed to convert raw ADC data in SD card log files.
+    /// internal scale, and timestamp clock values needed to interpret an SD card log file.
     /// </summary>
+    /// <remarks>
+    /// The device's own <see cref="DaqifiDevice.TimestampFrequency"/> is included because
+    /// firmware v3.7.2 and earlier write no timestamp frequency into SD card logs while still
+    /// reporting one in their live status message. Passed to
+    /// <see cref="SdCardParseOptions.ConfigurationOverride"/>, it fills that gap; a log that
+    /// does state its own frequency still wins, so this is a backstop and never an override of
+    /// better information. It is <c>0</c> when the device has not reported a frequency, which
+    /// leaves the parser's fallback in charge exactly as before.
+    /// </remarks>
     /// <param name="device">A connected and initialized device.</param>
     /// <returns>A configuration snapshot, or <c>null</c> if the device has no analog channels.</returns>
     public static SdCardDeviceConfiguration? FromDevice(DaqifiDevice device)
@@ -50,7 +59,7 @@ public sealed record SdCardDeviceConfiguration(
         return new SdCardDeviceConfiguration(
             AnalogPortCount: analogChannels.Count,
             DigitalPortCount: digitalCount,
-            TimestampFrequency: 0, // Let the parser use file-embedded or fallback frequency
+            TimestampFrequency: device.TimestampFrequency,
             DeviceSerialNumber: device.Metadata.SerialNumber,
             DevicePartNumber: device.Metadata.PartNumber,
             FirmwareRevision: device.Metadata.FirmwareVersion,

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -79,20 +79,23 @@ public sealed class SdCardFileParser
             }
         }
 
+        // Whatever the file itself stated, captured before the override is merged in so the
+        // two sources stay distinguishable when reporting which one was used.
+        var fileTimestampFrequency = config?.TimestampFrequency ?? 0u;
+
         // Apply ConfigurationOverride as a fallback for any fields not found in the file.
         // This is useful when the device is connected during download — the device's live
-        // status provides calibration, resolution, and port range values that may not be
-        // embedded in the SD card log file.
+        // status provides calibration, resolution, port range, and timestamp clock values
+        // that may not be embedded in the SD card log file.
         if (options.ConfigurationOverride != null)
         {
             config = MergeConfigurations(config, options.ConfigurationOverride);
         }
 
-        var timestampFrequency = config?.TimestampFrequency ?? 0u;
-        if (timestampFrequency == 0 && options.FallbackTimestampFrequency > 0)
-        {
-            timestampFrequency = options.FallbackTimestampFrequency;
-        }
+        var (timestampFrequency, timestampSource) = SdCardTimestampFrequencyResolver.Resolve(
+            fileTimestampFrequency,
+            options.ConfigurationOverride?.TimestampFrequency ?? 0u,
+            options.FallbackTimestampFrequency);
 
         var tickPeriod = timestampFrequency > 0
             ? 1.0 / timestampFrequency
@@ -106,7 +109,11 @@ public sealed class SdCardFileParser
             config,
             ct);
 
-        return new SdCardLogSession(fileName, fileCreatedDate, config, samples);
+        return new SdCardLogSession(fileName, fileCreatedDate, config, samples)
+        {
+            TimestampFrequency = timestampFrequency,
+            TimestampFrequencySource = timestampSource
+        };
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -64,13 +64,27 @@ public sealed class SdCardJsonFileParser
 
         var config = InferConfiguration(lines[0], options);
 
+        // JSON log lines carry raw tick counts and no frequency of their own, so the file can
+        // only ever contribute 0 here; a connected device's frequency is what stands between
+        // the caller's fallback guess and the data.
+        var (timestampFrequency, timestampSource) = SdCardTimestampFrequencyResolver.Resolve(
+            fileFrequencyHz: 0u,
+            options.ConfigurationOverride?.TimestampFrequency ?? 0u,
+            options.FallbackTimestampFrequency);
+
+        config = config with { TimestampFrequency = timestampFrequency };
+
         var samples = ParseJsonLines(
             lines,
             config,
             fileCreatedDate,
             options);
 
-        return new SdCardLogSession(fileName, fileCreatedDate, config, samples);
+        return new SdCardLogSession(fileName, fileCreatedDate, config, samples)
+        {
+            TimestampFrequency = timestampFrequency,
+            TimestampFrequencySource = timestampSource
+        };
     }
 
     /// <summary>
@@ -248,12 +262,12 @@ public sealed class SdCardJsonFileParser
         var parsed = TryParseJsonLine(firstLine);
         var analogCount = parsed?.analog.Count ?? 0;
 
-        var timestampFreq = options.FallbackTimestampFrequency;
-
         var inferred = new SdCardDeviceConfiguration(
             AnalogPortCount: analogCount,
             DigitalPortCount: 0,  // Cannot infer from data
-            TimestampFrequency: timestampFreq,
+            // The frequency is resolved by the caller, after the override merge, so that a
+            // connected device's real clock beats a fallback guess rather than losing to it.
+            TimestampFrequency: 0u,
             DeviceSerialNumber: null,
             DevicePartNumber: null,
             FirmwareRevision: null,

--- a/src/Daqifi.Core/Device/SdCard/SdCardLogSession.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardLogSession.cs
@@ -30,6 +30,27 @@ public sealed class SdCardLogSession
     public IAsyncEnumerable<SdCardLogEntry> Samples { get; }
 
     /// <summary>
+    /// Gets the timestamp clock frequency in Hz that was actually used to convert this log's
+    /// raw tick counts into times, or <c>0</c> when no conversion was possible.
+    /// </summary>
+    /// <remarks>
+    /// Read this together with <see cref="TimestampFrequencySource"/>. A frequency that does
+    /// not match the recording device rescales every timestamp in the session by a constant
+    /// factor, and nothing in the sample data reveals it.
+    /// </remarks>
+    public uint TimestampFrequency { get; init; }
+
+    /// <summary>
+    /// Gets where <see cref="TimestampFrequency"/> came from.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SdCardTimestampSource.Fallback"/> means the frequency was a guess supplied by
+    /// the caller rather than a figure reported by the file or the device, so the timestamps
+    /// should not be trusted as absolute elapsed time.
+    /// </remarks>
+    public SdCardTimestampSource TimestampFrequencySource { get; init; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SdCardLogSession"/> class.
     /// </summary>
     /// <param name="fileName">The source file name.</param>

--- a/src/Daqifi.Core/Device/SdCard/SdCardParseOptions.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardParseOptions.cs
@@ -32,12 +32,19 @@ public sealed class SdCardParseOptions
     /// it will be used to convert raw tick deltas to elapsed time.
     /// </para>
     /// <para>
-    /// This value is only used as a fallback — if the file contains a valid
-    /// <c>TimestampFreq</c>, it takes precedence.
+    /// This value is the last resort. A frequency stated by the file wins, and a frequency
+    /// reported by a connected device through <see cref="ConfigurationOverride"/> comes next;
+    /// this fallback applies only when neither is available.
     /// </para>
     /// <para>
-    /// Defaults to 50 MHz (the Nyquist device clock frequency). Set to 0 to
-    /// disable the fallback entirely.
+    /// Defaults to 50 MHz. That figure is a historical default and does <b>not</b> match
+    /// shipped Nyquist firmware, which reports a 42 MHz timestamp clock — converting 42 MHz
+    /// ticks as though they were 50 MHz makes every reconstructed timestamp roughly 19% fast.
+    /// Prefer supplying <see cref="ConfigurationOverride"/> from the connected device so this
+    /// guess is never needed, and check
+    /// <see cref="SdCardLogSession.TimestampFrequencySource"/> on the parsed session to see
+    /// whether it was. Set to 0 to disable the fallback entirely, which leaves tick counts
+    /// unconverted rather than converted with a guess.
     /// </para>
     /// </summary>
     public uint FallbackTimestampFrequency { get; set; } = 50_000_000;
@@ -47,8 +54,9 @@ public sealed class SdCardParseOptions
     /// config fill in any gaps not found in the file itself.
     /// <para>
     /// This is useful when the device is connected during download — the device's
-    /// live status provides calibration, resolution, and port range values that
-    /// may not be embedded in the SD card log file.
+    /// live status provides calibration, resolution, port range, and timestamp clock
+    /// values that may not be embedded in the SD card log file. Build one with
+    /// <see cref="SdCardDeviceConfiguration.FromDevice"/>.
     /// </para>
     /// </summary>
     public SdCardDeviceConfiguration? ConfigurationOverride { get; set; }

--- a/src/Daqifi.Core/Device/SdCard/SdCardTimestampFrequencyResolver.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTimestampFrequencyResolver.cs
@@ -1,0 +1,49 @@
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Picks the timestamp clock frequency an SD card log parser converts tick counts with, and
+/// records where it came from.
+/// </summary>
+/// <remarks>
+/// The precedence is the same for every log format: the file's own frequency, then a live
+/// device's, then the caller's fallback guess. The device only ever fills a gap the file left,
+/// so a connected device can never override a self-describing log — but it does beat the
+/// fallback, which is the whole point of supplying one.
+/// </remarks>
+internal static class SdCardTimestampFrequencyResolver
+{
+    /// <summary>
+    /// Resolves the frequency to use, in Hz, together with its source. A zero argument means
+    /// "not available" for each of the three inputs.
+    /// </summary>
+    /// <param name="fileFrequencyHz">Frequency embedded in the log file, or zero.</param>
+    /// <param name="deviceFrequencyHz">
+    /// Frequency from <see cref="SdCardParseOptions.ConfigurationOverride"/>, or zero.
+    /// </param>
+    /// <param name="fallbackFrequencyHz">
+    /// <see cref="SdCardParseOptions.FallbackTimestampFrequency"/>, or zero to disable it.
+    /// </param>
+    /// <returns>The frequency to convert with, and the source it came from.</returns>
+    public static (uint FrequencyHz, SdCardTimestampSource Source) Resolve(
+        uint fileFrequencyHz,
+        uint deviceFrequencyHz,
+        uint fallbackFrequencyHz)
+    {
+        if (fileFrequencyHz > 0)
+        {
+            return (fileFrequencyHz, SdCardTimestampSource.LogFile);
+        }
+
+        if (deviceFrequencyHz > 0)
+        {
+            return (deviceFrequencyHz, SdCardTimestampSource.Device);
+        }
+
+        if (fallbackFrequencyHz > 0)
+        {
+            return (fallbackFrequencyHz, SdCardTimestampSource.Fallback);
+        }
+
+        return (0u, SdCardTimestampSource.None);
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardTimestampSource.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTimestampSource.cs
@@ -1,0 +1,52 @@
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Where the timestamp clock frequency used to convert an SD card log's raw tick counts
+/// into wall-clock times came from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every timestamp in a parsed session is a tick count divided by this frequency, so a
+/// frequency that does not match the recording device rescales the entire session by a
+/// constant factor. That failure is invisible in the data itself — the samples still look
+/// evenly spaced, just at the wrong rate — which is why the source is reported alongside
+/// <see cref="SdCardLogSession.TimestampFrequency"/> rather than left implicit.
+/// </para>
+/// <para>
+/// <see cref="Fallback"/> is the value to watch for: it means nothing in the file and no
+/// connected device supplied a frequency, so
+/// <see cref="SdCardParseOptions.FallbackTimestampFrequency"/> was used as a guess.
+/// </para>
+/// </remarks>
+public enum SdCardTimestampSource
+{
+    /// <summary>
+    /// No frequency was available and the fallback was disabled
+    /// (<see cref="SdCardParseOptions.FallbackTimestampFrequency"/> set to zero), so tick
+    /// counts were not converted to elapsed time at all.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The frequency was read from the log file itself. This is the most trustworthy source:
+    /// it is what the device recorded at the time the log was written.
+    /// </summary>
+    LogFile = 1,
+
+    /// <summary>
+    /// The file carried no frequency, so the one reported by a live device via
+    /// <see cref="SdCardParseOptions.ConfigurationOverride"/> was used. Firmware v3.7.2 and
+    /// earlier embed no frequency in SD card logs but do report one in their live status
+    /// message, which makes this the normal source when a log is parsed straight after
+    /// download from the device that wrote it.
+    /// </summary>
+    Device = 2,
+
+    /// <summary>
+    /// Neither the file nor a connected device supplied a frequency, so
+    /// <see cref="SdCardParseOptions.FallbackTimestampFrequency"/> was used. The reconstructed
+    /// timestamps are only as accurate as that guess — if it does not match the recording
+    /// device's clock, every timestamp in the session is scaled by a constant factor.
+    /// </summary>
+    Fallback = 3
+}

--- a/src/Daqifi.Core/Device/TimestampProcessor.cs
+++ b/src/Daqifi.Core/Device/TimestampProcessor.cs
@@ -40,14 +40,22 @@ namespace Daqifi.Core.Device;
 public sealed class TimestampProcessor : ITimestampProcessor
 {
     /// <summary>
-    /// Default tick period in seconds (20 nanoseconds = 20E-9 seconds).
-    /// This corresponds to a 50MHz clock.
+    /// Default tick period in seconds (20 nanoseconds = 20E-9 seconds), corresponding to a
+    /// 50 MHz clock.
     /// </summary>
+    /// <remarks>
+    /// This is a historical default, not a measurement of any shipped board: current firmware
+    /// reports a 42 MHz timestamp clock, so relying on this value instead of the
+    /// device-reported frequency scales every reconstructed timestamp by roughly 1.19. Always
+    /// prefer <see cref="SetTimestampFrequency"/> with the device's own figure, and use
+    /// <see cref="HasTimestampFrequency"/> to find out whether that has happened.
+    /// </remarks>
     public const double DefaultTickPeriod = 20E-9;
 
     /// <summary>
-    /// Default timestamp clock frequency in Hz (50MHz), corresponding to
-    /// <see cref="DefaultTickPeriod"/>.
+    /// Default timestamp clock frequency in Hz (50 MHz), corresponding to
+    /// <see cref="DefaultTickPeriod"/>. See that field for why it should not be relied on in
+    /// place of the device-reported frequency.
     /// </summary>
     public const uint DefaultTimestampFrequency = 50_000_000;
 


### PR DESCRIPTION
## Why

Every timestamp reconstructed from an SD card log was about 19% fast. `SdCardDeviceConfiguration.FromDevice` was handed a live, initialized device and threw away the one thing it was uniquely able to supply — the device's real timestamp clock — so parsing fell back to 50 MHz while the hardware counts at 42 MHz. Nothing warned and the exit code was 0: a recording that really spanned 6.2 seconds simply reported 5.2, and `--sd-export-csv` baked the error into the `Time` column for anything downstream.

## What

Parse an SD log with the device connected and the timestamps now come out at the rate the data was actually logged at — 50.0 ms apart for a 20 Hz log instead of 42.0 ms. When neither the log file nor a connected device can supply a frequency, the parser still falls back to a guess, but the session now reports which frequency it used and where that number came from, so a wrong answer can no longer be mistaken for a right one.

## How

`FromDevice` now passes `device.TimestampFrequency` instead of a hardcoded 0, keeping 0 only when the device genuinely reported none. A log that states its own frequency still wins, so this is a backstop rather than an override of better data. `SdCardLogSession` gained two additive properties — `TimestampFrequency` and `TimestampFrequencySource` — that name the figure used and whether it came from the file, the device, or a fallback guess, mirroring the existing `ITimestampProcessor.HasTimestampFrequency` idea.

**Second bug fixed here, worth calling out on its own:** the CSV and JSON parsers seeded the fallback frequency *before* merging the device override, so a connected device's real clock could never win — it was always beaten by the 50 MHz guess. That made fix #1 inert for those two formats. All three parsers now share one precedence: file, then device, then fallback. One existing JSON test asserted the old behaviour explicitly ("Inferred frequency takes precedence"); that assertion is deliberately inverted in this PR, since it codified the bug.

## Bench test

Bench Nq1, FW 3.7.2, parsing `log_20260802_084946.bin` — the exact file from the issue, 125 samples logged at 20 Hz (50.0 ms expected).

**USB / serial, before (Core `main`):**
```
Timestamp freq:   0 Hz
first: [18:47:07.727]   last: [18:47:12.935]   125 samples
=> 5.208 s over 124 intervals = 42.00 ms
```

**USB / serial, after (this branch):**
```
Timestamp freq:   42000000 Hz
first: [18:47:15.470]   last: [18:47:21.670]   125 samples
=> 6.200 s over 124 intervals = 50.00 ms
```

**WiFi / TCP `192.168.1.30:9760`, after** (one consolidated run; SD-over-TCP works since #327):
```
Timestamp freq:   42000000 Hz
first: [18:48:02.786]   last: [18:48:08.936]
=> 6.150 s over 123 intervals = 50.00 ms
```

Supporting measurements from the same unit: the live status message reports `TimestampFreq = 42,000,000 Hz`, and raw stream tick deltas were 4,200,000 @ 10 Hz, 2,100,000 @ 20 Hz and 840,000 @ 50 Hz — each one exactly 42 MHz divided by the requested rate.

Full Core suite green: 2483 passed, 0 failed, on both net9.0 and net10.0, with 14 new tests.

### Not covered by this bench run

The fresh `--sd-log-start` → `--sd-list` → `--sd-download` repro cycle did not complete. Once SD logging stopped, every subsequent **serial** connect failed with `did not report its channel configuration within 8s` — twice, including after a 25 second settle — on a freshly power-cycled unit, while TCP to the same device kept working normally throughout. This looks like a previously unrecorded device behaviour (writing an SD log leaves the serial interface unable to complete init for a while) and is distinct from the known low-heap empty-transfer state, which presents as an empty marker-only download rather than a failed init. It is not caused by this change: the same binary downloaded and parsed successfully seconds earlier over the same port. The before/after evidence above does not depend on that cycle, since it uses the exact log file from the issue.

## Two things the reviewer should decide on

**1. The issue's claim that this is unrelated to firmware #716 is wrong, and this PR does not fix the residual error.** Timing the live stream against the host clock shows the counter advances at ~33.34 MHz in real time, not 42 MHz — and 33.34/42.0 = 0.794, exactly firmware #716's "streams at 79.4% of the requested rate". The tick deltas were perfectly uniform with no dropped samples or buffered backlog, at rates far below any bandwidth limit, so this is not a transport artifact: the device's declared timebase and its slow sample cadence are one and the same firmware defect. Practically, after this PR an SD timestamp matches the device's *declared* timebase and the nominal logged rate, but is still about 26% short of true wall-clock elapsed time until firmware corrects its clock constant. I deliberately did **not** bake 33.34 MHz into Core — trusting the device's declared frequency is the right contract, and a compensation constant would silently become wrong the moment firmware is fixed.

**2. `TimestampProcessor.DefaultTimestampFrequency` is left at 50 MHz.** Changing it to 42 MHz would retime data for every live-streaming consumer, not just the SD path, and it is only ever reached when a device reports no frequency at all. I corrected its documentation to say plainly that it matches no shipped board rather than swapping the value, and made the SD fallback observable instead. Happy to change the constant if you'd rather take that behaviour change.

Closes #426
