### PR TITLE
refactor(device): extract the session snapshot/restore decision into a collaborator (part of #344)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Internal/StreamingSessionSnapshotTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamingSessionSnapshotTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Internal;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="StreamingSessionSnapshot"/>, which records what a streaming session
+/// looked like at a drop and decides what putting it back implies (issue #379). These pin the
+/// decision itself; <c>DeviceReconnectTests</c> pins the effects the device applies from it.
+/// </summary>
+public class StreamingSessionSnapshotTests
+{
+    private static AnalogChannel Analog(int number, bool enabled)
+    {
+        var channel = new AnalogChannel(number);
+        channel.IsEnabled = enabled;
+        return channel;
+    }
+
+    private static DigitalChannel Digital(int number, bool enabled)
+    {
+        var channel = new DigitalChannel(number);
+        channel.IsEnabled = enabled;
+        return channel;
+    }
+
+    private static ReconnectOptions Policy(bool resumeStreaming = true) =>
+        new() { Enabled = true, ResumeStreaming = resumeStreaming };
+
+    [Fact]
+    public void Capture_RecordsOnlyTheEnabledChannels()
+    {
+        var channels = new IChannel[]
+        {
+            Analog(0, enabled: true),
+            Analog(1, enabled: false),
+            Digital(2, enabled: true),
+        };
+
+        var snapshot = StreamingSessionSnapshot.Capture(channels, isStreaming: true);
+
+        Assert.Equal(2, snapshot.EnabledChannelCount);
+        Assert.True(snapshot.WasStreaming);
+    }
+
+    [Fact]
+    public void Capture_TakesACopy_SoLaterChannelMutationCannotRewriteTheSession()
+    {
+        // This is the whole reason a snapshot exists: re-initialization after a reconnect goes on
+        // mutating these same channel objects (analog IsEnabled is resynced from the device's own
+        // reported mask on every status frame, #409), so a snapshot that held them by reference
+        // would describe the reconnected device rather than the session that was lost.
+        var enabled = Analog(0, enabled: true);
+        var disabled = Analog(1, enabled: false);
+
+        var snapshot = StreamingSessionSnapshot.Capture(new IChannel[] { enabled, disabled }, isStreaming: true);
+
+        enabled.IsEnabled = false;
+        disabled.IsEnabled = true;
+
+        var plan = snapshot.PlanRestore(new IChannel[] { enabled, disabled }, Policy());
+
+        Assert.Equal(new[] { 0 }, plan.ChannelsToEnable.Select(c => c.ChannelNumber));
+    }
+
+    [Fact]
+    public void Capture_WithNoChannelsEnabled_PlansNothingToEnable()
+    {
+        var snapshot = StreamingSessionSnapshot.Capture(
+            new IChannel[] { Analog(0, enabled: false) }, isStreaming: false);
+
+        var plan = snapshot.PlanRestore(new IChannel[] { Analog(0, enabled: false) }, Policy());
+
+        Assert.Equal(0, snapshot.EnabledChannelCount);
+        Assert.Empty(plan.ChannelsToEnable);
+        Assert.False(plan.ResumeStreaming);
+    }
+
+    [Fact]
+    public void PlanRestore_ReturnsTheReconnectedDevicesOwnChannelObjects_NotTheCapturedOnes()
+    {
+        // A reconnect can replace the channel objects wholesale, so matching has to be by identity
+        // (type + number) and the plan has to hand back the objects the device has now — enabling
+        // the old ones would set a flag on garbage.
+        var beforeDrop = Analog(3, enabled: true);
+        var snapshot = StreamingSessionSnapshot.Capture(new IChannel[] { beforeDrop }, isStreaming: true);
+
+        var afterReconnect = Analog(3, enabled: false);
+        var plan = snapshot.PlanRestore(new IChannel[] { afterReconnect }, Policy());
+
+        Assert.Same(afterReconnect, Assert.Single(plan.ChannelsToEnable));
+    }
+
+    [Fact]
+    public void PlanRestore_MatchesOnChannelTypeAsWellAsNumber()
+    {
+        // Analog 0 and digital 0 share a number and are different channels; a number-only match
+        // would enable the wrong one.
+        var snapshot = StreamingSessionSnapshot.Capture(
+            new IChannel[] { Analog(0, enabled: true), Digital(0, enabled: false) }, isStreaming: true);
+
+        var plan = snapshot.PlanRestore(
+            new IChannel[] { Analog(0, enabled: false), Digital(0, enabled: false) }, Policy());
+
+        var restored = Assert.Single(plan.ChannelsToEnable);
+        Assert.Equal(ChannelType.Analog, restored.Type);
+    }
+
+    [Fact]
+    public void PlanRestore_WhenTheDeviceComesBackSmaller_RestoresTheIntersection()
+    {
+        var snapshot = StreamingSessionSnapshot.Capture(
+            new IChannel[] { Analog(0, enabled: true), Analog(1, enabled: true) }, isStreaming: true);
+
+        var plan = snapshot.PlanRestore(new IChannel[] { Analog(0, enabled: false) }, Policy());
+
+        Assert.Equal(new[] { 0 }, plan.ChannelsToEnable.Select(c => c.ChannelNumber));
+    }
+
+    [Fact]
+    public void PlanRestore_IgnoresChannelsTheSessionNeverHad()
+    {
+        var snapshot = StreamingSessionSnapshot.Capture(
+            new IChannel[] { Analog(0, enabled: true) }, isStreaming: false);
+
+        var plan = snapshot.PlanRestore(
+            new IChannel[] { Analog(0, enabled: false), Analog(7, enabled: true) }, Policy());
+
+        Assert.Equal(new[] { 0 }, plan.ChannelsToEnable.Select(c => c.ChannelNumber));
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, false)]
+    public void PlanRestore_ResumesOnlyWhenTheSessionWasStreamingAndThePolicyAllowsIt(
+        bool wasStreaming, bool resumeStreaming, bool expected)
+    {
+        var snapshot = StreamingSessionSnapshot.Capture(
+            new IChannel[] { Analog(0, enabled: true) }, wasStreaming);
+
+        var plan = snapshot.PlanRestore(
+            new IChannel[] { Analog(0, enabled: false) }, Policy(resumeStreaming));
+
+        Assert.Equal(expected, plan.ResumeStreaming);
+    }
+
+    [Fact]
+    public void PlanRestore_CanBeCalledMoreThanOnce_WithoutConsumingTheSnapshot()
+    {
+        // The device keeps one snapshot field across reconnect attempts, so a failed attempt must
+        // not leave a snapshot that has already given up its contents.
+        var snapshot = StreamingSessionSnapshot.Capture(
+            new IChannel[] { Analog(0, enabled: true) }, isStreaming: true);
+
+        var first = snapshot.PlanRestore(new IChannel[] { Analog(0, enabled: false) }, Policy());
+        var second = snapshot.PlanRestore(new IChannel[] { Analog(0, enabled: false) }, Policy());
+
+        Assert.Single(first.ChannelsToEnable);
+        Assert.Single(second.ChannelsToEnable);
+        Assert.True(second.ResumeStreaming);
+    }
+
+    [Fact]
+    public void Capture_WithNullChannels_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => StreamingSessionSnapshot.Capture(null!, isStreaming: false));
+    }
+
+    [Fact]
+    public void PlanRestore_WithNullArguments_Throws()
+    {
+        var snapshot = StreamingSessionSnapshot.Capture(Array.Empty<IChannel>(), isStreaming: false);
+
+        Assert.Throws<ArgumentNullException>(() => snapshot.PlanRestore(null!, Policy()));
+        Assert.Throws<ArgumentNullException>(
+            () => snapshot.PlanRestore(new List<IChannel>(), null!));
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -515,42 +515,9 @@ namespace Daqifi.Core.Device
         /// </summary>
         private volatile StreamingSessionSnapshot? _sessionSnapshot;
 
-        /// <summary>
-        /// The subset of a streaming session that Core owns and can therefore put back: which
-        /// channels were enabled, and whether data was flowing.
-        /// </summary>
-        private sealed class StreamingSessionSnapshot
-        {
-            public StreamingSessionSnapshot(HashSet<(ChannelType Type, int Number)> enabledChannels, bool wasStreaming)
-            {
-                EnabledChannels = enabledChannels;
-                WasStreaming = wasStreaming;
-            }
-
-            /// <summary>
-            /// The enabled channels, held by identity rather than by reference: a reconnect can
-            /// replace the channel objects, and a device that came back with a different channel
-            /// count should restore the intersection rather than fail.
-            /// </summary>
-            public HashSet<(ChannelType Type, int Number)> EnabledChannels { get; }
-
-            public bool WasStreaming { get; }
-        }
-
         /// <inheritdoc />
-        protected override void CaptureSessionSnapshot()
-        {
-            var enabled = new HashSet<(ChannelType, int)>();
-            foreach (var channel in GetChannelsSnapshot())
-            {
-                if (channel.IsEnabled)
-                {
-                    enabled.Add((channel.Type, channel.ChannelNumber));
-                }
-            }
-
-            _sessionSnapshot = new StreamingSessionSnapshot(enabled, IsStreaming);
-        }
+        protected override void CaptureSessionSnapshot() =>
+            _sessionSnapshot = StreamingSessionSnapshot.Capture(GetChannelsSnapshot(), IsStreaming);
 
         /// <summary>
         /// Re-applies the enabled-channel set recorded at the drop and, if the policy says so,
@@ -558,16 +525,9 @@ namespace Daqifi.Core.Device
         /// </summary>
         /// <remarks>
         /// <para>
-        /// The enable set has to be replayed from the snapshot rather than read back off the
-        /// channel objects: <see cref="DaqifiDevice.PopulateChannelsFromStatus"/> resyncs analog
-        /// <c>IsEnabled</c> from the device's own enabled mask on every status message (#409), so by
-        /// the time re-initialization is done the in-memory view reflects the freshly reconnected
-        /// device, not the session that was lost.
-        /// </para>
-        /// <para>
-        /// The streaming frequency needs no replay — it is a host-side setting that the drop never
-        /// touched — but it does have to reach the device again, which is what the resumed
-        /// <see cref="StartStreaming"/> does.
+        /// What to restore is <see cref="StreamingSessionSnapshot.PlanRestore"/>'s decision; this
+        /// method owns the effects, and their order is the part that matters. See that method for
+        /// why the enable set is replayed from the snapshot rather than read back off the channels.
         /// </para>
         /// <para>
         /// A resumed stream is a genuinely new session: timestamp reconstruction re-anchors and the
@@ -598,32 +558,24 @@ namespace Daqifi.Core.Device
             cancellationToken.ThrowIfCancellationRequested();
 
             // Normalize to a known state before re-applying: whatever the device came back with is
-            // not necessarily what it had, and the enable commands are set-replace anyway.
+            // not necessarily what it had, and the enable commands are set-replace anyway. The
+            // channel list is read afterwards so the plan is built against the post-reset objects.
             DisableAllChannels();
 
-            var toEnable = new List<IChannel>();
-            foreach (var channel in GetChannelsSnapshot())
+            var plan = snapshot.PlanRestore(GetChannelsSnapshot(), options);
+            if (plan.ChannelsToEnable.Count > 0)
             {
-                if (snapshot.EnabledChannels.Contains((channel.Type, channel.ChannelNumber)))
-                {
-                    toEnable.Add(channel);
-                }
-            }
-
-            if (toEnable.Count > 0)
-            {
-                EnableChannels(toEnable);
+                EnableChannels(plan.ChannelsToEnable);
             }
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var resumeStreaming = snapshot.WasStreaming && options.ResumeStreaming;
-            if (resumeStreaming)
+            if (plan.ResumeStreaming)
             {
                 StartStreaming();
             }
 
-            return Task.FromResult(resumeStreaming);
+            return Task.FromResult(plan.ResumeStreaming);
         }
 
         #endregion

--- a/src/Daqifi.Core/Device/Internal/StreamingSessionSnapshot.cs
+++ b/src/Daqifi.Core/Device/Internal/StreamingSessionSnapshot.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using Daqifi.Core.Channel;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Internal
+{
+    /// <summary>
+    /// What a captured session says should happen on the way back: the channels to re-enable, and
+    /// whether the stream itself should be restarted.
+    /// </summary>
+    /// <remarks>
+    /// A plan is a decision, not an action. Nothing here has touched the device — the caller applies
+    /// it, in the order that matters, through the device's own members.
+    /// </remarks>
+    internal readonly struct SessionRestorePlan
+    {
+        internal SessionRestorePlan(IReadOnlyList<IChannel> channelsToEnable, bool resumeStreaming)
+        {
+            ChannelsToEnable = channelsToEnable;
+            ResumeStreaming = resumeStreaming;
+        }
+
+        /// <summary>
+        /// Gets the channel objects, drawn from the ones the device has <em>now</em>, that were
+        /// enabled when the connection dropped. Empty when none of them survived the reconnect.
+        /// </summary>
+        public IReadOnlyList<IChannel> ChannelsToEnable { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the interrupted stream should be restarted — true only
+        /// when data really was flowing at the drop <em>and</em> the policy allows resuming.
+        /// </summary>
+        public bool ResumeStreaming { get; }
+    }
+
+    /// <summary>
+    /// The subset of a streaming session that Core owns and can therefore put back: which channels
+    /// were enabled, and whether data was flowing (issue #379).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Deciding is separated from applying, the same split <see cref="SessionCommandInterpreter"/>
+    /// uses. Capturing the session and working out what restoring it implies are pure operations
+    /// over a channel list, pinned directly by <c>StreamingSessionSnapshotTests</c>; the effects
+    /// they imply — disabling everything first, sending the enable mask, restarting the stream —
+    /// stay on the device, which is the only thing that owns them.
+    /// </para>
+    /// <para>
+    /// The enabled set is held by channel <em>identity</em> (type and number) rather than by
+    /// reference, because a reconnect can replace the channel objects wholesale, and a device that
+    /// came back reporting a different channel count should restore the intersection rather than
+    /// fail.
+    /// </para>
+    /// </remarks>
+    internal sealed class StreamingSessionSnapshot
+    {
+        private readonly HashSet<(ChannelType Type, int Number)> _enabledChannels;
+
+        private StreamingSessionSnapshot(HashSet<(ChannelType Type, int Number)> enabledChannels, bool wasStreaming)
+        {
+            _enabledChannels = enabledChannels;
+            WasStreaming = wasStreaming;
+        }
+
+        /// <summary>Gets a value indicating whether data was flowing when the connection dropped.</summary>
+        public bool WasStreaming { get; }
+
+        /// <summary>Gets how many channels were enabled at the drop.</summary>
+        public int EnabledChannelCount => _enabledChannels.Count;
+
+        /// <summary>
+        /// Records the session as it stands: the identities of every enabled channel in
+        /// <paramref name="channels"/>, plus <paramref name="isStreaming"/>.
+        /// </summary>
+        /// <remarks>
+        /// The channel state is copied out immediately rather than held by reference, so a snapshot
+        /// keeps describing the instant it was taken even though the caller goes on mutating those
+        /// same channel objects — which is exactly what re-initialization after a reconnect does.
+        /// </remarks>
+        /// <param name="channels">The device's channels at the moment of the drop.</param>
+        /// <param name="isStreaming">Whether the device was streaming at the moment of the drop.</param>
+        public static StreamingSessionSnapshot Capture(IEnumerable<IChannel> channels, bool isStreaming)
+        {
+            ArgumentNullException.ThrowIfNull(channels);
+
+            var enabled = new HashSet<(ChannelType, int)>();
+            foreach (var channel in channels)
+            {
+                if (channel.IsEnabled)
+                {
+                    enabled.Add((channel.Type, channel.ChannelNumber));
+                }
+            }
+
+            return new StreamingSessionSnapshot(enabled, isStreaming);
+        }
+
+        /// <summary>
+        /// Works out what putting this session back means for the device as it is <em>now</em>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The enable set is replayed from the snapshot rather than read back off the channel
+        /// objects: <see cref="DaqifiDevice.PopulateChannelsFromStatus"/> resyncs analog
+        /// <c>IsEnabled</c> from the device's own enabled mask on every status message (#409), so by
+        /// the time re-initialization is done the in-memory view reflects the freshly reconnected
+        /// device, not the session that was lost.
+        /// </para>
+        /// <para>
+        /// The streaming frequency needs no replay — it is a host-side setting that the drop never
+        /// touched — but it does have to reach the device again, which is what the caller's resumed
+        /// <see cref="DaqifiStreamingDevice.StartStreaming"/> does.
+        /// </para>
+        /// </remarks>
+        /// <param name="currentChannels">The channels the reconnected device is reporting.</param>
+        /// <param name="options">The reconnect policy; <see cref="ReconnectOptions.ResumeStreaming"/> gates the restart.</param>
+        /// <returns>The channels to re-enable and whether to restart the stream.</returns>
+        public SessionRestorePlan PlanRestore(IEnumerable<IChannel> currentChannels, ReconnectOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(currentChannels);
+            ArgumentNullException.ThrowIfNull(options);
+
+            var toEnable = new List<IChannel>();
+            foreach (var channel in currentChannels)
+            {
+                if (_enabledChannels.Contains((channel.Type, channel.ChannelNumber)))
+                {
+                    toEnable.Add(channel);
+                }
+            }
+
+            return new SessionRestorePlan(toEnable, WasStreaming && options.ResumeStreaming);
+        }
+    }
+}


### PR DESCRIPTION
Part of #344 — **not merging, this is for review.**

## Problem

`DaqifiStreamingDevice` still carried the whole #379 reconnect-snapshot mechanism inline: a private nested `StreamingSessionSnapshot` class, `CaptureSessionSnapshot`, and a `RestoreSessionSnapshotAsync` that mixed *deciding what to restore* with *applying it*. That's ~120 lines of the god-class doing work that is really just set arithmetic over a channel list.

## Fix

New `Device/Internal/StreamingSessionSnapshot` (with a `SessionRestorePlan` result), following the exact decision/effect split #439 established for `SessionCommandInterpreter`:

- **Moves out (pure):** recording which channels were enabled at the drop, and matching that set against the channels the reconnected device is now reporting to produce the channel objects to enable plus whether to resume.
- **Stays on the device (effects, and their order matters):** clearing `IsStreaming`, the two cancellation checks, `DisableAllChannels()` before re-applying, `EnableChannels(...)`, and `StartStreaming()`.

Deliberately **host-free** — no `IDeviceOperationHost` member added, no new field, no constructor wiring. That keeps the public surface and the internal seam untouched, and it keeps this slice's hunks disjoint from the still-open #440.

One small tightening that came with the move: the enabled set is now private to the snapshot (`EnabledChannelCount` is all that's exposed) instead of a publicly-readable `HashSet`, so identity matching can't be bypassed.

`DaqifiStreamingDevice.cs`: **1196 → 1148** lines.

## Evidence this changed nothing

`DeviceReconnectTests` is left **completely untouched** on purpose — all 44 of its tests are the "the extraction changed nothing" evidence, and editing them would weaken that.

**Tests:** +13 new `StreamingSessionSnapshotTests`. FULL suite green on **net9 + net10** — 2667 passed / 2 skipped each (+23 `Daqifi.Mcp.Tests` on net9; Mcp is net9-only), 0 warnings.

**Bench (real Nq1, fw 3.7.2, USB, non-destructive — 12/12 checks passed).** A physical unplug isn't available unattended, so instead of skipping hardware validation the harness drove the protected capture/restore members directly on a live device and tore the session down the way re-initialization does:

- Established a live session through raw `Send` (mask `3` @ 200 Hz) — 395 samples each on Analog0/Analog1 over 2.5 s.
- `CaptureSessionSnapshot()`, then `StopStreaming()` + `DisableAllChannels()`: 0 channels enabled, **0 samples** arriving.
- `RestoreSessionSnapshotAsync(ResumeStreaming: true)` → returned `true`, `IsStreaming` back to `true`, **exactly** `Analog0,Analog1` re-enabled, and **395 samples each flowing again** with nothing on any other channel. That last part is the bit a mock can't show: the plan handed back the device's *live* channel objects, so the enable mask actually reached the firmware.
- `RestoreSessionSnapshotAsync(ResumeStreaming: false)` → returned `false`, channels restored, `IsStreaming` stayed `false`, and **0 samples** — the stream really was not restarted.

(158 Hz effective vs 200 Hz requested is the known fw 3.7.2 clock mismatch, not a regression.)

closes nothing on its own — part of #344.