### PR TITLE
test(firmware): guard the canceled-settle case against a persisted network config

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1740,6 +1740,16 @@ public class FirmwareUpdateServiceTests
                 "SYSTem:COMMunicate:LAN:APPLY"
             ],
             device.SentCommands);
+
+        // State the guarantee this test exists for on its own terms, not as a side effect of the
+        // sequence above. The Assert.Equal already implies both of these today, but it is the
+        // assertion most likely to be edited: every change to the recovery sequence rewrites that
+        // list, and whoever rewrites it is thinking about the commands they are adding, not about
+        // the two that must never appear. Spelled out separately, a cancel that starts persisting
+        // a network configuration fails on a line that says so, instead of looking like one more
+        // expected-list update to wave through.
+        Assert.DoesNotContain("SYSTem:COMMunicate:LAN:ENAbled 1", device.SentCommands);
+        Assert.DoesNotContain("SYSTem:COMMunicate:LAN:SAVE", device.SentCommands);
     }
 
     [Fact]


### PR DESCRIPTION
## Rescoped

This PR originally reconciled the WiFi prep/recovery expectations that [#444](https://github.com/daqifi/daqifi-core/pull/444) and [#445](https://github.com/daqifi/daqifi-core/pull/445) left crossed, which had `main` red. [#456](https://github.com/daqifi/daqifi-core/pull/456) landed that same reconciliation first, so `main` is green and that part of this PR became redundant — and conflicting.

Rebased onto `main` and narrowed to the one thing #456 did **not** carry.

## What's left

`UpdateWifiModuleAsync_WhenCanceledDuringTransparentModeExitSettle_LeavesLanRestoreUnsent` pins the entire recovery sequence with a single `Assert.Equal`. That already implies `LAN:ENAbled 1` and `LAN:SAVE` never go out — but only implies it.

That expected list is the assertion in this file most likely to be rewritten: every change to the recovery sequence edits it, and whoever edits it is thinking about the commands they're adding, not the two that must never appear. The invariant — **a canceled flash must never persist a network configuration** — is load-bearing enough to say out loud:

```csharp
Assert.DoesNotContain("SYSTem:COMMunicate:LAN:ENAbled 1", device.SentCommands);
Assert.DoesNotContain("SYSTem:COMMunicate:LAN:SAVE", device.SentCommands);
```

Now a cancel that starts persisting config fails on a line that says exactly that, rather than looking like one more expected-list update to wave through.

## Notes

- Assertions only; no production change.
- The two command literals are the ones `ScpiMessageProducer.EnableNetworkLan` / `SaveNetworkLan` emit, and match how the success-path tests in this same file spell them — so the guards are not vacuous.
- `UpdateWifiModuleAsync` tests green on net9.0 (24 passed).

If you'd rather not carry the extra guard, closing this is reasonable — #456 already delivered the fix that made `main` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)