### PR TITLE
refactor(device): extract channel/DIO/PWM/analog-out control into a collaborator (part of #344)

### DIFF
--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -259,6 +259,7 @@ namespace Daqifi.Core.Device
             // Built here rather than in field initializers because each needs `this` as its host,
             // which a field initializer cannot reference. Every constructor routes through this
             // method, so they are always in place before the device is handed to a caller.
+            _channelControl = new ChannelControlOperations(this);
             _networkOperations = new NetworkConfigurationOperations(this);
             _sdCardOperations = new SdCardOperations(this);
             _lanChipInfoOperations = new LanChipInfoOperations(this);
@@ -275,7 +276,7 @@ namespace Daqifi.Core.Device
             {
                 if (e.Status != ConnectionStatus.Connected)
                 {
-                    _lastSentPwmFrequencyHz = null;
+                    _channelControl.ResetSentPwmFrequency();
                 }
             };
         }
@@ -651,7 +652,7 @@ namespace Daqifi.Core.Device
             {
                 foreach (var channel in SnapshotChannels())
                 {
-                    if (channel.Type != ChannelType.Analog || channel.ChannelNumber > MaxAdcBitmaskChannel)
+                    if (channel.Type != ChannelType.Analog || channel.ChannelNumber > ChannelControlOperations.MaxAdcBitmaskChannel)
                     {
                         continue;
                     }
@@ -1268,128 +1269,24 @@ namespace Daqifi.Core.Device
             }
         }
 
-        /// <summary>
-        /// The maximum analog channel number that can be encoded in the ADC enable bitmask.
-        /// The mask is a 32-bit value (<c>1u &lt;&lt; ChannelNumber</c>), so channel numbers must be 0-31.
-        /// </summary>
-        private const int MaxAdcBitmaskChannel = 31;
+        /// <inheritdoc />
+        public void EnableChannel(IChannel channel) => _channelControl.EnableChannel(channel);
 
         /// <inheritdoc />
-        public void EnableChannel(IChannel channel)
-        {
-            ArgumentNullException.ThrowIfNull(channel);
-            SetChannelsEnabled(new[] { channel }, enabled: true);
-        }
+        public void EnableChannels(IEnumerable<IChannel> channels) => _channelControl.EnableChannels(channels);
 
         /// <inheritdoc />
-        public void EnableChannels(IEnumerable<IChannel> channels)
-        {
-            ArgumentNullException.ThrowIfNull(channels);
-            SetChannelsEnabled(channels as IReadOnlyList<IChannel> ?? channels.ToList(), enabled: true);
-        }
+        public void DisableChannel(IChannel channel) => _channelControl.DisableChannel(channel);
 
         /// <inheritdoc />
-        public void DisableChannel(IChannel channel)
-        {
-            ArgumentNullException.ThrowIfNull(channel);
-            SetChannelsEnabled(new[] { channel }, enabled: false);
-        }
-
-        /// <inheritdoc />
-        public void DisableAllChannels()
-        {
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            (bool HasChannels, uint Mask) adcMask = default;
-            (bool HasChannels, bool AnyEnabled) dioState = default;
-
-            // Mutate and derive the outbound masks in one critical section — see the matching
-            // comment in SetChannelsEnabled (#409) for why the gap matters.
-            WithChannelsLock(() =>
-            {
-                foreach (var channel in SnapshotChannels())
-                {
-                    channel.IsEnabled = false;
-                }
-
-                adcMask = ComputeAdcEnableMask();
-                dioState = ComputeDioEnableState();
-            });
-
-            // Push the cleared state for whichever channel types this device actually has.
-            if (adcMask.HasChannels)
-            {
-                Send(ScpiMessageProducer.EnableAdcChannels(adcMask.Mask.ToString(CultureInfo.InvariantCulture)));
-            }
-
-            if (dioState.HasChannels)
-            {
-                Send(dioState.AnyEnabled
-                    ? ScpiMessageProducer.EnableDioPorts()
-                    : ScpiMessageProducer.DisableDioPorts());
-            }
-        }
+        public void DisableAllChannels() => _channelControl.DisableAllChannels();
 
         /// <inheritdoc />
         public void SetDioDirection(IChannel channel, ChannelDirection direction)
-        {
-            // Argument validation precedes the connection (state) check so misuse surfaces
-            // the same exception type regardless of connection state.
-            ArgumentNullException.ThrowIfNull(channel);
-
-            if (channel.Type != ChannelType.Digital)
-            {
-                throw new ArgumentException("Direction can only be set on digital channels.", nameof(channel));
-            }
-
-            if (direction != ChannelDirection.Input && direction != ChannelDirection.Output)
-            {
-                throw new ArgumentOutOfRangeException(nameof(direction), direction, "Direction must be Input or Output.");
-            }
-
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            EnsureChannelBelongs(channel);
-
-            channel.Direction = direction;
-            Send(ScpiMessageProducer.SetDioPortDirection(
-                channel.ChannelNumber,
-                direction == ChannelDirection.Output ? 1 : 0));
-        }
+            => _channelControl.SetDioDirection(channel, direction);
 
         /// <inheritdoc />
-        public void SetDioValue(IChannel channel, bool value)
-        {
-            ArgumentNullException.ThrowIfNull(channel);
-
-            // Gate on Type (matching SetDioDirection) rather than the IDigitalChannel interface,
-            // so both DIO methods accept the same set of channels. The SCPI command only needs
-            // the channel number; OutputValue mirroring is best-effort local bookkeeping.
-            if (channel.Type != ChannelType.Digital)
-            {
-                throw new ArgumentException("A digital output value can only be set on digital channels.", nameof(channel));
-            }
-
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            EnsureChannelBelongs(channel);
-
-            if (channel is IDigitalChannel digitalChannel)
-            {
-                digitalChannel.OutputValue = value;
-            }
-
-            Send(ScpiMessageProducer.SetDioPortState(channel.ChannelNumber, value ? 1 : 0));
-        }
+        public void SetDioValue(IChannel channel, bool value) => _channelControl.SetDioValue(channel, value);
 
         /// <summary>
         /// The lowest PWM frequency the firmware reproduces correctly. Below this the firmware's
@@ -1414,133 +1311,17 @@ namespace Daqifi.Core.Device
         /// mirroring <see cref="SetPwmFrequency"/>; defaults to <see cref="DefaultPwmFrequencyHz"/>
         /// (a commandable value) until a frequency has been set this session.
         /// </summary>
-        public int PwmFrequencyHz { get; private set; } = DefaultPwmFrequencyHz;
-
-        /// <summary>
-        /// The PWM frequency actually sent to the device this connection, or <c>null</c> if none has
-        /// been sent yet (also reset to <c>null</c> on disconnect). Distinct from
-        /// <see cref="PwmFrequencyHz"/>, which carries a session default before anything is sent —
-        /// this drives the skip-if-unchanged guard so a fresh connection always sends. See #345.
-        /// </summary>
-        private int? _lastSentPwmFrequencyHz;
+        public int PwmFrequencyHz => _channelControl.PwmFrequencyHz;
 
         /// <inheritdoc />
-        public void SetPwmEnabled(IChannel channel, bool enabled)
-        {
-            ArgumentNullException.ThrowIfNull(channel);
-
-            if (channel.Type != ChannelType.Digital)
-            {
-                throw new ArgumentException("PWM can only be controlled on digital channels.", nameof(channel));
-            }
-
-            // Enabling PWM on a non-capable channel must be blocked here: the firmware flags the
-            // channel PWM-active before its capability check fails and never rolls that back,
-            // leaving the channel dead to digital writes. Disabling is that state's only recovery
-            // command, so it is accepted on any digital channel.
-            if (enabled && channel is not IDigitalChannel { IsPwmCapable: true })
-            {
-                throw new ArgumentException(
-                    $"Channel {channel.ChannelNumber} does not support PWM. PWM-capable channels: {PwmCapableChannelList}.",
-                    nameof(channel));
-            }
-
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            EnsureChannelBelongs(channel);
-
-            if (channel is IDigitalChannel digitalChannel)
-            {
-                digitalChannel.IsPwmEnabled = enabled;
-                if (!enabled)
-                {
-                    // Disabling PWM leaves the pin high-impedance and the firmware zeroes its
-                    // stored output value; mirror that so local state doesn't claim a driven level.
-                    // Direction is intentionally left as-is: the firmware keeps the channel's
-                    // stored direction and re-applies it (resuming driving) on the next state or
-                    // direction write, or on the next streaming tick — verified on hardware.
-                    digitalChannel.OutputValue = false;
-                }
-            }
-
-            Send(ScpiMessageProducer.SetPwmChannelEnabled(channel.ChannelNumber, enabled));
-        }
+        public void SetPwmEnabled(IChannel channel, bool enabled) => _channelControl.SetPwmEnabled(channel, enabled);
 
         /// <inheritdoc />
         public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent)
-        {
-            ArgumentNullException.ThrowIfNull(channel);
-
-            if (channel.Type != ChannelType.Digital)
-            {
-                throw new ArgumentException("PWM can only be controlled on digital channels.", nameof(channel));
-            }
-
-            if (channel is not IDigitalChannel { IsPwmCapable: true })
-            {
-                throw new ArgumentException(
-                    $"Channel {channel.ChannelNumber} does not support PWM. PWM-capable channels: {PwmCapableChannelList}.",
-                    nameof(channel));
-            }
-
-            // Duty 0 is rejected rather than forwarded: the firmware stores it but never writes
-            // the compare register, so the output keeps toggling at the previous duty while the
-            // stored value claims 0. Stopping the output is SetPwmEnabled(channel, false).
-            if (dutyCyclePercent is < 1 or > 100)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(dutyCyclePercent), dutyCyclePercent,
-                    "Duty cycle must be 1-100 percent. To stop the output, use SetPwmEnabled(channel, false).");
-            }
-
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            EnsureChannelBelongs(channel);
-
-            if (channel is IDigitalChannel digitalChannel)
-            {
-                digitalChannel.PwmDutyCyclePercent = dutyCyclePercent;
-            }
-
-            Send(ScpiMessageProducer.SetPwmChannelDutyCycle(channel.ChannelNumber, dutyCyclePercent));
-        }
+            => _channelControl.SetPwmDutyCycle(channel, dutyCyclePercent);
 
         /// <inheritdoc />
-        public void SetPwmFrequency(int frequencyHz)
-        {
-            if (frequencyHz is < MinPwmFrequencyHz or > MaxPwmFrequencyHz)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(frequencyHz), frequencyHz,
-                    $"PWM frequency must be {MinPwmFrequencyHz}-{MaxPwmFrequencyHz} Hz.");
-            }
-
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            // Skip the redundant round-trip when the device already has this frequency (from a
-            // send earlier this connection). The cache is cleared on disconnect so a fresh
-            // connection always sends. PwmFrequencyHz still reflects the commanded value. See #345.
-            if (frequencyHz == _lastSentPwmFrequencyHz)
-            {
-                return;
-            }
-
-            // The SCPI command is addressed to a channel, but the firmware drives all PWM from
-            // one shared timer and applies the frequency to every channel. Channel 0 is used as
-            // the address because it is PWM-capable on all supported hardware.
-            Send(ScpiMessageProducer.SetPwmChannelFrequency(0, frequencyHz));
-            _lastSentPwmFrequencyHz = frequencyHz;
-            PwmFrequencyHz = frequencyHz;
-        }
+        public void SetPwmFrequency(int frequencyHz) => _channelControl.SetPwmFrequency(frequencyHz);
 
         /// <summary>
         /// Sets and persists the device's user-defined friendly name to NVM, then optimistically
@@ -1597,46 +1378,9 @@ namespace Daqifi.Core.Device
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Comma-separated PWM-capable channel numbers for error messages, derived from this
-        /// device's channel collection.
-        /// </summary>
-        private string PwmCapableChannelList
-        {
-            get
-            {
-                var capable = new List<int>();
-                foreach (var ch in SnapshotChannels())
-                {
-                    if (ch is IDigitalChannel { IsPwmCapable: true })
-                    {
-                        capable.Add(ch.ChannelNumber);
-                    }
-                }
-                capable.Sort();
-                return capable.Count > 0 ? string.Join(", ", capable) : "none on this device";
-            }
-        }
-
         /// <inheritdoc />
         public void SetAnalogOutput(int channelNumber, double voltage)
-        {
-            if (channelNumber < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
-            }
-
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            // Analog-output (DAC) channels are addressed by number; they are not part of the
-            // populated Channels collection (PopulateChannelsFromStatus creates analog *input*
-            // channels only). Stage the level, then latch it.
-            Send(ScpiMessageProducer.SetAnalogOutputVoltage(channelNumber, voltage));
-            Send(ScpiMessageProducer.UpdateDacOutputs);
-        }
+            => _channelControl.SetAnalogOutput(channelNumber, voltage);
 
         /// <inheritdoc />
         public void Reboot()
@@ -1767,190 +1511,6 @@ namespace Daqifi.Core.Device
             Send(ScpiMessageProducer.LoadVoltagePrecision);
         }
 
-        /// <summary>
-        /// Sets the enabled state for a set of channels, then sends one device command per affected
-        /// channel type (the ADC enable bitmask for analog, the global DIO enable for digital).
-        /// Validation runs before any mutation so an invalid entry leaves device state untouched.
-        /// </summary>
-        private void SetChannelsEnabled(IReadOnlyList<IChannel> channels, bool enabled)
-        {
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            // Validate everything up front so a bad entry can't leave a partially-applied state.
-            foreach (var channel in channels)
-            {
-                if (channel is null)
-                {
-                    throw new ArgumentException("The channel collection contains a null entry.", nameof(channels));
-                }
-
-                EnsureChannelBelongs(channel);
-            }
-
-            var touchedAnalog = false;
-            var touchedDigital = false;
-            var adcMask = (HasChannels: false, Mask: 0u);
-            var dioState = (HasChannels: false, AnyEnabled: false);
-
-            // Mutate IsEnabled and derive the outbound masks from it in one critical section, so
-            // a status frame resyncing analog IsEnabled from the device (#409) on the consumer
-            // thread cannot interleave between the mutation and the read that computes the mask —
-            // which would otherwise send a mask reflecting a value the status frame is about to
-            // overwrite, silently failing to apply the requested enable/disable on the device.
-            WithChannelsLock(() =>
-            {
-                foreach (var channel in channels)
-                {
-                    channel.IsEnabled = enabled;
-
-                    if (channel.Type == ChannelType.Analog)
-                    {
-                        touchedAnalog = true;
-                    }
-                    else if (channel.Type == ChannelType.Digital)
-                    {
-                        touchedDigital = true;
-                    }
-                }
-
-                if (touchedAnalog)
-                {
-                    adcMask = ComputeAdcEnableMask();
-                }
-
-                if (touchedDigital)
-                {
-                    dioState = ComputeDioEnableState();
-                }
-            });
-
-            if (touchedAnalog && adcMask.HasChannels)
-            {
-                Send(ScpiMessageProducer.EnableAdcChannels(adcMask.Mask.ToString(CultureInfo.InvariantCulture)));
-            }
-
-            if (touchedDigital && dioState.HasChannels)
-            {
-                Send(dioState.AnyEnabled
-                    ? ScpiMessageProducer.EnableDioPorts()
-                    : ScpiMessageProducer.DisableDioPorts());
-            }
-        }
-
-        /// <summary>
-        /// Computes the ADC enable bitmask over all currently-enabled analog channels. Must be
-        /// called under <see cref="DaqifiDevice.WithChannelsLock{T}"/> alongside any IsEnabled
-        /// mutation it should reflect (#409) — see <see cref="SetChannelsEnabled"/>.
-        /// </summary>
-        private (bool HasChannels, uint Mask) ComputeAdcEnableMask()
-        {
-            uint mask = 0;
-            var hasAnalogChannels = false;
-
-            foreach (var channel in SnapshotChannels())
-            {
-                if (channel.Type != ChannelType.Analog)
-                {
-                    continue;
-                }
-
-                hasAnalogChannels = true;
-
-                if (!channel.IsEnabled)
-                {
-                    continue;
-                }
-
-                if (channel.ChannelNumber > MaxAdcBitmaskChannel)
-                {
-                    throw new InvalidOperationException(
-                        $"Analog channel number {channel.ChannelNumber} exceeds the maximum ({MaxAdcBitmaskChannel}) that can be encoded in the ADC enable bitmask.");
-                }
-
-                mask |= 1u << channel.ChannelNumber;
-            }
-
-            return (hasAnalogChannels, mask);
-        }
-
-        /// <summary>
-        /// Recomputes the ADC enable bitmask over all currently-enabled analog channels and sends it.
-        /// Does nothing when the device has no analog channels. The firmware treats the value as a
-        /// set-replace, so the full mask of enabled analog channels is sent every time.
-        /// </summary>
-        private void SendAdcEnableMask()
-        {
-            var (hasAnalogChannels, mask) = WithChannelsLock(ComputeAdcEnableMask);
-
-            if (!hasAnalogChannels)
-            {
-                return;
-            }
-
-            Send(ScpiMessageProducer.EnableAdcChannels(mask.ToString(CultureInfo.InvariantCulture)));
-        }
-
-        /// <summary>
-        /// Computes whether any digital channel is enabled. Must be called under
-        /// <see cref="DaqifiDevice.WithChannelsLock{T}"/> alongside any IsEnabled mutation it
-        /// should reflect — see <see cref="SetChannelsEnabled"/>.
-        /// </summary>
-        private (bool HasChannels, bool AnyEnabled) ComputeDioEnableState()
-        {
-            var hasDigitalChannels = false;
-            var anyEnabled = false;
-
-            foreach (var channel in SnapshotChannels())
-            {
-                if (channel.Type != ChannelType.Digital)
-                {
-                    continue;
-                }
-
-                hasDigitalChannels = true;
-
-                if (channel.IsEnabled)
-                {
-                    anyEnabled = true;
-                }
-            }
-
-            return (hasDigitalChannels, anyEnabled);
-        }
-
-        /// <summary>
-        /// Sends the global DIO enable command reflecting whether any digital channel is enabled.
-        /// Does nothing when the device has no digital channels. The firmware exposes only a global
-        /// DIO enable, so per-channel digital enabling is collapsed to this aggregate state.
-        /// </summary>
-        private void SendDioEnableState()
-        {
-            var (hasDigitalChannels, anyEnabled) = WithChannelsLock(ComputeDioEnableState);
-
-            if (!hasDigitalChannels)
-            {
-                return;
-            }
-
-            Send(anyEnabled
-                ? ScpiMessageProducer.EnableDioPorts()
-                : ScpiMessageProducer.DisableDioPorts());
-        }
-
-        /// <summary>
-        /// Throws when the supplied channel is not part of this device's populated channel collection,
-        /// which would mean mutating it could not affect the device-level enable state.
-        /// </summary>
-        private void EnsureChannelBelongs(IChannel channel)
-        {
-            if (!SnapshotChannels().Contains(channel))
-            {
-                throw new ArgumentException("The specified channel does not belong to this device.", nameof(channel));
-            }
-        }
 
         // -----------------------------------------------------------------
         // Delegation to the operation collaborators.
@@ -1962,6 +1522,9 @@ namespace Daqifi.Core.Device
         // this file, so every call still passes through this device's own
         // virtual members and any subclass override of them.
         // -----------------------------------------------------------------
+
+        /// <summary>Channel enable/disable, DIO, PWM and analog output (<see cref="IStreamingDevice"/>).</summary>
+        private ChannelControlOperations _channelControl = null!;
 
         /// <summary>WiFi/LAN configuration (<see cref="INetworkConfigurable"/>).</summary>
         private NetworkConfigurationOperations _networkOperations = null!;
@@ -2155,6 +1718,10 @@ namespace Daqifi.Core.Device
         void IDeviceOperationHost.StopStreaming() => StopStreaming();
 
         void IDeviceOperationHost.Send<T>(IOutboundMessage<T> message) => Send(message);
+
+        IReadOnlyList<IChannel> IDeviceOperationHost.SnapshotChannels() => SnapshotChannels();
+
+        void IDeviceOperationHost.WithChannelsLock(Action action) => WithChannelsLock(action);
 
 #pragma warning disable CA1068 // Matches the seam it forwards to.
         Task<IReadOnlyList<string>> IDeviceOperationHost.ExecuteTextCommandAsync(

--- a/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
@@ -1,0 +1,482 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Producers;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Internal
+{
+    /// <summary>
+    /// The channel-control half of <see cref="IStreamingDevice"/> — analog/digital enable, DIO
+    /// direction and level, PWM, and the analog output — extracted from
+    /// <see cref="DaqifiStreamingDevice"/> (#344) so the device delegates rather than hosts it.
+    /// Owns the PWM frequency bookkeeping that goes with those commands.
+    /// </summary>
+    /// <remarks>
+    /// Everything here reaches the device through <see cref="IDeviceOperationHost"/>, so each
+    /// command still passes through the device's own virtual <c>Send</c> and the same channels
+    /// lock the status-frame resync uses (#409).
+    /// </remarks>
+    internal sealed class ChannelControlOperations
+    {
+        /// <summary>
+        /// The maximum analog channel number that can be encoded in the ADC enable bitmask.
+        /// The mask is a 32-bit value (<c>1u &lt;&lt; ChannelNumber</c>), so channel numbers must be 0-31.
+        /// Shared with the device's tracking of a raw ADC-enable command, which decodes the same mask.
+        /// </summary>
+        internal const int MaxAdcBitmaskChannel = 31;
+
+        private readonly IDeviceOperationHost _host;
+
+        internal ChannelControlOperations(IDeviceOperationHost host)
+        {
+            _host = host ?? throw new ArgumentNullException(nameof(host));
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.PwmFrequencyHz" />
+        internal int PwmFrequencyHz { get; private set; } = DaqifiStreamingDevice.DefaultPwmFrequencyHz;
+
+        /// <summary>
+        /// The PWM frequency actually sent to the device this connection, or <c>null</c> if none has
+        /// been sent yet (also reset to <c>null</c> on disconnect). Distinct from
+        /// <see cref="PwmFrequencyHz"/>, which carries a session default before anything is sent —
+        /// this drives the skip-if-unchanged guard so a fresh connection always sends. See #345.
+        /// </summary>
+        private int? _lastSentPwmFrequencyHz;
+
+        /// <summary>
+        /// Clears the "already-sent" PWM frequency cache, so the next <see cref="SetPwmFrequency"/>
+        /// sends even if the value is unchanged. Called on any transition away from Connected —
+        /// after one the device's runtime PWM state is no longer trustworthy. See #345.
+        /// </summary>
+        internal void ResetSentPwmFrequency() => _lastSentPwmFrequencyHz = null;
+
+        /// <inheritdoc cref="IStreamingDevice.EnableChannel" />
+        internal void EnableChannel(IChannel channel)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+            SetChannelsEnabled(new[] { channel }, enabled: true);
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.EnableChannels" />
+        internal void EnableChannels(IEnumerable<IChannel> channels)
+        {
+            ArgumentNullException.ThrowIfNull(channels);
+            SetChannelsEnabled(channels as IReadOnlyList<IChannel> ?? channels.ToList(), enabled: true);
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.DisableChannel" />
+        internal void DisableChannel(IChannel channel)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+            SetChannelsEnabled(new[] { channel }, enabled: false);
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.DisableAllChannels" />
+        internal void DisableAllChannels()
+        {
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            (bool HasChannels, uint Mask) adcMask = default;
+            (bool HasChannels, bool AnyEnabled) dioState = default;
+
+            // Mutate and derive the outbound masks in one critical section — see the matching
+            // comment in SetChannelsEnabled (#409) for why the gap matters.
+            _host.WithChannelsLock(() =>
+            {
+                foreach (var channel in _host.SnapshotChannels())
+                {
+                    channel.IsEnabled = false;
+                }
+
+                adcMask = ComputeAdcEnableMask();
+                dioState = ComputeDioEnableState();
+            });
+
+            // Push the cleared state for whichever channel types this device actually has.
+            if (adcMask.HasChannels)
+            {
+                _host.Send(ScpiMessageProducer.EnableAdcChannels(adcMask.Mask.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            if (dioState.HasChannels)
+            {
+                _host.Send(dioState.AnyEnabled
+                    ? ScpiMessageProducer.EnableDioPorts()
+                    : ScpiMessageProducer.DisableDioPorts());
+            }
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.SetDioDirection" />
+        internal void SetDioDirection(IChannel channel, ChannelDirection direction)
+        {
+            // Argument validation precedes the connection (state) check so misuse surfaces
+            // the same exception type regardless of connection state.
+            ArgumentNullException.ThrowIfNull(channel);
+
+            if (channel.Type != ChannelType.Digital)
+            {
+                throw new ArgumentException("Direction can only be set on digital channels.", nameof(channel));
+            }
+
+            if (direction != ChannelDirection.Input && direction != ChannelDirection.Output)
+            {
+                throw new ArgumentOutOfRangeException(nameof(direction), direction, "Direction must be Input or Output.");
+            }
+
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            EnsureChannelBelongs(channel);
+
+            channel.Direction = direction;
+            _host.Send(ScpiMessageProducer.SetDioPortDirection(
+                channel.ChannelNumber,
+                direction == ChannelDirection.Output ? 1 : 0));
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.SetDioValue" />
+        internal void SetDioValue(IChannel channel, bool value)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+
+            // Gate on Type (matching SetDioDirection) rather than the IDigitalChannel interface,
+            // so both DIO methods accept the same set of channels. The SCPI command only needs
+            // the channel number; OutputValue mirroring is best-effort local bookkeeping.
+            if (channel.Type != ChannelType.Digital)
+            {
+                throw new ArgumentException("A digital output value can only be set on digital channels.", nameof(channel));
+            }
+
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            EnsureChannelBelongs(channel);
+
+            if (channel is IDigitalChannel digitalChannel)
+            {
+                digitalChannel.OutputValue = value;
+            }
+
+            _host.Send(ScpiMessageProducer.SetDioPortState(channel.ChannelNumber, value ? 1 : 0));
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.SetPwmEnabled" />
+        internal void SetPwmEnabled(IChannel channel, bool enabled)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+
+            if (channel.Type != ChannelType.Digital)
+            {
+                throw new ArgumentException("PWM can only be controlled on digital channels.", nameof(channel));
+            }
+
+            // Enabling PWM on a non-capable channel must be blocked here: the firmware flags the
+            // channel PWM-active before its capability check fails and never rolls that back,
+            // leaving the channel dead to digital writes. Disabling is that state's only recovery
+            // command, so it is accepted on any digital channel.
+            if (enabled && channel is not IDigitalChannel { IsPwmCapable: true })
+            {
+                throw new ArgumentException(
+                    $"Channel {channel.ChannelNumber} does not support PWM. PWM-capable channels: {PwmCapableChannelList}.",
+                    nameof(channel));
+            }
+
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            EnsureChannelBelongs(channel);
+
+            if (channel is IDigitalChannel digitalChannel)
+            {
+                digitalChannel.IsPwmEnabled = enabled;
+                if (!enabled)
+                {
+                    // Disabling PWM leaves the pin high-impedance and the firmware zeroes its
+                    // stored output value; mirror that so local state doesn't claim a driven level.
+                    // Direction is intentionally left as-is: the firmware keeps the channel's
+                    // stored direction and re-applies it (resuming driving) on the next state or
+                    // direction write, or on the next streaming tick — verified on hardware.
+                    digitalChannel.OutputValue = false;
+                }
+            }
+
+            _host.Send(ScpiMessageProducer.SetPwmChannelEnabled(channel.ChannelNumber, enabled));
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.SetPwmDutyCycle" />
+        internal void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+
+            if (channel.Type != ChannelType.Digital)
+            {
+                throw new ArgumentException("PWM can only be controlled on digital channels.", nameof(channel));
+            }
+
+            if (channel is not IDigitalChannel { IsPwmCapable: true })
+            {
+                throw new ArgumentException(
+                    $"Channel {channel.ChannelNumber} does not support PWM. PWM-capable channels: {PwmCapableChannelList}.",
+                    nameof(channel));
+            }
+
+            // Duty 0 is rejected rather than forwarded: the firmware stores it but never writes
+            // the compare register, so the output keeps toggling at the previous duty while the
+            // stored value claims 0. Stopping the output is SetPwmEnabled(channel, false).
+            if (dutyCyclePercent is < 1 or > 100)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(dutyCyclePercent), dutyCyclePercent,
+                    "Duty cycle must be 1-100 percent. To stop the output, use SetPwmEnabled(channel, false).");
+            }
+
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            EnsureChannelBelongs(channel);
+
+            if (channel is IDigitalChannel digitalChannel)
+            {
+                digitalChannel.PwmDutyCyclePercent = dutyCyclePercent;
+            }
+
+            _host.Send(ScpiMessageProducer.SetPwmChannelDutyCycle(channel.ChannelNumber, dutyCyclePercent));
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.SetPwmFrequency" />
+        internal void SetPwmFrequency(int frequencyHz)
+        {
+            if (frequencyHz is < DaqifiStreamingDevice.MinPwmFrequencyHz or > DaqifiStreamingDevice.MaxPwmFrequencyHz)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(frequencyHz), frequencyHz,
+                    $"PWM frequency must be {DaqifiStreamingDevice.MinPwmFrequencyHz}-{DaqifiStreamingDevice.MaxPwmFrequencyHz} Hz.");
+            }
+
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            // Skip the redundant round-trip when the device already has this frequency (from a
+            // send earlier this connection). The cache is cleared on disconnect so a fresh
+            // connection always sends. PwmFrequencyHz still reflects the commanded value. See #345.
+            if (frequencyHz == _lastSentPwmFrequencyHz)
+            {
+                return;
+            }
+
+            // The SCPI command is addressed to a channel, but the firmware drives all PWM from
+            // one shared timer and applies the frequency to every channel. Channel 0 is used as
+            // the address because it is PWM-capable on all supported hardware.
+            _host.Send(ScpiMessageProducer.SetPwmChannelFrequency(0, frequencyHz));
+            _lastSentPwmFrequencyHz = frequencyHz;
+            PwmFrequencyHz = frequencyHz;
+        }
+
+        /// <summary>
+        /// Comma-separated PWM-capable channel numbers for error messages, derived from this
+        /// device's channel collection.
+        /// </summary>
+        private string PwmCapableChannelList
+        {
+            get
+            {
+                var capable = new List<int>();
+                foreach (var ch in _host.SnapshotChannels())
+                {
+                    if (ch is IDigitalChannel { IsPwmCapable: true })
+                    {
+                        capable.Add(ch.ChannelNumber);
+                    }
+                }
+                capable.Sort();
+                return capable.Count > 0 ? string.Join(", ", capable) : "none on this device";
+            }
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.SetAnalogOutput" />
+        internal void SetAnalogOutput(int channelNumber, double voltage)
+        {
+            if (channelNumber < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
+            }
+
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            // Analog-output (DAC) channels are addressed by number; they are not part of the
+            // populated Channels collection (PopulateChannelsFromStatus creates analog *input*
+            // channels only). Stage the level, then latch it.
+            _host.Send(ScpiMessageProducer.SetAnalogOutputVoltage(channelNumber, voltage));
+            _host.Send(ScpiMessageProducer.UpdateDacOutputs);
+        }
+
+        /// <summary>
+        /// Sets the enabled state for a set of channels, then sends one device command per affected
+        /// channel type (the ADC enable bitmask for analog, the global DIO enable for digital).
+        /// Validation runs before any mutation so an invalid entry leaves device state untouched.
+        /// </summary>
+        private void SetChannelsEnabled(IReadOnlyList<IChannel> channels, bool enabled)
+        {
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            // Validate everything up front so a bad entry can't leave a partially-applied state.
+            foreach (var channel in channels)
+            {
+                if (channel is null)
+                {
+                    throw new ArgumentException("The channel collection contains a null entry.", nameof(channels));
+                }
+
+                EnsureChannelBelongs(channel);
+            }
+
+            var touchedAnalog = false;
+            var touchedDigital = false;
+            var adcMask = (HasChannels: false, Mask: 0u);
+            var dioState = (HasChannels: false, AnyEnabled: false);
+
+            // Mutate IsEnabled and derive the outbound masks from it in one critical section, so
+            // a status frame resyncing analog IsEnabled from the device (#409) on the consumer
+            // thread cannot interleave between the mutation and the read that computes the mask —
+            // which would otherwise send a mask reflecting a value the status frame is about to
+            // overwrite, silently failing to apply the requested enable/disable on the device.
+            _host.WithChannelsLock(() =>
+            {
+                foreach (var channel in channels)
+                {
+                    channel.IsEnabled = enabled;
+
+                    if (channel.Type == ChannelType.Analog)
+                    {
+                        touchedAnalog = true;
+                    }
+                    else if (channel.Type == ChannelType.Digital)
+                    {
+                        touchedDigital = true;
+                    }
+                }
+
+                if (touchedAnalog)
+                {
+                    adcMask = ComputeAdcEnableMask();
+                }
+
+                if (touchedDigital)
+                {
+                    dioState = ComputeDioEnableState();
+                }
+            });
+
+            if (touchedAnalog && adcMask.HasChannels)
+            {
+                _host.Send(ScpiMessageProducer.EnableAdcChannels(adcMask.Mask.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            if (touchedDigital && dioState.HasChannels)
+            {
+                _host.Send(dioState.AnyEnabled
+                    ? ScpiMessageProducer.EnableDioPorts()
+                    : ScpiMessageProducer.DisableDioPorts());
+            }
+        }
+
+        /// <summary>
+        /// Computes the ADC enable bitmask over all currently-enabled analog channels. Must be
+        /// called under <see cref="IDeviceOperationHost.WithChannelsLock"/> alongside any IsEnabled
+        /// mutation it should reflect (#409) — see <see cref="SetChannelsEnabled"/>.
+        /// </summary>
+        private (bool HasChannels, uint Mask) ComputeAdcEnableMask()
+        {
+            uint mask = 0;
+            var hasAnalogChannels = false;
+
+            foreach (var channel in _host.SnapshotChannels())
+            {
+                if (channel.Type != ChannelType.Analog)
+                {
+                    continue;
+                }
+
+                hasAnalogChannels = true;
+
+                if (!channel.IsEnabled)
+                {
+                    continue;
+                }
+
+                if (channel.ChannelNumber > MaxAdcBitmaskChannel)
+                {
+                    throw new InvalidOperationException(
+                        $"Analog channel number {channel.ChannelNumber} exceeds the maximum ({MaxAdcBitmaskChannel}) that can be encoded in the ADC enable bitmask.");
+                }
+
+                mask |= 1u << channel.ChannelNumber;
+            }
+
+            return (hasAnalogChannels, mask);
+        }
+
+        /// <summary>
+        /// Computes whether any digital channel is enabled. Must be called under
+        /// <see cref="IDeviceOperationHost.WithChannelsLock"/> alongside any IsEnabled mutation it
+        /// should reflect — see <see cref="SetChannelsEnabled"/>.
+        /// </summary>
+        private (bool HasChannels, bool AnyEnabled) ComputeDioEnableState()
+        {
+            var hasDigitalChannels = false;
+            var anyEnabled = false;
+
+            foreach (var channel in _host.SnapshotChannels())
+            {
+                if (channel.Type != ChannelType.Digital)
+                {
+                    continue;
+                }
+
+                hasDigitalChannels = true;
+
+                if (channel.IsEnabled)
+                {
+                    anyEnabled = true;
+                }
+            }
+
+            return (hasDigitalChannels, anyEnabled);
+        }
+
+        /// <summary>
+        /// Throws when the supplied channel is not part of this device's populated channel collection,
+        /// which would mean mutating it could not affect the device-level enable state.
+        /// </summary>
+        private void EnsureChannelBelongs(IChannel channel)
+        {
+            if (!_host.SnapshotChannels().Contains(channel))
+            {
+                throw new ArgumentException("The specified channel does not belong to this device.", nameof(channel));
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
+++ b/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device.SdCard;
 
@@ -54,6 +55,16 @@ namespace Daqifi.Core.Device.Internal
 
         /// <inheritdoc cref="DaqifiDevice.Send{T}"/>
         void Send<T>(IOutboundMessage<T> message);
+
+        /// <inheritdoc cref="DaqifiDevice.GetChannelsSnapshot"/>
+        IReadOnlyList<IChannel> SnapshotChannels();
+
+        /// <summary>
+        /// Runs <paramref name="action"/> under the device's channels lock, so a collaborator that
+        /// mutates <see cref="IChannel.IsEnabled"/> and derives outbound state from it does both in
+        /// one critical section (#409). Blocking I/O — <see cref="Send{T}"/> — must stay outside it.
+        /// </summary>
+        void WithChannelsLock(Action action);
 
         /// <inheritdoc cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
 #pragma warning disable CA1068 // Matches the seam it forwards to, which orders these for source compatibility.


### PR DESCRIPTION
## Problem

`DaqifiStreamingDevice` is 2,189 lines and still hosts five responsibilities. #422 extracted four of them; its status comment named the **channel / DIO / PWM / analog-out block** as the next one, and said why it was deliberately left behind:

> It needs the `IDeviceOperationHost` seam widened for channel-collection access and the channels lock — a materially larger diff that would have been verified less carefully alongside the rest.

This is that extraction, on its own, with that verification.

## Fix

`ChannelControlOperations` (internal, `Device/Internal/`) now owns:

- channel enable/disable and the ADC-bitmask / global-DIO-enable derivation (`EnableChannel(s)`, `DisableChannel`, `DisableAllChannels`, `SetChannelsEnabled`, `ComputeAdcEnableMask`, `ComputeDioEnableState`, `EnsureChannelBelongs`)
- DIO direction and level
- PWM enable / duty cycle / frequency, plus the `PwmFrequencyHz` bookkeeping and the skip-if-unchanged cache (#345)
- the analog output

`DaqifiStreamingDevice` keeps the public surface and forwards, exactly as it does for the SD, network, LAN-info and diagnostics collaborators.

**The seam widening this needed.** `IDeviceOperationHost` gains `SnapshotChannels()` and `WithChannelsLock(Action)`. The lock is the whole reason this block was hard: mutating `IChannel.IsEnabled` and computing the outbound mask from it must happen in **one** critical section, or a status frame resyncing `IsEnabled` from the device (#409) can interleave between them and silently drop the just-requested channel from the mask. The collaborator therefore reaches *the device's* lock rather than taking one of its own. Both new members forward to members the device already had, so every command still passes through the device's own virtual `Send` — a subclass override (and every test double) still intercepts all of it.

**No public API change.** The three PWM constants and `PwmFrequencyHz` stay on `DaqifiStreamingDevice` with their docs; every moved method keeps its signature, its validation order (argument checks before the connected check), and its exception `paramName`.

**One deletion.** `SendAdcEnableMask` and `SendDioEnableState` are gone. They are private and have had **no callers since #411**, which replaced their call sites with the under-lock computation — `git log -S` confirms that commit removed the last use. Carrying dead code into a new file seemed worse than deleting it; it is called out here rather than buried.

`DaqifiStreamingDevice`: **2,189 → 1,756 lines.**

## Verification

**The move is mechanical, and that is checked rather than asserted.** A normalized statement multiset diff (comments/whitespace stripped, `_host.` and the const qualifications canonicalized) of every line the device lost against every line the collaborator gained leaves exactly three residues, all enumerated: the two dead methods above, `MaxAdcBitmaskChannel` becoming `internal` (the device's raw-command tracking decodes the same mask and now references it there), and `_lastSentPwmFrequencyHz = null` becoming the one-line `ResetSentPwmFrequency()`. Nothing else changed.

**Test suite unchanged and green** — the acceptance criterion this issue asks for. 2,529 passed / 2 skipped on **net9 and net10**, plus 23 in `Daqifi.Mcp.Tests`. Zero test edits: the existing coverage already pins the foreign-channel guards, the disconnected guards, the PWM range/duty/capability rules, the analog-out sequence, and — importantly — the #409 concurrent-resync regression test, which hammers a status resync against 500 `EnableChannel` calls and would fail or deadlock if the lock discipline had been broken by routing it through the seam. Release build: 0 warnings on both TFMs.

**Bench-validated on the real Nq1 (fw 3.7.2, USB)**, because a mask that is computed correctly and never reaches the device looks identical to a green unit test:

```
Connected: Nq1 fw=3.7.2 sn=9090539562006014104
Channels: 16 analog, 16 digital
DisableAllChannels: ok
EnableChannels(0,1,2): ok
  streamed 78 frames, analog values/frame (mode) = 3  [expect 3]
DisableChannel(1): ok
  streamed 78 frames, analog values/frame (mode) = 2  [expect 2]
PwmFrequencyHz (session default) = 1000
SetPwmFrequency(2500) -> PwmFrequencyHz = 2500
SetPwmFrequency(2500) again (skip-if-unchanged): ok
SetDioDirection(ch 0, Input) -> Direction = Input
Foreign-channel guard: throws ArgumentException as expected
PWM range guard: throws ArgumentOutOfRangeException as expected
BENCH RESULT: PASS
```

The frame counts confirm the recomputed mask actually took effect on the device, not just in local state. Strictly non-destructive: nothing here drives a pin (PWM frequency is the shared timer with no channel enabled; DIO direction was set to `Input`, which is high-Z), writes NVM, or reboots.

## Still open on #344 after this

Frame decode (the hot path, warrants its own PR), `WifiModuleUpdater` at 816 lines pending #271, and the scope question about `DaqifiDevice` now being the largest file in the repo.

Closes nothing — **part of #344**.

**Not merging — opened for your review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)