### PR TITLE
docs(diagnostics): command history is oldest first, not newest first (part of #344)

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -908,7 +908,8 @@ if (device is IDeviceDiagnostics diagnostics)
     LogLevelSetting applied = await diagnostics.SetLogLevelAsync("STREAM", 2);
     Console.WriteLine($"{applied.Module}: {applied.Level} (ceiling {applied.Ceiling})");
 
-    // SCPI command history (newest first) and error-queue depth (non-destructive).
+    // SCPI command history (oldest first — the device numbers lines backwards from
+    // the present, so the newest command is last) and error-queue depth (non-destructive).
     IReadOnlyList<string> history = await diagnostics.GetCommandHistoryAsync();
     int queuedErrors = await diagnostics.GetSystemErrorCountAsync();
 

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/CommandHistoryParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/CommandHistoryParserTests.cs
@@ -28,6 +28,28 @@ public class CommandHistoryParserTests
     }
 
     [Fact]
+    public void Parse_ReturnsOldestFirst_BecauseDeviceNumbersLinesBackwardsAndPrintsNewestLast()
+    {
+        // Bench-confirmed on a real Nq1 (fw 3.7.2): the "<n>:" prefix counts backwards
+        // from the present, so "1:" is the NEWEST command and the firmware prints it last.
+        // The decisive evidence is that SYSTem:LOG:CMDHistory? — necessarily the most recent
+        // command when the device builds the reply — lands in the final slot of its own answer.
+        var lines = new[]
+        {
+            "Last 3 commands:",
+            "3: A",
+            "2: B",
+            "1: C",
+        };
+
+        var commands = CommandHistoryParser.Parse(lines);
+
+        // C is the newest command; it is last. Do not "fix" this by reversing the list —
+        // the device's order is a chronological transcript and consumers depend on it.
+        Assert.Equal(new[] { "A", "B", "C" }, commands);
+    }
+
+    [Fact]
     public void Parse_PreservesColonsWithinCommand()
     {
         var lines = new[] { "Last 1 commands:", "1: SYSTem:LOG:LEVel STREAM,2" };

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -1183,8 +1183,10 @@ public class ScpiMessageProducer
     /// Creates a query message to read the device's recent SCPI command history.
     /// </summary>
     /// <remarks>
-    /// Returns the most recent commands seen on the USB interface, newest first, prefixed with a
-    /// <c>Last N commands:</c> header (or <c>No command history</c> when empty).
+    /// Returns the most recent commands seen on the USB interface, oldest first, prefixed with a
+    /// <c>Last N commands:</c> header (or <c>No command history</c> when empty). Each command line
+    /// carries an <c>&lt;n&gt;:</c> prefix counting backwards from the present — <c>1:</c> is the most
+    /// recent command — so the newest entry is printed last.
     /// Command: SYSTem:LOG:CMDHistory?
     /// Example: messageProducer.Send(ScpiMessageProducer.GetCommandHistory);
     /// </remarks>

--- a/src/Daqifi.Core/Device/Diagnostics/CommandHistoryParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/CommandHistoryParser.cs
@@ -9,9 +9,11 @@ namespace Daqifi.Core.Device.Diagnostics;
 /// </summary>
 /// <remarks>
 /// The firmware returns a <c>Last N commands:</c> header followed by one <c>&lt;n&gt;: &lt;command&gt;</c>
-/// line per remembered command (newest first), or the single line <c>No command history</c> when the
-/// buffer is empty. This parser strips the header and the numeric prefix, returning just the command
-/// text in the order the device reported it.
+/// line per remembered command, or the single line <c>No command history</c> when the buffer is empty.
+/// The <c>&lt;n&gt;</c> prefix counts backwards from the present — <c>1:</c> is the most recent command —
+/// and the firmware prints the lines in descending order, so the newest command comes last. This parser
+/// strips the header and the numeric prefix, returning just the command text in the order the device
+/// reported it: oldest first.
 /// </remarks>
 public static class CommandHistoryParser
 {
@@ -21,7 +23,7 @@ public static class CommandHistoryParser
     /// Parses command-history response lines into command strings.
     /// </summary>
     /// <param name="lines">The raw response lines from the device.</param>
-    /// <returns>The remembered commands (newest first); empty when there is no history.</returns>
+    /// <returns>The remembered commands (oldest first); empty when there is no history.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="lines"/> is null.</exception>
     public static IReadOnlyList<string> Parse(IEnumerable<string> lines)
     {

--- a/src/Daqifi.Core/Device/Diagnostics/IDeviceDiagnostics.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/IDeviceDiagnostics.cs
@@ -51,8 +51,14 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <summary>
         /// Reads the device's recent SCPI command history (<c>SYSTem:LOG:CMDHistory?</c>).
         /// </summary>
+        /// <remarks>
+        /// The device numbers its history lines backwards from the present — <c>1:</c> is the most recent
+        /// command — and prints them in descending order, so the newest command arrives last. That numeric
+        /// prefix is stripped, and the device's order is preserved: the result reads as a chronological
+        /// transcript. The history query itself is the last entry in its own reply.
+        /// </remarks>
         /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
-        /// <returns>The remembered commands, newest first; empty when there is no history.</returns>
+        /// <returns>The remembered commands, oldest first; empty when there is no history.</returns>
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         Task<IReadOnlyList<string>> GetCommandHistoryAsync(CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
## Summary

`GetCommandHistoryAsync` is documented as returning the remembered commands **"newest first"**. The device actually emits them **oldest first**. This PR fixes the prose — it does **not** change the returned order.

**Not merging — for review.**

## Bench evidence

Confirmed three times on a real Nq1 running fw 3.7.2. Full evidence is posted at [daqifi-core#344 (comment)](https://github.com/daqifi/daqifi-core/issues/344#issuecomment-5200914378).

The wire format is a `Last N commands:` header followed by `<n>: <command>` lines where `<n>` counts **backwards from the present** — `1:` is the most recent command, and it is printed **last**:

```
Last 3 commands:
3: SYSTem:LOG:TEST
2: SYSTem:STReam:STATS?
1: SYSTem:MEMory:FREE?
```

The decisive evidence: when you call the history query itself, `SYSTem:LOG:CMDHistory?` appears in the **last** slot of the returned list. It is necessarily the most recent command the device has seen at the moment it builds the reply, so if the list were newest-first it would be at index 0.

## Why the docs, and not the code

The parser and its unit-test fixture were **both already correct**. `CommandHistoryParserTests` already used the true descending `3: / 2: / 1:` layout, and `CommandHistoryParser` faithfully preserves the device's order. Only the prose was wrong.

Deliberately **not** reversing the returned list: the device's order is a meaningful chronological transcript, and flipping it would be a silent breaking change for any consumer already reading it correctly.

## Changes

Five sites claimed "newest first" and all five were wrong. Each now says oldest first and explains that the stripped `<n>:` prefix counts backwards from the present:

1. [IDeviceDiagnostics.cs:55](src/Daqifi.Core/Device/Diagnostics/IDeviceDiagnostics.cs) — `<returns>`, plus a new `<remarks>` explaining the numbering
2. [CommandHistoryParser.cs:12](src/Daqifi.Core/Device/Diagnostics/CommandHistoryParser.cs) — class remarks
3. [CommandHistoryParser.cs:24](src/Daqifi.Core/Device/Diagnostics/CommandHistoryParser.cs) — `Parse` `<returns>`
4. [ScpiMessageProducer.cs:1186](src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs) — `GetCommandHistory` remarks
5. [DEVICE_INTERFACES.md:911](docs/DEVICE_INTERFACES.md) — the diagnostics recipe comment (a fifth site found during the sweep, same wrong claim)

Plus a new parser test, `Parse_ReturnsOldestFirst_BecauseDeviceNumbersLinesBackwardsAndPrintsNewestLast`, that pins the direction against the real `Last 3 commands: / 3: A / 2: B / 1: C` layout and asserts exactly `[A, B, C]` — with C documented as the newest — so the contract cannot silently drift back.

No production behavior changes; the only non-doc change is the added test.

## Testing

Build clean on both TFMs, 0 warnings / 0 errors. Full suite run on **net9.0 and net10.0**:

- `Daqifi.Core.Tests` — 2699 passed, 2 skipped, **5 failed** on each TFM
- `Daqifi.Mcp.Tests` — 23 passed
- Diagnostics area specifically (including the new test) — 59/59 passed on both TFMs

⚠️ The 5 failures are **pre-existing on `main` and unrelated to this PR**. All five are in `FirmwareUpdateServiceTests` (WiFi module update / LAN recovery sequencing) and appear to come from the recently merged #444 / #445 WiFi prep commits. Verified by stashing this branch's changes and re-running against a clean tree at `7965b26` — the identical 5 tests fail:

- `UpdateWifiModuleAsync_WhenCanceledAfterEnteringUpdateMode_StillTakesDeviceBackOut`
- `UpdateWifiModuleAsync_WhenCanceledDuringTransparentModeExitSettle_LeavesLanRestoreUnsent`
- `UpdateWifiModuleAsync_WhenFlashToolFails_TakesDeviceBackOutOfLanUpdateMode`
- `UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresAfterReconnect_StillFinishesTheBridgeExit`
- `UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresWaitingForReconnect_SendsNoBridgeExit`

They all assert on expected SCPI command sequences and are failing on an unexpected leading `SYSTem:POWer:STATe 1`. Worth a separate look — this PR touches none of that code.

Part of #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
