### PR TITLE
test(device): bound the two unbounded awaits in the live-stream device tests

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTests.cs
@@ -69,10 +69,17 @@ namespace Daqifi.Core.Tests.Device
 
             using var cts = new CancellationTokenSource();
 
-            // Disposed explicitly below rather than by `await using`: a regression here leaves the
-            // read parked, and disposing an async iterator whose MoveNextAsync is still in flight
-            // throws NotSupportedException from the finally, masking the TimeoutException that
-            // actually names the problem.
+            // Disposed explicitly below rather than by `await using`. A regression here leaves the
+            // read parked, and DisposeAsync on an async iterator whose MoveNextAsync is still in
+            // flight throws NotSupportedException from its own guard — before the iterator body's
+            // finally runs — which would mask the TimeoutException that actually names the problem.
+            //
+            // That also means the enumerator is deliberately abandoned on the failure path: the
+            // unsubscribe is unreachable there by construction, since making dispose legal would
+            // require awaiting the very read that is never going to complete. Harmless — `device`
+            // is created per-test and reachable from nothing else, the leaked handler only writes
+            // into a bounded drop-oldest buffer, and the whole graph is garbage once the test
+            // returns. The happy path below disposes normally.
             var e = device.StreamSamplesAsync(cts.Token).GetAsyncEnumerator();
             var moveNext = e.MoveNextAsync();
             cts.Cancel();

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTests.cs
@@ -12,6 +12,15 @@ namespace Daqifi.Core.Tests.Device
 {
     public class DaqifiStreamingDeviceLiveStreamTests
     {
+        /// <summary>
+        /// Upper bound on every await in this file. The live stream's reads are unbounded by design —
+        /// it waits for the next sample — so a regression in cancellation, in delivery, or in argument
+        /// validation would otherwise park a test forever and stall the whole run. Every wait here is
+        /// bounded so such a regression surfaces as a fast <see cref="TimeoutException"/> instead.
+        /// Generous enough not to flake on a loaded CI agent.
+        /// </summary>
+        private static readonly TimeSpan MoveNextTimeout = TimeSpan.FromSeconds(5);
+
         [Fact]
         public async Task StreamSamplesAsync_YieldsInjectedSample_WithChannelAndValue()
         {
@@ -24,7 +33,7 @@ namespace Daqifi.Core.Tests.Device
             var moveNext = e.MoveNextAsync(); // runs the body: subscribes synchronously, then awaits
             device.InvokeStreamMessage(AnalogFrame(1000, 1.5f));
 
-            Assert.True(await moveNext.AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.True(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
             Assert.Same(ai0, e.Current.Channel);
             Assert.Equal(1.5, e.Current.Sample.Value);
             Assert.Equal(1000u, e.Current.Sample.DeviceTimestamp);
@@ -43,11 +52,11 @@ namespace Daqifi.Core.Tests.Device
             device.InvokeStreamMessage(AnalogFrame(1010, 2f));
             device.InvokeStreamMessage(AnalogFrame(1020, 3f));
 
-            Assert.True(await first.AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.True(await first.AsTask().WaitAsync(MoveNextTimeout));
             Assert.Equal(1.0, e.Current.Sample.Value);
-            Assert.True(await e.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.True(await e.MoveNextAsync().AsTask().WaitAsync(MoveNextTimeout));
             Assert.Equal(2.0, e.Current.Sample.Value);
-            Assert.True(await e.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.True(await e.MoveNextAsync().AsTask().WaitAsync(MoveNextTimeout));
             Assert.Equal(3.0, e.Current.Sample.Value);
         }
 
@@ -59,11 +68,22 @@ namespace Daqifi.Core.Tests.Device
             device.StartStreaming();
 
             using var cts = new CancellationTokenSource();
-            await using var e = device.StreamSamplesAsync(cts.Token).GetAsyncEnumerator();
+
+            // Disposed explicitly below rather than by `await using`: a regression here leaves the
+            // read parked, and disposing an async iterator whose MoveNextAsync is still in flight
+            // throws NotSupportedException from the finally, masking the TimeoutException that
+            // actually names the problem.
+            var e = device.StreamSamplesAsync(cts.Token).GetAsyncEnumerator();
             var moveNext = e.MoveNextAsync();
             cts.Cancel();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await moveNext);
+            // Bounded on purpose: if cancellation ever stops ending the read, an unbounded await here
+            // would park forever and hang the whole run. The timeout turns that into a fast, named
+            // failure (TimeoutException instead of the expected OperationCanceledException).
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => moveNext.AsTask().WaitAsync(MoveNextTimeout));
+            await e.DisposeAsync();
+
             Assert.True(device.IsStreaming); // cancelling enumeration must NOT stop the device stream
         }
 
@@ -80,7 +100,7 @@ namespace Daqifi.Core.Tests.Device
             // Push far more than the buffer holds, synchronously, before the reader runs.
             for (uint i = 0; i < 20; i++) device.InvokeStreamMessage(AnalogFrame(1000 + i * 10, i));
 
-            Assert.True(await moveNext.AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.True(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
             Assert.True(device.DroppedLiveSampleCount > 0, "drop-oldest should have dropped and counted overflow samples");
         }
 
@@ -105,7 +125,7 @@ namespace Daqifi.Core.Tests.Device
             cts.Cancel();
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
-                () => enumeration.WaitAsync(TimeSpan.FromSeconds(5)));
+                () => enumeration.WaitAsync(MoveNextTimeout));
             Assert.True(device.IsStreaming);
         }
 
@@ -113,10 +133,17 @@ namespace Daqifi.Core.Tests.Device
         public async Task StreamSamplesAsync_InvalidBufferCapacity_Throws()
         {
             var device = CreateStreaming(analogCount: 1);
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+
+            // Bounded on purpose: were the validation to stop throwing, this enumeration would block
+            // on an empty buffer that nothing ever writes to, so an unbounded await would hang the run
+            // rather than fail it.
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                () => ConsumeAsync().WaitAsync(MoveNextTimeout));
+
+            async Task ConsumeAsync()
             {
                 await foreach (var _ in device.StreamSamplesAsync(CancellationToken.None, bufferCapacity: 0)) { }
-            });
+            }
         }
 
         #region Helpers


### PR DESCRIPTION
## What

Two tests in `DaqifiStreamingDeviceLiveStreamTests` awaited without a bound, so a regression in the code they cover would **hang CI indefinitely rather than fail it**:

| Test | Unbounded await | What a regression does today |
|---|---|---|
| `StreamSamplesAsync_Cancellation_EndsEnumeration_ButNotDeviceStream` | `await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await moveNext);` | If cancellation ever stops ending the read, this parks forever |
| `StreamSamplesAsync_InvalidBufferCapacity_Throws` | `await foreach (...bufferCapacity: 0)` inside `ThrowsAsync` | If the capacity validation stops throwing, the enumeration blocks on an empty buffer nothing ever writes to |

The repo has no global xUnit timeout and no `[Fact(Timeout=...)]` usage, so nothing else bounded them.

## How

Applies the pattern already established for the extracted collaborator in `LiveSampleStreamTests` (#440):

- One named `MoveNextTimeout` field, documented as to why it exists. The five inline `TimeSpan.FromSeconds(5)` literals already in this file collapse into it, so the file has one bound rather than a field plus scattered literals.
- `.AsTask().WaitAsync(MoveNextTimeout)` on the cancellation await.
- The `await foreach` lifted into a local `ConsumeAsync()` that `WaitAsync` can bound.

One deviation worth calling out: the cancellation test now disposes its enumerator **explicitly** rather than via `await using`. Under a real regression the read stays parked, and disposing an async iterator whose `MoveNextAsync` is still in flight throws `NotSupportedException` from the `finally` — which replaces and masks the `TimeoutException` that actually names the problem. Verified empirically; with `await using` the regression reported `NotSupportedException`, and with the explicit dispose it reports `TimeoutException`. This matches how the equivalent test in `LiveSampleStreamTests` is already structured.

## Verification

Each regression simulated in turn, then restored:

| Simulated regression | Result |
|---|---|
| Removed the `cts.Cancel()` call | `Assert.ThrowsAny() Failure ... Actual: typeof(System.TimeoutException)` — **failed in 5s** |
| Passed a valid `bufferCapacity: 4` | `Assert.Throws() Failure ... Actual: typeof(System.TimeoutException)` — **failed in 5s** |

Both previously would have hung. Restored to `bufferCapacity: 0` and the `Cancel()` call; the class passes 6/6 on both TFMs.

Release build: **0 warnings, 0 errors**. Full suite in Release on net9.0 and net10.0: **2587 passed, 0 failed, 2 skipped** each, plus `Daqifi.Mcp.Tests` 23/23.

## Heads-up: `main` is currently red, unrelated to this PR

Five tests in `FirmwareUpdateServiceTests` fail on a **clean checkout of `origin/main`** (verified by stashing this change — same five fail without it):

- `UpdateWifiModuleAsync_WhenFlashToolFails_TakesDeviceBackOutOfLanUpdateMode`
- `UpdateWifiModuleAsync_WhenCanceledAfterEnteringUpdateMode_StillTakesDeviceBackOut`
- `UpdateWifiModuleAsync_WhenCanceledDuringTransparentModeExitSettle_LeavesLanRestoreUnsent`
- `UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresWaitingForReconnect_SendsNoBridgeExit`
- `UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresAfterReconnect_StillFinishesTheBridgeExit`

```
Expected: ["SYSTem:COMMUnicate:LAN:FWUpdate", "SYSTem:USB:SetTransparentMode 0", "SYSTem:COMMunicate:LAN:APPLY"]
Actual:   ["SYSTem:POWer:STATe 1", "SYSTem:COMMUnicate:LAN:FWUpdate", "SYSTem:USB:SetTransparentMode 0", "SYSTem:COMMunicate:LAN:APPLY"]
```

Semantic merge race between two PRs that were each green on their own base: #445 added these tests with the pre-power-up sequences, then #444 made the prep sequence prepend `SYSTem:POWer:STATe 1`. Out of scope here — tracked separately.

The full-suite numbers quoted above therefore exclude `FirmwareUpdateServiceTests`; everything else is green on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)