### PR TITLE
fix(discovery): wait out an abandoned port claim instead of reporting no devices

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -286,7 +286,8 @@ public class SerialDeviceFinderTests
     private static SerialDeviceFinder CreateFinderWithProbes(
         string[] ports,
         Func<string, CancellationToken, Task<IDeviceInfo?>> probe,
-        int hardTimeoutMs)
+        int hardTimeoutMs,
+        int? drainWaitMs = null)
     {
         var daqifiProvider = new RecordingUsbPortDescriptorProvider(_ =>
             new UsbPortDescriptor(DaqifiUsbIds.VendorId, DaqifiUsbIds.CdcProductId));
@@ -296,6 +297,10 @@ public class SerialDeviceFinderTests
             portNameProvider: () => ports,
             probeOverride: probe);
         finder.PortProbeHardTimeoutMs = hardTimeoutMs;
+        if (drainWaitMs.HasValue)
+        {
+            finder.AbandonedClaimDrainWaitMs = drainWaitMs.Value;
+        }
         return finder;
     }
 
@@ -536,6 +541,223 @@ public class SerialDeviceFinderTests
         // The healthy port is reported by at least one sweep (the loser of a
         // healthy-port claim race skips it for that sweep by design).
         Assert.Contains(results, r => r.Any(d => d.PortName == "COM_OK_CONC"));
+    }
+
+    // --- abandoned-claim drain wait -----------------------------------------
+    //
+    // Bench-measured on a real Nq1 (fw 3.7.2, USB, macOS): a pass that ends by
+    // TIMEOUT or CALLER CANCELLATION abandons its in-flight probe but leaves the
+    // PortClaims entry behind with Probe.IsCompleted == false. Pre-fix, every
+    // subsequent pass took the `return null` path in ~1ms (proof the port was never
+    // opened — a real pass costs ~800ms) until the probe finally unwound ~490ms
+    // later. A caller that retries promptly — Daqifi.Mcp's DaqifiAgent builds a
+    // fresh SerialDeviceFinder per DiscoverAsync call — burned every retry inside
+    // that window and concluded no device was attached.
+    //
+    // These tests drive the same state machine with a gated fake probe: the first
+    // probe hangs until the test releases it, standing in for the uncancellable
+    // native I/O that TryGetDeviceInfoAsync is unwinding.
+
+    private sealed class DrainProbe
+    {
+        private readonly TaskCompletionSource<IDeviceInfo?> _firstProbeGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _firstProbeStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _calls;
+
+        /// <summary>Completes once the abandoned first probe is genuinely in flight.</summary>
+        public Task FirstProbeStarted => _firstProbeStarted.Task;
+
+        public int Calls => Volatile.Read(ref _calls);
+
+        /// <summary>Simulates the stuck I/O finally unwinding and releasing the claim.</summary>
+        public void ReleaseFirstProbe() => _firstProbeGate.TrySetResult(null);
+
+        public Task<IDeviceInfo?> Probe(string portName, CancellationToken cancellationToken)
+        {
+            // First call hangs on the gate — abandoned by the caller's pass, but
+            // still holding the claim. Every later call is a healthy ~instant probe.
+            if (Interlocked.Increment(ref _calls) == 1)
+            {
+                _firstProbeStarted.TrySetResult(true);
+                return _firstProbeGate.Task;
+            }
+
+            return Task.FromResult<IDeviceInfo?>(FakeDevice(portName));
+        }
+    }
+
+    /// <summary>
+    /// Runs a pass that abandons its probe the way the bench runs did, and returns
+    /// once that probe is confirmed in flight with its claim left behind.
+    /// </summary>
+    private static async Task<DrainProbe> AbandonProbeViaTimedOutPassAsync(string port)
+    {
+        SerialDeviceFinder.ResetPortQuarantineForTests();
+        var drainProbe = new DrainProbe();
+
+        using (var first = CreateFinderWithProbes(new[] { port }, drainProbe.Probe, hardTimeoutMs: 150))
+        {
+            Assert.Empty(await first.DiscoverAsync(CancellationToken.None));
+        }
+
+        // The claim is only interesting if the probe really started and is stuck.
+        await drainProbe.FirstProbeStarted.WaitAsync(TimeSpan.FromSeconds(10));
+        return drainProbe;
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_AfterTimedOutPass_WaitsForAbandonedClaimAndFindsDevice()
+    {
+        const string port = "COM_DRAIN_TIMEOUT";
+        var drainProbe = await AbandonProbeViaTimedOutPassAsync(port);
+
+        // Fresh finder immediately after — the one-shot MCP DaqifiAgent shape.
+        using var second = CreateFinderWithProbes(
+            new[] { port }, drainProbe.Probe, hardTimeoutMs: 5000, drainWaitMs: 2000);
+
+        // The abandoned probe unwinds partway through the second pass's drain wait,
+        // mirroring the measured ~490ms claim hold.
+        var sweep = second.DiscoverAsync(CancellationToken.None);
+        await Task.Delay(150);
+        drainProbe.ReleaseFirstProbe();
+
+        var devices = (await sweep).ToList();
+
+        Assert.Equal(port, Assert.Single(devices).PortName);
+        Assert.Equal(2, drainProbe.Calls);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_AfterCancelledPass_WaitsForAbandonedClaimAndFindsDevice()
+    {
+        // Same failure, reached the other way: the bench's 200ms caller-cancellation
+        // row. ProbeSafelyAsync abandons the claim before rethrowing the OCE, so the
+        // next pass hits the identical stale-claim state.
+        SerialDeviceFinder.ResetPortQuarantineForTests();
+        const string port = "COM_DRAIN_CANCEL";
+        var drainProbe = new DrainProbe();
+
+        using (var first = CreateFinderWithProbes(new[] { port }, drainProbe.Probe, hardTimeoutMs: 60_000))
+        using (var cts = new CancellationTokenSource(150))
+        {
+            Assert.Empty(await first.DiscoverAsync(cts.Token));
+        }
+
+        await drainProbe.FirstProbeStarted.WaitAsync(TimeSpan.FromSeconds(10));
+
+        using var second = CreateFinderWithProbes(
+            new[] { port }, drainProbe.Probe, hardTimeoutMs: 5000, drainWaitMs: 2000);
+
+        var sweep = second.DiscoverAsync(CancellationToken.None);
+        await Task.Delay(150);
+        drainProbe.ReleaseFirstProbe();
+
+        Assert.Equal(port, Assert.Single(await sweep).PortName);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_AfterTimedOutPass_WithoutDrainWait_SilentlyReportsNoDevices()
+    {
+        // Pins the exact regression the drain wait removes: with the wait disabled
+        // the follow-up pass reports "no devices" without ever reopening the port,
+        // even though the device is present and the claim is about to clear.
+        const string port = "COM_DRAIN_DISABLED";
+        var drainProbe = await AbandonProbeViaTimedOutPassAsync(port);
+
+        using var second = CreateFinderWithProbes(
+            new[] { port }, drainProbe.Probe, hardTimeoutMs: 5000, drainWaitMs: 0);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var devices = await second.DiscoverAsync(CancellationToken.None);
+        stopwatch.Stop();
+
+        Assert.Empty(devices);
+        Assert.Equal(1, drainProbe.Calls); // port never reopened — the silent miss
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(500),
+            $"Skip took {stopwatch.ElapsedMilliseconds}ms — expected the immediate ~1ms bail-out.");
+
+        drainProbe.ReleaseFirstProbe();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_WedgedPort_DrainWaitExpiresWithoutReProbing()
+    {
+        // The drain wait must not weaken the #294/#295 thread-leak bound: a probe
+        // that never completes is still only ever started ONCE, and the waiting pass
+        // gives up at the window rather than hanging. Nothing new is spawned — the
+        // pass awaits the EXISTING probe task — so no second thread can be blocked.
+        const string port = "COM_DRAIN_WEDGED";
+        var drainProbe = await AbandonProbeViaTimedOutPassAsync(port);
+
+        using var second = CreateFinderWithProbes(
+            new[] { port }, drainProbe.Probe, hardTimeoutMs: 5000, drainWaitMs: 300);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var devices = await second.DiscoverAsync(CancellationToken.None);
+        stopwatch.Stop();
+
+        Assert.Empty(devices);
+        Assert.Equal(1, drainProbe.Calls);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Wedged port held the pass for {stopwatch.ElapsedMilliseconds}ms — the drain wait is not bounded.");
+
+        drainProbe.ReleaseFirstProbe();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_DrainWait_IsBoundedByCallerTimeout()
+    {
+        // The wait is capped by the caller's own budget as well as the window, so a
+        // caller asking for a fast answer still gets one (empty, as documented on
+        // IDeviceFinder.DiscoverAsync) instead of blocking for the full window.
+        const string port = "COM_DRAIN_BUDGET";
+        var drainProbe = await AbandonProbeViaTimedOutPassAsync(port);
+
+        using var second = CreateFinderWithProbes(
+            new[] { port }, drainProbe.Probe, hardTimeoutMs: 5000, drainWaitMs: 10_000);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var devices = await second.DiscoverAsync(TimeSpan.FromMilliseconds(250));
+        stopwatch.Stop();
+
+        Assert.Empty(devices);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(3),
+            $"Caller timeout of 250ms was overrun by {stopwatch.ElapsedMilliseconds}ms — the drain wait ignores the caller's budget.");
+
+        drainProbe.ReleaseFirstProbe();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_DrainWait_DoesNotDelayOtherPortsOnTheSameSweep()
+    {
+        // One draining port must not hold up the rest of the sweep: probes run
+        // concurrently and DeviceDiscovered fires per-probe (#294), so a healthy
+        // port on the same pass reports while the drain wait is still pending.
+        const string draining = "COM_DRAIN_MIXED";
+        const string healthy = "COM_OK_MIXED";
+        var drainProbe = await AbandonProbeViaTimedOutPassAsync(draining);
+
+        using var second = CreateFinderWithProbes(
+            new[] { draining, healthy },
+            (p, ct) => p == draining ? drainProbe.Probe(p, ct) : Task.FromResult<IDeviceInfo?>(FakeDevice(p)),
+            hardTimeoutMs: 5000,
+            drainWaitMs: 3000);
+
+        var reported = new TaskCompletionSource<IDeviceInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        second.DeviceDiscovered += (_, args) =>
+        {
+            if (args.DeviceInfo.PortName == healthy)
+            {
+                reported.TrySetResult(args.DeviceInfo);
+            }
+        };
+
+        var sweep = second.DiscoverAsync(CancellationToken.None);
+        var winner = await Task.WhenAny(reported.Task, Task.Delay(2000));
+        Assert.Same(reported.Task, winner);
+
+        drainProbe.ReleaseFirstProbe();
+        Assert.Contains(await sweep, d => d.PortName == healthy);
     }
 
     private sealed class RecordingUsbPortDescriptorProvider : IUsbPortDescriptorProvider

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -558,6 +558,12 @@ public class SerialDeviceFinderTests
     // probe hangs until the test releases it, standing in for the uncancellable
     // native I/O that TryGetDeviceInfoAsync is unwinding.
 
+    // Every discovery await in these tests is bounded: a regression that stops
+    // DiscoverAsync from settling must fail the test, not hang CI (Qodo #454 pass 1
+    // #1). Generous relative to the drain windows under test so it never fires on
+    // timing jitter.
+    private static readonly TimeSpan SweepGuard = TimeSpan.FromSeconds(30);
+
     private sealed class DrainProbe
     {
         private readonly TaskCompletionSource<IDeviceInfo?> _firstProbeGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -597,7 +603,7 @@ public class SerialDeviceFinderTests
 
         using (var first = CreateFinderWithProbes(new[] { port }, drainProbe.Probe, hardTimeoutMs: 150))
         {
-            Assert.Empty(await first.DiscoverAsync(CancellationToken.None));
+            Assert.Empty(await first.DiscoverAsync(CancellationToken.None).WaitAsync(SweepGuard));
         }
 
         // The claim is only interesting if the probe really started and is stuck.
@@ -621,7 +627,7 @@ public class SerialDeviceFinderTests
         await Task.Delay(150);
         drainProbe.ReleaseFirstProbe();
 
-        var devices = (await sweep).ToList();
+        var devices = (await sweep.WaitAsync(SweepGuard)).ToList();
 
         Assert.Equal(port, Assert.Single(devices).PortName);
         Assert.Equal(2, drainProbe.Calls);
@@ -640,7 +646,7 @@ public class SerialDeviceFinderTests
         using (var first = CreateFinderWithProbes(new[] { port }, drainProbe.Probe, hardTimeoutMs: 60_000))
         using (var cts = new CancellationTokenSource(150))
         {
-            Assert.Empty(await first.DiscoverAsync(cts.Token));
+            Assert.Empty(await first.DiscoverAsync(cts.Token).WaitAsync(SweepGuard));
         }
 
         await drainProbe.FirstProbeStarted.WaitAsync(TimeSpan.FromSeconds(10));
@@ -652,7 +658,7 @@ public class SerialDeviceFinderTests
         await Task.Delay(150);
         drainProbe.ReleaseFirstProbe();
 
-        Assert.Equal(port, Assert.Single(await sweep).PortName);
+        Assert.Equal(port, Assert.Single(await sweep.WaitAsync(SweepGuard)).PortName);
     }
 
     [Fact]
@@ -668,7 +674,7 @@ public class SerialDeviceFinderTests
             new[] { port }, drainProbe.Probe, hardTimeoutMs: 5000, drainWaitMs: 0);
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        var devices = await second.DiscoverAsync(CancellationToken.None);
+        var devices = await second.DiscoverAsync(CancellationToken.None).WaitAsync(SweepGuard);
         stopwatch.Stop();
 
         Assert.Empty(devices);
@@ -693,7 +699,7 @@ public class SerialDeviceFinderTests
             new[] { port }, drainProbe.Probe, hardTimeoutMs: 5000, drainWaitMs: 300);
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        var devices = await second.DiscoverAsync(CancellationToken.None);
+        var devices = await second.DiscoverAsync(CancellationToken.None).WaitAsync(SweepGuard);
         stopwatch.Stop();
 
         Assert.Empty(devices);
@@ -717,7 +723,7 @@ public class SerialDeviceFinderTests
             new[] { port }, drainProbe.Probe, hardTimeoutMs: 5000, drainWaitMs: 10_000);
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        var devices = await second.DiscoverAsync(TimeSpan.FromMilliseconds(250));
+        var devices = await second.DiscoverAsync(TimeSpan.FromMilliseconds(250)).WaitAsync(SweepGuard);
         stopwatch.Stop();
 
         Assert.Empty(devices);
@@ -733,6 +739,8 @@ public class SerialDeviceFinderTests
         // One draining port must not hold up the rest of the sweep: probes run
         // concurrently and DeviceDiscovered fires per-probe (#294), so a healthy
         // port on the same pass reports while the drain wait is still pending.
+        // This is the UNDER-capacity case (2 ports, MaxParallelProbes is 4) — see
+        // MoreDrainingPortsThanProbeSlots for the case that actually contends.
         const string draining = "COM_DRAIN_MIXED";
         const string healthy = "COM_OK_MIXED";
         var drainProbe = await AbandonProbeViaTimedOutPassAsync(draining);
@@ -757,7 +765,82 @@ public class SerialDeviceFinderTests
         Assert.Same(reported.Task, winner);
 
         drainProbe.ReleaseFirstProbe();
-        Assert.Contains(await sweep, d => d.PortName == healthy);
+        Assert.Contains(await sweep.WaitAsync(SweepGuard), d => d.PortName == healthy);
+    }
+
+    /// <summary>
+    /// Multi-port variant of <see cref="DrainProbe"/>: the FIRST probe of each named
+    /// port hangs on a shared gate, so a whole sweep's worth of ports can be left
+    /// abandoned-and-draining at once. Any later probe of the same port succeeds.
+    /// </summary>
+    private sealed class MultiDrainProbe
+    {
+        private readonly TaskCompletionSource<IDeviceInfo?> _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> _firstProbeSeen = new();
+        private readonly string[] _drainPorts;
+
+        public MultiDrainProbe(string[] drainPorts) => _drainPorts = drainPorts;
+
+        public void ReleaseAll() => _gate.TrySetResult(null);
+
+        public Task<IDeviceInfo?> Probe(string portName, CancellationToken cancellationToken)
+        {
+            if (Array.IndexOf(_drainPorts, portName) >= 0 && _firstProbeSeen.TryAdd(portName, 0))
+            {
+                return _gate.Task;
+            }
+
+            return Task.FromResult<IDeviceInfo?>(FakeDevice(portName));
+        }
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_MoreDrainingPortsThanProbeSlots_StillProbesHealthyPortPromptly()
+    {
+        // Qodo #454 pass 1 #2: DiscoverAsync used to hold a probeGate slot across the
+        // WHOLE ProbeSafelyAsync call, so a drain wait — which opens no port and only
+        // awaits an already-running task — still consumed one of the MaxParallelProbes
+        // (4) slots. A pass whose predecessor timed out with every slot busy could
+        // therefore park every slot on drain waits and starve a healthy port for the
+        // full window. The gate is now taken around the port open only.
+        //
+        // Five draining ports guarantees contention against the cap of four.
+        SerialDeviceFinder.ResetPortQuarantineForTests();
+        var drainPorts = new[]
+        {
+            "COM_SLOT_1", "COM_SLOT_2", "COM_SLOT_3", "COM_SLOT_4", "COM_SLOT_5"
+        };
+        const string healthy = "COM_SLOT_OK";
+        var probes = new MultiDrainProbe(drainPorts);
+
+        // Pass 1: every drain port hangs and is abandoned by the hard timeout.
+        using (var first = CreateFinderWithProbes(drainPorts, probes.Probe, hardTimeoutMs: 200))
+        {
+            Assert.Empty(await first.DiscoverAsync(CancellationToken.None).WaitAsync(SweepGuard));
+        }
+
+        // Pass 2: all five are inside a deliberately long drain window, and the
+        // healthy port is last in the port list — worst case for slot starvation.
+        using var second = CreateFinderWithProbes(
+            [.. drainPorts, healthy], probes.Probe, hardTimeoutMs: 5000, drainWaitMs: 10_000);
+
+        var reported = new TaskCompletionSource<IDeviceInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        second.DeviceDiscovered += (_, args) =>
+        {
+            if (args.DeviceInfo.PortName == healthy)
+            {
+                reported.TrySetResult(args.DeviceInfo);
+            }
+        };
+
+        var sweep = second.DiscoverAsync(CancellationToken.None);
+
+        // Pre-fix this waited out the 10s drain window; now it needs only a slot.
+        var winner = await Task.WhenAny(reported.Task, Task.Delay(3000));
+        Assert.Same(reported.Task, winner);
+
+        probes.ReleaseAll();
+        Assert.Contains(await sweep.WaitAsync(SweepGuard), d => d.PortName == healthy);
     }
 
     private sealed class RecordingUsbPortDescriptorProvider : IUsbPortDescriptorProvider

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -804,12 +804,13 @@ public class SerialDeviceFinderTests
         // therefore park every slot on drain waits and starve a healthy port for the
         // full window. The gate is now taken around the port open only.
         //
-        // Five draining ports guarantees contention against the cap of four.
+        // Sized from the cap rather than hard-coded, so raising MaxParallelProbes
+        // can't quietly leave this test under-subscribed and no longer contending.
         SerialDeviceFinder.ResetPortQuarantineForTests();
-        var drainPorts = new[]
-        {
-            "COM_SLOT_1", "COM_SLOT_2", "COM_SLOT_3", "COM_SLOT_4", "COM_SLOT_5"
-        };
+        var drainPorts = Enumerable
+            .Range(1, SerialDeviceFinder.MaxParallelProbes + 1)
+            .Select(i => $"COM_SLOT_{i}")
+            .ToArray();
         const string healthy = "COM_SLOT_OK";
         var probes = new MultiDrainProbe(drainPorts);
 

--- a/src/Daqifi.Core/Device/Discovery/IDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/IDeviceFinder.cs
@@ -23,6 +23,14 @@ public interface IDeviceFinder
     /// <summary>
     /// Discovers devices asynchronously with a cancellation token.
     /// </summary>
+    /// <remarks>
+    /// An empty result means "nothing answered within the budget you gave", not
+    /// "no device is attached". A transport may need to finish releasing resources
+    /// from a previous pass that ended by timeout or cancellation — see
+    /// <see cref="SerialDeviceFinder"/>, which absorbs that wait internally but only
+    /// as far as the caller's own budget allows. Give a realistic timeout rather
+    /// than retrying tightly on an empty result.
+    /// </remarks>
     /// <param name="cancellationToken">Cancellation token to abort the operation.</param>
     /// <returns>A task containing the collection of discovered devices.</returns>
     Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default);
@@ -30,6 +38,11 @@ public interface IDeviceFinder
     /// <summary>
     /// Discovers devices asynchronously with a timeout.
     /// </summary>
+    /// <remarks>
+    /// Returns an empty result rather than throwing when the timeout elapses. See
+    /// <see cref="DiscoverAsync(CancellationToken)"/> for why an empty result is not
+    /// proof that no device is attached.
+    /// </remarks>
     /// <param name="timeout">The timeout for discovery.</param>
     /// <returns>A task containing the collection of discovered devices.</returns>
     Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout);

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -56,7 +56,11 @@ public class SerialDeviceFinder : DeviceFinderBase
     // pass. Most OS serial stacks tolerate 4-8 simultaneous opens cleanly;
     // beyond that, IO failures and slow opens stack up. Common case (with
     // VID/PID classifier) leaves 0-1 candidates so this cap rarely engages.
-    private const int MaxParallelProbes = 4;
+    //
+    // Internal so the slot-contention test can size its port list from the cap
+    // instead of hard-coding it — a raised cap would otherwise leave that test
+    // silently under-subscribed and no longer testing contention at all.
+    internal const int MaxParallelProbes = 4;
     // Hard ceiling on a single port probe. A wedged USB CDC device can hang
     // SerialPort.Open() inside native GetCommState indefinitely — no exception,
     // no cancellation (Open is uncancellable blocking I/O) — observed live on a

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -18,6 +18,22 @@ namespace Daqifi.Core.Device.Discovery;
 /// Discovers DAQiFi devices connected via USB/Serial ports.
 /// Probes each port by sending SCPI commands and validating protobuf responses.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Port probes are claimed process-wide so a wedged USB CDC device can block at
+/// most one thread per port (see issues #294 / #295). A pass that ends by timeout
+/// or cancellation abandons its in-flight probe and leaves the claim behind while
+/// that probe unwinds — bench-measured at ~490ms on a real Nq1.
+/// </para>
+/// <para>
+/// A pass that starts inside that drain window waits (bounded by both the window
+/// and the caller's own timeout / token) for the claim to clear before probing, so
+/// a prompt retry after a timed-out pass finds the device instead of silently
+/// reporting none. Callers therefore do not need to hand-roll a backoff, but they
+/// should still allow a realistic timeout: a retry given less budget than the drain
+/// needs will report nothing, exactly as it would have before.
+/// </para>
+/// </remarks>
 public class SerialDeviceFinder : DeviceFinderBase
 {
     #region Constants
@@ -78,6 +94,10 @@ public class SerialDeviceFinder : DeviceFinderBase
     // attempt replace a still-stuck claim per TTL window, so a recovered port
     // re-appears without a process restart at a bounded leak rate).
     //
+    // A claim abandoned by a timed-out / cancelled pass is usually NOT wedged; it
+    // drains in ~490ms. Within AbandonedClaimDrainWaitMs a fresh pass waits for it
+    // rather than reporting the port absent — see ProbeSafelyAsync.
+    //
     // STATIC on purpose: a wedged COM port is machine-global state, not finder
     // state.
     private static readonly ConcurrentDictionary<string, PortProbeClaim> PortClaims = new();
@@ -109,6 +129,24 @@ public class SerialDeviceFinder : DeviceFinderBase
 
     // Internal so tests can exercise the TTL retry without waiting 30s.
     internal static int QuarantineRetryTtlMs { get; set; } = DefaultQuarantineRetryTtlMs;
+
+    // How long AFTER abandonment a claim is still treated as "probably draining"
+    // rather than "wedged". A pass that ends by timeout or caller cancellation
+    // abandons its in-flight probe, but that probe is usually NOT wedged — it is
+    // unwinding TryGetDeviceInfoAsync's cleanup (consumer/producer StopSafely, DTR
+    // drop + 50ms settle, port close). Bench-measured on a real Nq1 (fw 3.7.2, USB,
+    // macOS): the claim was held 488/490/491ms across three runs, then auto-released
+    // by the abandonment continuation.
+    //
+    // Within this window a fresh pass WAITS for the claim to clear instead of
+    // skipping the port; past it, the port is presumed genuinely wedged and skipped
+    // immediately as before. 1s is ~2x the measured drain — enough headroom for a
+    // loaded thread pool, still short enough that a truly wedged port costs at most
+    // one sub-second wait before ageing out of the window entirely.
+    private const int DefaultAbandonedClaimDrainWaitMs = 1000;
+
+    // Internal so tests can shrink the drain wait instead of burning ~1s per case.
+    internal int AbandonedClaimDrainWaitMs { get; set; } = DefaultAbandonedClaimDrainWaitMs;
 
     /// <summary>
     /// Test seam: clears the process-wide port quarantine so hang-simulation
@@ -303,9 +341,10 @@ public class SerialDeviceFinder : DeviceFinderBase
     /// </summary>
     /// <param name="portName">The serial port name.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Device info if a DAQiFi device responds, null otherwise. Swallows
-    /// non-cancellation exceptions so a single failing port doesn't tear down the
-    /// whole concurrent probe pass; cancellation propagates so Task.WhenAll
+    /// <returns>Device info if a DAQiFi device responds, null otherwise — including
+    /// when the port is claimed by a probe that is still genuinely in flight.
+    /// Swallows non-cancellation exceptions so a single failing port doesn't tear
+    /// down the whole concurrent probe pass; cancellation propagates so Task.WhenAll
     /// short-circuits when the caller's token is canceled.</returns>
     private async Task<IDeviceInfo?> ProbeSafelyAsync(string portName, CancellationToken cancellationToken)
     {
@@ -319,12 +358,15 @@ public class SerialDeviceFinder : DeviceFinderBase
             // instances sweep concurrently.
             claim = new PortProbeClaim();
             var claimed = false;
-            // Two attempts: the second handles exactly one stale-completed claim
-            // (its release continuation raced us) by clearing it and re-claiming
-            // immediately, so an available port isn't skipped for a whole sweep —
-            // that miss is invisible to the 2-3s desktop sweeps but real for
-            // one-shot MCP discovery calls (Qodo pass 5 #3).
-            for (var attempt = 0; attempt < 2 && !claimed; attempt++)
+            var drainWaited = false;
+            // Up to three attempts. Attempt 2 handles exactly one stale-completed
+            // claim (its release continuation raced us) by clearing it and
+            // re-claiming immediately, so an available port isn't skipped for a
+            // whole sweep — that miss is invisible to the 2-3s desktop sweeps but
+            // real for one-shot MCP discovery calls (Qodo pass 5 #3). Attempt 3
+            // covers the drain wait below, whose worst path is
+            // wait -> observe completed claim -> clear -> claim.
+            for (var attempt = 0; attempt < 3 && !claimed; attempt++)
             {
                 var existing = PortClaims.GetOrAdd(portName, claim);
                 if (ReferenceEquals(existing, claim))
@@ -341,17 +383,66 @@ public class SerialDeviceFinder : DeviceFinderBase
                 }
 
                 var abandonedAt = existing.AbandonedAtTicks;
-                if (abandonedAt >= 0
-                    && Environment.TickCount64 - abandonedAt >= QuarantineRetryTtlMs
-                    && PortClaims.TryUpdate(portName, claim, existing))
+                if (abandonedAt >= 0)
                 {
-                    // TTL elapsed on a still-stuck claim — we won the retry.
-                    claimed = true;
-                    break;
+                    var abandonedForMs = Environment.TickCount64 - abandonedAt;
+                    if (abandonedForMs >= QuarantineRetryTtlMs
+                        && PortClaims.TryUpdate(portName, claim, existing))
+                    {
+                        // TTL elapsed on a still-stuck claim — we won the retry.
+                        claimed = true;
+                        break;
+                    }
+
+                    // Freshly abandoned: the PREVIOUS pass ended by timeout or
+                    // caller cancellation and left this claim behind while its
+                    // probe unwinds — measured ~490ms, not wedged. The
+                    // skip below costs ~1ms, so a caller that retries promptly
+                    // (the MCP DaqifiAgent builds a fresh finder per call) would
+                    // burn every retry inside the drain window and conclude no
+                    // device exists. Wait for the claim to clear instead, bounded
+                    // by both the drain window and the caller's own budget.
+                    //
+                    // This starts NO new probe and blocks NO new thread — we await
+                    // the EXISTING probe task — so the one-blocked-thread-per-port
+                    // bound from #294/#295 is untouched. A genuinely wedged port
+                    // just burns the remaining window once and then ages out of it.
+                    var pending = existing.Probe;
+                    // Long arithmetic on purpose: abandonedForMs is unbounded (a
+                    // claim whose TTL retry lost the race can be arbitrarily old),
+                    // so narrowing it first could overflow into a large positive
+                    // budget. Computed this way the result is always
+                    // <= AbandonedClaimDrainWaitMs, making the cast below safe.
+                    var drainBudgetMs = AbandonedClaimDrainWaitMs - abandonedForMs;
+                    if (!drainWaited && pending != null && drainBudgetMs > 0
+                        && !cancellationToken.IsCancellationRequested)
+                    {
+                        drainWaited = true;
+                        using (var drainCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                        {
+                            drainCts.CancelAfter((int)drainBudgetMs);
+                            try
+                            {
+                                await pending.WaitAsync(drainCts.Token).ConfigureAwait(false);
+                            }
+                            catch
+                            {
+                                // Drain window elapsed, caller cancelled, or the
+                                // abandoned probe faulted. Its own continuation
+                                // already observed any fault; all we needed was the
+                                // "no longer in flight" edge. Re-check below.
+                            }
+                        }
+
+                        // Surface caller cancellation rather than reporting the port
+                        // as absent (mirrors the hard-timeout path below).
+                        cancellationToken.ThrowIfCancellationRequested();
+                        continue;
+                    }
                 }
 
-                // In flight elsewhere, inside the TTL window, or another instance
-                // won the race — the port is spoken for.
+                // In flight elsewhere, still wedged past the drain window but inside
+                // the TTL, or another instance won the race — the port is spoken for.
                 return null;
             }
             if (!claimed)

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -267,30 +267,29 @@ public class SerialDeviceFinder : DeviceFinderBase
             // Cap concurrency at MaxParallelProbes so a 20-port system with
             // a missing descriptor provider doesn't open 20 serial handles at
             // once — most platforms throttle quietly above ~8 concurrent opens.
+            //
+            // The gate is taken INSIDE ProbeSafelyAsync, around the port open only.
+            // Holding it across the whole call would let the abandoned-claim drain
+            // wait — which opens nothing and merely awaits an already-running task —
+            // occupy a slot, so a pass whose predecessor timed out with every slot
+            // busy could park all MaxParallelProbes slots on drain waits and delay a
+            // healthy port behind them (Qodo #454 pass 1 #2).
             var maxConcurrency = Math.Max(1, Math.Min(MaxParallelProbes, availablePorts.Count));
             using var probeGate = new SemaphoreSlim(maxConcurrency, maxConcurrency);
 
             var probeTasks = availablePorts.Select(async portName =>
             {
-                await probeGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try
+                var deviceInfo = await ProbeSafelyAsync(portName, probeGate, cancellationToken).ConfigureAwait(false);
+                if (deviceInfo != null)
                 {
-                    var deviceInfo = await ProbeSafelyAsync(portName, cancellationToken).ConfigureAwait(false);
-                    if (deviceInfo != null)
-                    {
-                        // Raise per-probe rather than after Task.WhenAll: one hung port
-                        // must not silence every healthy device on the system (#294).
-                        // Fires on a worker thread, possibly concurrently with other
-                        // probes' events — handlers own their thread marshaling (both
-                        // desktop apps already dispatch to their UI thread).
-                        OnDeviceDiscovered(deviceInfo);
-                    }
-                    return deviceInfo;
+                    // Raise per-probe rather than after Task.WhenAll: one hung port
+                    // must not silence every healthy device on the system (#294).
+                    // Fires on a worker thread, possibly concurrently with other
+                    // probes' events — handlers own their thread marshaling (both
+                    // desktop apps already dispatch to their UI thread).
+                    OnDeviceDiscovered(deviceInfo);
                 }
-                finally
-                {
-                    probeGate.Release();
-                }
+                return deviceInfo;
             }).ToList();
 
             // Catch OCE here so the DiscoveryCompleted event always fires
@@ -340,13 +339,20 @@ public class SerialDeviceFinder : DeviceFinderBase
     /// Opens the port, sends GetDeviceInfo command, and waits for a status response.
     /// </summary>
     /// <param name="portName">The serial port name.</param>
+    /// <param name="probeGate">
+    /// Caps concurrent port opens for the sweep. Held only around the probe itself,
+    /// never around claim acquisition or the abandoned-claim drain wait — neither
+    /// opens a port, and holding a slot through them would throttle healthy ports
+    /// behind ports that are merely draining.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Device info if a DAQiFi device responds, null otherwise — including
     /// when the port is claimed by a probe that is still genuinely in flight.
     /// Swallows non-cancellation exceptions so a single failing port doesn't tear
     /// down the whole concurrent probe pass; cancellation propagates so Task.WhenAll
     /// short-circuits when the caller's token is canceled.</returns>
-    private async Task<IDeviceInfo?> ProbeSafelyAsync(string portName, CancellationToken cancellationToken)
+    private async Task<IDeviceInfo?> ProbeSafelyAsync(
+        string portName, SemaphoreSlim probeGate, CancellationToken cancellationToken)
     {
         PortProbeClaim? claim = null;
         var claimHandedToContinuation = false;
@@ -452,64 +458,76 @@ public class SerialDeviceFinder : DeviceFinderBase
 
             var probe = _probeOverride ?? TryGetDeviceInfoAsync;
 
-            // Task.Run: SerialPort.Open() (and DiscardInBuffer etc.) are synchronous
-            // blocking I/O that would otherwise run on the CALLING thread up to the
-            // probe's first await — in the desktop apps that thread is the UI thread,
-            // and a slow or stuck open froze the whole window (#294). Pass
-            // CancellationToken.None to Task.Run itself: the inner token still
-            // cancels the probe's delays; we never want "cancelled before start"
-            // to look like a probe fault.
-            var probeTask = Task.Run(() => probe(portName, cancellationToken), CancellationToken.None);
-            claim.Probe = probeTask;
-
-            // Hard per-port ceiling: a wedged CDC device hangs Open() inside native
-            // GetCommState with no exception, so the catch below never fires and,
-            // pre-#294, Task.WhenAll in DiscoverAsync never settled. Open() is
-            // uncancellable, so on timeout the stuck task is ABANDONED — its own
-            // finally block closes the port if the kernel ever completes the I/O.
-            var winner = await Task.WhenAny(
-                probeTask,
-                Task.Delay(PortProbeHardTimeoutMs, cancellationToken)).ConfigureAwait(false);
-
-            if (winner != probeTask)
+            // Take a probe slot only now. Claim acquisition and the drain wait above
+            // open no port, so gating them would just throttle healthy ports behind
+            // ports that are draining. Released the moment this probe settles or is
+            // abandoned — an abandoned probe holds no slot on later sweeps either.
+            await probeGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
             {
-                if (probeTask.IsCompletedSuccessfully)
+                // Task.Run: SerialPort.Open() (and DiscardInBuffer etc.) are synchronous
+                // blocking I/O that would otherwise run on the CALLING thread up to the
+                // probe's first await — in the desktop apps that thread is the UI thread,
+                // and a slow or stuck open froze the whole window (#294). Pass
+                // CancellationToken.None to Task.Run itself: the inner token still
+                // cancels the probe's delays; we never want "cancelled before start"
+                // to look like a probe fault.
+                var probeTask = Task.Run(() => probe(portName, cancellationToken), CancellationToken.None);
+                claim.Probe = probeTask;
+
+                // Hard per-port ceiling: a wedged CDC device hangs Open() inside native
+                // GetCommState with no exception, so the catch below never fires and,
+                // pre-#294, Task.WhenAll in DiscoverAsync never settled. Open() is
+                // uncancellable, so on timeout the stuck task is ABANDONED — its own
+                // finally block closes the port if the kernel ever completes the I/O.
+                var winner = await Task.WhenAny(
+                    probeTask,
+                    Task.Delay(PortProbeHardTimeoutMs, cancellationToken)).ConfigureAwait(false);
+
+                if (winner != probeTask)
                 {
-                    // The probe finished right at the timeout/cancellation boundary —
-                    // honor DiscoverAsync's "settle for whatever probes already
-                    // finished cleanly" contract instead of discarding a completed
-                    // result (Qodo pass 5 #4). The finally releases our claim.
-                    return await probeTask.ConfigureAwait(false);
+                    if (probeTask.IsCompletedSuccessfully)
+                    {
+                        // The probe finished right at the timeout/cancellation boundary —
+                        // honor DiscoverAsync's "settle for whatever probes already
+                        // finished cleanly" contract instead of discarding a completed
+                        // result (Qodo pass 5 #4). The finally releases our claim.
+                        return await probeTask.ConfigureAwait(false);
+                    }
+
+                    // Whether the wait ended by timeout or by caller cancellation, the
+                    // uncancellable probe may still be blocked in native I/O — mark the
+                    // claim abandoned BEFORE surfacing cancellation, so a cancelled sweep
+                    // can't walk away from an untracked probe (Qodo PR #295 pass 2 #1).
+                    claim.AbandonedAtTicks = Environment.TickCount64;
+                    claimHandedToContinuation = true;
+
+                    // When the abandoned I/O finally completes (any way), observe its
+                    // fault so it can't surface as an UnobservedTaskException, and release
+                    // the claim — atomically only if it's still ours (a TTL retry may have
+                    // replaced it with a newer attempt that must survive).
+                    var abandonedClaim = claim;
+                    _ = probeTask.ContinueWith(
+                        t =>
+                        {
+                            _ = t.Exception;
+                            ReleaseClaimIfOwned(portName, abandonedClaim);
+                        },
+                        CancellationToken.None,
+                        TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+
+                    // Surface caller cancellation only after tracking the abandoned probe.
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return null;
                 }
 
-                // Whether the wait ended by timeout or by caller cancellation, the
-                // uncancellable probe may still be blocked in native I/O — mark the
-                // claim abandoned BEFORE surfacing cancellation, so a cancelled sweep
-                // can't walk away from an untracked probe (Qodo PR #295 pass 2 #1).
-                claim.AbandonedAtTicks = Environment.TickCount64;
-                claimHandedToContinuation = true;
-
-                // When the abandoned I/O finally completes (any way), observe its
-                // fault so it can't surface as an UnobservedTaskException, and release
-                // the claim — atomically only if it's still ours (a TTL retry may have
-                // replaced it with a newer attempt that must survive).
-                var abandonedClaim = claim;
-                _ = probeTask.ContinueWith(
-                    t =>
-                    {
-                        _ = t.Exception;
-                        ReleaseClaimIfOwned(portName, abandonedClaim);
-                    },
-                    CancellationToken.None,
-                    TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
-
-                // Surface caller cancellation only after tracking the abandoned probe.
-                cancellationToken.ThrowIfCancellationRequested();
-                return null;
+                return await probeTask.ConfigureAwait(false);
             }
-
-            return await probeTask.ConfigureAwait(false);
+            finally
+            {
+                probeGate.Release();
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {


### PR DESCRIPTION
> **For review only — please do not merge.**

## The problem

A `SerialDeviceFinder` pass that ends by **timeout** or **caller cancellation** abandons its in-flight probe, but the `PortClaims` entry survives with `Probe.IsCompleted == false`. The stale-claim recovery in `ProbeSafelyAsync` only clears a **completed** claim, so every subsequent pass takes the `return null` path and silently reports the port as absent.

Bench-measured on a real Nq1 (fw 3.7.2, USB, macOS) against `origin/main` @ 4b8eed2 — [full evidence](https://github.com/daqifi/daqifi-core/issues/183#issuecomment-5201118880):

| preceding pass | next pass | latency |
|---|---|---|
| completed normally (control, 3/3) | FOUND | 766-817 ms |
| timed out at 300 ms (3/3) | no devices | ~1 ms |
| cancelled at 200 ms (2/2) | no devices | ~1 ms |

The ~1 ms proves the port was never opened — a real pass costs ~800 ms. The claim was held **488/490/491 ms** across three runs before auto-releasing: nowhere near the 30 s `QuarantineRetryTtlMs`, so the abandoned probe was **draining, not wedged**. Because each skipped attempt costs ~1 ms, a naive immediate-retry loop burns ~18 retries inside the window and concludes no device exists.

The 2-3 s desktop sweep never lands inside that window (`ContinuousDeviceFinder` was confirmed unaffected). The gap is the **one-shot caller that retries promptly** — exactly the `Daqifi.Mcp` shape, where `DaqifiAgent.DiscoverAsync` builds a fresh `SerialDeviceFinder` per call.

## Option chosen: 3 (bounded wait), with 1's documentation folded in

| Option | Verdict |
|---|---|
| 1 — documentation only | Rejected as the fix. Leaves the failure mode in place and asks every caller to work around it. Its substance is still worth having, so the contract note is included. |
| 2 — surface the skip | Rejected. Makes the miss *diagnosable* but not *fixed* — `Daqifi.Mcp` and every future one-shot caller would still have to implement backoff, and it adds public API surface to do it. |
| **3 — bounded wait** | **Chosen.** Fixes it in one place for all callers, with no API change. |

The decisive point for option 3: **waiting on an existing claim's probe task starts no new probe and blocks no new thread.** The wait awaits the `Task` that is *already* running, so the thread-leak bound from #294/#295 that motivated the claim is preserved for free — no tradeoff to make.

## What changed

When a claim is abandoned-but-in-flight and less than `AbandonedClaimDrainWaitMs` (1 s, ~2x the measured drain) has elapsed since abandonment, `ProbeSafelyAsync` waits for it to clear before giving up, then re-attempts the claim. The wait is bounded by **both** the drain window and the caller's own token/timeout, via a linked CTS.

Behaviour for a **genuinely wedged** port is unchanged in the way that matters: the pass burns the remaining window **once**, then the claim ages out of the window and is skipped in ~1 ms exactly as before. Nothing is re-probed, and the `QuarantineRetryTtlMs` recovery path is untouched.

The claim loop goes from 2 attempts to 3 — the drain wait's worst path is `wait → observe completed claim → clear → claim`.

Also documented on `IDeviceFinder.DiscoverAsync` that an empty result means "nothing answered within the budget you gave", not "no device is attached" — so callers give a realistic timeout rather than retrying tightly.

## Tests

Five new tests in `SerialDeviceFinderTests`, using the existing internal seams (`probeOverride`, `portNameProvider`, `ResetPortQuarantineForTests`, `PortProbeHardTimeoutMs`) plus a new internal `AbandonedClaimDrainWaitMs` knob. A gated fake probe (`DrainProbe`) stands in for the uncancellable native I/O, so the state machine is driven deterministically with **no hardware**:

- `AfterTimedOutPass_WaitsForAbandonedClaimAndFindsDevice` — the bench timeout row
- `AfterCancelledPass_WaitsForAbandonedClaimAndFindsDevice` — the bench cancellation row
- `AfterTimedOutPass_WithoutDrainWait_SilentlyReportsNoDevices` — pins the regression itself: port never reopened, bail-out under 500 ms
- `WedgedPort_DrainWaitExpiresWithoutReProbing` — the thread-leak bound holds; probe started exactly once
- `DrainWait_IsBoundedByCallerTimeout` — a 250 ms caller is not held for a 10 s window
- `DrainWait_DoesNotDelayOtherPortsOnTheSameSweep` — one draining port doesn't stall the rest of the pass
- `MoreDrainingPortsThanProbeSlots_StillProbesHealthyPortPromptly` *(added in review round 1)* — 5 draining ports against the cap of 4, healthy port last

Every discovery await is bounded by a 30 s `SweepGuard`, so a regression fails the test rather than hanging CI.

**Each fix was confirmed against the unfixed code**, not just asserted:
- the two "finds the device" tests fail with the drain-wait branch disabled;
- `MoreDrainingPortsThanProbeSlots` fails with the probe slot held across the whole call.

Timing-sensitive cases were run 5x for flakiness — stable.

## Review round 1 (Qodo) — both findings accepted

| # | Finding | Resolution |
|---|---|---|
| 1 | Drain wait consumes probe slots | **Real.** The gate was held across the whole `ProbeSafelyAsync` call, so a drain wait (which opens no port) occupied one of 4 slots. A pass that times out with every slot busy abandons all its probes at once, so the next pass can park every slot on drain waits. Gate now wraps only the port open. My existing 2-port test never contended and passed either way — replaced that false confidence with the 5-port test above. |
| 2 | Drain tests can hang | **Real.** All new discovery awaits now bounded by `SweepGuard`. |

## Verification

- Discovery tests: **180/180 green on net9.0 and net10.0**.
- Full solution: **2710 passed, 2 skipped, 0 failed** on both net9.0 and net10.0.

(An earlier revision of this PR noted 5 failing `FirmwareUpdateServiceTests`; those were pre-existing on `main` and have since been fixed by #456, now merged in here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
