### PR TITLE
test(winc): make the abandoned-open tests deterministic instead of timing-based

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/Winc/WincFlasherTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Winc/WincFlasherTests.cs
@@ -650,9 +650,16 @@ public class WincFlasherTests
 
         public void Open()
         {
-            // Bounded so a test that fails before releasing surfaces its own assertion rather than
-            // parking a pool thread for the life of the run.
-            _release.Wait(TimeSpan.FromSeconds(30));
+            // Bounded at the tests' own 10 s wait rather than above it. A test that fails before
+            // releasing surfaces its own assertion first either way, but anything longer leaves this
+            // parked on a pool thread after the test has finished — extra contention in the suite
+            // whose load sensitivity is the reason this class exists.
+            if (!_release.Wait(TimeSpan.FromSeconds(10)))
+            {
+                throw new InvalidOperationException(
+                    "Test bug: ReleaseFault was never called, so the gated open timed out.");
+            }
+
             throw new InvalidOperationException("abandoned-open-fault");
         }
 

--- a/src/Daqifi.Core.Tests/Firmware/Winc/WincFlasherTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Winc/WincFlasherTests.cs
@@ -332,7 +332,7 @@ public class WincFlasherTests
         // to hand to the logger. So a logger that captures the exception proves the read happened,
         // using a seam that exists for production reasons rather than a test-only hook.
         var logger = new CapturingLogger();
-        var port = new FaultingAfterDelayPort(TimeSpan.FromMilliseconds(150));
+        var port = new FaultingOnReleasePort();
         var inspector = new WincModuleInspector(
             (_, _) => port,
             logger,
@@ -340,6 +340,10 @@ public class WincFlasherTests
             openTimeout: TimeSpan.FromMilliseconds(50));
 
         await Assert.ThrowsAsync<TimeoutException>(() => inspector.ReadIdentityAsync("COM1"));
+
+        // Only now let the abandoned open fault, so it provably lands after the timeout rather than
+        // racing it.
+        port.ReleaseFault();
 
         var observed = await logger.FirstException.WaitAsync(TimeSpan.FromSeconds(10));
 
@@ -356,7 +360,7 @@ public class WincFlasherTests
         // Releasing the handle is the whole reason the abandonment continuation exists. If a
         // throwing logger could skip past the disposal, the abandoned port would leak and break
         // every later open until the process exits — strictly worse than the fault being reported.
-        var port = new FaultingAfterDelayPort(TimeSpan.FromMilliseconds(150));
+        var port = new FaultingOnReleasePort();
         var inspector = new WincModuleInspector(
             (_, _) => port,
             new ThrowingLogger(),
@@ -364,6 +368,10 @@ public class WincFlasherTests
             openTimeout: TimeSpan.FromMilliseconds(50));
 
         await Assert.ThrowsAsync<TimeoutException>(() => inspector.ReadIdentityAsync("COM1"));
+
+        // Only now let the abandoned open fault, so it provably lands after the timeout rather than
+        // racing it.
+        port.ReleaseFault();
 
         // Disposal must still happen despite the observation throwing.
         await port.Disposed.WaitAsync(TimeSpan.FromSeconds(10));
@@ -608,23 +616,43 @@ public class WincFlasherTests
     }
 
     /// <summary>
-    /// A port whose <see cref="Open"/> blocks briefly and then throws, standing in for an open that
-    /// is abandoned on the timeout and only fails afterwards.
+    /// A port whose <see cref="Open"/> blocks until the test releases it and then throws, standing
+    /// in for an open that is abandoned on the timeout and only fails afterwards.
     /// </summary>
-    private sealed class FaultingAfterDelayPort(TimeSpan delay) : IWincSerialPort
+    /// <remarks>
+    /// The fault is gated on a signal rather than a wall-clock delay because the ordering has to be
+    /// guaranteed, not merely likely. An earlier version slept 150 ms against a 50 ms
+    /// <c>openTimeout</c> and leaned on that margin, but <see cref="Task.WaitAsync(TimeSpan)"/> only
+    /// times out when its timer fires <em>before</em> the task completes — so a runner contended
+    /// enough to slip a 50 ms timer past 150 ms saw the fault land first, and the assertion caught
+    /// <see cref="InvalidOperationException"/> instead of <see cref="TimeoutException"/>. That
+    /// reddened unrelated PRs under full-suite load while passing in isolation. Holding the fault
+    /// until the timeout has already been observed removes the timing assumption entirely.
+    /// </remarks>
+    private sealed class FaultingOnReleasePort : IWincSerialPort
     {
+        private readonly SemaphoreSlim _release = new(0, 1);
+
         private readonly TaskCompletionSource _disposed =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         /// <summary>Completes when the port is disposed, so tests can await it deterministically.</summary>
         internal Task Disposed => _disposed.Task;
 
+        /// <summary>
+        /// Lets the blocked open proceed to its fault. Call only once the timeout has been observed,
+        /// which is what makes the abandoned-open ordering deterministic.
+        /// </summary>
+        internal void ReleaseFault() => _release.Release();
+
         public bool IsOpen => false;
         public int BaudRate { get; set; } = 115200;
 
         public void Open()
         {
-            Thread.Sleep(delay);
+            // Bounded so a test that fails before releasing surfaces its own assertion rather than
+            // parking a pool thread for the life of the run.
+            _release.Wait(TimeSpan.FromSeconds(30));
             throw new InvalidOperationException("abandoned-open-fault");
         }
 


### PR DESCRIPTION
## Why

Two tests in `WincFlasherTests` fail on CI at random and are currently blocking every open PR in this repo — #427, #428 and #429 all went red on them, and none of those PRs touch WINC code at all. They pass when you run them on your own machine, which is the worst kind of failure: it looks like the PR broke something, and the natural next step is to start changing working code to appease it.

## What

The two tests now pass reliably. Nothing about the behaviour they check has changed — this is a test-only fix, no production code is touched.

## How

Both tests set up a fake serial port that fails 150 ms after you open it, against an inspector that gives up waiting after 50 ms, and then assert that you get the "gave up waiting" error. That only holds if the 50 ms clock actually fires first, and on a busy CI machine running 2,485 tests it often doesn't — .NET's `WaitAsync` only reports a timeout if its timer goes off *before* the task finishes, so a delayed timer means the port's failure gets reported instead, and the test fails on the wrong exception type.

Instead of a 150 ms delay, the fake port now waits for the test to explicitly tell it to fail, and the test only does that *after* it has already seen the timeout. So the order is guaranteed by construction rather than by hoping one clock beats another. The wait is capped at 30 s so a genuinely broken test reports its own failure instead of hanging.

## Evidence

- Failing on CI across unrelated PRs, alternating between the two sibling tests and between net9.0/net10.0 — the signature of a load-dependent race, not a real break:
  - #429 → `Inspector_ObservesTheFaultOfAnAbandonedOpen` (net9.0), then `Inspector_DisposesTheAbandonedPort_EvenWhenObservingTheFaultThrows` (net10.0) on re-run
  - #428 → `Inspector_DisposesTheAbandonedPort_EvenWhenObservingTheFaultThrows` (net10.0), twice
  - `feature/native-winc-flasher`, the branch that introduced the tests, failed it on its own branch too
- Same assertion every time: `Assert.Throws() Failure: Exception type was not an exact match`
- Clean `main` @ 359bf74 passes locally 5/5 in isolation and 5/5 full-suite — it does not reproduce on an idle machine, which is why it slipped through
- This branch: full suite green 3/3 rounds with **both frameworks running concurrently** to load the machine — 2,469 passed, 0 failed each round
- Release build clean, 0 warnings

Introduced by #423 (`359bf74`).

Not merging — for review.