### PR TITLE
feat(firmware): own the canonical WiFi prep and post-flash recovery SCPI sequences (part of #269)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1668,6 +1668,155 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateWifiModuleAsync_WhenCanceledDuringTransparentModeExitSettle_LeavesLanRestoreUnsent()
+    {
+        // Pins that the settle genuinely sits BETWEEN the transparent-mode exit and the LAN
+        // restore, not before the exit or after the whole recovery block: cancellation is raised
+        // from inside the transparent-mode Send, so only a wait positioned between the two can
+        // stop LAN:ENAbled/APPLY/SAVE from going out. Also proves the wait observes the caller's
+        // token rather than sleeping through a cancel.
+        using var cts = new CancellationTokenSource();
+        var device = new FakeStreamingDevice("COM33");
+        device.OnCommandSent = command =>
+        {
+            if (command == "SYSTem:USB:SetTransparentMode 0")
+            {
+                cts.Cancel();
+            }
+        };
+
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(
+                0,
+                timedOut: false,
+                TimeSpan.FromMilliseconds(10),
+                ["verify passed", "Operation completed successfully"],
+                [])
+        };
+
+        var options = CreateFastOptions();
+        options.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(5);
+        options.PostWifiReconnectDelay = TimeSpan.FromMilliseconds(5);
+        // Long enough that a missing wait would let the LAN restore slip out before the cancel
+        // is seen. The cancel is already raised by the time the wait starts, so it ends at once
+        // rather than actually costing 30s.
+        options.PostUsbTransparentModeExitDelay = TimeSpan.FromSeconds(30);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir, cancellationToken: cts.Token));
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(
+            [
+                "SYSTem:POWer:STATe 1",
+                "SYSTem:COMMUnicate:LAN:FWUpdate",
+                "SYSTem:USB:SetTransparentMode 0"
+            ],
+            device.SentCommands);
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenTransparentModeExitDelayIsZero_StillSendsFullRecoverySequence()
+    {
+        // Zero means "skip the wait", not "skip the step". A consumer that collapses the delay
+        // (or a transport that needs no pacing) must still get the whole recovery sequence.
+        var device = new FakeStreamingDevice("COM34");
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(
+                0,
+                timedOut: false,
+                TimeSpan.FromMilliseconds(10),
+                ["verify passed", "Operation completed successfully"],
+                [])
+        };
+
+        var options = CreateFastOptions();
+        options.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(5);
+        options.PostWifiReconnectDelay = TimeSpan.FromMilliseconds(5);
+        options.PostUsbTransparentModeExitDelay = TimeSpan.Zero;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(device, firmwareDir);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(
+            [
+                "SYSTem:POWer:STATe 1",
+                "SYSTem:COMMUnicate:LAN:FWUpdate",
+                "SYSTem:USB:SetTransparentMode 0",
+                "SYSTem:COMMunicate:LAN:ENAbled 1",
+                "SYSTem:COMMunicate:LAN:APPLY",
+                "SYSTem:COMMunicate:LAN:SAVE"
+            ],
+            device.SentCommands);
+    }
+
+    [Fact]
+    public void FirmwareUpdateServiceOptions_PostUsbTransparentModeExitDelay_DefaultsToBridgeDeactivationPace()
+    {
+        // The default is the behavior: a consumer that upgrades without touching options gets
+        // the pacing. 100ms is not arbitrary — it is the same inter-command wait
+        // WifiBridgeActivator.Deactivate already uses for this exact mode transition over a raw
+        // serial port, so the managed-connection path is paced identically. Pinned so the two
+        // cannot silently drift apart.
+        var options = new FirmwareUpdateServiceOptions();
+
+        Assert.Equal(TimeSpan.FromMilliseconds(100), options.PostUsbTransparentModeExitDelay);
+        options.Validate();
+    }
+
+    [Fact]
+    public void FirmwareUpdateServiceOptions_Validate_RejectsNegativeTransparentModeExitDelayButAllowsZero()
+    {
+        // Zero is the documented "skip the wait" escape hatch and must stay legal; a negative
+        // value is a misconfiguration that would otherwise reach Task.Delay.
+        var options = new FirmwareUpdateServiceOptions { PostUsbTransparentModeExitDelay = TimeSpan.Zero };
+        options.Validate();
+
+        options.PostUsbTransparentModeExitDelay = TimeSpan.FromMilliseconds(-1);
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+        Assert.Equal(nameof(FirmwareUpdateServiceOptions.PostUsbTransparentModeExitDelay), exception.ParamName);
+    }
+
+    [Fact]
     public async Task UpdateWifiModuleAsync_WhenCanceledDuringPowerOnSettle_NeverEntersLanUpdateMode()
     {
         // Pins that the settle delay is genuinely awaited BETWEEN the power-on and the
@@ -4381,7 +4530,10 @@ public class FirmwareUpdateServiceTests
             // Skip the WINC power-on settle wait — fakes don't model power state,
             // so the delay is pure latency here. Individual tests re-enable it
             // where the power-on behavior itself is under test.
-            PowerOnWifiModuleSettleDelay = TimeSpan.Zero
+            PowerOnWifiModuleSettleDelay = TimeSpan.Zero,
+            // Same reasoning for the transparent-mode exit settle: the fake device has no
+            // bridge to leave. Tests that exercise the wait itself set it explicitly.
+            PostUsbTransparentModeExitDelay = TimeSpan.Zero
         };
     }
 

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1583,9 +1583,16 @@ public class FirmwareUpdateServiceTests
         }
 
         Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+
+        // The canonical WiFi-update prep and post-flash recovery sequences Core now owns end to
+        // end (part of #269). The power-on leads the prep because LAN commands are rejected while
+        // the WINC is unpowered, and the transparent-mode exit leads the recovery because the LAN
+        // commands after it would otherwise be forwarded to the WINC instead of interpreted.
         Assert.Equal(
             [
+                "SYSTem:POWer:STATe 1",
                 "SYSTem:COMMUnicate:LAN:FWUpdate",
+                "SYSTem:USB:SetTransparentMode 0",
                 "SYSTem:COMMunicate:LAN:ENAbled 1",
                 "SYSTem:COMMunicate:LAN:APPLY",
                 "SYSTem:COMMunicate:LAN:SAVE"
@@ -1603,6 +1610,179 @@ public class FirmwareUpdateServiceTests
         // means only the PIC32 CRC check (a genuine flash failure) is ever reported as Verifying.
         Assert.Contains(progressEvents, p => p.State == FirmwareUpdateState.ReconnectingAfterFlash);
         Assert.DoesNotContain(progressEvents, p => p.State == FirmwareUpdateState.Verifying);
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenPowerOnBeforeLanUpdateModeDisabled_SkipsPowerOnButStillRestoresTransparentMode()
+    {
+        // The opt-out exists for consumers that already powered the module on themselves. It must
+        // affect the prep half ONLY — the post-flash transparent-mode exit is recovery of state
+        // the flash disturbed and is not conditional on it.
+        var device = new FakeStreamingDevice("COM31");
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(
+                0,
+                timedOut: false,
+                TimeSpan.FromMilliseconds(10),
+                ["verify passed", "Operation completed successfully"],
+                [])
+        };
+
+        var options = CreateFastOptions();
+        options.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(5);
+        options.PostWifiReconnectDelay = TimeSpan.FromMilliseconds(5);
+        options.PowerOnWifiModuleBeforeLanUpdateMode = false;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await service.UpdateWifiModuleAsync(device, firmwareDir);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(FirmwareUpdateState.Complete, service.CurrentState);
+        Assert.Equal(
+            [
+                "SYSTem:COMMUnicate:LAN:FWUpdate",
+                "SYSTem:USB:SetTransparentMode 0",
+                "SYSTem:COMMunicate:LAN:ENAbled 1",
+                "SYSTem:COMMunicate:LAN:APPLY",
+                "SYSTem:COMMunicate:LAN:SAVE"
+            ],
+            device.SentCommands);
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenCanceledDuringPowerOnSettle_NeverEntersLanUpdateMode()
+    {
+        // Pins that the settle delay is genuinely awaited BETWEEN the power-on and the
+        // update-mode command, not before both or after both: cancellation is raised from
+        // inside the power-on Send, so only a wait sitting between the two sends can stop
+        // LAN:FWUpdate from going out. Also proves the wait observes the caller's token
+        // instead of sleeping the device into update mode after a cancel.
+        using var cts = new CancellationTokenSource();
+        var device = new FakeStreamingDevice("COM32");
+        device.OnCommandSent = command =>
+        {
+            if (command == "SYSTem:POWer:STATe 1")
+            {
+                cts.Cancel();
+            }
+        };
+
+        var options = CreateFastOptions();
+        // Long enough that the cancel, not the elapsed time, is what ends the wait — and long
+        // enough that a missing wait would let LAN:FWUpdate slip out before the cancel is seen.
+        options.PowerOnWifiModuleSettleDelay = TimeSpan.FromSeconds(30);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir, cancellationToken: cts.Token));
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Equal(["SYSTem:POWer:STATe 1"], device.SentCommands);
+        Assert.Equal(0, device.DisconnectCalls);
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenCanceledDuringVersionCheck_SendsNoPreparationCommands()
+    {
+        // A cancel that lands after the operation lock is taken but before device prep must not
+        // still power the module on or flip the device into LAN firmware-update mode — update
+        // mode leaves the device unusable until it is taken back out of it, which a canceled
+        // caller will not be around to do. The version check is the real window for this: it
+        // returns a status object rather than observing the token itself, so without an explicit
+        // check the prep step runs both Sends before its first await notices the cancellation.
+        using var cts = new CancellationTokenSource();
+
+        var downloadService = new FakeFirmwareDownloadService
+        {
+            // Cancel from inside the check, then return normally: the check completes, decides a
+            // flash is needed (19.5.4 is below the supported minimum), and hands control to prep.
+            OnGetLatestWifiRelease = cts.Cancel
+        };
+
+        var device = new FakeLanChipInfoStreamingDevice(
+            "COM33",
+            chipInfo: new LanChipInfo
+            {
+                ChipId = 1234,
+                FwVersion = "19.5.4",
+                BuildDate = "Jan  8 2019"
+            });
+
+        var options = CreateFastOptions();
+        // Keeps SentCommands to just the prep commands under test — the probe's own power-on is
+        // a different code path with its own coverage.
+        options.PowerOnWifiModuleBeforeProbe = false;
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            downloadService,
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir, cancellationToken: cts.Token));
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+
+        Assert.Empty(device.SentCommands);
+    }
+
+    [Fact]
+    public void FirmwareUpdateServiceOptions_PowerOnWifiModuleBeforeLanUpdateMode_DefaultsToTrue()
+    {
+        // The default is the behavior change: a consumer that upgrades without touching options
+        // gets the power-on prep. Pinned so it cannot be flipped off silently.
+        var options = new FirmwareUpdateServiceOptions();
+
+        Assert.True(options.PowerOnWifiModuleBeforeLanUpdateMode);
+        Assert.Equal(TimeSpan.FromSeconds(1), options.PowerOnWifiModuleSettleDelay);
+        options.Validate();
     }
 
     [Fact]
@@ -4242,6 +4422,12 @@ public class FirmwareUpdateServiceTests
         public int ConnectFailuresBeforeSuccess { get; set; }
         public List<string> SentCommands { get; } = [];
 
+        /// <summary>
+        /// Invoked synchronously after each text command is recorded, so a test can react to a
+        /// specific command (e.g. cancel the operation) at the exact point the device sees it.
+        /// </summary>
+        public Action<string>? OnCommandSent { get; set; }
+
         public event EventHandler<DeviceStatusEventArgs>? StatusChanged;
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived
         {
@@ -4282,6 +4468,7 @@ public class FirmwareUpdateServiceTests
             if (message is IOutboundMessage<string> textMessage)
             {
                 SentCommands.Add(textMessage.Data);
+                OnCommandSent?.Invoke(textMessage.Data);
             }
         }
 
@@ -4805,8 +4992,17 @@ public class FirmwareUpdateServiceTests
             return Task.FromResult<(string ExtractedPath, string Version)?>(null);
         }
 
+        /// <summary>
+        /// Invoked at the start of <see cref="GetLatestWifiReleaseAsync"/>. Gives a test a hook
+        /// inside the WiFi version check — the last thing that runs before the update's device-prep
+        /// step — so it can, for example, cancel the operation at exactly that point.
+        /// </summary>
+        public Action? OnGetLatestWifiRelease { get; set; }
+
         public Task<FirmwareReleaseInfo?> GetLatestWifiReleaseAsync(CancellationToken cancellationToken = default)
         {
+            OnGetLatestWifiRelease?.Invoke();
+
             return LatestWifiReleaseException is not null
                 ? Task.FromException<FirmwareReleaseInfo?>(LatestWifiReleaseException)
                 : Task.FromResult(LatestWifiRelease);

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -90,6 +90,20 @@ public sealed class FirmwareUpdateServiceOptions
     public TimeSpan PostWifiReconnectDelay { get; set; } = TimeSpan.FromSeconds(2);
 
     /// <summary>
+    /// Delay after the post-flash recovery sequence sends
+    /// <see cref="Communication.Producers.ScpiMessageProducer.SetUsbTransparencyMode"/> <c>0</c>
+    /// and before the LAN restore commands that follow it. Leaving the USB-to-WINC transparent
+    /// bridge is a device-side mode transition, not an instantaneous one: until the SCPI console
+    /// path is re-established, bytes arriving on the port are still forwarded to the WINC as raw
+    /// data, so a LAN command sent too soon is swallowed by the bridge and the configuration
+    /// silently fails to restore. <see cref="WifiBridgeActivator.Deactivate(string, System.Threading.CancellationToken)"/>
+    /// already paces the same transition by the same amount over a raw serial port; this is the
+    /// managed-connection equivalent. Set to <see cref="TimeSpan.Zero"/> to skip the wait (e.g.
+    /// unit tests).
+    /// </summary>
+    public TimeSpan PostUsbTransparentModeExitDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
     /// Delay observed at the WINC "Power cycle WINC and set to bootloader mode" prompt before the
     /// empty continue line is sent to the flash tool. Gives the WiFi firmware time to finish its
     /// bridge-mode initialization — especially after <see cref="WifiBridgeActivationCallback"/>
@@ -391,9 +405,10 @@ public sealed class FirmwareUpdateServiceOptions
         ValidatePositive(WifiProcessTimeout, nameof(WifiProcessTimeout));
         ValidatePositive(WifiFlashRetryDelay, nameof(WifiFlashRetryDelay));
 
-        // These two permit Zero (= "skip the wait"); only reject negatives.
+        // These three permit Zero (= "skip the wait"); only reject negatives.
         ValidateNonNegative(PostLanDisconnectPortReleaseDelay, nameof(PostLanDisconnectPortReleaseDelay));
         ValidateNonNegative(WincBootPromptResponseDelay, nameof(WincBootPromptResponseDelay));
+        ValidateNonNegative(PostUsbTransparentModeExitDelay, nameof(PostUsbTransparentModeExitDelay));
 
         if (WifiFlashAttempts < 1)
         {

--- a/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
+++ b/src/Daqifi.Core/Firmware/FirmwareUpdateServiceOptions.cs
@@ -278,9 +278,25 @@ public sealed class FirmwareUpdateServiceOptions
     public bool PowerOnWifiModuleBeforeProbe { get; set; } = true;
 
     /// <summary>
-    /// Delay after sending the WINC power-on command, before the first chip-info probe.
-    /// Only consulted when <see cref="PowerOnWifiModuleBeforeProbe"/> is <c>true</c>. Gives the
-    /// module time to power up and start responding to <c>GETChipInfo?</c> queries.
+    /// When true, the WiFi-update prep sequence sends
+    /// <see cref="Communication.Producers.ScpiMessageProducer.TurnDeviceOn"/> and waits
+    /// <see cref="PowerOnWifiModuleSettleDelay"/> before
+    /// <see cref="Communication.Producers.ScpiMessageProducer.SetLanFirmwareUpdateMode"/>.
+    /// The WINC module is powered off in standby and right after a PIC32 reflash, and LAN
+    /// commands issued in that state are rejected (SCPI <c>-200</c>), so the update-mode flag
+    /// never takes effect and the external flash tool then finds no bridge to talk to. Powering
+    /// the module on first — the same order <c>daqifi-desktop</c> hand-rolls today — closes that
+    /// gap. Defaults to <c>true</c>; set to <c>false</c> for consumers that have already powered
+    /// the module on themselves and want the legacy prep sequence.
+    /// </summary>
+    public bool PowerOnWifiModuleBeforeLanUpdateMode { get; set; } = true;
+
+    /// <summary>
+    /// Delay after sending the WINC power-on command, giving the module time to power up before
+    /// the next command reaches it. Consulted in both places Core powers the module on: before
+    /// the first chip-info probe (see <see cref="PowerOnWifiModuleBeforeProbe"/>) and before the
+    /// LAN firmware-update mode command (see <see cref="PowerOnWifiModuleBeforeLanUpdateMode"/>).
+    /// Set to <see cref="TimeSpan.Zero"/> to skip the wait.
     /// </summary>
     public TimeSpan PowerOnWifiModuleSettleDelay { get; set; } = TimeSpan.FromSeconds(1);
 
@@ -443,8 +459,9 @@ public sealed class FirmwareUpdateServiceOptions
         ValidatePositive(LanChipInfoRetryDelay, nameof(LanChipInfoRetryDelay));
         ValidatePositive(LanChipInfoTotalTimeout, nameof(LanChipInfoTotalTimeout));
 
-        // Only consulted when PowerOnWifiModuleBeforeProbe is true, but validated
-        // unconditionally so a misconfiguration surfaces even if the flag is
+        // Only consulted when PowerOnWifiModuleBeforeProbe or
+        // PowerOnWifiModuleBeforeLanUpdateMode is true, but validated
+        // unconditionally so a misconfiguration surfaces even if a flag is
         // toggled on later without re-touching this value.
         ValidateNonNegative(PowerOnWifiModuleSettleDelay, nameof(PowerOnWifiModuleSettleDelay));
 

--- a/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
+++ b/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
@@ -73,9 +73,29 @@ internal sealed class WifiModuleUpdater
                 {
                     FirmwareUpdateContext.EnsureDeviceConnected(device);
 
+                    // Observe cancellation before the first state-changing Send below: a
+                    // prep step that is already canceled must not still power the module on
+                    // or flip the device into LAN firmware-update mode.
+                    stateToken.ThrowIfCancellationRequested();
+
                     if (device.IsStreaming)
                     {
                         device.StopStreaming();
+                    }
+
+                    // The WINC is powered off in standby and right after a PIC32 reflash, and LAN
+                    // commands are rejected (-200) in that state — so LAN:FWUpdate would silently
+                    // fail to take effect and the flash tool would find no bridge. Power it on and
+                    // let it settle first. This is the prep order daqifi-desktop hand-rolls today
+                    // (EnableLanUpdateMode: POWer:STATe 1 → settle → LAN:FWUpdate); owning it here
+                    // is what lets a consumer drop that workaround (part of #269).
+                    if (Options.PowerOnWifiModuleBeforeLanUpdateMode)
+                    {
+                        device.Send(ScpiMessageProducer.TurnDeviceOn);
+                        if (Options.PowerOnWifiModuleSettleDelay > TimeSpan.Zero)
+                        {
+                            await Task.Delay(Options.PowerOnWifiModuleSettleDelay, stateToken).ConfigureAwait(false);
+                        }
                     }
 
                     device.Send(ScpiMessageProducer.SetLanFirmwareUpdateMode);
@@ -141,6 +161,15 @@ internal sealed class WifiModuleUpdater
                 {
                     await Task.Delay(Options.PostWifiReconnectDelay, stateToken).ConfigureAwait(false);
                     await _context.WaitForSerialReconnectAsync(device, stateToken).ConfigureAwait(false);
+
+                    // Leave the USB-to-WINC transparent bridge FIRST. While transparent mode is on
+                    // the SCPI console layer is bypassed, so the LAN commands below would be
+                    // forwarded to the WINC as raw bytes instead of being interpreted by the
+                    // device — the LAN configuration would silently not be restored. Sent
+                    // unconditionally: it is a no-op when the device is not in transparent mode,
+                    // and restoring the pre-flash state is the entire job of this step. Completes
+                    // the recovery half of daqifi-desktop's ResetLanAfterUpdate (part of #269).
+                    device.Send(ScpiMessageProducer.SetUsbTransparencyMode(0));
                     device.Send(ScpiMessageProducer.EnableNetworkLan);
                     device.Send(ScpiMessageProducer.ApplyNetworkLan);
                     device.Send(ScpiMessageProducer.SaveNetworkLan);

--- a/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
+++ b/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
@@ -170,6 +170,19 @@ internal sealed class WifiModuleUpdater
                     // and restoring the pre-flash state is the entire job of this step. Completes
                     // the recovery half of daqifi-desktop's ResetLanAfterUpdate (part of #269).
                     device.Send(ScpiMessageProducer.SetUsbTransparencyMode(0));
+
+                    // Leaving the bridge is a device-side mode transition, not an instantaneous
+                    // one. Until the SCPI console path is back, bytes on the port are still
+                    // forwarded to the WINC as raw data, so a LAN command sent immediately after
+                    // can be swallowed by the bridge and the restore silently does nothing —
+                    // the same intermittent failure the exit itself exists to prevent.
+                    // WifiBridgeActivator.Deactivate already paces this exact transition by the
+                    // same amount over a raw serial port; this is the managed-connection twin.
+                    if (Options.PostUsbTransparentModeExitDelay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(Options.PostUsbTransparentModeExitDelay, stateToken).ConfigureAwait(false);
+                    }
+
                     device.Send(ScpiMessageProducer.EnableNetworkLan);
                     device.Send(ScpiMessageProducer.ApplyNetworkLan);
                     device.Send(ScpiMessageProducer.SaveNetworkLan);


### PR DESCRIPTION
Part of #269 (item 4: "LAN-update-mode prep + post-flash recovery sequences").

**Not merging — this is for your review.**

## The gap

`daqifi-desktop` wraps Core's `UpdateWifiModuleAsync` with two hand-rolled SCPI sequences because Core's own versions are incomplete. Both are reusable device/protocol logic that belongs in Core.

### Prep: the WINC has to be powered before `LAN:FWUpdate`

Core's prep was `LAN:FWUpdate` → settle → `Disconnect`. But the WINC module is powered off in standby and right after a PIC32 reflash, and LAN commands are rejected with SCPI `-200` in that state — so the update-mode flag never takes effect and the external flash tool then finds no bridge to talk to. Desktop's `SerialStreamingDevice.EnableLanUpdateMode` works around this with `POWer:STATe 1` → settle → `LAN:FWUpdate`.

Core now does the same, gated by a new `PowerOnWifiModuleBeforeLanUpdateMode` (default `true`) that mirrors the existing `PowerOnWifiModuleBeforeProbe` opt-out for consumers that already powered the module on themselves.

### Recovery: transparent mode has to be exited *first*

Core's recovery was `LAN:ENAbled 1` → `LAN:APPLY` → `LAN:SAVE`. While the USB-to-WINC transparent bridge is on, the SCPI console layer is bypassed, so those three are forwarded to the WINC as raw bytes instead of being interpreted — the LAN configuration is silently not restored. Desktop's `ResetLanAfterUpdate` leads with `SYSTem:USB:SetTransparentMode 0`.

Core now sends it first. Unconditional rather than option-gated: it is a no-op when the device is not in transparent mode, and restoring the pre-flash state is the entire job of that step.

### Cancellation

The prep step now observes cancellation before its first state-changing `Send`. The WiFi version check that runs just before it returns a *status object* rather than throwing, so a cancel landing in that window previously still powered the module on and flipped the device into LAN update mode — a state a canceled caller will not be around to undo.

## Scope notes

- `PowerOnWifiModuleSettleDelay` is now consulted by both power-on sites (probe and prep). Its default (1s) and the existing probe behavior are unchanged; setting it to `Zero` reproduces today's prep timing exactly.
- Item 1 of #269 (post-disconnect port-release wait) is already implemented as `PostLanDisconnectPortReleaseDelay` — untouched here.
- No interface changed; the only public-API addition is the one new option.

## Tests

**+8** (4 in the original change, 4 more in the review fix below), baseline measured on a clean detached `origin/main` worktree (2690 at `4b8eed2`) rather than taken from notes; branch = **2698**, so exactly +8 with zero losses. FULL suite green on **net9 + net10** (2698 passed / 2 skipped each, +23 `Daqifi.Mcp.Tests` on net9 — Mcp is net9-only). 0 warnings.

The existing happy-path test's exact-sequence assertion was updated rather than relaxed, so the full ordered prep+recovery sequence is pinned in one place.

**Mutation-checked (6 mutations, all caught):**

| mutation | result |
|---|---|
| drop the power-on entirely | 2 fail |
| settle delay before the power-on instead of after | 1 fail |
| ignore `PowerOnWifiModuleBeforeLanUpdateMode` (always power on) | 1 fail |
| drop the transparent-mode exit | 2 fail |
| move the transparent-mode exit after `LAN:SAVE` | 2 fail |
| drop the pre-prep cancellation check | 1 fail |

The last one is worth calling out: the cancellation check *survived* my first attempt at a test (an already-canceled token, which the operation lock rejects on its own before prep is reached). The test was rewritten to cancel from inside the version check — the only window the check actually defends — and now fails without it. A test that passes with and without the line under test is not evidence.

## Bench (real Nq1, fw 3.7.2, USB, non-destructive)

Scratchpad harness `ProjectReference`d at this branch's Core. Every command the new sequences add or reorder was sent to the real device and the SCPI error queue drained after each:

```
baseline error-queue drain popped 0 stale entr(ies)
PASS baseline chip-info (SCPI console alive)      | scpiErrors=none | id=1377184 fw=19.7.7 build=Mar 30 2022
PASS prep: SYSTem:POWer:STATe 1                   | scpiErrors=none | chip-info still reads
PASS recovery: SYSTem:USB:SetTransparentMode 0    | scpiErrors=none | chip-info still reads
PASS recovery: SYSTem:COMMunicate:LAN:ENAbled 1   | scpiErrors=none | chip-info still reads
PASS recovery: SetTransparentMode 0 (repeat)      | scpiErrors=none | chip-info still reads
PASS negative control: bogus command IS reported  | scpiErrors=-113,"Undefined header"
error queue left clean: popped=none
```

The negative control matters: without it, `scpiErrors=none` could just mean this firmware never populates the error queue. A deliberately bogus header comes back as `-113,"Undefined header"`, so the clean results above are real evidence that fw 3.7.2 accepts `SYSTem:USB:SetTransparentMode 0` — including as a repeat no-op on a device that was never in transparent mode, which is how every non-flash path will hit it.

**Deliberately not sent on the bench**, and why:

- `SYSTem:COMMUnicate:LAN:FWUpdate` — flips the device into WiFi-update/bridge mode, which needs a power cycle to leave.
- `SYSTem:USB:SetTransparentMode 1` — bypasses the SCPI console, so the `0` that would undo it is forwarded to the WINC instead of interpreted. Unrecoverable without a power cycle. This is precisely why the ordering fix matters, and also why the "wrong order fails" case cannot be demonstrated non-destructively; the unit tests pin the order instead.
- `LAN:APPLY` / `LAN:SAVE` — WiFi connect-churn hazard on the bench unit.

Chip info was identical before and after every step (`id=1377184 fw=19.7.7 build=Mar 30 2022`), and the error queue was left clean.



---

## Review fix (`06bcf8a`) — pace the transparent-mode exit

Qodo flagged that the recovery sequence sent `LAN:ENAbled/APPLY/SAVE` **immediately** after `SYSTem:USB:SetTransparentMode 0`, with no settle. Reproduced against the code rather than taken on faith, and the in-repo precedent decides it: `WifiBridgeActivator.Deactivate` already paces this exact transition, waiting `InterCommandDelay` (100 ms) after `SetUsbTransparencyMode(0)` before continuing — over a raw serial port, on the same firmware. The managed-connection path had no equivalent, so a LAN command could still land while the bridge was tearing down and be swallowed as raw bytes: the very failure the transparent-mode exit was added to prevent, just narrowed to a race.

Note the desktop reference impl (`SerialStreamingDevice.ResetLanAfterUpdate`) has no wait either — this is one of the latent bugs the port into Core is meant to fix, not a behavior to preserve.

**New option:** `PostUsbTransparentModeExitDelay`, default **100 ms** (deliberately the activator's pace, pinned by a test so the two cannot drift apart), `TimeSpan.Zero` to skip. Validated non-negative next to the other skip-able lifecycle delays. The wait observes the state token, so a cancel during it leaves the LAN restore unsent.

**Tests: +4.** The cancel test raises cancellation from *inside* the transparent-mode `Send`, which is what makes it position-sensitive: only a wait sitting between the exit and the restore can keep `LAN:ENAbled/APPLY/SAVE` off the wire. Mutation-checked, all 5 caught — deleting the wait, hoisting it above the exit, sinking it below `LAN:SAVE`, drifting the default off 100 ms, and dropping the validation each fail a test. Sources restored from a byte-identical backup (sha verified) before committing.

**Bench (real Nq1, fw 3.7.2, USB, non-destructive).** Harness `ProjectReference`'d at the branch's Core. A bogus `SYSTem:NOTAREALCOMMAND?` returned `-113,"Undefined header"` first, so `scpiErrors=none` below is real evidence and not a dead queue. The paced sequence (`SetTransparentMode 0` → 100 ms → `LAN:ENAbled 1`) and a repeat of it — the already-off no-op path every non-flash caller hits — both left the error queue clean, elapsed 102 ms, with chip info unchanged before and after (`id=1377184 fw=19.7.7 build=Mar 30 2022`). `LAN:APPLY`/`LAN:SAVE` (WiFi connect-churn hazard) and `SetTransparentMode 1` (unrecoverable without a power cycle) deliberately not sent; the ordering itself stays pinned by the unit tests.
