### PR TITLE
refactor(device): extract the USB stream-interface routing decision into a collaborator (part of #344)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Internal/UsbStreamInterfaceInitializerTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/UsbStreamInterfaceInitializerTests.cs
@@ -1,0 +1,208 @@
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Internal;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="UsbStreamInterfaceInitializer"/>, which decides whether a device being
+/// initialized must have its stream re-routed to USB and how hard to retry a transient rejection.
+/// These pin the decision itself; <c>DaqifiDeviceInitializeTests</c> pins what the device does with
+/// it end to end.
+/// </summary>
+public class UsbStreamInterfaceInitializerTests
+{
+    private const string ScpiError = "**ERROR: -200, \"Execution error\"";
+
+    /// <summary>Bound on every wait so a policy regression fails the run instead of parking it.</summary>
+    private static readonly TimeSpan RouteTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Records every attempt and answers each one from a queued script, so a test states the
+    /// device's answers rather than the sender's mechanics.
+    /// </summary>
+    private sealed class ScriptedSender
+    {
+        private readonly Queue<IReadOnlyList<string>> _responses = new();
+
+        public int AttemptCount { get; private set; }
+
+        public List<CancellationToken> ObservedTokens { get; } = new();
+
+        public ScriptedSender Answers(params string[] lines)
+        {
+            _responses.Enqueue(lines);
+            return this;
+        }
+
+        public Task<IReadOnlyList<string>> SendAsync(CancellationToken cancellationToken)
+        {
+            AttemptCount++;
+            ObservedTokens.Add(cancellationToken);
+
+            // An unscripted attempt is a test bug, not a silent success: surface it.
+            Assert.True(_responses.Count > 0, "The sender was invoked more times than the test scripted.");
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    private static Task RouteAsync(
+        ScriptedSender sender,
+        bool isUsbConnection = true,
+        bool preserveActiveStream = false,
+        CancellationToken cancellationToken = default)
+        => UsbStreamInterfaceInitializer
+            .RouteStreamToUsbAsync(isUsbConnection, preserveActiveStream, sender.SendAsync, cancellationToken)
+            .WaitAsync(RouteTimeout);
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    public void OnlyAUsbSessionThatOwnsTheStream_Routes(
+        bool isUsbConnection,
+        bool preserveActiveStream,
+        bool expected)
+    {
+        // A non-USB connection has nothing to route, and an observe-only session must not steal the
+        // stream from the session already receiving it (#385).
+        Assert.Equal(
+            expected,
+            UsbStreamInterfaceInitializer.ShouldRouteStreamToUsb(isUsbConnection, preserveActiveStream));
+    }
+
+    [Fact]
+    public async Task ANonUsbConnection_SendsNothing()
+    {
+        var sender = new ScriptedSender();
+
+        await RouteAsync(sender, isUsbConnection: false);
+
+        Assert.Equal(0, sender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task AnObserveOnlySession_SendsNothing()
+    {
+        var sender = new ScriptedSender();
+
+        await RouteAsync(sender, preserveActiveStream: true);
+
+        Assert.Equal(0, sender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task ASkippedRoute_DoesNotObserveCancellation()
+    {
+        // Deliberate: there is no work to abandon, and the caller re-checks cancellation before it
+        // marks the device ready, so a token cancelled here is still honored — just not by throwing
+        // out of a step that did nothing.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var sender = new ScriptedSender();
+
+        await RouteAsync(sender, preserveActiveStream: true, cancellationToken: cts.Token);
+
+        Assert.Equal(0, sender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task ACleanResponse_RoutesOnce()
+    {
+        var sender = new ScriptedSender().Answers("0");
+
+        await RouteAsync(sender);
+
+        Assert.Equal(1, sender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task AnEmptyResponse_IsNotTreatedAsAnError()
+    {
+        // The firmware answers this command with nothing at all on the happy path, so "no lines"
+        // must mean success rather than an unclassifiable failure.
+        var sender = new ScriptedSender().Answers();
+
+        await RouteAsync(sender);
+
+        Assert.Equal(1, sender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task ATransientRejection_IsRetriedAndSucceeds()
+    {
+        // The firmware persists the last-used stream interface across sessions and can reject the
+        // command right after connect; that is the case retrying exists for (#310).
+        var sender = new ScriptedSender()
+            .Answers(ScpiError)
+            .Answers("0");
+
+        await RouteAsync(sender);
+
+        Assert.Equal(2, sender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task APersistentRejection_FailsAfterExhaustingRetries()
+    {
+        var sender = new ScriptedSender()
+            .Answers(ScpiError)
+            .Answers(ScpiError);
+
+        var ex = await Assert.ThrowsAsync<ScpiInitializationErrorException>(() => RouteAsync(sender));
+
+        // Literal rather than MaxRetries + 1: deriving it from the constant would make this test
+        // agree with any retry budget, including one silently reduced to zero.
+        Assert.Equal(2, sender.AttemptCount);
+        Assert.Equal(ScpiError, ex.LastScpiError);
+        Assert.Equal(new[] { ScpiError }, ex.RawDeviceResponse);
+    }
+
+    [Fact]
+    public async Task TheReportedFailure_IsTheLastAttemptsResponse()
+    {
+        // Reporting the first attempt's response would describe an error the device has already
+        // moved past — the caller needs the answer that actually ended the routing.
+        var sender = new ScriptedSender()
+            .Answers("ERROR: -113, \"Undefined header\"")
+            .Answers("noise", "  " + ScpiError + "  ");
+
+        var ex = await Assert.ThrowsAsync<ScpiInitializationErrorException>(() => RouteAsync(sender));
+
+        Assert.Equal(ScpiError, ex.LastScpiError);
+        Assert.Equal(new[] { "noise", "  " + ScpiError + "  " }, ex.RawDeviceResponse);
+    }
+
+    [Fact]
+    public async Task CancellationBetweenAttempts_StopsBeforeTheRetry()
+    {
+        // The settle delay is cancellable, so a token cancelled while waiting must abandon the retry
+        // rather than send a command into a session that is being torn down.
+        using var cts = new CancellationTokenSource();
+        var sender = new ScriptedSender().Answers(ScpiError);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(10));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => RouteAsync(sender, cancellationToken: cts.Token));
+
+        Assert.Equal(1, sender.AttemptCount);
+    }
+
+    [Fact]
+    public async Task TheCallersToken_ReachesEveryAttempt()
+    {
+        using var cts = new CancellationTokenSource();
+        var sender = new ScriptedSender()
+            .Answers(ScpiError)
+            .Answers("0");
+
+        await RouteAsync(sender, cancellationToken: cts.Token);
+
+        Assert.Equal(new[] { cts.Token, cts.Token }, sender.ObservedTokens);
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -31,17 +31,10 @@ namespace Daqifi.Core.Device
     public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost
     {
         /// <summary>
-        /// Maximum number of retry attempts for the USB stream-interface command sent during
-        /// <see cref="OnDeviceInitializingAsync"/> when the device returns a transient SCPI error
-        /// (e.g. because the firmware still has the interface set from a prior WiFi session).
+        /// Response window allowed for the USB stream-interface command sent during
+        /// <see cref="OnDeviceInitializingAsync"/>.
         /// </summary>
-        private const int UsbStreamInterfaceMaxRetries = 1;
-
-        /// <summary>
-        /// Delay in milliseconds before retrying the USB stream-interface command after a
-        /// transient SCPI error.
-        /// </summary>
-        private const int UsbStreamInterfaceRetryDelayMs = 150;
+        private const int UsbStreamInterfaceResponseTimeoutMs = 500;
 
         /// <summary>
         /// Raised when a stream frame was withheld from consumers because the device should not have
@@ -227,20 +220,17 @@ namespace Daqifi.Core.Device
         /// <see cref="DaqifiDevice.InitializeAsync"/> after the standard SCPI sequence.
         /// </summary>
         /// <remarks>
-        /// The DAQiFi firmware persists the last configured stream interface across sessions.
-        /// If the device was previously set to stream to WiFi (<c>SYSTem:STReam:INTerface 1</c>),
-        /// it will continue sending data over WiFi even when connected via USB — causing the serial
-        /// consumer to receive nothing. Sending <c>SYSTem:STReam:INTerface 0</c> during USB
-        /// initialization ensures data flows to the serial port.
+        /// Whether to route at all, and how hard to retry a transient rejection, is
+        /// <see cref="UsbStreamInterfaceInitializer"/>'s decision; this hook supplies the effect —
+        /// the actual command send — and the connection facts the decision needs.
+        ///
+        /// The send goes through <c>DaqifiDevice.ExecuteTextCommandAsync</c> so the command is sent
+        /// in text mode (protobuf consumer temporarily stopped) and any SCPI error response is
+        /// captured rather than garbling the protobuf stream.
         ///
         /// This runs inside the base <see cref="DaqifiDevice.InitializeAsync"/> exception handling
         /// (before the device is marked initialized/ready), so a cancellation or SCPI error here
         /// leaves the device in a consistent state and re-initializable, rather than falsely Ready.
-        ///
-        /// The routing command is global device state: it takes the stream away from whatever
-        /// interface it was going to, so a second session running it steals another session's data
-        /// (#385). It is therefore skipped entirely when <paramref name="preserveActiveStream"/>
-        /// is set.
         /// </remarks>
         /// <param name="preserveActiveStream">
         /// When <c>true</c>, this initialization must leave a stream another session is already
@@ -254,59 +244,17 @@ namespace Daqifi.Core.Device
         /// command because it still has the interface set from a prior WiFi-streaming session,
         /// within the tight response window right after connect.
         /// </exception>
-        protected override async Task OnDeviceInitializingAsync(
+        protected override Task OnDeviceInitializingAsync(
             bool preserveActiveStream,
-            CancellationToken cancellationToken)
-        {
-            if (!IsUsbConnection)
-            {
-                return;
-            }
-
-            // An observe-only session must not re-route the device's single global stream: doing so
-            // would take the data away from the session that is already receiving it (#385). The
-            // interface is left exactly as the owning session configured it.
-            //
-            // Returning without observing the token is deliberate: there is no work to abandon, and
-            // InitializeAsync re-checks cancellation before it marks the device Ready, so a token
-            // cancelled during this hook is still honored.
-            if (preserveActiveStream)
-            {
-                return;
-            }
-
-            // Direct streaming to the USB interface. Uses ExecuteTextCommandAsync so the
-            // command is sent in text mode (protobuf consumer temporarily stopped) and any
-            // SCPI error response is captured rather than garbling the protobuf stream.
-            //
-            // The firmware persists the last-used stream interface across sessions, so this can
-            // transiently reject with a -200 "Execution error" right after connect. Retry with a
-            // settle delay before treating it as a hard failure (mirrors the SD card retry).
-            IReadOnlyList<string> lines = Array.Empty<string>();
-            for (var attempt = 0; attempt <= UsbStreamInterfaceMaxRetries; attempt++)
-            {
-                if (attempt > 0)
-                {
-                    await Task.Delay(UsbStreamInterfaceRetryDelayMs, cancellationToken).ConfigureAwait(false);
-                }
-
-                lines = await ExecuteTextCommandAsync(
+            CancellationToken cancellationToken) =>
+            UsbStreamInterfaceInitializer.RouteStreamToUsbAsync(
+                IsUsbConnection,
+                preserveActiveStream,
+                ct => ExecuteTextCommandAsync(
                     () => Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.Usb)),
-                    responseTimeoutMs: 500,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                if (!ScpiResponseClassifier.ContainsScpiError(lines))
-                {
-                    return;
-                }
-            }
-
-            var lastScpiError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
-            throw new ScpiInitializationErrorException(
-                "Device returned a SCPI error while setting stream interface to USB.",
-                lines,
-                lastScpiError);
-        }
+                    responseTimeoutMs: UsbStreamInterfaceResponseTimeoutMs,
+                    cancellationToken: ct),
+                cancellationToken);
 
         /// <summary>
         /// Starts streaming data from the device at the configured frequency.

--- a/src/Daqifi.Core/Device/Internal/UsbStreamInterfaceInitializer.cs
+++ b/src/Daqifi.Core/Device/Internal/UsbStreamInterfaceInitializer.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Internal
+{
+    /// <summary>
+    /// Decides whether a device being initialized must have its stream re-routed to USB, and how
+    /// hard to try, given only what the caller reports about the connection.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The DAQiFi firmware persists the last configured stream interface across sessions. If the
+    /// device was previously set to stream to WiFi (<c>SYSTem:STReam:INTerface 1</c>), it keeps
+    /// sending data over WiFi even when connected via USB — so the serial consumer receives nothing
+    /// until <c>SYSTem:STReam:INTerface 0</c> is sent.
+    /// </para>
+    /// <para>
+    /// This type owns the decision (route or skip, retry or fail) and nothing else. Sending the
+    /// command is the caller's effect, supplied as a delegate, so the policy is testable without a
+    /// device, a transport, or a wire.
+    /// </para>
+    /// </remarks>
+    internal static class UsbStreamInterfaceInitializer
+    {
+        /// <summary>
+        /// Maximum number of retry attempts for the USB stream-interface command when the device
+        /// returns a transient SCPI error (e.g. because the firmware still has the interface set
+        /// from a prior WiFi session).
+        /// </summary>
+        internal const int MaxRetries = 1;
+
+        /// <summary>
+        /// Delay in milliseconds before retrying the USB stream-interface command after a transient
+        /// SCPI error.
+        /// </summary>
+        internal const int RetryDelayMs = 150;
+
+        /// <summary>
+        /// Decides whether the stream-routing command should be sent at all.
+        /// </summary>
+        /// <remarks>
+        /// The routing command is global device state: it takes the stream away from whatever
+        /// interface it was going to, so a second session running it steals another session's data
+        /// (#385). An observe-only session must therefore skip it entirely, and a non-USB connection
+        /// has nothing to route.
+        /// </remarks>
+        /// <param name="isUsbConnection">Whether the device is connected over USB/serial.</param>
+        /// <param name="preserveActiveStream">
+        /// Whether this initialization must leave a stream another session is already running
+        /// untouched.
+        /// </param>
+        /// <returns><c>true</c> when the command should be sent; otherwise <c>false</c>.</returns>
+        internal static bool ShouldRouteStreamToUsb(bool isUsbConnection, bool preserveActiveStream)
+            => isUsbConnection && !preserveActiveStream;
+
+        /// <summary>
+        /// Routes the device's stream to USB, retrying a transient SCPI rejection before treating it
+        /// as a hard failure.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When <see cref="ShouldRouteStreamToUsb"/> says to skip, this returns without invoking
+        /// <paramref name="setStreamInterfaceToUsbAsync"/> and without observing
+        /// <paramref name="cancellationToken"/>. Not observing it is deliberate: there is no work to
+        /// abandon, and the caller's initialization re-checks cancellation before it marks the device
+        /// ready, so a token cancelled during this step is still honored.
+        /// </para>
+        /// <para>
+        /// The firmware can transiently reject the command with a <c>-200 "Execution error"</c> right
+        /// after connect, so a rejection is retried once after a settle delay (mirrors the SD card
+        /// retry). Only a rejection that persists across every attempt is a failure.
+        /// </para>
+        /// </remarks>
+        /// <param name="isUsbConnection">Whether the device is connected over USB/serial.</param>
+        /// <param name="preserveActiveStream">
+        /// Whether this initialization must leave a stream another session is already running
+        /// untouched.
+        /// </param>
+        /// <param name="setStreamInterfaceToUsbAsync">
+        /// Sends the routing command and returns the device's response lines. Invoked once per
+        /// attempt.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token to observe while routing.</param>
+        /// <returns>A task representing the asynchronous routing operation.</returns>
+        /// <exception cref="ScpiInitializationErrorException">
+        /// Thrown when the device returns a SCPI error on every attempt.
+        /// </exception>
+        internal static async Task RouteStreamToUsbAsync(
+            bool isUsbConnection,
+            bool preserveActiveStream,
+            Func<CancellationToken, Task<IReadOnlyList<string>>> setStreamInterfaceToUsbAsync,
+            CancellationToken cancellationToken)
+        {
+            if (!ShouldRouteStreamToUsb(isUsbConnection, preserveActiveStream))
+            {
+                return;
+            }
+
+            IReadOnlyList<string> lines = Array.Empty<string>();
+            for (var attempt = 0; attempt <= MaxRetries; attempt++)
+            {
+                if (attempt > 0)
+                {
+                    await Task.Delay(RetryDelayMs, cancellationToken).ConfigureAwait(false);
+                }
+
+                lines = await setStreamInterfaceToUsbAsync(cancellationToken).ConfigureAwait(false);
+
+                if (!ScpiResponseClassifier.ContainsScpiError(lines))
+                {
+                    return;
+                }
+            }
+
+            var lastScpiError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
+            throw new ScpiInitializationErrorException(
+                "Device returned a SCPI error while setting stream interface to USB.",
+                lines,
+                lastScpiError);
+        }
+    }
+}


### PR DESCRIPTION
Part of #344. Another incremental slice of the `DaqifiStreamingDevice` decomposition — same shape as #439 and #441: **host-free**, no `IDeviceOperationHost` additions, no public surface change.

## Problem

`OnDeviceInitializingAsync` carried the entire USB stream-routing policy inline, mixed in with the send itself:

- whether to route at all (skip on non-USB; skip on an observe-only session, per #385)
- how many times to retry a transient SCPI rejection, and how long to settle between attempts (#310)
- how to turn a rejection that persists across every attempt into a typed `ScpiInitializationErrorException`

None of that needs a device to decide, but all of it was only reachable through a connected device with a transport, so every test of the policy had to stand up a fake device end to end.

## Fix

New `Device/Internal/UsbStreamInterfaceInitializer`. It takes the two connection facts the decision depends on (`isUsbConnection`, `preserveActiveStream`) plus a delegate that performs the send.

**Decision moves out.** Route-or-skip, retry budget, settle delay, error classification, and the typed throw.

**Effect stays on the device.** The hook still builds the `ExecuteTextCommandAsync` call, so the command goes out in text mode with the protobuf consumer stopped and any SCPI error response is captured rather than garbling the protobuf stream. The 500 ms response window stayed on the device too — it is a call-shape detail of the device's own helper, not part of the routing policy — but it is now a named constant instead of an inline literal.

The documented deliberate behavior of **not** observing the cancellation token on the skip path is preserved and is now pinned by a test rather than only by a comment.

`DaqifiStreamingDevice.cs`: **1196 → 1144** lines.

## Conflict surface

Deliberately chosen to be disjoint from the two open slices. This PR's hunks are at L33-44 and L224-309; #440's are at L15-23 / L196-203 / L633-700 / L942, and #441's are at L515-629. No overlap, and no shared new files.

## Testing

- **+14 new `UsbStreamInterfaceInitializerTests`.** Full suite green on **net9 + net10**: 2653 → **2667 passed / 2 skipped** on each (+23 Daqifi.Mcp.Tests on net9; Mcp is net9-only). 0 warnings. The baseline was measured on a clean `origin/main` worktree, so the +14 is exact and nothing was lost.
- `DaqifiDeviceInitializeTests` left **untouched on purpose** — they are the evidence that the extraction changed nothing end to end.
- **Mutation-checked rather than assumed.** Setting `MaxRetries` to 0 and dropping `preserveActiveStream` from the gate made **7 of the 14** new tests fail, including the retry and #385 skip rules; restoring from a byte-identical backup was verified before committing. One test that had derived its expectation from `MaxRetries + 1` (and so survived the mutation) now asserts a literal 2.

## Bench (real Nq1, fw 3.7.2, USB, non-destructive)

Not just "it still streams" — the device was first put into the exact state this code exists to recover from. `SYSTem:STReam:INTerface 1` was sent from the shell (accepted, `0,"No error"`), routing the device's stream to WiFi. The example CLI was then built against this branch's Core and run over USB:

- **791 samples in 5 s** across Analog0/Analog1, `--min-samples 300` passed, exit 0.

With the routing broken, that run would have received nothing at all — so the extracted initializer is what put the data back on the serial port. 158 Hz effective vs 200 Hz requested is the known fw 3.7.2 clock mismatch, not a regression. The bench was explicitly returned to `SYSTem:STReam:INTerface 0` afterwards and confirmed error-free.

---

Not merging — for review.