### PR TITLE
fix(firmware): take the device back out of WiFi update mode when a flash fails (part of #269)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1715,6 +1715,173 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
+    public async Task UpdateWifiModuleAsync_WhenFlashToolFails_TakesDeviceBackOutOfLanUpdateMode()
+    {
+        // Once LAN:FWUpdate lands the device bypasses its SCPI console and bridges USB straight
+        // to the WINC. Only the success path used to walk it back out, so a failed flash left the
+        // module unreachable until someone power-cycled it — which is why daqifi-desktop still
+        // wraps this call in its own recovery finally (#269 item 2).
+        var device = new FakeStreamingDevice("COM11");
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(
+                1,
+                timedOut: false,
+                TimeSpan.FromMilliseconds(10),
+                ["some output"],
+                ["fatal"])
+        };
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            CreateFastOptions());
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            var exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir));
+
+            // The recovery must not swallow or reshape the real failure.
+            Assert.Equal(FirmwareUpdateState.Programming, exception.FailedState);
+            Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+
+            // Same two commands, in the same order, as the raw-serial WifiBridgeActivator.Deactivate
+            // twin: hand the port back to the SCPI console, then kick the WiFi manager out of its
+            // bridge-mode state machine. Deliberately no LAN:ENAbled/SAVE — persisting a network
+            // configuration off the back of a flash that did not complete is not this step's job.
+            Assert.Equal(
+                [
+                    "SYSTem:COMMUnicate:LAN:FWUpdate",
+                    "SYSTem:USB:SetTransparentMode 0",
+                    "SYSTem:COMMunicate:LAN:APPLY"
+                ],
+                device.SentCommands);
+
+            // Prep disconnected the device to hand the port to the flash tool, so the recovery had
+            // to bring the transport back before it could send anything.
+            Assert.Equal(1, device.DisconnectCalls);
+            Assert.True(device.ConnectAttempts >= 1);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenCanceledAfterEnteringUpdateMode_StillTakesDeviceBackOut()
+    {
+        // The worst stranding case: LAN:FWUpdate is already on the wire and the caller cancels
+        // before prep even gets to the disconnect. The caller's token is canceled by definition
+        // here, so the recovery has to run on a token of its own or it would never send anything.
+        var device = new FakeStreamingDevice("COM12");
+
+        var options = CreateFastOptions();
+        // Long enough that cancellation lands inside it, and inside the 2s PreparingDeviceTimeout
+        // so the state timeout is not what ends the wait.
+        options.PostLanFirmwareModeDelay = TimeSpan.FromSeconds(1);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir, cancellationToken: cts.Token));
+
+            Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+
+            Assert.Equal(
+                [
+                    "SYSTem:COMMUnicate:LAN:FWUpdate",
+                    "SYSTem:USB:SetTransparentMode 0",
+                    "SYSTem:COMMunicate:LAN:APPLY"
+                ],
+                device.SentCommands);
+
+            // Cancellation landed before prep reached the disconnect, so the recovery found the
+            // transport already up — the exit is not conditional on having been disconnected.
+            Assert.Equal(0, device.DisconnectCalls);
+            Assert.Equal(0, device.ConnectAttempts);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresMidSequence_StillSurfacesTheOriginalFailure()
+    {
+        // The recovery is bounded by the post-flash reconnect budget and is best-effort: running
+        // out of it part-way must cost the caller nothing but the un-sent tail of the sequence.
+        // Here the budget is shorter than the pause the bridge exit needs, so the transparent-mode
+        // exit goes out and the LAN:APPLY that follows it does not.
+        var device = new FakeStreamingDevice("COM13");
+
+        var options = CreateFastOptions();
+        options.PostLanFirmwareModeDelay = TimeSpan.FromSeconds(1);
+        // Also the ReconnectingAfterFlash budget, which is what bounds the recovery.
+        options.VerifyingTimeout = TimeSpan.FromMilliseconds(50);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        try
+        {
+            // The original cancellation still surfaces — a recovery that ran out of budget must
+            // not turn into the exception the caller sees.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir, cancellationToken: cts.Token));
+
+            Assert.Equal(
+                [
+                    "SYSTem:COMMUnicate:LAN:FWUpdate",
+                    "SYSTem:USB:SetTransparentMode 0"
+                ],
+                device.SentCommands);
+
+            Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task UpdateWifiModuleAsync_WhenToolExitsZeroButNeverReportsSuccess_FailsFromOutput()
     {
         // The port-not-released / "false success" case: the WINC tool couldn't open the serial

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1831,12 +1831,13 @@ public class FirmwareUpdateServiceTests
     }
 
     [Fact]
-    public async Task UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresMidSequence_StillSurfacesTheOriginalFailure()
+    public async Task UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresAfterReconnect_StillFinishesTheBridgeExit()
     {
-        // The recovery is bounded by the post-flash reconnect budget and is best-effort: running
-        // out of it part-way must cost the caller nothing but the un-sent tail of the sequence.
-        // Here the budget is shorter than the pause the bridge exit needs, so the transparent-mode
-        // exit goes out and the LAN:APPLY that follows it does not.
+        // The recovery budget bounds the wait for the transport to come back, not the two-command
+        // exit that follows it. Here the budget (50ms) is already spent by the time the pause
+        // between the two commands elapses, and the LAN:APPLY still goes out: stopping half way
+        // would hand the console back while leaving the WiFi manager in its bridge-mode state
+        // machine, which is a worse place to leave the device than either end of the sequence.
         var device = new FakeStreamingDevice("COM13");
 
         var options = CreateFastOptions();
@@ -1861,19 +1862,131 @@ public class FirmwareUpdateServiceTests
 
         try
         {
-            // The original cancellation still surfaces — a recovery that ran out of budget must
-            // not turn into the exception the caller sees.
+            // The original cancellation still surfaces — the recovery must never turn into the
+            // exception the caller sees.
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 () => service.UpdateWifiModuleAsync(device, firmwareDir, cancellationToken: cts.Token));
 
             Assert.Equal(
                 [
                     "SYSTem:COMMUnicate:LAN:FWUpdate",
-                    "SYSTem:USB:SetTransparentMode 0"
+                    "SYSTem:USB:SetTransparentMode 0",
+                    "SYSTem:COMMunicate:LAN:APPLY"
                 ],
                 device.SentCommands);
 
             Assert.Equal(FirmwareUpdateState.Failed, service.CurrentState);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresWaitingForReconnect_SendsNoBridgeExit()
+    {
+        // The one thing the budget does bound: a transport that never comes back. Prep hands the
+        // port to the flash tool, the flash fails, and the device then refuses every reconnect —
+        // the recovery must give up after the budget instead of waiting forever, and must not
+        // pretend to send commands down a transport that is not there.
+        var device = new FakeStreamingDevice("COM14")
+        {
+            // Consumed one per Connect() attempt; far more than the budget allows, so the
+            // reconnect loop never succeeds.
+            ConnectFailuresBeforeSuccess = int.MaxValue
+        };
+
+        var options = CreateFastOptions();
+        // Also the ReconnectingAfterFlash budget, which is what bounds the recovery.
+        options.VerifyingTimeout = TimeSpan.FromMilliseconds(50);
+
+        var externalProcessRunner = new FakeExternalProcessRunner
+        {
+            NextResult = new ExternalProcessResult(
+                1,
+                timedOut: false,
+                TimeSpan.FromMilliseconds(10),
+                ["some output"],
+                ["fatal"])
+        };
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            externalProcessRunner,
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            var exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir));
+
+            // The flash failure, not the recovery's timeout, is what the caller sees.
+            Assert.Equal(FirmwareUpdateState.Programming, exception.FailedState);
+
+            Assert.Equal(["SYSTem:COMMUnicate:LAN:FWUpdate"], device.SentCommands);
+            Assert.True(device.ConnectAttempts >= 1);
+        }
+        finally
+        {
+            Directory.Delete(firmwareDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateWifiModuleAsync_WhenDeviceIsNotConnected_DoesNotAttemptTheBridgeExit()
+    {
+        // The connectivity precondition fails with the update-mode command definitively un-sent,
+        // so there is no bridge to leave. Arming the recovery for it would turn an immediate
+        // "device must be connected" failure into a full ReconnectingAfterFlash wait (45s by
+        // default) for a transport that was never gone.
+        var device = new FakeStreamingDevice("COM15");
+        device.Disconnect();
+
+        var options = CreateFastOptions();
+        // Deliberately generous: if the recovery were armed here, its reconnect loop would run for
+        // this long and the assertion on elapsed time below would catch it.
+        options.VerifyingTimeout = TimeSpan.FromSeconds(30);
+
+        var service = new FirmwareUpdateService(
+            new FakeHidTransport(),
+            new FakeFirmwareDownloadService(),
+            new FakeExternalProcessRunner(),
+            NullLogger<FirmwareUpdateService>.Instance,
+            new FakeBootloaderProtocol([[0x10]]),
+            new FakeHidDeviceEnumerator([]),
+            options);
+
+        var firmwareDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(firmwareDir, "winc_flash_tool.cmd"), "@echo off");
+
+        try
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            var exception = await Assert.ThrowsAsync<FirmwareUpdateException>(
+                () => service.UpdateWifiModuleAsync(device, firmwareDir));
+
+            stopwatch.Stop();
+
+            Assert.Equal(FirmwareUpdateState.PreparingDevice, exception.FailedState);
+
+            // Nothing was sent, and — the point of the test — nothing was retried either. The
+            // device this fake models is one that would reconnect on the very first attempt, so a
+            // single Connect() call would be enough to mask the regression; assert zero.
+            Assert.Empty(device.SentCommands);
+            Assert.Equal(0, device.ConnectAttempts);
+
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(10),
+                $"Expected an immediate failure, took {stopwatch.Elapsed}.");
         }
         finally
         {

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -36,8 +36,15 @@ public static class WifiBridgeActivator
     // (isCdcHostConnected) before accepting commands. Match SerialStreamTransport
     // defaults so port settings stay in one place.
     private static readonly TimeSpan DtrSettleDelay = TimeSpan.FromMilliseconds(200);
-    private static readonly TimeSpan InterCommandDelay = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan ApplySettleDelay = TimeSpan.FromMilliseconds(300);
+
+    /// <summary>
+    /// Pause between the transparent-mode exit and the command that follows it. Shared with
+    /// <c>WifiModuleUpdater</c>'s managed-connection twin of <see cref="Deactivate"/> so the two
+    /// paths that walk a device out of bridge mode cannot pace it differently: the delay is a
+    /// property of the firmware's mode transition, not of the transport used to drive it.
+    /// </summary>
+    internal static readonly TimeSpan InterCommandDelay = TimeSpan.FromMilliseconds(100);
 
     // Hard ceiling for the async overloads' worker task. The healthy path costs
     // ~600ms of scripted delays (DtrSettleDelay + InterCommandDelay +

--- a/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
+++ b/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
@@ -55,6 +55,14 @@ internal sealed class WifiModuleUpdater
     {
         const long totalBytes = 100;
 
+        // Read only by the failure paths at the bottom of this method. Once the prepare step is
+        // entered the device may be sitting in LAN firmware-update / USB-transparent bridge mode,
+        // where the SCPI console is bypassed and the module stays unusable until something takes
+        // it back out — a power cycle, or the bridge-exit below. Today only the *successful* path
+        // restores it, so a failed or canceled flash strands the device; that is exactly why
+        // daqifi-desktop still wraps this call in its own recovery finally (part of #269).
+        var mayBeInLanUpdateMode = false;
+
         try
         {
             if (!skipVersionCheck
@@ -65,6 +73,13 @@ internal sealed class WifiModuleUpdater
 
             _context.TransitionToState(FirmwareUpdateState.PreparingDevice, "Preparing device for WiFi module update.");
             _context.ReportProgress(progress, FirmwareUpdateState.PreparingDevice, 0, _context.CurrentOperation, 0, totalBytes);
+
+            // Armed *before* the prepare step rather than after the update-mode command inside it,
+            // deliberately: a cancellation or state timeout can land between the command reaching
+            // the device and this method regaining control, so Core cannot know how far prep got.
+            // A redundant bridge-exit on a device that never entered update mode is a no-op; a
+            // skipped one leaves a bridged device needing a power cycle. Bias to the harmless side.
+            mayBeInLanUpdateMode = true;
 
             await _context.ExecuteWithStateTimeoutAsync(
                 FirmwareUpdateState.PreparingDevice,
@@ -152,6 +167,11 @@ internal sealed class WifiModuleUpdater
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Before reporting the outcome: a canceled WiFi flash is the single most likely way to
+            // leave the module bridged, so the exit runs here too — on its own token, since the
+            // caller's is already canceled by definition on this path.
+            await TryLeaveLanUpdateModeAfterFailureAsync(device, mayBeInLanUpdateMode).ConfigureAwait(false);
+
             _context.TransitionToState(FirmwareUpdateState.Failed, "WiFi module update canceled.");
             _context.ReportProgress(progress, FirmwareUpdateState.Failed, _context.LastReportedPercent, _context.CurrentOperation, 0, totalBytes);
             Logger.LogWarning("WiFi module update canceled.");
@@ -161,6 +181,11 @@ internal sealed class WifiModuleUpdater
         {
             var failedState = _context.CurrentState;
             var failedOperation = _context.CurrentOperation;
+
+            // Captured above first, so the reported failure names the step that actually failed
+            // rather than the recovery attempt that follows it.
+            await TryLeaveLanUpdateModeAfterFailureAsync(device, mayBeInLanUpdateMode).ConfigureAwait(false);
+
             _context.TransitionToState(FirmwareUpdateState.Failed, failedOperation);
             _context.ReportProgress(progress, FirmwareUpdateState.Failed, _context.LastReportedPercent, failedOperation, 0, totalBytes);
             Logger.LogError(ex, "WiFi module update failed in state {State}.", failedState);
@@ -863,5 +888,66 @@ internal sealed class WifiModuleUpdater
         }
 
         return $"Process output excerpt: {string.Join(" | ", excerpt)}";
+    }
+
+    /// <summary>
+    /// Best-effort attempt to take the device back out of LAN firmware-update / USB-transparent
+    /// bridge mode after a WiFi update failed or was canceled. Never throws: the original failure
+    /// is what the caller needs to see, and a recovery that cannot reach the device must not
+    /// replace it.
+    /// </summary>
+    /// <remarks>
+    /// This is the managed-connection twin of <see cref="WifiBridgeActivator.Deactivate"/>, and
+    /// sends the same two commands in the same order with the same pause between them:
+    /// <c>SYSTem:USB:SetTransparentMode 0</c> hands the port back to the SCPI console, then
+    /// <c>LAN:APPLY</c> kicks the WiFi manager out of its bridge-mode state machine.
+    /// <para>
+    /// Deliberately NOT the success path's full <c>LAN:ENAbled</c>/<c>APPLY</c>/<c>SAVE</c>
+    /// restore: that persists a configuration, which has no business running off the back of a
+    /// flash that did not complete. The job here is only to make the device answerable again.
+    /// </para>
+    /// </remarks>
+    private async Task TryLeaveLanUpdateModeAfterFailureAsync(IStreamingDevice device, bool mayBeInLanUpdateMode)
+    {
+        if (!mayBeInLanUpdateMode)
+        {
+            return;
+        }
+
+        try
+        {
+            // A fresh token, never the caller's: on the cancellation path the caller's token is
+            // already canceled, and that is precisely the case where the device most needs the
+            // exit. Bounded by the post-flash reconnect budget because that is the same physical
+            // operation — waiting for the serial transport to come back — and a host that tuned
+            // it for slow re-enumeration should get that tuning here too. The worst case (the
+            // device never returns) costs that budget once, which is the right price for not
+            // stranding a bridged module.
+            using var restoreCts = new CancellationTokenSource(
+                Options.GetStateTimeout(FirmwareUpdateState.ReconnectingAfterFlash));
+
+            // Prep disconnects the device, so on almost every failure path the transport has to
+            // come back before anything can be sent. Returns immediately when still connected.
+            await _context.WaitForSerialReconnectAsync(device, restoreCts.Token).ConfigureAwait(false);
+
+            device.Send(ScpiMessageProducer.SetUsbTransparencyMode(0));
+
+            // Leaving the bridge is a device-side mode transition, not an instantaneous one:
+            // until the SCPI console path is back, bytes on the port are still forwarded raw to
+            // the WINC, so a command sent immediately after can be swallowed by the bridge.
+            await Task.Delay(WifiBridgeActivator.InterCommandDelay, restoreCts.Token).ConfigureAwait(false);
+
+            device.Send(ScpiMessageProducer.ApplyNetworkLan);
+
+            Logger.LogInformation(
+                "Sent the WiFi bridge-exit sequence after a failed WiFi module update.");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(
+                ex,
+                "Could not take the device out of WiFi update mode after a failed update; it may still be in " +
+                "USB-transparent bridge mode and need a power cycle.");
+        }
     }
 }

--- a/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
+++ b/src/Daqifi.Core/Firmware/WifiModuleUpdater.cs
@@ -55,12 +55,13 @@ internal sealed class WifiModuleUpdater
     {
         const long totalBytes = 100;
 
-        // Read only by the failure paths at the bottom of this method. Once the prepare step is
-        // entered the device may be sitting in LAN firmware-update / USB-transparent bridge mode,
-        // where the SCPI console is bypassed and the module stays unusable until something takes
-        // it back out — a power cycle, or the bridge-exit below. Today only the *successful* path
-        // restores it, so a failed or canceled flash strands the device; that is exactly why
+        // Read only by the failure paths at the bottom of this method. Once the update-mode command
+        // is on the wire the device may be sitting in LAN firmware-update / USB-transparent bridge
+        // mode, where the SCPI console is bypassed and the module stays unusable until something
+        // takes it back out — a power cycle, or the bridge-exit below. Today only the *successful*
+        // path restores it, so a failed or canceled flash strands the device; that is exactly why
         // daqifi-desktop still wraps this call in its own recovery finally (part of #269).
+        // Armed inside the prepare step, at the one point where "may be bridged" becomes true.
         var mayBeInLanUpdateMode = false;
 
         try
@@ -73,13 +74,6 @@ internal sealed class WifiModuleUpdater
 
             _context.TransitionToState(FirmwareUpdateState.PreparingDevice, "Preparing device for WiFi module update.");
             _context.ReportProgress(progress, FirmwareUpdateState.PreparingDevice, 0, _context.CurrentOperation, 0, totalBytes);
-
-            // Armed *before* the prepare step rather than after the update-mode command inside it,
-            // deliberately: a cancellation or state timeout can land between the command reaching
-            // the device and this method regaining control, so Core cannot know how far prep got.
-            // A redundant bridge-exit on a device that never entered update mode is a no-op; a
-            // skipped one leaves a bridged device needing a power cycle. Bias to the harmless side.
-            mayBeInLanUpdateMode = true;
 
             await _context.ExecuteWithStateTimeoutAsync(
                 FirmwareUpdateState.PreparingDevice,
@@ -94,6 +88,19 @@ internal sealed class WifiModuleUpdater
                     }
 
                     device.Send(ScpiMessageProducer.SetLanFirmwareUpdateMode);
+
+                    // Armed here rather than before the whole prepare step. Everything above this
+                    // line fails with the update-mode command definitively un-sent, and arming for
+                    // those turns an immediate "device must be connected" failure into a full
+                    // ReconnectingAfterFlash wait for a transport that was never gone. Immediately
+                    // *after* the Send is as early as it can honestly be: Send is synchronous and
+                    // no await separates it from this line, so nothing can interleave between them.
+                    // From here on Core must assume the mode took — a cancel or state timeout can
+                    // land while the device is still acting on a command it already received. A
+                    // redundant bridge-exit on a device that never entered update mode is a no-op;
+                    // a skipped one leaves a bridged device needing a power cycle.
+                    mayBeInLanUpdateMode = true;
+
                     await Task.Delay(Options.PostLanFirmwareModeDelay, stateToken).ConfigureAwait(false);
                     device.Disconnect();
 
@@ -918,9 +925,10 @@ internal sealed class WifiModuleUpdater
         {
             // A fresh token, never the caller's: on the cancellation path the caller's token is
             // already canceled, and that is precisely the case where the device most needs the
-            // exit. Bounded by the post-flash reconnect budget because that is the same physical
-            // operation — waiting for the serial transport to come back — and a host that tuned
-            // it for slow re-enumeration should get that tuning here too. The worst case (the
+            // exit. It bounds the reconnect wait and nothing else, because waiting for a serial
+            // transport to come back is the only step here that can take unbounded time. The
+            // post-flash reconnect budget is the natural size for it — the same physical operation,
+            // already tunable by a host that knows its re-enumeration is slow. The worst case (the
             // device never returns) costs that budget once, which is the right price for not
             // stranding a bridged module.
             using var restoreCts = new CancellationTokenSource(
@@ -930,12 +938,17 @@ internal sealed class WifiModuleUpdater
             // come back before anything can be sent. Returns immediately when still connected.
             await _context.WaitForSerialReconnectAsync(device, restoreCts.Token).ConfigureAwait(false);
 
+            // Past the reconnect the two-command exit runs to completion instead of re-observing
+            // the budget. Half of it is the one outcome worse than not starting: the console is
+            // handed back but the WiFi manager is left in its bridge-mode state machine, so the
+            // device looks answerable while its module still is not. The un-cancelled tail is a
+            // fixed pause plus two synchronous writes, so the helper stays bounded either way.
             device.Send(ScpiMessageProducer.SetUsbTransparencyMode(0));
 
             // Leaving the bridge is a device-side mode transition, not an instantaneous one:
             // until the SCPI console path is back, bytes on the port are still forwarded raw to
             // the WINC, so a command sent immediately after can be swallowed by the bridge.
-            await Task.Delay(WifiBridgeActivator.InterCommandDelay, restoreCts.Token).ConfigureAwait(false);
+            await Task.Delay(WifiBridgeActivator.InterCommandDelay).ConfigureAwait(false);
 
             device.Send(ScpiMessageProducer.ApplyNetworkLan);
 


### PR DESCRIPTION
Part of #269 (item 2 — removes the consumer-side recovery workaround).

**Not merging — this is for your review.**

## The bug

`UpdateWifiModuleAsync` sends `SYSTem:COMMUnicate:LAN:FWUpdate`, which bridges USB straight through to the WINC and bypasses the device's SCPI console. Only the **successful** path walked it back out. A failed flash, a state timeout, or a cancel left the module unreachable until someone power-cycled the device.

That is precisely why `daqifi-desktop` still wraps Core's call in its own recovery `finally` (`SerialStreamingDevice.ResetLanAfterUpdate` + a raw transparent-mode exit) — one of the workarounds #269 exists to move into Core.

## The fix

Both failure exits of `WifiModuleUpdater.RunUpdateAsync` now run a best-effort bridge exit before reporting the failure. It is the **managed-connection twin of the already-shipped `WifiBridgeActivator.Deactivate`** — same two commands, same order, same pause:

```
SYSTem:USB:SetTransparentMode 0   →   100 ms   →   SYSTem:COMMunicate:LAN:APPLY
```

The pause is now one shared `internal` constant rather than two copies, so the raw-serial path and the managed path cannot pace the same firmware transition differently.

Design calls worth reviewing:

- **Not** the success path's full `LAN:ENAbled`/`APPLY`/`SAVE` restore. Persisting a network configuration off the back of a flash that did not complete is not this step's job; the job is only to make the device answerable again. This also keeps the failure path from adding WiFi connect churn beyond the single `APPLY` that leaves bridge mode.
- **Never throws.** The caller still sees the original failure, unchanged — a recovery that cannot reach the device must not replace the reason the update failed.
- **Runs on a token of its own**, never the caller's. On the cancellation path the caller's token is canceled by definition, and that is exactly when the device most needs the exit.
- **Bounded by the post-flash reconnect budget** (`ReconnectingAfterFlash` → `VerifyingTimeout`). Same physical operation — waiting for the serial transport to come back — and already tunable by a host that knows its re-enumeration is slow.
- **Armed before prep, not after the update-mode command inside it.** A cancel or state timeout can land between the command reaching the device and the method regaining control, so Core cannot know how far prep got. A redundant bridge exit on a device that never entered update mode is a no-op (bench-confirmed below); a skipped one strands a bridged module.

**No new options. No public API change.** `WifiBridgeActivator.InterCommandDelay` went from `private` to `internal`.

## Tests

**+3** (2690 → 2693). Full suite green on **net9.0 and net10.0**: 2693 passed / 2 skipped each, +23 Mcp on net9, **0 warnings**.

1. Flash tool fails → exact recovery sequence sent, device reconnected first (prep had disconnected it), original `FirmwareUpdateException`/`Programming` unchanged.
2. Canceled after `LAN:FWUpdate` but before prep's disconnect → recovery still runs on its own token; `DisconnectCalls == 0` pins that the exit is not conditional on having been disconnected.
3. Recovery budget spent by the time the bridge-exit pause elapses → the sequence still finishes, and the original cancellation still surfaces unchanged. *(Rewritten by the review fix below — it originally pinned the opposite, torn-in-half outcome.)*
4. Recovery budget expires while waiting for a transport that never comes back → nothing is sent and the original flash failure surfaces. *(Added by the review fix.)*
5. Device was never connected → no recovery attempted at all, `ConnectAttempts == 0`, immediate failure. *(Added by the review fix.)*

The existing happy-path test already asserts the success sequence by exact equality, so "no bridge exit on success" stays pinned there.

**Mutation-checked, 6/6 caught:** recovery never runs (3 fail), skip recovery when the caller canceled (2), drop the inter-command pace (1), swap the two commands (3), send the full `ENAbled`/`APPLY`/`SAVE` instead (2), and an unbounded recovery budget — which **hangs the suite** rather than failing a test, since the reconnect loop then has nothing to stop it. Source restored from a byte-identical backup (sha verified) before committing.

Note for anyone repeating this: deleting the recovery calls outright does **not** compile under `TreatWarningsAsErrors` (CS0219, the flag becomes write-only), so that mutation had to be expressed as an always-true guard inside the helper.

## Bench (real Nq1, fw 3.7.2, USB, non-destructive)

Scratchpad harness `ProjectReference`'d at this branch's Core.

- **Negative control first** — bogus `SYSTem:NOTAREALCOMMAND?` → `-113,"Undefined header"`. Without it the clean queues below would be worthless evidence.
- `SYSTem:USB:SetTransparentMode 0` with the 102 ms pace → `scpiErrors=none`. This is the already-off no-op path, i.e. exactly what the conservative arming hits on a device that never entered bridge mode.
- **Repeat** of the same exit (a consumer with its own `finally`, or a retried update) → `scpiErrors=none`.
- WINC chip info identical before and after: `id=1377184 fw=19.7.7 build=Mar 30 2022`. Device still answering, final queue clean.

**Deliberately not exercised, and the harness gates on it rather than assuming:** the trailing `LAN:APPLY` was skipped because the probe found the WINC **powered**, where `APPLY` starts a real WiFi association and connect-churn is a known way to wedge this bench unit. `LAN:APPLY` is unchanged shipped behavior on both the success path and `WifiBridgeActivator.Deactivate`; the ordering and pacing around it are pinned by the unit tests above. `SetTransparentMode 1` was never sent — it is unrecoverable over a managed connection, which is also why "wrong order fails" cannot be shown non-destructively.

## Merge safety

Verified with `git merge-tree` against both open loop PRs: **clean** against #443 and **clean** against #444. Hunks were mapped first and deliberately placed clear of both.



---

## Review fix (`1967c2e`)

Both Qodo findings addressed — [full reasoning in this comment](https://github.com/daqifi/daqifi-core/pull/445#issuecomment-5200481177).

**"Recovery armed too early" — valid, fixed as suggested.** `mayBeInLanUpdateMode` was armed before the prepare step, so a device that was never connected — and therefore never bridged — still ran the recovery, whose reconnect loop then waited out the full `ReconnectingAfterFlash` budget (**45 s by default**). An immediate "device must be connected" failure became a 45-second one. Armed inside the prepare delegate now, immediately after the `LAN:FWUpdate` send — as early as it can honestly be, since `Send` is synchronous and no `await` separates it from the assignment.

**"Missing pre-send cancel check" — the race is real, the prescribed fix inverts the helper's purpose.** Guarding the sends with the *budget* token could only ever turn a recovery that had already got the transport back into a device left bridged. The genuine problem the finding surfaced is that the budget was observed by the pause between the two commands but not by the sends around it, so the sequence could be torn in half — console handed back, WiFi manager still in its bridge-mode state machine. **The budget now bounds the reconnect wait and nothing else**, and the two-command exit runs to completion once the transport is back; the un-cancelled tail is a fixed 100 ms plus two synchronous writes.

**Tests: +2 net (2693 → 2695)**, zero losses. FULL suite green net9 + net10 (2695 passed / 2 skipped each, +23 Mcp on net9), 0 warnings. **Mutation-checked 4/4** on the fix itself. `git merge-tree` re-verified **clean against #443 and #444**.

**Bench re-run (real Nq1, fw 3.7.2, USB, non-destructive) — 5/5.** Negative control (`-113,"Undefined header"`) first, then the paced `SetTransparentMode 0` exit and a repeat of it both `scpiErrors=none` (elapsed 102 ms), WINC chip info identical before/after, final queue clean.
