### PR TITLE
feat(firmware): share the LAN chip-info retry probe as public API (part of #269)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/LanChipInfoProviderExtensionsTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/LanChipInfoProviderExtensionsTests.cs
@@ -1,0 +1,443 @@
+using System.Diagnostics;
+using System.Net;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Daqifi.Core.Firmware;
+
+namespace Daqifi.Core.Tests.Firmware;
+
+/// <summary>
+/// The bounded chip-info probe that <see cref="LanChipInfoProviderExtensions.GetLanChipInfoWithRetryAsync"/>
+/// exposes for consumers (issue #269). Core's own WiFi status check runs the same code, so the
+/// end-to-end expectations live in <c>FirmwareUpdateServiceTests</c>; these pin the probe itself.
+/// </summary>
+public class LanChipInfoProviderExtensionsTests
+{
+    private static LanChipInfo SampleChipInfo => new()
+    {
+        ChipId = 1377184,
+        FwVersion = "19.7.7",
+        BuildDate = "Mar 30 2022"
+    };
+
+    private static LanChipInfoRetryOptions FastOptions(
+        int maxAttempts = 3,
+        bool kickLanApply = true) => new()
+        {
+            MaxAttempts = maxAttempts,
+            RetryDelay = TimeSpan.FromMilliseconds(5),
+            TotalTimeout = TimeSpan.FromSeconds(30),
+            KickLanApplyOnNotInitialized = kickLanApply,
+        };
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenFirstAttemptSucceeds_QueriesOnce()
+    {
+        var device = new ScriptedLanChipInfoDevice(SampleChipInfo);
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("19.7.7", result.ChipInfo!.FwVersion);
+        Assert.False(result.WasLanNotInitialized);
+        Assert.Equal(1, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenTransientFailuresPrecedeSuccess_RetriesUntilItReads()
+    {
+        // #144: right after a PIC32 update the application is up while WiFi is still starting, so
+        // the first queries fail. Taking the first failure as the answer is what sends a caller
+        // into a needless multi-minute reflash of already-current firmware.
+        var device = new ScriptedLanChipInfoDevice(
+            new InvalidOperationException("transient"),
+            new InvalidOperationException("transient"),
+            SampleChipInfo);
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenEveryAttemptFails_ReturnsUnavailableWithoutThrowing()
+    {
+        var device = new ScriptedLanChipInfoDevice(new InvalidOperationException("still broken"));
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.ChipInfo);
+        Assert.False(result.WasLanNotInitialized);
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenProviderReturnsNull_RetriesAndReportsUnavailable()
+    {
+        // An unrecognizable response is a null, not an exception — it must be retried too.
+        var device = new ScriptedLanChipInfoDevice((object?)null);
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.WasLanNotInitialized);
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenLanNotInitialized_SendsLanApplyExactlyOnceAndRecovers()
+    {
+        // #203: LAN:ENAbled=1 but the WINC state machine hasn't reached INITIALIZED, so the query
+        // answers SCPI -200. One LAN:APPLY resolves it; kicking on every attempt would tear the
+        // module down and re-init it repeatedly, risking an already-associated link.
+        var device = new ScriptedLanChipInfoDevice(
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""),
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""),
+            SampleChipInfo);
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+        Assert.Equal(1, device.LanApplySentCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenLanNotInitializedExhaustsBudget_ReportsThatSpecifically()
+    {
+        var device = new ScriptedLanChipInfoDevice(
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""));
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.WasLanNotInitialized);
+        Assert.Equal(1, device.LanApplySentCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenALaterFailureIsNotLanNotInitialized_ReportsTheTerminalCondition()
+    {
+        // The flag describes how the probe actually ended, not whether -200 was ever seen. A stale
+        // "not initialized" would send a caller off kicking APPLY at a module that failed for some
+        // entirely different reason on the attempt that mattered.
+        var device = new ScriptedLanChipInfoDevice(
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""),
+            new InvalidOperationException("transport went away"),
+            new InvalidOperationException("transport went away"));
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.WasLanNotInitialized);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenKickDisabled_DoesNotSendLanApply()
+    {
+        var device = new ScriptedLanChipInfoDevice(
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""));
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions(kickLanApply: false));
+
+        Assert.True(result.WasLanNotInitialized);
+        Assert.Equal(0, device.LanApplySentCount);
+        Assert.DoesNotContain("SYSTem:COMMunicate:LAN:APPLY", device.SentCommands);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenDeviceDisconnected_DoesNotSendLanApply()
+    {
+        // There is nothing to send through: the kick would throw or, worse, silently queue.
+        var device = new ScriptedLanChipInfoDevice(
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""))
+        {
+            IsConnected = false
+        };
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.True(result.WasLanNotInitialized);
+        Assert.Equal(0, device.LanApplySentCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenLanApplySendThrows_KeepsRetrying()
+    {
+        // Best effort: a failed kick must not abort the probe — the module may still settle on its
+        // own within the remaining attempts.
+        var device = new ScriptedLanChipInfoDevice(
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""),
+            SampleChipInfo)
+        {
+            ThrowOnSend = true
+        };
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenProviderIsNotAStreamingDevice_StillProbesWithoutKicking()
+    {
+        // The kick needs a device to send through. A bare provider simply doesn't get one, and that
+        // must not be an error.
+        var provider = new ScriptedLanChipInfoProvider(
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""),
+            SampleChipInfo);
+
+        var result = await provider.GetLanChipInfoWithRetryAsync(FastOptions());
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, provider.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenTotalTimeoutExpires_StopsEarlyWithoutThrowing()
+    {
+        // The wall-clock ceiling is the point: attempts × the device's own response timeout plus
+        // the delays can far outrun what the caller meant to spend, and this runs under a lock.
+        var device = new ScriptedLanChipInfoDevice(new InvalidOperationException("slow and broken"));
+        var options = new LanChipInfoRetryOptions
+        {
+            MaxAttempts = 50,
+            RetryDelay = TimeSpan.FromMilliseconds(20),
+            TotalTimeout = TimeSpan.FromMilliseconds(120),
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = await device.GetLanChipInfoWithRetryAsync(options);
+        stopwatch.Stop();
+
+        Assert.False(result.Succeeded);
+        Assert.True(
+            device.GetLanChipInfoCallCount < 50,
+            $"Expected the total-timeout budget to cut the probe short, but all 50 attempts ran ({device.GetLanChipInfoCallCount}).");
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenCallerCancels_Throws()
+    {
+        // The caller's own cancellation is the one thing that is not absorbed into a result.
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var device = new ScriptedLanChipInfoDevice(SampleChipInfo);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => device.GetLanChipInfoWithRetryAsync(FastOptions(), cancellationToken: cts.Token));
+
+        Assert.Equal(0, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenCancelledRacingNotInitialized_DoesNotSendLanApply()
+    {
+        // A cancellation that lands between the -200 detection and the kick must not still leave a
+        // state-changing command on the device.
+        using var cts = new CancellationTokenSource();
+        var device = new ScriptedLanChipInfoDevice(
+            new LanNotInitializedException("**ERROR: -200, \"Execution error\""));
+        device.OnGetLanChipInfo = cts.Cancel;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => device.GetLanChipInfoWithRetryAsync(FastOptions(), cancellationToken: cts.Token));
+
+        Assert.Equal(0, device.LanApplySentCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenMaxAttemptsBelowOne_StillMakesOneAttempt()
+    {
+        // The options object is a plain settable record a consumer can get wrong; a probe that
+        // queries nothing at all and reports "unavailable" would be indistinguishable from a dead
+        // module.
+        var device = new ScriptedLanChipInfoDevice(SampleChipInfo);
+
+        var result = await device.GetLanChipInfoWithRetryAsync(FastOptions(maxAttempts: 0));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenSingleAttemptFails_DoesNotWaitTheRetryDelay()
+    {
+        // No delay after the final attempt — otherwise every exhausted probe pays for a retry it
+        // never makes.
+        var device = new ScriptedLanChipInfoDevice(new InvalidOperationException("broken"));
+        var options = new LanChipInfoRetryOptions
+        {
+            MaxAttempts = 1,
+            RetryDelay = TimeSpan.FromSeconds(10),
+            TotalTimeout = TimeSpan.FromSeconds(30),
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = await device.GetLanChipInfoWithRetryAsync(options);
+        stopwatch.Stop();
+
+        Assert.False(result.Succeeded);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"A single-attempt probe waited {stopwatch.Elapsed} — the trailing retry delay was applied.");
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WithoutOptions_UsesCoreDefaults()
+    {
+        var device = new ScriptedLanChipInfoDevice(SampleChipInfo);
+
+        var result = await device.GetLanChipInfoWithRetryAsync();
+
+        Assert.True(result.Succeeded);
+
+        var defaults = new LanChipInfoRetryOptions();
+        Assert.Equal(3, defaults.MaxAttempts);
+        Assert.Equal(TimeSpan.FromSeconds(2), defaults.RetryDelay);
+        Assert.Equal(TimeSpan.FromSeconds(8), defaults.TotalTimeout);
+        Assert.True(defaults.KickLanApplyOnNotInitialized);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenProviderIsNull_Throws()
+    {
+        ILanChipInfoProvider? provider = null;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => provider!.GetLanChipInfoWithRetryAsync());
+    }
+
+    /// <summary>
+    /// A provider whose successive answers are scripted: each outcome is a <see cref="LanChipInfo"/>
+    /// to return, an <see cref="Exception"/> to fault with, or null for an unparseable response. The
+    /// last outcome repeats, so "always fails" is a one-element script.
+    /// </summary>
+    private class ScriptedLanChipInfoProvider : ILanChipInfoProvider
+    {
+        private readonly IReadOnlyList<object?> _outcomes;
+        private int _next;
+
+        public ScriptedLanChipInfoProvider(params object?[] outcomes)
+        {
+            _outcomes = outcomes.Length > 0 ? outcomes : [null];
+        }
+
+        public int GetLanChipInfoCallCount { get; private set; }
+
+        /// <summary>Runs as the query lands, for tests that need to race it.</summary>
+        public Action? OnGetLanChipInfo { get; set; }
+
+        public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
+        {
+            GetLanChipInfoCallCount++;
+            OnGetLanChipInfo?.Invoke();
+
+            var outcome = _outcomes[Math.Min(_next, _outcomes.Count - 1)];
+            _next++;
+
+            // A faulted task rather than a synchronous throw: that is how a real async device
+            // surfaces a failure, and it is the path the probe's catch clauses actually see.
+            return outcome switch
+            {
+                Exception ex => Task.FromException<LanChipInfo?>(ex),
+                LanChipInfo info => Task.FromResult<LanChipInfo?>(info),
+                _ => Task.FromResult<LanChipInfo?>(null),
+            };
+        }
+    }
+
+    /// <summary>
+    /// The scripted provider as a full device, so the probe can find something to send the
+    /// <c>LAN:APPLY</c> kick through.
+    /// </summary>
+    private sealed class ScriptedLanChipInfoDevice : ScriptedLanChipInfoProvider, IStreamingDevice
+    {
+        public ScriptedLanChipInfoDevice(params object?[] outcomes)
+            : base(outcomes)
+        {
+        }
+
+        /// <summary>Number of <c>SYSTem:COMMunicate:LAN:APPLY</c> commands sent.</summary>
+        public int LanApplySentCount { get; private set; }
+
+        public List<string> SentCommands { get; } = [];
+
+        /// <summary>Makes <see cref="Send{T}"/> fail, standing in for a transport that has gone away.</summary>
+        public bool ThrowOnSend { get; set; }
+
+        public string Name => "SCRIPTED";
+        public IPAddress? IpAddress => null;
+        public bool IsConnected { get; set; } = true;
+        public ConnectionStatus Status => IsConnected ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        public int StreamingFrequency { get; set; }
+        public bool IsStreaming { get; private set; }
+
+        public event EventHandler<DeviceStatusEventArgs>? StatusChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<MessageReceivedEventArgs>? MessageReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred
+        {
+            add { }
+            remove { }
+        }
+
+        public void Connect() => IsConnected = true;
+
+        public void Disconnect() => IsConnected = false;
+
+        public void Send<T>(IOutboundMessage<T> message)
+        {
+            if (ThrowOnSend)
+            {
+                throw new InvalidOperationException("Simulated transport failure.");
+            }
+
+            if (message is IOutboundMessage<string> textMessage)
+            {
+                SentCommands.Add(textMessage.Data);
+                if (textMessage.Data == "SYSTem:COMMunicate:LAN:APPLY")
+                {
+                    LanApplySentCount++;
+                }
+            }
+        }
+
+        public void StartStreaming() => IsStreaming = true;
+        public void StopStreaming() => IsStreaming = false;
+        public void EnableChannel(IChannel channel) { }
+        public void EnableChannels(IEnumerable<IChannel> channels) { }
+        public void DisableChannel(IChannel channel) { }
+        public void DisableAllChannels() { }
+        public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
+        public void SetDioValue(IChannel channel, bool value) { }
+        public void SetPwmEnabled(IChannel channel, bool enabled) { }
+        public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent) { }
+        public void SetPwmFrequency(int frequencyHz) { }
+        public int PwmFrequencyHz => 0;
+        public void SetAnalogOutput(int channelNumber, double voltage) { }
+        public void Reboot() => Disconnect();
+        public void SaveAdcCalibration() { }
+        public void LoadAdcCalibration() { }
+        public void SaveVoltagePrecision() { }
+        public void LoadVoltagePrecision() { }
+        public void SetAdcCalibrationSlope(int channelNumber, double calM) { }
+        public void SetAdcCalibrationOffset(int channelNumber, double calB) { }
+        public void SaveFactoryAdcCalibration() { }
+        public void LoadFactoryAdcCalibration() { }
+        public void UseAdcCalibration(int bank) { }
+    }
+}

--- a/src/Daqifi.Core.Tests/Firmware/LanChipInfoProviderExtensionsTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/LanChipInfoProviderExtensionsTests.cs
@@ -288,6 +288,96 @@ public class LanChipInfoProviderExtensionsTests
     }
 
     [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenTotalTimeoutIsNegative_MakesNoAttemptWithoutThrowing()
+    {
+        // A budget of "less than nothing" is the same as no budget, which the option documents as
+        // "no attempt is made". Handing it straight to CancellationTokenSource would instead throw
+        // ArgumentOutOfRangeException out of a probe whose whole contract is that failures come back
+        // as an unavailable result.
+        var device = new ScriptedLanChipInfoDevice(SampleChipInfo);
+        var options = new LanChipInfoRetryOptions
+        {
+            MaxAttempts = 3,
+            RetryDelay = TimeSpan.FromMilliseconds(5),
+            TotalTimeout = TimeSpan.FromSeconds(-5),
+        };
+
+        var result = await device.GetLanChipInfoWithRetryAsync(options);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.WasLanNotInitialized);
+        Assert.Equal(0, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenTotalTimeoutIsInfinite_SpendsEveryAttempt()
+    {
+        // Timeout.InfiniteTimeSpan is negative, but it is how .NET spells "no ceiling" and must keep
+        // meaning that — collapsing it into the no-budget case would silently turn an unbounded
+        // probe into one that never queries at all.
+        var device = new ScriptedLanChipInfoDevice(new InvalidOperationException("broken"));
+        var options = new LanChipInfoRetryOptions
+        {
+            MaxAttempts = 3,
+            RetryDelay = TimeSpan.FromMilliseconds(5),
+            TotalTimeout = Timeout.InfiniteTimeSpan,
+        };
+
+        var result = await device.GetLanChipInfoWithRetryAsync(options);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenRetryDelayIsNegative_KeepsRetryingWithoutThrowing()
+    {
+        // Same reasoning as the budget: a negative pause is a misconfiguration, not a reason to
+        // throw ArgumentOutOfRangeException out of Task.Delay midway through the loop.
+        var device = new ScriptedLanChipInfoDevice(
+            new InvalidOperationException("transient"),
+            new InvalidOperationException("transient"),
+            SampleChipInfo);
+        var options = new LanChipInfoRetryOptions
+        {
+            MaxAttempts = 3,
+            RetryDelay = TimeSpan.FromSeconds(-1),
+            TotalTimeout = TimeSpan.FromSeconds(30),
+        };
+
+        var result = await device.GetLanChipInfoWithRetryAsync(options);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(3, device.GetLanChipInfoCallCount);
+    }
+
+    [Fact]
+    public async Task GetLanChipInfoWithRetryAsync_WhenRetryDelayIsInfinite_DoesNotHangBetweenAttempts()
+    {
+        // An infinite *pause* inside a bounded retry has no meaning, and with an equally unbounded
+        // budget nothing would ever release it — the probe would hang on the caller's thread
+        // forever. The guard token bounds a regression here to 10s instead of wedging the suite.
+        using var guard = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var device = new ScriptedLanChipInfoDevice(new InvalidOperationException("broken"));
+        var options = new LanChipInfoRetryOptions
+        {
+            MaxAttempts = 2,
+            RetryDelay = Timeout.InfiniteTimeSpan,
+            TotalTimeout = Timeout.InfiniteTimeSpan,
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = await device.GetLanChipInfoWithRetryAsync(options, cancellationToken: guard.Token);
+        stopwatch.Stop();
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(2, device.GetLanChipInfoCallCount);
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"An infinite retry delay stalled the probe for {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
     public async Task GetLanChipInfoWithRetryAsync_WithoutOptions_UsesCoreDefaults()
     {
         var device = new ScriptedLanChipInfoDevice(SampleChipInfo);

--- a/src/Daqifi.Core/Firmware/LanChipInfoProviderExtensions.cs
+++ b/src/Daqifi.Core/Firmware/LanChipInfoProviderExtensions.cs
@@ -23,8 +23,15 @@ public sealed record LanChipInfoRetryOptions
     public int MaxAttempts { get; init; } = 3;
 
     /// <summary>
-    /// Gets the pause between attempts. Not applied after the final attempt.
+    /// Gets the pause between attempts. Not applied after the final attempt. Negative values —
+    /// including <see cref="Timeout.InfiniteTimeSpan"/> — are treated as no pause at all.
     /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="TotalTimeout"/>, <see cref="Timeout.InfiniteTimeSpan"/> is not honored
+    /// here: an infinite <i>pause</i> inside a bounded retry has no meaning, and with an equally
+    /// unbounded budget nothing would ever release it. Use <see cref="MaxAttempts"/> = 1 to say
+    /// "don't retry".
+    /// </remarks>
     public TimeSpan RetryDelay { get; init; } = TimeSpan.FromSeconds(2);
 
     /// <summary>
@@ -37,7 +44,8 @@ public sealed record LanChipInfoRetryOptions
     /// while an operation lock is held. Expiry ends the probe with the same "unavailable"
     /// result as an exhausted attempt count rather than throwing; only the caller's own
     /// cancellation surfaces as <see cref="OperationCanceledException"/>.
-    /// A non-positive value leaves no budget at all, so no attempt is made.
+    /// A non-positive value leaves no budget at all, so no attempt is made — with the single
+    /// exception of <see cref="Timeout.InfiniteTimeSpan"/>, which means the opposite: no ceiling.
     /// </remarks>
     public TimeSpan TotalTimeout { get; init; } = TimeSpan.FromSeconds(8);
 
@@ -98,7 +106,9 @@ public static class LanChipInfoProviderExtensions
     /// Failures are absorbed: an exhausted budget comes back as a result with a null
     /// <see cref="LanChipInfoProbeResult.ChipInfo"/>, not an exception — the caller decides what an
     /// unreadable module means. The one exception that does propagate is the caller's own
-    /// cancellation.
+    /// cancellation. That extends to a misconfigured budget: out-of-range option values are
+    /// normalized to their documented meaning (see <see cref="LanChipInfoRetryOptions"/>) rather
+    /// than thrown back at the caller from partway through the loop.
     /// </para>
     /// </remarks>
     /// <param name="provider">The device to query. When it is also an <see cref="IStreamingDevice"/>, it is what the <c>LAN:APPLY</c> kick is sent through.</param>
@@ -122,9 +132,13 @@ public static class LanChipInfoProviderExtensions
         // — DaqifiStreamingDevice implements both — and when it isn't, there is simply no kick.
         var device = provider as IStreamingDevice;
 
+        // The options are a plain settable record a consumer can get wrong, so every value is
+        // normalized into something the loop can spend rather than passed straight to a BCL call
+        // that would throw — this probe's contract is that failures come back as an unavailable
+        // result, and that has to hold for a misconfigured budget too.
         var maxAttempts = Math.Max(1, effectiveOptions.MaxAttempts);
-        var retryDelay = effectiveOptions.RetryDelay;
-        var totalTimeout = effectiveOptions.TotalTimeout;
+        var retryDelay = NormalizeRetryDelay(effectiveOptions.RetryDelay);
+        var totalTimeout = NormalizeTotalTimeout(effectiveOptions.TotalTimeout);
 
         // Tracks the most recent failure's classification (reset on any non-LanNotInitialized
         // outcome) so the caller can report the specific not-initialized condition only when that
@@ -250,4 +264,34 @@ public static class LanChipInfoProviderExtensions
             lastFailureWasLanNotInitialized);
         return new LanChipInfoProbeResult(null, lastFailureWasLanNotInitialized);
     }
+
+    /// <summary>
+    /// Clamps the retry pause to something <see cref="Task.Delay(TimeSpan, CancellationToken)"/>
+    /// accepts.
+    /// </summary>
+    /// <remarks>
+    /// Every negative value collapses to "no pause", <see cref="Timeout.InfiniteTimeSpan"/>
+    /// included. Other negatives would throw <see cref="ArgumentOutOfRangeException"/> partway
+    /// through a probe documented to absorb failures, and the infinite sentinel would stall the
+    /// caller between attempts until something else cancelled — forever, when
+    /// <see cref="LanChipInfoRetryOptions.TotalTimeout"/> is unbounded too. Both are
+    /// misconfigurations, and retrying immediately is the bounded reading of them.
+    /// </remarks>
+    private static TimeSpan NormalizeRetryDelay(TimeSpan retryDelay) =>
+        retryDelay < TimeSpan.Zero ? TimeSpan.Zero : retryDelay;
+
+    /// <summary>
+    /// Clamps the wall-clock budget to something <see cref="CancellationTokenSource"/> accepts.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Timeout.InfiniteTimeSpan"/> is kept as the one meaningful negative: it is how
+    /// .NET spells "no ceiling" and <see cref="CancellationTokenSource"/> already reads it that
+    /// way. Any other negative becomes <see cref="TimeSpan.Zero"/> — the "no budget, so no
+    /// attempt" outcome the option documents — instead of the
+    /// <see cref="ArgumentOutOfRangeException"/> the constructor would throw.
+    /// </remarks>
+    private static TimeSpan NormalizeTotalTimeout(TimeSpan totalTimeout) =>
+        totalTimeout < TimeSpan.Zero && totalTimeout != Timeout.InfiniteTimeSpan
+            ? TimeSpan.Zero
+            : totalTimeout;
 }

--- a/src/Daqifi.Core/Firmware/LanChipInfoProviderExtensions.cs
+++ b/src/Daqifi.Core/Firmware/LanChipInfoProviderExtensions.cs
@@ -1,0 +1,253 @@
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// How <see cref="LanChipInfoProviderExtensions.GetLanChipInfoWithRetryAsync"/> spends its
+/// retry budget.
+/// </summary>
+/// <remarks>
+/// The defaults are the ones Core's own WiFi firmware-status check uses
+/// (<see cref="FirmwareUpdateServiceOptions.LanChipInfoMaxAttempts"/> and friends), so a consumer
+/// that just wants "what Core does" can pass nothing at all.
+/// </remarks>
+public sealed record LanChipInfoRetryOptions
+{
+    /// <summary>
+    /// Gets the maximum number of chip-info queries to make. Values below 1 are treated as 1 —
+    /// the probe always makes at least one attempt.
+    /// </summary>
+    public int MaxAttempts { get; init; } = 3;
+
+    /// <summary>
+    /// Gets the pause between attempts. Not applied after the final attempt.
+    /// </summary>
+    public TimeSpan RetryDelay { get; init; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Gets the wall-clock ceiling for the whole probe, including the per-attempt device
+    /// timeouts and the retry delays.
+    /// </summary>
+    /// <remarks>
+    /// Needed because <see cref="MaxAttempts"/> × the device's own response timeout plus the
+    /// delays can far exceed what the caller intended to spend — and this probe usually runs
+    /// while an operation lock is held. Expiry ends the probe with the same "unavailable"
+    /// result as an exhausted attempt count rather than throwing; only the caller's own
+    /// cancellation surfaces as <see cref="OperationCanceledException"/>.
+    /// A non-positive value leaves no budget at all, so no attempt is made.
+    /// </remarks>
+    public TimeSpan TotalTimeout { get; init; } = TimeSpan.FromSeconds(8);
+
+    /// <summary>
+    /// Gets a value indicating whether to send a single <c>LAN:APPLY</c> when the device reports
+    /// its WINC state machine is not initialized (SCPI <c>-200</c>).
+    /// </summary>
+    /// <remarks>
+    /// Sent at most once per probe: repeatedly kicking APPLY would tear down and re-initialize
+    /// the WINC on every failed attempt, which risks disrupting an already-associated WiFi link
+    /// for no additional benefit. Only possible when the provider is also the connected
+    /// <see cref="IStreamingDevice"/> — there is nothing to send the command through otherwise.
+    /// </remarks>
+    public bool KickLanApplyOnNotInitialized { get; init; } = true;
+}
+
+/// <summary>
+/// The outcome of a bounded chip-info probe: what was read, and — when nothing was — whether the
+/// device was specifically reporting an uninitialized WINC state machine.
+/// </summary>
+/// <param name="ChipInfo">The chip info that was read, or <see langword="null"/> if the probe never got one.</param>
+/// <param name="WasLanNotInitialized">
+/// Whether the <i>final</i> failure was a <see cref="LanNotInitializedException"/>. Reset by any
+/// other kind of failure, so it describes the terminal condition rather than an earlier attempt.
+/// Meaningless when <see cref="ChipInfo"/> is non-null.
+/// </param>
+public readonly record struct LanChipInfoProbeResult(LanChipInfo? ChipInfo, bool WasLanNotInitialized)
+{
+    /// <summary>Gets a value indicating whether the probe read the chip info.</summary>
+    public bool Succeeded => ChipInfo is not null;
+}
+
+/// <summary>
+/// Retry helpers for <see cref="ILanChipInfoProvider"/>.
+/// </summary>
+public static class LanChipInfoProviderExtensions
+{
+    /// <summary>
+    /// Queries the device's WiFi chip info with a bounded retry, so a transiently-unready WINC
+    /// module reports what it actually is rather than "unavailable".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A single <see cref="ILanChipInfoProvider.GetLanChipInfoAsync"/> is not a reliable answer to
+    /// "what WiFi firmware is on this device". Right after a PIC32 firmware update the application
+    /// is up while WiFi is still finishing startup (#144), and a module whose state machine has not
+    /// reached INITIALIZED answers SCPI <c>-200</c> instead of JSON (#203). Both clear on their own
+    /// within seconds. Treating the first failure as the answer is what sends a caller into a
+    /// needless multi-minute WiFi reflash of already-current firmware — which is exactly why every
+    /// consumer ended up hand-rolling this loop (issue #269).
+    /// </para>
+    /// <para>
+    /// This is the same probe Core runs inside
+    /// <see cref="IFirmwareUpdateService.CheckWifiFirmwareStatusAsync"/>, exposed so consumers share
+    /// one implementation instead of reimplementing it.
+    /// </para>
+    /// <para>
+    /// Failures are absorbed: an exhausted budget comes back as a result with a null
+    /// <see cref="LanChipInfoProbeResult.ChipInfo"/>, not an exception — the caller decides what an
+    /// unreadable module means. The one exception that does propagate is the caller's own
+    /// cancellation.
+    /// </para>
+    /// </remarks>
+    /// <param name="provider">The device to query. When it is also an <see cref="IStreamingDevice"/>, it is what the <c>LAN:APPLY</c> kick is sent through.</param>
+    /// <param name="options">The retry budget; <see langword="null"/> uses <see cref="LanChipInfoRetryOptions"/>'s defaults.</param>
+    /// <param name="logger">Optional logger for per-attempt diagnostics.</param>
+    /// <param name="cancellationToken">Cancels the probe. Unlike the internal budget, this surfaces as <see cref="OperationCanceledException"/>.</param>
+    /// <returns>What was read, and how the probe ended if nothing was.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="provider"/> is null.</exception>
+    public static async Task<LanChipInfoProbeResult> GetLanChipInfoWithRetryAsync(
+        this ILanChipInfoProvider provider,
+        LanChipInfoRetryOptions? options = null,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        var effectiveOptions = options ?? new LanChipInfoRetryOptions();
+        var log = logger ?? NullLogger.Instance;
+
+        // The APPLY kick needs a way to reach the device. In practice the provider is the device
+        // — DaqifiStreamingDevice implements both — and when it isn't, there is simply no kick.
+        var device = provider as IStreamingDevice;
+
+        var maxAttempts = Math.Max(1, effectiveOptions.MaxAttempts);
+        var retryDelay = effectiveOptions.RetryDelay;
+        var totalTimeout = effectiveOptions.TotalTimeout;
+
+        // Tracks the most recent failure's classification (reset on any non-LanNotInitialized
+        // outcome) so the caller can report the specific not-initialized condition only when that
+        // was genuinely the terminal one, not stale from an earlier attempt.
+        var lastFailureWasLanNotInitialized = false;
+        var hasSentLanApply = false;
+
+        // Linking the caller's token preserves cancellation semantics; the timeout CTS just adds a
+        // deadline, and the `when` filters below tell the two apart so only the caller's
+        // cancellation is allowed to escape.
+        using var timeoutCts = new CancellationTokenSource(totalTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+        var linkedToken = linkedCts.Token;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                linkedToken.ThrowIfCancellationRequested();
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                log.LogDebug(
+                    "LAN chip-info probe hit total timeout ({Timeout}) before attempt {Attempt}/{Max}.",
+                    totalTimeout,
+                    attempt,
+                    maxAttempts);
+                return new LanChipInfoProbeResult(null, lastFailureWasLanNotInitialized);
+            }
+
+            try
+            {
+                var chipInfo = await provider.GetLanChipInfoAsync(linkedToken).ConfigureAwait(false);
+                if (chipInfo != null)
+                {
+                    if (attempt > 1)
+                    {
+                        log.LogDebug(
+                            "LAN chip-info query succeeded on attempt {Attempt}/{Max}.",
+                            attempt,
+                            maxAttempts);
+                    }
+                    return new LanChipInfoProbeResult(chipInfo, false);
+                }
+                lastFailureWasLanNotInitialized = false;
+                log.LogDebug(
+                    "LAN chip-info query returned null on attempt {Attempt}/{Max}.",
+                    attempt,
+                    maxAttempts);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                log.LogDebug(
+                    "LAN chip-info probe hit total timeout ({Timeout}) during attempt {Attempt}/{Max}.",
+                    totalTimeout,
+                    attempt,
+                    maxAttempts);
+                return new LanChipInfoProbeResult(null, lastFailureWasLanNotInitialized);
+            }
+            catch (LanNotInitializedException ex)
+            {
+                lastFailureWasLanNotInitialized = true;
+                log.LogDebug(
+                    ex,
+                    "LAN chip-info query on attempt {Attempt}/{Max} reported the WINC state machine is not initialized.",
+                    attempt,
+                    maxAttempts);
+
+                if (effectiveOptions.KickLanApplyOnNotInitialized && !hasSentLanApply && device is { IsConnected: true })
+                {
+                    // Observe cancellation before this state-changing Send: a cancelled probe must
+                    // not still kick APPLY on the device. Uses the caller's token (not the linked
+                    // timeout token) so a total-timeout expiry alone doesn't suppress a kick the
+                    // caller never actually asked to cancel.
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    hasSentLanApply = true;
+                    try
+                    {
+                        device.Send(ScpiMessageProducer.ApplyNetworkLan);
+                        log.LogDebug("Sent LAN:APPLY to initialize the WINC state machine after a not-initialized chip-info response.");
+                    }
+                    catch (Exception sendEx) when (sendEx is not OperationCanceledException)
+                    {
+                        // Best-effort: falling through to the normal retry delay/loop below still
+                        // gives the device a chance to recover on its own.
+                        log.LogDebug(sendEx, "Failed to send LAN:APPLY after a not-initialized chip-info response; continuing retry loop without it.");
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                lastFailureWasLanNotInitialized = false;
+                log.LogDebug(
+                    ex,
+                    "LAN chip-info query failed on attempt {Attempt}/{Max}.",
+                    attempt,
+                    maxAttempts);
+            }
+
+            if (attempt < maxAttempts)
+            {
+                try
+                {
+                    await Task.Delay(retryDelay, linkedToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    log.LogDebug(
+                        "LAN chip-info probe hit total timeout ({Timeout}) during retry delay after attempt {Attempt}/{Max}.",
+                        totalTimeout,
+                        attempt,
+                        maxAttempts);
+                    return new LanChipInfoProbeResult(null, lastFailureWasLanNotInitialized);
+                }
+            }
+        }
+
+        log.LogDebug(
+            "LAN chip-info query exhausted {Max} attempts; reporting the module as unreadable (not-initialized: {NotInitialized}).",
+            maxAttempts,
+            lastFailureWasLanNotInitialized);
+        return new LanChipInfoProbeResult(null, lastFailureWasLanNotInitialized);
+    }
+}

--- a/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
+++ b/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
@@ -226,16 +226,15 @@ internal sealed class WifiModuleUpdater
             }
         }
 
-        // Bounded retry for the LAN chip-info probe (closes #144). Right
-        // after a PIC32 firmware update the application is up while WiFi
-        // is still finishing startup, so the first chip-info query can
-        // transiently fail; without retry, the WiFi version decision
-        // would short-circuit to ChipInfoUnavailable and flow on to a
-        // multi-minute reflash of already-current WiFi firmware. The
-        // retry budget is bounded (LanChipInfoMaxAttempts × RetryDelay)
-        // and observes cancellation between attempts.
-        var (chipInfo, wasLanNotInitialized) = await TryGetLanChipInfoWithRetryAsync(
-            device, lanChipInfoProvider, cancellationToken).ConfigureAwait(false);
+        // Bounded retry for the LAN chip-info probe (closes #144, #203): without it the WiFi
+        // version decision short-circuits to ChipInfoUnavailable on a module that is merely
+        // still starting up, and flows on to a multi-minute reflash of already-current
+        // firmware. The loop itself is public API (issue #269) so consumers share one
+        // implementation of it rather than each hand-rolling their own; see
+        // GetLanChipInfoWithRetryAsync for what it does and why.
+        var (chipInfo, wasLanNotInitialized) = await lanChipInfoProvider
+            .GetLanChipInfoWithRetryAsync(BuildLanChipInfoRetryOptions(), Logger, cancellationToken)
+            .ConfigureAwait(false);
         if (chipInfo == null)
         {
             return new WifiFirmwareStatus
@@ -377,148 +376,21 @@ internal sealed class WifiModuleUpdater
         }
     }
 
-    private async Task<(LanChipInfo? ChipInfo, bool WasLanNotInitialized)> TryGetLanChipInfoWithRetryAsync(
-        IStreamingDevice device,
-        ILanChipInfoProvider lanChipInfoProvider,
-        CancellationToken cancellationToken)
+    /// <summary>
+    /// Projects this service's chip-info retry settings onto the shared probe's options.
+    /// </summary>
+    /// <remarks>
+    /// Read fresh on every probe rather than cached: <see cref="FirmwareUpdateServiceOptions"/>
+    /// stays mutable after the service is constructed, so a caller that adjusts the budget between
+    /// calls gets the budget it asked for.
+    /// </remarks>
+    private LanChipInfoRetryOptions BuildLanChipInfoRetryOptions() => new()
     {
-        var maxAttempts = Math.Max(1, Options.LanChipInfoMaxAttempts);
-        var retryDelay = Options.LanChipInfoRetryDelay;
-        var totalTimeout = Options.LanChipInfoTotalTimeout;
-
-        // Tracks the most recent failure's classification (reset on any
-        // non-LanNotInitialized outcome) so the caller can report the
-        // specific WifiFirmwareStatusReason.LanNotInitialized only when
-        // that was genuinely the terminal condition, not stale from an
-        // earlier attempt. Sent at most once per probe (closes #203) —
-        // repeatedly kicking APPLY would tear down and re-init the WINC
-        // on every failed attempt, risking disruption of an already-
-        // associated WiFi link for no additional benefit.
-        var lastFailureWasLanNotInitialized = false;
-        var hasSentLanApply = false;
-
-        // Wall-clock budget guards against the pathological case where
-        // attempt-count × per-attempt-timeout + retry-delay sum vastly
-        // exceeds the configured retry budget (e.g., 3 × 2s device timeout
-        // + 2 × 2s delay = ~10s while the operation lock is held). Linking
-        // the caller's CT preserves cancellation semantics; the timeout
-        // CTS just adds a deadline.
-        using var timeoutCts = new CancellationTokenSource(totalTimeout);
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken, timeoutCts.Token);
-        var linkedToken = linkedCts.Token;
-
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            try
-            {
-                linkedToken.ThrowIfCancellationRequested();
-            }
-            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-            {
-                Logger.LogDebug(
-                    "LAN chip-info probe hit total timeout ({Timeout}) before attempt {Attempt}/{Max}.",
-                    totalTimeout,
-                    attempt,
-                    maxAttempts);
-                return (null, lastFailureWasLanNotInitialized);
-            }
-
-            try
-            {
-                var chipInfo = await lanChipInfoProvider.GetLanChipInfoAsync(linkedToken).ConfigureAwait(false);
-                if (chipInfo != null)
-                {
-                    if (attempt > 1)
-                    {
-                        Logger.LogDebug(
-                            "LAN chip-info query succeeded on attempt {Attempt}/{Max}.",
-                            attempt,
-                            maxAttempts);
-                    }
-                    return (chipInfo, false);
-                }
-                lastFailureWasLanNotInitialized = false;
-                Logger.LogDebug(
-                    "LAN chip-info query returned null on attempt {Attempt}/{Max}.",
-                    attempt,
-                    maxAttempts);
-            }
-            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-            {
-                Logger.LogDebug(
-                    "LAN chip-info probe hit total timeout ({Timeout}) during attempt {Attempt}/{Max}.",
-                    totalTimeout,
-                    attempt,
-                    maxAttempts);
-                return (null, lastFailureWasLanNotInitialized);
-            }
-            catch (LanNotInitializedException ex)
-            {
-                lastFailureWasLanNotInitialized = true;
-                Logger.LogDebug(
-                    ex,
-                    "LAN chip-info query on attempt {Attempt}/{Max} reported the WINC state machine is not initialized.",
-                    attempt,
-                    maxAttempts);
-
-                if (Options.KickLanApplyOnNotInitialized && !hasSentLanApply && device.IsConnected)
-                {
-                    // Observe cancellation before this state-changing Send, mirroring
-                    // the WINC power-on guard above: a cancelled probe must not still
-                    // kick APPLY on the device. Uses the caller's token (not the
-                    // linked timeout token) so a total-timeout expiry alone doesn't
-                    // suppress a kick the caller never actually asked to cancel.
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    hasSentLanApply = true;
-                    try
-                    {
-                        device.Send(ScpiMessageProducer.ApplyNetworkLan);
-                        Logger.LogDebug("Sent LAN:APPLY to initialize the WINC state machine after a not-initialized chip-info response.");
-                    }
-                    catch (Exception sendEx) when (sendEx is not OperationCanceledException)
-                    {
-                        // Best-effort: falling through to the normal retry delay/loop
-                        // below still gives the device a chance to recover on its own.
-                        Logger.LogDebug(sendEx, "Failed to send LAN:APPLY after a not-initialized chip-info response; continuing retry loop without it.");
-                    }
-                }
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                lastFailureWasLanNotInitialized = false;
-                Logger.LogDebug(
-                    ex,
-                    "LAN chip-info query failed on attempt {Attempt}/{Max}.",
-                    attempt,
-                    maxAttempts);
-            }
-
-            if (attempt < maxAttempts)
-            {
-                try
-                {
-                    await Task.Delay(retryDelay, linkedToken).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                {
-                    Logger.LogDebug(
-                        "LAN chip-info probe hit total timeout ({Timeout}) during retry delay after attempt {Attempt}/{Max}.",
-                        totalTimeout,
-                        attempt,
-                        maxAttempts);
-                    return (null, lastFailureWasLanNotInitialized);
-                }
-            }
-        }
-
-        Logger.LogDebug(
-            "LAN chip-info query exhausted {Max} attempts; reporting status as {Reason}.",
-            maxAttempts,
-            lastFailureWasLanNotInitialized ? WifiFirmwareStatusReason.LanNotInitialized : WifiFirmwareStatusReason.ChipInfoUnavailable);
-        return (null, lastFailureWasLanNotInitialized);
-    }
+        MaxAttempts = Options.LanChipInfoMaxAttempts,
+        RetryDelay = Options.LanChipInfoRetryDelay,
+        TotalTimeout = Options.LanChipInfoTotalTimeout,
+        KickLanApplyOnNotInitialized = Options.KickLanApplyOnNotInitialized,
+    };
 
     private ExternalProcessRequest BuildWifiProcessRequest(
         IStreamingDevice device,


### PR DESCRIPTION
Part of #269 (item 5: *"a `GetLanChipInfoAsync(retries, delay)` helper in Core would let every consumer share it"*).

**Not merging — opened for your review.**

## Why

A single `GetLanChipInfoAsync` is not a reliable answer to "what WiFi firmware is on this device":

- right after a PIC32 update the application is up while WiFi is still finishing startup (#144), and
- a module whose state machine has not reached INITIALIZED answers SCPI `-200` instead of JSON (#203).

Both clear on their own within seconds. Treating the first failure as the answer is what sends a caller into a needless multi-minute reflash of already-current firmware.

Core already had the bounded retry that handles this — but it was `private` to `WifiModuleUpdater`, so every consumer hand-rolled its own. `daqifi-desktop` wraps the call in a 3×/2s `TryGetLanChipInfoAsync` of its own, which is precisely the duplication #269 exists to remove.

## What changed

- **New public API** (`Daqifi.Core.Firmware`): `ILanChipInfoProvider.GetLanChipInfoWithRetryAsync(...)` extension, plus `LanChipInfoRetryOptions` (budget) and `LanChipInfoProbeResult` (what was read + whether the terminal failure was specifically "WINC not initialized").
- **`WifiModuleUpdater` now calls it** instead of its own copy: `TryGetLanChipInfoWithRetryAsync` (~140 lines) is gone, replaced by a small `BuildLanChipInfoRetryOptions()` projection of `FirmwareUpdateServiceOptions`. One implementation, not two.
- **Additive only.** No interface changed, nothing removed from the public surface. `LanChipInfoRetryOptions`' defaults are the ones Core itself uses (3 attempts / 2 s apart / 8 s total / kick enabled), so `GetLanChipInfoWithRetryAsync()` with no arguments is "what Core does".

Behavior is deliberately unchanged, including the parts that are easy to lose in a move:

- attempt count clamped to at least 1 (a probe that queries nothing would be indistinguishable from a dead module);
- the wall-clock budget ends the probe with an *unavailable result*, not an exception — only the **caller's** cancellation propagates;
- the `LAN:APPLY` kick is sent **at most once** per probe and only to a connected device (repeated kicks re-init the WINC and risk an already-associated link);
- the cancellation check *before* that state-changing send;
- the not-initialized flag describes the **terminal** failure, reset by any other kind — a stale one would send a caller kicking APPLY at a module that failed for an unrelated reason.

The probe finds the device for the kick by `provider as IStreamingDevice` (in practice the provider *is* the device — `DaqifiStreamingDevice` implements both). A bare provider simply gets no kick, which is covered by a test.

## Tests

**+22 new** `LanChipInfoProviderExtensionsTests` (18 with the original commit, +4 with the review fix below). Baseline measured on a clean `origin/main` worktree at `4b8eed2` (**2690**) rather than taken from notes; this branch is **2712** — exactly +22, zero losses. Full suite green on **net9 + net10** (2712 passed / 2 skipped each, plus 23 Mcp on net9), 0 warnings.

The 22 existing `FirmwareUpdateServiceTests` assertions covering this retry (#144 / #203 / kick-once / cancel-race / total-timeout) were left **untouched on purpose** — they are the evidence that routing the updater through the shared helper changed nothing.

**Mutation-checked rather than assumed to bite.** Eight mutations of the new implementation, each run against the new tests:

| mutation | result |
|---|---|
| kick fires on every attempt | 2 tests fail |
| drop `Math.Max(1, MaxAttempts)` | 1 fails |
| drop the not-initialized flag reset | 1 fails |
| delay after the final attempt too | 1 fails |
| drop the pre-kick cancellation check | 1 fails |
| ignore `IsConnected` before kicking | 1 fails |
| ignore `KickLanApplyOnNotInitialized` | 1 fails |

(An eighth — deleting the `!hasSentLanApply` guard outright — doesn't compile under `TreatWarningsAsErrors`, so it was re-expressed as "kick every attempt".) Implementation restored from a byte-identical backup and diffed before committing.

## Bench (real Nq1, fw 3.7.2, USB `/dev/cu.usbmodem1101`, non-destructive)

Scratchpad harness with a ProjectReference straight at this branch's Core, so the new public API is what actually ran against hardware.

- **Real WINC read through the new probe:** `chipId=1377184 fwVersion=19.7.7 buildDate=Mar 30 2022` — identical to the single-shot `GetLanChipInfoAsync` baseline taken immediately before it (1061 ms), so the wrapper returns the device's own answer unaltered.
- **The retry loop drives real device I/O, not just a mock.** A flaky decorator failed the first two queries; the loop retried and the **third attempt reached the hardware** and came back with the same chip info (`attempts=3 realDeviceCalls=1`, 1563 ms ≈ 2 × 400 ms delay + the device call). Per-attempt debug logging surfaced through the injected `ILogger`. This decorator is also the not-a-streaming-device path, so the "no kick available" branch ran on hardware too.
- Probe after `SYSTem:POWer:STATe 1` + 1 s settle (what Core's own status check does): succeeded in 560 ms.
- No `LAN:APPLY` was sent in any run — the kick was left disabled, since the bench module is already initialized and repeated APPLYs are the WiFi-churn hazard the once-only guard exists for.

**One honest observation, pre-existing and unchanged by this PR:** a 900 ms `TotalTimeout` against a 20-attempt budget did **not** cut a single in-flight query short — the run returned successfully at 1059 ms. The device-side text exchange doesn't observe the linked token mid-flight on this path, so the budget bounds the loop *between* attempts rather than acting as a hard deadline. That is exactly what it was written for (attempts × per-attempt timeout + delays overrunning while a lock is held), and it is the same behavior main has today; the docs now say so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review fix (`0d903a7`) — the retry budget is normalized, not thrown

Qodo caught a real gap in the new public surface, [confirmed red before fixing](https://github.com/daqifi/daqifi-core/pull/443#discussion_r3725654639): `LanChipInfoRetryOptions` is a settable record, but `RetryDelay` went straight to `Task.Delay` and `TotalTimeout` straight to `CancellationTokenSource`. Three misconfigurations escaped a probe whose stated contract is that failures come back as a result:

| option | before |
|---|---|
| `TotalTimeout` negative | `ArgumentOutOfRangeException` from the CTS ctor — despite the option's own doc promising "no budget, so no attempt" |
| `RetryDelay` negative | `ArgumentOutOfRangeException` from `Task.Delay`, partway through the loop |
| both `Timeout.InfiniteTimeSpan` | hung between attempts with nothing left to release it |

Normalized in the same clamp-don't-throw spirit as the existing `Math.Max(1, MaxAttempts)`, rather than validated — throwing would contradict the "failures are absorbed" contract, and `FirmwareUpdateServiceOptions.Validate()` throws because it is an up-front config object, not a per-call budget.

One deliberate asymmetry, now documented on both properties: `Timeout.InfiniteTimeSpan` keeps meaning "no ceiling" for `TotalTimeout` (that is what .NET and `CancellationTokenSource` already mean by it) but folds into "no pause" for `RetryDelay`, where an infinite pause inside a *bounded* retry has no reading other than the hang above. Every other negative becomes zero. Defaults are provably identity, so the shipped path is unchanged.

Both subtle branches mutation-checked: clamping the infinite budget to zero fails 2 tests; honoring an infinite `RetryDelay` fails 1 (the 10s hang returns).

**Re-benched on the real Nq1** (fw 3.7.2, USB, non-destructive, kick disabled) — the defaults line matches the pre-fix baseline, the negative budget returns in 0 ms having made no attempt, and the bottom three all previously threw or hung:

```
[defaults]                  OK chipId=1377184 fw=19.7.7 build=Mar 30 2022  (1064 ms)
[negative-total-timeout]    UNAVAILABLE (notInitialized=False)             (0 ms)
[negative-retry-delay]      OK chipId=1377184 fw=19.7.7 build=Mar 30 2022  (1053 ms)
[infinite-delay-and-budget] OK chipId=1377184 fw=19.7.7 build=Mar 30 2022  (1060 ms)
[infinite-budget-only]      OK chipId=1377184 fw=19.7.7 build=Mar 30 2022  (1059 ms)
```
