### PR TITLE
feat(device): confirming variants for the silent administration commands

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DeviceNotConnectedExceptionTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceNotConnectedExceptionTests.cs
@@ -145,6 +145,15 @@ namespace Daqifi.Core.Tests.Device
             yield return Site("GetStreamStatsAsync", d => d.GetStreamStatsAsync());
             yield return Site("GetMemoryDiagnosticsAsync", d => d.GetMemoryDiagnosticsAsync());
             yield return Site("SetFriendlyNameAsync", d => d.SetFriendlyNameAsync("Lab Nq1"));
+            yield return Site("SaveAdcCalibrationAsync", d => d.SaveAdcCalibrationAsync());
+            yield return Site("LoadAdcCalibrationAsync", d => d.LoadAdcCalibrationAsync());
+            yield return Site("SaveFactoryAdcCalibrationAsync", d => d.SaveFactoryAdcCalibrationAsync());
+            yield return Site("LoadFactoryAdcCalibrationAsync", d => d.LoadFactoryAdcCalibrationAsync());
+            yield return Site("UseAdcCalibrationAsync", d => d.UseAdcCalibrationAsync(1));
+            yield return Site("SetAdcCalibrationSlopeAsync", d => d.SetAdcCalibrationSlopeAsync(0, 1.0));
+            yield return Site("SetAdcCalibrationOffsetAsync", d => d.SetAdcCalibrationOffsetAsync(0, 0.0));
+            yield return Site("SaveVoltagePrecisionAsync", d => d.SaveVoltagePrecisionAsync());
+            yield return Site("LoadVoltagePrecisionAsync", d => d.LoadVoltagePrecisionAsync());
 
             static object[] Site(string name, Func<DaqifiStreamingDevice, Task> call) => [name, call];
         }

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -290,6 +290,23 @@ public class DeviceAdministrationOperationsTests
     }
 
     /// <summary>
+    /// The verdict trails the command, so the exchange must not be allowed to close on the default
+    /// 250ms inactivity window: on a device that echoes, the echo starts that clock and a merely-slow
+    /// verdict would read as a missing one, failing a command the device had accepted. Same reason the
+    /// SD listing raises its own completion window — its terminator is this same query.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmingOperation_AsksForAWindowLongEnoughForTheVerdictToTrailAnEcho()
+    {
+        var host = new FakeHost { IsConnected = true, ExchangeResponse = new[] { NoError } };
+
+        await new DeviceAdministrationOperations(host).SaveAdcCalibrationAsync();
+
+        Assert.Equal(3000, host.LastResponseTimeoutMs);
+        Assert.Equal(1000, host.LastCompletionTimeoutMs);
+    }
+
+    /// <summary>
     /// A device that volunteers <c>**ERROR: ...</c> alongside the command is complaining about that
     /// command directly, so it is classified from the line itself rather than from the queue reply.
     /// </summary>
@@ -307,6 +324,43 @@ public class DeviceAdministrationOperationsTests
 
         Assert.Equal(-113, ex.ErrorCode);
         Assert.Equal("**ERROR: -113,\"Undefined header\"", ex.DeviceResponse);
+    }
+
+    /// <summary>
+    /// <c>ERROR</c> lines the classifier matches but that carry no readable code — a bare token, or a
+    /// non-numeric one. These are still refusals, so they must throw; what they must not do is report
+    /// a code of <c>0</c>, the one value SCPI reserves for "no error". The raw line survives, since it
+    /// is the only diagnostic there is.
+    /// </summary>
+    [Theory]
+    [InlineData("ERROR")]
+    [InlineData("**ERROR")]
+    [InlineData("ERROR: something went wrong")]
+    public async Task ConfirmingOperation_WhenAVolunteeredErrorLineCarriesNoCode_ThrowsWithoutClaimingCodeZero(
+        string errorLine)
+    {
+        var host = new FakeHost { IsConnected = true, ExchangeResponse = new[] { errorLine } };
+
+        var ex = await Assert.ThrowsAsync<DeviceCommandFailedException>(
+            () => new DeviceAdministrationOperations(host).LoadAdcCalibrationAsync());
+
+        Assert.Null(ex.ErrorCode);
+        Assert.Equal(errorLine, ex.DeviceResponse);
+        Assert.Contains(errorLine, ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The guard behind the assertion above: these lines really do classify as SCPI errors while
+    /// yielding no code, so the null-code path is reachable rather than theoretical.
+    /// </summary>
+    [Theory]
+    [InlineData("ERROR")]
+    [InlineData("**ERROR")]
+    [InlineData("ERROR: something went wrong")]
+    public void CodelessErrorLines_ClassifyAsScpiErrorsButYieldNoCode(string errorLine)
+    {
+        Assert.True(ScpiResponseClassifier.IsScpiErrorLine(errorLine));
+        Assert.False(ScpiResponseClassifier.TryExtractErrorCode(errorLine, out _));
     }
 
     public static IEnumerable<object[]> UnreadableVerdicts()
@@ -448,6 +502,12 @@ public class DeviceAdministrationOperationsTests
         /// <summary>What a text exchange hands back — the device's side of a confirming command.</summary>
         public IReadOnlyList<string> ExchangeResponse { get; set; } = Array.Empty<string>();
 
+        /// <summary>The response timeout the last exchange asked for.</summary>
+        public int? LastResponseTimeoutMs { get; private set; }
+
+        /// <summary>The completion timeout the last exchange asked for.</summary>
+        public int? LastCompletionTimeoutMs { get; private set; }
+
         public void Send<T>(IOutboundMessage<T> message)
         {
             if (++_sendCount == FailSendAt)
@@ -484,6 +544,9 @@ public class DeviceAdministrationOperationsTests
         {
             Assert.Null(prepareAsync);
             Assert.Null(finalizeAsync);
+
+            LastResponseTimeoutMs = responseTimeoutMs;
+            LastCompletionTimeoutMs = completionTimeoutMs;
 
             Calls.Add("exchange");
             setupAction();

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -370,10 +370,17 @@ public class DeviceAdministrationOperationsTests
     /// Code 0 never reaches <see cref="DeviceCommandFailedException.ErrorCode"/> from any path, which
     /// is what lets callers branch on it: a non-null code always means a real refusal.
     /// </summary>
+    /// <remarks>
+    /// The line itself must survive. Dropping it would leave the failure reporting silence from a
+    /// device that plainly answered — the diagnostic a reader needs most when a device is speaking a
+    /// dialect this classifier does not expect. And the message must not call that code unreadable:
+    /// it is right there, it just says "no error", which cannot describe a refusal.
+    /// </remarks>
     [Theory]
     [InlineData("**ERROR: 0,\"No error\"")]
     [InlineData("ERROR: 0,\"No error\"")]
-    public async Task ConfirmingOperation_NeverReportsErrorCodeZero(string errorLine)
+    public async Task ConfirmingOperation_NeverReportsErrorCodeZero_ButKeepsTheLineAndDescribesItHonestly(
+        string errorLine)
     {
         var host = new FakeHost { IsConnected = true, ExchangeResponse = new[] { errorLine } };
 
@@ -383,6 +390,10 @@ public class DeviceAdministrationOperationsTests
             () => new DeviceAdministrationOperations(host).LoadAdcCalibrationAsync());
 
         Assert.NotEqual(0, ex.ErrorCode ?? -1);
+        Assert.Equal(errorLine, ex.DeviceResponse);
+        Assert.Contains(errorLine, ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("not readable", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("no readable", ex.Message, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -400,6 +411,11 @@ public class DeviceAdministrationOperationsTests
         Assert.Equal("**ERROR: 0,\"No error\"", ex.DeviceResponse);
         Assert.Equal("CONFigure:ADC:LOADcal", ex.Command);
         Assert.DoesNotContain("rejected", ex.Message, StringComparison.Ordinal);
+
+        // The code is readable — it just says "no error". Claiming otherwise would contradict the
+        // line quoted alongside it in the same message.
+        Assert.DoesNotContain("no readable", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("no error", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -350,6 +350,42 @@ public class DeviceAdministrationOperationsTests
     }
 
     /// <summary>
+    /// An <c>ERROR</c>-shaped line whose code is <c>0</c> says "no error", so it is not evidence of a
+    /// refusal — a device that answers the queue read in that shape rather than the bare one must not
+    /// be reported as having rejected a command it accepted. The bare verdict alongside it decides.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmingOperation_WhenAnErrorShapedLineSaysCodeZero_DoesNotTreatItAsARefusal()
+    {
+        var host = new FakeHost
+        {
+            IsConnected = true,
+            ExchangeResponse = new[] { "**ERROR: 0,\"No error\"", NoError },
+        };
+
+        await new DeviceAdministrationOperations(host).LoadAdcCalibrationAsync();
+    }
+
+    /// <summary>
+    /// Code 0 never reaches <see cref="DeviceCommandFailedException.ErrorCode"/> from any path, which
+    /// is what lets callers branch on it: a non-null code always means a real refusal.
+    /// </summary>
+    [Theory]
+    [InlineData("**ERROR: 0,\"No error\"")]
+    [InlineData("ERROR: 0,\"No error\"")]
+    public async Task ConfirmingOperation_NeverReportsErrorCodeZero(string errorLine)
+    {
+        var host = new FakeHost { IsConnected = true, ExchangeResponse = new[] { errorLine } };
+
+        // No bare verdict accompanies it, so this is unconfirmed rather than refused — but either
+        // way the one thing it must not be is a reported error code of 0.
+        var ex = await Assert.ThrowsAsync<DeviceCommandFailedException>(
+            () => new DeviceAdministrationOperations(host).LoadAdcCalibrationAsync());
+
+        Assert.NotEqual(0, ex.ErrorCode ?? -1);
+    }
+
+    /// <summary>
     /// The guard behind the assertion above: these lines really do classify as SCPI errors while
     /// yielding no code, so the null-code path is reachable rather than theoretical.
     /// </summary>

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -386,6 +386,32 @@ public class DeviceAdministrationOperationsTests
     }
 
     /// <summary>
+    /// The never-zero contract holds at the API boundary too, not just on the paths this collaborator
+    /// happens to take: constructing the exception directly with <c>0</c> records "no readable code"
+    /// rather than a refusal under SCPI's "no error" value. Normalised rather than rejected, because a
+    /// constructor that threw would swap a diagnosable device failure for an argument error.
+    /// </summary>
+    [Fact]
+    public void DeviceCommandFailedException_ConstructedWithCodeZero_ReportsNoCodeAndKeepsTheLine()
+    {
+        var ex = new DeviceCommandFailedException("CONFigure:ADC:LOADcal", 0, "**ERROR: 0,\"No error\"");
+
+        Assert.Null(ex.ErrorCode);
+        Assert.Equal("**ERROR: 0,\"No error\"", ex.DeviceResponse);
+        Assert.Equal("CONFigure:ADC:LOADcal", ex.Command);
+        Assert.DoesNotContain("rejected", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeviceCommandFailedException_ConstructedWithARealCode_KeepsIt()
+    {
+        var ex = new DeviceCommandFailedException("CONFigure:ADC:LOADcal", -200, "-200,\"Execution error\"");
+
+        Assert.Equal(-200, ex.ErrorCode);
+        Assert.Contains("rejected", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The guard behind the assertion above: these lines really do classify as SCPI errors while
     /// yielding no code, so the null-code path is reachable rather than theoretical.
     /// </summary>

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -186,10 +186,251 @@ public class DeviceAdministrationOperationsTests
 
     #endregion
 
+    #region Confirming variants
+
+    /// <summary>The reply a device gives to <c>SYSTem:ERRor?</c> when the queue is clean.</summary>
+    private const string NoError = "0,\"No error\"";
+
     /// <summary>
-    /// An <see cref="IDeviceOperationHost"/> that records, in order, the only two things this block
-    /// is allowed to do to a device: send a command, and (for reboot) disconnect. Everything else
-    /// throws.
+    /// What the bench saw on a real Nyquist (fw 3.7.2) when its user calibration bank had never been
+    /// written — see the evidence on #344.
+    /// </summary>
+    private const string ExecutionError = "-200,\"Execution error\"";
+
+    /// <summary>
+    /// Every confirming variant, paired with the command text it must put on the wire. The two
+    /// coefficient commands carry arguments, so the expected text is a prefix of what goes out.
+    /// </summary>
+    public static IEnumerable<object[]> ConfirmingOperations()
+    {
+        yield return Site("SaveAdcCalibrationAsync", "CONFigure:ADC:SAVEcal", (a, t) => a.SaveAdcCalibrationAsync(t));
+        yield return Site("LoadAdcCalibrationAsync", "CONFigure:ADC:LOADcal", (a, t) => a.LoadAdcCalibrationAsync(t));
+        yield return Site("SaveFactoryAdcCalibrationAsync", "CONFigure:ADC:SAVEFcal", (a, t) => a.SaveFactoryAdcCalibrationAsync(t));
+        yield return Site("LoadFactoryAdcCalibrationAsync", "CONFigure:ADC:LOADFcal", (a, t) => a.LoadFactoryAdcCalibrationAsync(t));
+        yield return Site("SaveVoltagePrecisionAsync", "CONFigure:VOLTage:SAVE", (a, t) => a.SaveVoltagePrecisionAsync(t));
+        yield return Site("LoadVoltagePrecisionAsync", "CONFigure:VOLTage:LOAD", (a, t) => a.LoadVoltagePrecisionAsync(t));
+        yield return Site("UseAdcCalibrationAsync(0)", "CONFigure:ADC:USECal 0", (a, t) => a.UseAdcCalibrationAsync(0, t));
+        yield return Site("UseAdcCalibrationAsync(1)", "CONFigure:ADC:USECal 1", (a, t) => a.UseAdcCalibrationAsync(1, t));
+        yield return Site("SetAdcCalibrationSlopeAsync", "CONFigure:ADC:chanCALM ", (a, t) => a.SetAdcCalibrationSlopeAsync(2, 1.0025, t));
+        yield return Site("SetAdcCalibrationOffsetAsync", "CONFigure:ADC:chanCALB ", (a, t) => a.SetAdcCalibrationOffsetAsync(3, -0.0031, t));
+
+        // The collaborator is internal, so the delegate cannot be typed over it on a public test
+        // method — object is the widest type the signature can carry, and Invoke casts it back.
+        static object[] Site(string name, string command, Func<DeviceAdministrationOperations, CancellationToken, Task> call)
+            => [name, command, call];
+    }
+
+    private static Task Invoke(object call, FakeHost host, CancellationToken cancellationToken = default)
+        => ((Func<DeviceAdministrationOperations, CancellationToken, Task>)call)(
+            new DeviceAdministrationOperations(host), cancellationToken);
+
+    /// <summary>
+    /// The shape of a confirming command, in order: drain the error queue, then — in one exchange —
+    /// the command and the <c>SYSTem:ERRor?</c> that reads the device's verdict on it. The drain is
+    /// what makes the verdict attributable: without it, the entry popped afterwards could belong to
+    /// any earlier command. That it happens before the exchange rather than inside it is the whole
+    /// reason the ordering is asserted and not just the set of calls.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ConfirmingOperations))]
+    public async Task ConfirmingOperation_WhenTheDeviceAccepts_DrainsThenSendsTheCommandAndReadsTheVerdict(
+        string siteName,
+        string expectedCommand,
+        object call)
+    {
+        _ = siteName;
+        var host = new FakeHost { IsConnected = true, ExchangeResponse = new[] { NoError } };
+
+        await Invoke(call, host);
+
+        Assert.Equal(4, host.Calls.Count);
+        Assert.Equal("drain:16", host.Calls[0]);
+        Assert.Equal("exchange", host.Calls[1]);
+        Assert.StartsWith("send:" + expectedCommand, host.Calls[2], StringComparison.Ordinal);
+        Assert.Equal("send:SYSTem:ERRor?", host.Calls[3]);
+    }
+
+    /// <summary>
+    /// The whole point of this surface. <c>LoadAdcCalibration()</c> returns normally against a device
+    /// that answered <c>-200</c>; the confirming variant refuses to call that a success, and hands the
+    /// caller the device's own code and line rather than a generic failure.
+    /// </summary>
+    [Fact]
+    public async Task LoadAdcCalibrationAsync_WhenTheDeviceReportsAnError_ThrowsWithTheDeviceCode()
+    {
+        var host = new FakeHost { IsConnected = true, ExchangeResponse = new[] { ExecutionError } };
+
+        var ex = await Assert.ThrowsAsync<DeviceCommandFailedException>(
+            () => new DeviceAdministrationOperations(host).LoadAdcCalibrationAsync());
+
+        Assert.Equal("CONFigure:ADC:LOADcal", ex.Command);
+        Assert.Equal(-200, ex.ErrorCode);
+        Assert.Equal(ExecutionError, ex.DeviceResponse);
+    }
+
+    /// <summary>
+    /// Every confirming variant classifies the same way — a refusal is a refusal whichever command
+    /// drew it, and none of them may report success on one.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ConfirmingOperations))]
+    public async Task ConfirmingOperation_WhenTheDeviceReportsAnError_Throws(
+        string siteName,
+        string expectedCommand,
+        object call)
+    {
+        _ = siteName;
+        var host = new FakeHost { IsConnected = true, ExchangeResponse = new[] { ExecutionError } };
+
+        var ex = await Assert.ThrowsAsync<DeviceCommandFailedException>(() => Invoke(call, host));
+
+        Assert.StartsWith(expectedCommand, ex.Command, StringComparison.Ordinal);
+        Assert.Equal(-200, ex.ErrorCode);
+        Assert.Equal(ExecutionError, ex.DeviceResponse);
+    }
+
+    /// <summary>
+    /// A device that volunteers <c>**ERROR: ...</c> alongside the command is complaining about that
+    /// command directly, so it is classified from the line itself rather than from the queue reply.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmingOperation_WhenTheDeviceVolunteersAnErrorLine_ThrowsWithThatCode()
+    {
+        var host = new FakeHost
+        {
+            IsConnected = true,
+            ExchangeResponse = new[] { "**ERROR: -113,\"Undefined header\"", NoError },
+        };
+
+        var ex = await Assert.ThrowsAsync<DeviceCommandFailedException>(
+            () => new DeviceAdministrationOperations(host).SaveVoltagePrecisionAsync());
+
+        Assert.Equal(-113, ex.ErrorCode);
+        Assert.Equal("**ERROR: -113,\"Undefined header\"", ex.DeviceResponse);
+    }
+
+    public static IEnumerable<object[]> UnreadableVerdicts()
+    {
+        // Nothing came back at all — a timeout, or a device that stopped answering.
+        yield return [Array.Empty<string>()];
+        // Something came back, but nothing in it is a SYSTem:ERRor? reply.
+        yield return [new[] { "CONFigure:ADC:LOADcal" }];
+    }
+
+    /// <summary>
+    /// No readable verdict is not a success. The command may or may not have been applied, and saying
+    /// so — with a null <see cref="DeviceCommandFailedException.ErrorCode"/> to separate it from a
+    /// refusal — is the only honest answer available.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(UnreadableVerdicts))]
+    public async Task ConfirmingOperation_WhenTheVerdictIsUnreadable_ThrowsWithoutAnErrorCode(string[] response)
+    {
+        var host = new FakeHost { IsConnected = true, ExchangeResponse = response };
+
+        var ex = await Assert.ThrowsAsync<DeviceCommandFailedException>(
+            () => new DeviceAdministrationOperations(host).LoadAdcCalibrationAsync());
+
+        Assert.Equal("CONFigure:ADC:LOADcal", ex.Command);
+        Assert.Null(ex.ErrorCode);
+        Assert.Contains("did not confirm", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A trailing <c>0,"No error"</c> is the verdict even when the device volunteered other output
+    /// first — the last error-queue reply in the exchange is the one this command's query drew.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmingOperation_WhenExtraOutputPrecedesACleanVerdict_Succeeds()
+    {
+        var host = new FakeHost
+        {
+            IsConnected = true,
+            ExchangeResponse = new[] { "CONFigure:ADC:LOADcal", string.Empty, NoError },
+        };
+
+        await new DeviceAdministrationOperations(host).LoadAdcCalibrationAsync();
+    }
+
+    [Theory]
+    [MemberData(nameof(ConfirmingOperations))]
+    public async Task ConfirmingOperation_WhenNotConnected_ThrowsAndTouchesNothing(
+        string siteName,
+        string expectedCommand,
+        object call)
+    {
+        _ = siteName;
+        _ = expectedCommand;
+        var host = new FakeHost { IsConnected = false };
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(() => Invoke(call, host));
+
+        // Not even the drain: a refused command must not touch the device's error queue.
+        Assert.Empty(host.Calls);
+    }
+
+    [Theory]
+    [MemberData(nameof(ConfirmingOperations))]
+    public async Task ConfirmingOperation_AlreadyCancelled_ThrowsAndTouchesNothing(
+        string siteName,
+        string expectedCommand,
+        object call)
+    {
+        _ = siteName;
+        _ = expectedCommand;
+        var host = new FakeHost { IsConnected = true };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Invoke(call, host, cts.Token));
+
+        Assert.Empty(host.Calls);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public async Task UseAdcCalibrationAsync_InvalidBank_ThrowsBeforeTouchingTheDevice(int bank)
+    {
+        var host = new FakeHost { IsConnected = true };
+
+        var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => new DeviceAdministrationOperations(host).UseAdcCalibrationAsync(bank));
+
+        Assert.Equal("bank", ex.ParamName);
+        Assert.Empty(host.Calls);
+    }
+
+    [Fact]
+    public async Task SetAdcCalibrationSlopeAsync_NegativeChannel_ThrowsBeforeTouchingTheDevice()
+    {
+        var host = new FakeHost { IsConnected = true };
+
+        var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => new DeviceAdministrationOperations(host).SetAdcCalibrationSlopeAsync(-1, 1.0));
+
+        Assert.Equal("channelNumber", ex.ParamName);
+        Assert.Empty(host.Calls);
+    }
+
+    [Fact]
+    public async Task SetAdcCalibrationOffsetAsync_NegativeChannel_ThrowsBeforeTouchingTheDevice()
+    {
+        var host = new FakeHost { IsConnected = true };
+
+        var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => new DeviceAdministrationOperations(host).SetAdcCalibrationOffsetAsync(-1, 0.0));
+
+        Assert.Equal("channelNumber", ex.ParamName);
+        Assert.Empty(host.Calls);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// An <see cref="IDeviceOperationHost"/> that records, in order, the things this block is
+    /// allowed to do to a device: send a command, run a text exchange, drain the error queue, and
+    /// (for reboot) disconnect. Everything else throws.
     /// </summary>
     private sealed class FakeHost : IDeviceOperationHost
     {
@@ -203,6 +444,9 @@ public class DeviceAdministrationOperationsTests
 
         /// <summary>1-based index of the send that should throw, or 0 for none.</summary>
         public int FailSendAt { get; set; }
+
+        /// <summary>What a text exchange hands back — the device's side of a confirming command.</summary>
+        public IReadOnlyList<string> ExchangeResponse { get; set; } = Array.Empty<string>();
 
         public void Send<T>(IOutboundMessage<T> message)
         {
@@ -225,13 +469,34 @@ public class DeviceAdministrationOperationsTests
         public void StopStreaming() => throw new NotSupportedException();
         public IReadOnlyList<IChannel> SnapshotChannels() => throw new NotSupportedException();
         public void WithChannelsLock(Action action) => throw new NotSupportedException();
+        /// <summary>
+        /// Runs the setup action so its sends land in <see cref="Calls"/> in order, then answers with
+        /// <see cref="ExchangeResponse"/>. The <c>exchange</c> marker is recorded first so a test can
+        /// see that the drain happened outside this exchange rather than inside it.
+        /// </summary>
         public Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
             Action setupAction,
             int responseTimeoutMs = 1000,
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null) => throw new NotSupportedException();
+            Func<Task>? finalizeAsync = null)
+        {
+            Assert.Null(prepareAsync);
+            Assert.Null(finalizeAsync);
+
+            Calls.Add("exchange");
+            setupAction();
+            return Task.FromResult(ExchangeResponse);
+        }
+
+        public Task<IReadOnlyList<string>> DrainErrorQueueAsync(
+            int maxIterations = 256,
+            CancellationToken cancellationToken = default)
+        {
+            Calls.Add("drain:" + maxIterations);
+            return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+        }
         public Task ExecuteRawCaptureAsync(
             Func<Stream, CancellationToken, Task> rawAction,
             CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -295,6 +295,9 @@ public class LiveSampleStreamTests
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
             Func<Task>? finalizeAsync = null) => throw new NotSupportedException();
+        public Task<IReadOnlyList<string>> DrainErrorQueueAsync(
+            int maxIterations = 256,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task ExecuteRawCaptureAsync(
             Func<Stream, CancellationToken, Task> rawAction,
             CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -449,6 +449,9 @@ public class StreamFrameDecoderTests
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
             Func<Task>? finalizeAsync = null) => throw new NotSupportedException();
+        public Task<IReadOnlyList<string>> DrainErrorQueueAsync(
+            int maxIterations = 256,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task ExecuteRawCaptureAsync(
             Func<Stream, CancellationToken, Task> rawAction,
             CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
@@ -84,5 +84,28 @@ namespace Daqifi.Core.Tests.Device
         {
             Assert.False(ScpiResponseClassifier.IsSystemErrorReplyLine(line));
         }
+
+        [Theory]
+        [InlineData("0,\"No error\"", 0)]
+        [InlineData("+0,\"No error\"", 0)]
+        [InlineData("-200,\"Execution error\"", -200)]
+        [InlineData("-420, \"Query UNTERMINATED\"", -420)]
+        [InlineData("  -113,\"Undefined header\"  \r\n", -113)]
+        public void TryParseSystemErrorReplyCode_ReadsTheCode(string line, int expected)
+        {
+            Assert.True(ScpiResponseClassifier.TryParseSystemErrorReplyCode(line, out var code));
+            Assert.Equal(expected, code);
+        }
+
+        [Theory]
+        [InlineData("**ERROR: -200,\"Execution error\"")]  // the volunteered form, not a queue reply
+        [InlineData("Error !! No SD Card Detected")]
+        [InlineData("99999999999999,\"Overflows an int\"")]
+        [InlineData("")]
+        public void TryParseSystemErrorReplyCode_RejectsWhatIsNotACode(string line)
+        {
+            Assert.False(ScpiResponseClassifier.TryParseSystemErrorReplyCode(line, out var code));
+            Assert.Equal(0, code);
+        }
     }
 }

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -26,7 +26,7 @@ namespace Daqifi.Core.Device
     /// Represents a DAQiFi device that supports data streaming functionality.
     /// Extends the base DaqifiDevice with streaming-specific operations.
     /// </summary>
-    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost
+    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, IConfirmingDeviceAdministration, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost
     {
         /// <summary>
         /// Response window allowed for the USB stream-interface command sent during
@@ -792,6 +792,42 @@ namespace Daqifi.Core.Device
         /// <inheritdoc />
         public void LoadVoltagePrecision() => _administration.LoadVoltagePrecision();
 
+        /// <inheritdoc />
+        public Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default)
+            => _administration.SaveAdcCalibrationAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default)
+            => _administration.LoadAdcCalibrationAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default)
+            => _administration.SetAdcCalibrationSlopeAsync(channelNumber, calM, cancellationToken);
+
+        /// <inheritdoc />
+        public Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default)
+            => _administration.SetAdcCalibrationOffsetAsync(channelNumber, calB, cancellationToken);
+
+        /// <inheritdoc />
+        public Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default)
+            => _administration.SaveFactoryAdcCalibrationAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default)
+            => _administration.LoadFactoryAdcCalibrationAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default)
+            => _administration.UseAdcCalibrationAsync(bank, cancellationToken);
+
+        /// <inheritdoc />
+        public Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default)
+            => _administration.SaveVoltagePrecisionAsync(cancellationToken);
+
+        /// <inheritdoc />
+        public Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default)
+            => _administration.LoadVoltagePrecisionAsync(cancellationToken);
+
 
         // -----------------------------------------------------------------
         // Delegation to the operation collaborators.
@@ -1028,6 +1064,11 @@ namespace Daqifi.Core.Device
             => ExecuteTextCommandAsync(
                 setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken, prepareAsync, finalizeAsync);
 #pragma warning restore CA1068
+
+        Task<IReadOnlyList<string>> IDeviceOperationHost.DrainErrorQueueAsync(
+            int maxIterations,
+            CancellationToken cancellationToken)
+            => DrainErrorQueueAsync(maxIterations, cancellationToken);
 
         Task IDeviceOperationHost.ExecuteRawCaptureAsync(
             Func<Stream, CancellationToken, Task> rawAction,

--- a/src/Daqifi.Core/Device/DeviceCommandFailedException.cs
+++ b/src/Daqifi.Core/Device/DeviceCommandFailedException.cs
@@ -91,7 +91,12 @@ namespace Daqifi.Core.Device
 
         private static string BuildRefusalMessage(string command, int errorCode, string deviceResponse)
             => errorCode == 0
-                ? BuildUnreadableVerdictMessage(command, deviceResponse)
+                // Not the "unreadable code" wording: the code here is perfectly readable, it just
+                // says "no error", which cannot describe a refusal. Saying it is unreadable would be
+                // factually wrong about a line the reader can see for themselves.
+                ? $"The device did not confirm '{command}': it answered {deviceResponse}, which reports "
+                  + "SCPI code 0 (\"no error\") and so does not describe a refusal. No usable verdict "
+                  + "was returned, so whether the command was applied is unknown."
                 : $"The device rejected '{command}' with SCPI error {errorCode} ({deviceResponse}). "
                   + "The command did not take effect.";
 

--- a/src/Daqifi.Core/Device/DeviceCommandFailedException.cs
+++ b/src/Daqifi.Core/Device/DeviceCommandFailedException.cs
@@ -65,17 +65,35 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Initializes a new instance reporting that the device <em>refused</em> the command.
         /// </summary>
+        /// <remarks>
+        /// Passing <c>0</c> is not a refusal — SCPI reserves it for "no error" — so it is recorded as
+        /// <see cref="ErrorCode"/> <c>null</c> ("no readable code") rather than stored as-is, and the
+        /// message says so. That keeps the never-<c>0</c> contract true no matter who calls this,
+        /// which is what lets consumers branch on <see cref="ErrorCode"/> at all.
+        /// <para>
+        /// Deliberately normalised rather than rejected with an <see cref="ArgumentOutOfRangeException"/>.
+        /// Exceptions are constructed on failure paths, and a constructor that throws would replace a
+        /// diagnosable device failure with an argument error — losing the diagnosis, which is the very
+        /// failure mode this type exists to prevent. <see cref="DeviceResponse"/> is preserved either
+        /// way, so nothing the device said is lost.
+        /// </para>
+        /// </remarks>
         /// <param name="command">The SCPI command that was sent.</param>
-        /// <param name="errorCode">The SCPI error code the device reported.</param>
+        /// <param name="errorCode">The SCPI error code the device reported. <c>0</c> is normalised to <c>null</c> — see the remarks.</param>
         /// <param name="deviceResponse">The raw device line the code was read from.</param>
         public DeviceCommandFailedException(string command, int errorCode, string deviceResponse)
-            : base($"The device rejected '{command}' with SCPI error {errorCode} ({deviceResponse}). "
-                   + "The command did not take effect.")
+            : base(BuildRefusalMessage(command, errorCode, deviceResponse))
         {
             Command = command;
-            ErrorCode = errorCode;
+            ErrorCode = errorCode == 0 ? null : errorCode;
             DeviceResponse = deviceResponse;
         }
+
+        private static string BuildRefusalMessage(string command, int errorCode, string deviceResponse)
+            => errorCode == 0
+                ? BuildUnreadableVerdictMessage(command, deviceResponse)
+                : $"The device rejected '{command}' with SCPI error {errorCode} ({deviceResponse}). "
+                  + "The command did not take effect.";
 
         /// <summary>
         /// Initializes a new instance reporting that no SCPI error code could be read — either the

--- a/src/Daqifi.Core/Device/DeviceCommandFailedException.cs
+++ b/src/Daqifi.Core/Device/DeviceCommandFailedException.cs
@@ -1,0 +1,80 @@
+using System;
+
+#nullable enable
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Thrown by the confirming (<c>...Async</c>) device-administration commands when the device did
+    /// not accept the command — or when it never said whether it did.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The fire-and-forget administration commands (<see cref="IStreamingDevice.LoadAdcCalibration"/>
+    /// and friends) return <c>void</c> and parse no reply, so a device that refuses the command is
+    /// indistinguishable from one that carried it out. Bench evidence on a real Nyquist running
+    /// firmware 3.7.2: <c>CONFigure:ADC:LOADcal</c> answers <c>-200,"Execution error"</c> on a unit
+    /// whose user calibration bank was never written, and the caller learns nothing. The confirming
+    /// variants close that gap by reading the device's SCPI error queue after the command and
+    /// raising this exception rather than reporting a success the device never gave.
+    /// </para>
+    /// <para>
+    /// <see cref="ErrorCode"/> separates the two conditions this covers. A non-null code is the
+    /// device's own verdict: it answered, and the answer was a refusal — the command did not take
+    /// effect. A <c>null</c> code means the outcome is <em>unknown</em>: the verification query went
+    /// unanswered, so the command may or may not have been applied. Neither is a success, which is
+    /// why both surface as an exception, but a caller that retries should treat them differently —
+    /// a refusal will be refused again, whereas an unanswered query usually means the link or the
+    /// device needs attention first.
+    /// </para>
+    /// </remarks>
+    public class DeviceCommandFailedException : Exception
+    {
+        /// <summary>
+        /// The SCPI command whose outcome this exception reports, e.g. <c>CONFigure:ADC:LOADcal</c>.
+        /// </summary>
+        public string Command { get; }
+
+        /// <summary>
+        /// The SCPI error code the device reported, e.g. <c>-200</c> for an execution error; <c>null</c>
+        /// when the device never answered the verification query and the command's outcome is therefore
+        /// unknown rather than known-bad.
+        /// </summary>
+        public int? ErrorCode { get; }
+
+        /// <summary>
+        /// The raw device line this verdict was read from, when there was one.
+        /// </summary>
+        public string? DeviceResponse { get; }
+
+        /// <summary>
+        /// Initializes a new instance reporting that the device <em>refused</em> the command.
+        /// </summary>
+        /// <param name="command">The SCPI command that was sent.</param>
+        /// <param name="errorCode">The SCPI error code the device reported.</param>
+        /// <param name="deviceResponse">The raw device line the code was read from.</param>
+        public DeviceCommandFailedException(string command, int errorCode, string deviceResponse)
+            : base($"The device rejected '{command}' with SCPI error {errorCode} ({deviceResponse}). "
+                   + "The command did not take effect.")
+        {
+            Command = command;
+            ErrorCode = errorCode;
+            DeviceResponse = deviceResponse;
+        }
+
+        /// <summary>
+        /// Initializes a new instance reporting that the command's outcome could <em>not be
+        /// confirmed</em> — the device did not answer the verification query.
+        /// </summary>
+        /// <param name="command">The SCPI command that was sent.</param>
+        /// <param name="deviceResponse">The raw device line that was expected to carry the verdict, if any.</param>
+        public DeviceCommandFailedException(string command, string? deviceResponse = null)
+            : base($"The device did not confirm '{command}': its error queue was not readable after the "
+                   + "command, so whether it was applied is unknown. Check the connection and retry.")
+        {
+            Command = command;
+            ErrorCode = null;
+            DeviceResponse = deviceResponse;
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/DeviceCommandFailedException.cs
+++ b/src/Daqifi.Core/Device/DeviceCommandFailedException.cs
@@ -19,13 +19,25 @@ namespace Daqifi.Core.Device
     /// raising this exception rather than reporting a success the device never gave.
     /// </para>
     /// <para>
-    /// <see cref="ErrorCode"/> separates the two conditions this covers. A non-null code is the
-    /// device's own verdict: it answered, and the answer was a refusal — the command did not take
-    /// effect. A <c>null</c> code means the outcome is <em>unknown</em>: the verification query went
-    /// unanswered, so the command may or may not have been applied. Neither is a success, which is
-    /// why both surface as an exception, but a caller that retries should treat them differently —
-    /// a refusal will be refused again, whereas an unanswered query usually means the link or the
-    /// device needs attention first.
+    /// <see cref="ErrorCode"/> and <see cref="DeviceResponse"/> together say how much is known:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b>Code present</b> — the device answered and the answer was a refusal. The command did not
+    /// take effect, and retrying it unchanged will be refused again.
+    /// </description></item>
+    /// <item><description>
+    /// <b>No code, but a <see cref="DeviceResponse"/></b> — the device answered, but with nothing
+    /// carrying a readable code: a bare <c>ERROR</c>, or a queue reply whose code would not parse.
+    /// The command is not confirmed, and the raw line is all there is to go on.
+    /// </description></item>
+    /// <item><description>
+    /// <b>Neither</b> — nothing readable came back at all, so whether the command was applied is
+    /// <em>unknown</em>. Usually the link or the device needs attention before a retry is meaningful.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// None of the three is a success, which is why all of them throw.
     /// </para>
     /// </remarks>
     public class DeviceCommandFailedException : Exception
@@ -37,13 +49,16 @@ namespace Daqifi.Core.Device
 
         /// <summary>
         /// The SCPI error code the device reported, e.g. <c>-200</c> for an execution error; <c>null</c>
-        /// when the device never answered the verification query and the command's outcome is therefore
-        /// unknown rather than known-bad.
+        /// when no code could be read — either because nothing came back or because what did carried no
+        /// readable code. Never <c>0</c>: that is the value SCPI reserves for "no error", so a refusal
+        /// is never reported under it. Pair with <see cref="DeviceResponse"/> to tell an unreadable
+        /// refusal from silence.
         /// </summary>
         public int? ErrorCode { get; }
 
         /// <summary>
-        /// The raw device line this verdict was read from, when there was one.
+        /// The raw device line this verdict was read from; <c>null</c> when the device said nothing
+        /// readable at all.
         /// </summary>
         public string? DeviceResponse { get; }
 
@@ -63,18 +78,25 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
-        /// Initializes a new instance reporting that the command's outcome could <em>not be
-        /// confirmed</em> — the device did not answer the verification query.
+        /// Initializes a new instance reporting that no SCPI error code could be read — either the
+        /// device said nothing readable (outcome unknown), or it complained in a form carrying no code
+        /// (a refusal whose reason is only in the raw line).
         /// </summary>
         /// <param name="command">The SCPI command that was sent.</param>
-        /// <param name="deviceResponse">The raw device line that was expected to carry the verdict, if any.</param>
+        /// <param name="deviceResponse">The raw device line, when there was one; <c>null</c> when nothing readable came back.</param>
         public DeviceCommandFailedException(string command, string? deviceResponse = null)
-            : base($"The device did not confirm '{command}': its error queue was not readable after the "
-                   + "command, so whether it was applied is unknown. Check the connection and retry.")
+            : base(BuildUnreadableVerdictMessage(command, deviceResponse))
         {
             Command = command;
             ErrorCode = null;
             DeviceResponse = deviceResponse;
         }
+
+        private static string BuildUnreadableVerdictMessage(string command, string? deviceResponse)
+            => deviceResponse == null
+                ? $"The device did not confirm '{command}': its error queue was not readable after the "
+                  + "command, so whether it was applied is unknown. Check the connection and retry."
+                : $"The device did not confirm '{command}': it answered {deviceResponse}, which carries no "
+                  + "readable SCPI error code. The command was not confirmed to have taken effect.";
     }
 }

--- a/src/Daqifi.Core/Device/IConfirmingDeviceAdministration.cs
+++ b/src/Daqifi.Core/Device/IConfirmingDeviceAdministration.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// The confirming counterparts to the fire-and-forget device-administration commands on
+    /// <see cref="IStreamingDevice"/>: each sends the same firmware primitive and then asks the device
+    /// whether it accepted it, so a refusal cannot pass for a success.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IStreamingDevice.LoadAdcCalibration"/> and the rest of that block return <c>void</c>
+    /// and parse no reply. Bench evidence on a Nyquist running firmware 3.7.2 shows what that costs:
+    /// <c>CONFigure:ADC:LOADcal</c> answers <c>-200,"Execution error"</c> on a unit whose user
+    /// calibration bank was never written, and the caller is told nothing — "load the user calibration
+    /// bank" is a silent no-op that reports success. Sending the identical primitive by hand produced
+    /// the same refusal, so this is the firmware's behavior rather than a defect in Core; what Core
+    /// owes the caller is a way to find out.
+    /// </para>
+    /// <para>
+    /// This is a separate interface rather than more members on <see cref="IStreamingDevice"/> so
+    /// existing implementers of that interface keep compiling, and it follows the same shape as the
+    /// other capability slices this device exposes
+    /// (<see cref="Network.INetworkConfigurable"/>, <see cref="SdCard.ISdCardOperations"/>,
+    /// <see cref="Firmware.ILanChipInfoProvider"/>, <see cref="Diagnostics.IDeviceDiagnostics"/>) — test for it
+    /// before use:
+    /// </para>
+    /// <code>
+    /// if (device is IConfirmingDeviceAdministration admin)
+    /// {
+    ///     await admin.LoadAdcCalibrationAsync(cancellationToken);
+    /// }
+    /// </code>
+    /// <para>
+    /// Confirmation is not free: it needs text exchanges rather than a single write, so the
+    /// <c>void</c> commands remain the right choice while streaming or when a silent no-op is
+    /// acceptable. Nothing here changes what goes on the wire for those.
+    /// </para>
+    /// </remarks>
+    public interface IConfirmingDeviceAdministration
+    {
+        /// <summary>
+        /// Persists the device's current ADC calibration coefficients to the <b>user</b> NVM bank, and confirms
+        /// the device accepted the command.
+        /// </summary>
+        /// <inheritdoc cref="LoadAdcCalibrationAsync" path="/remarks" />
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Restores the device's ADC calibration coefficients from the <b>user</b> NVM bank into its runtime, and
+        /// confirms the device accepted the command.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Sends the same firmware primitive as the <c>void</c> command it mirrors, then reads the device's SCPI
+        /// error queue so a refusal surfaces as <see cref="DeviceCommandFailedException"/> instead of passing for
+        /// success. The queue is drained first, so the entry read afterwards belongs to this command and not to an
+        /// older one — which also means anything the queue was already holding is discarded; read it with
+        /// <see cref="DaqifiDevice.DrainErrorQueueAsync"/> beforehand if those entries matter.
+        /// </para>
+        /// <para>
+        /// This costs two or more text exchanges, each of which pauses the protobuf consumer and takes the
+        /// device's operation lock. Do not call it during active streaming or concurrently with another device
+        /// operation; the <c>void</c> command remains the one to use in those situations.
+        /// </para>
+        /// </remarks>
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sets a single channel's ADC calibration slope (CalM) in device RAM, and confirms the device accepted
+        /// the command.
+        /// </summary>
+        /// <inheritdoc cref="LoadAdcCalibrationAsync" path="/remarks" />
+        /// <param name="channelNumber">The analog input channel number.</param>
+        /// <param name="calM">The calibration slope (gain) coefficient.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="channelNumber"/> is negative.</exception>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sets a single channel's ADC calibration offset (CalB) in device RAM, and confirms the device accepted
+        /// the command.
+        /// </summary>
+        /// <inheritdoc cref="LoadAdcCalibrationAsync" path="/remarks" />
+        /// <param name="channelNumber">The analog input channel number.</param>
+        /// <param name="calB">The calibration offset coefficient.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="channelNumber"/> is negative.</exception>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Persists the device's current ADC calibration coefficients to the <b>factory</b> NVM bank, and confirms
+        /// the device accepted the command.
+        /// </summary>
+        /// <inheritdoc cref="LoadAdcCalibrationAsync" path="/remarks" />
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Restores the device's ADC calibration coefficients from the <b>factory</b> NVM bank into its runtime,
+        /// and confirms the device accepted the command.
+        /// </summary>
+        /// <inheritdoc cref="LoadAdcCalibrationAsync" path="/remarks" />
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Selects which ADC calibration bank the device applies (<c>0</c> = factory, <c>1</c> = user), and
+        /// confirms the device accepted the command.
+        /// </summary>
+        /// <inheritdoc cref="LoadAdcCalibrationAsync" path="/remarks" />
+        /// <param name="bank">The calibration bank: <c>0</c> = factory, <c>1</c> = user.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="bank"/> is not 0 or 1.</exception>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Persists the device's current voltage precision setting to NVM, and confirms the device accepted the
+        /// command.
+        /// </summary>
+        /// <inheritdoc cref="LoadAdcCalibrationAsync" path="/remarks" />
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Restores the device's voltage precision setting from NVM into its runtime, and confirms the device
+        /// accepted the command.
+        /// </summary>
+        /// <inheritdoc cref="LoadAdcCalibrationAsync" path="/remarks" />
+        /// <param name="cancellationToken">A cancellation token to observe while the exchange runs.</param>
+        /// <returns>A task that completes once the device has confirmed the command.</returns>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceCommandFailedException">Thrown when the device refused the command, or did not confirm it.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Daqifi.Core/Device/IConfirmingDeviceAdministration.cs
+++ b/src/Daqifi.Core/Device/IConfirmingDeviceAdministration.cs
@@ -38,7 +38,10 @@ namespace Daqifi.Core.Device
     /// <para>
     /// Confirmation is not free: it needs text exchanges rather than a single write, so the
     /// <c>void</c> commands remain the right choice while streaming or when a silent no-op is
-    /// acceptable. Nothing here changes what goes on the wire for those.
+    /// acceptable. Nothing here changes what goes on the wire for those. Measured on the bench
+    /// Nyquist (fw 3.7.2, USB CDC), one confirming command costs about <b>3 seconds</b> — a drain
+    /// exchange plus the confirming exchange, each of which pauses the protobuf consumer and holds
+    /// the device's operation lock. Budget for that before putting one in a loop over 16 channels.
     /// </para>
     /// </remarks>
     public interface IConfirmingDeviceAdministration

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -150,6 +150,25 @@ namespace Daqifi.Core.Device
         /// </remarks>
         void Reboot();
 
+        // -----------------------------------------------------------------
+        // ADC calibration and voltage precision.
+        //
+        // Every command in this block exists in two shapes. The void one is
+        // fire-and-forget: it puts the SCPI primitive on the wire and parses no
+        // reply, so a device that refuses the command is indistinguishable from
+        // one that carried it out. That is not hypothetical — a Nyquist running
+        // firmware 3.7.2 answers CONFigure:ADC:LOADcal with -200,"Execution
+        // error" when its user bank was never written, and LoadAdcCalibration()
+        // returns as though the bank had loaded.
+        //
+        // The confirming twin, on IConfirmingDeviceAdministration, sends the same
+        // primitive and then reads the device's SCPI error queue, throwing
+        // DeviceCommandFailedException unless the device confirms it accepted
+        // the command. It costs text exchanges and the device's full attention;
+        // the void one costs a single write and stays usable mid-stream. Pick by
+        // whether a silent no-op is acceptable.
+        // -----------------------------------------------------------------
+
         /// <summary>
         /// Persists the device's current ADC calibration coefficients to the <b>user</b> NVM bank so they survive a reboot.
         /// </summary>
@@ -157,6 +176,8 @@ namespace Daqifi.Core.Device
         /// A thin wrapper over the firmware NVM primitive (<c>CONFigure:ADC:SAVEcal</c>). Pair with
         /// <see cref="LoadAdcCalibration"/> to restore them. Use <see cref="SaveFactoryAdcCalibration"/> to write the
         /// <b>factory</b> bank instead, and <see cref="UseAdcCalibration"/> to choose which bank the device applies.
+        /// Fire-and-forget: a device that refuses this reports nothing — use
+        /// <see cref="IConfirmingDeviceAdministration.SaveAdcCalibrationAsync"/> when that matters.
         /// </remarks>
         void SaveAdcCalibration();
 
@@ -165,6 +186,9 @@ namespace Daqifi.Core.Device
         /// </summary>
         /// <remarks>
         /// The inverse of <see cref="SaveAdcCalibration"/> (firmware primitive <c>CONFigure:ADC:LOADcal</c>).
+        /// Fire-and-forget: on a unit whose user bank was never written the device answers
+        /// <c>-200,"Execution error"</c> and this method still returns normally — use
+        /// <see cref="IConfirmingDeviceAdministration.LoadAdcCalibrationAsync"/> when that matters.
         /// </remarks>
         void LoadAdcCalibration();
 
@@ -176,7 +200,8 @@ namespace Daqifi.Core.Device
         /// <remarks>
         /// <b>RAM only</b> (firmware primitive <c>CONFigure:ADC:chanCALM</c>). The value is lost on reboot unless
         /// persisted with <see cref="SaveAdcCalibration"/> (user bank) or <see cref="SaveFactoryAdcCalibration"/>
-        /// (factory bank).
+        /// (factory bank). Fire-and-forget: a device that refuses this reports nothing — use
+        /// <see cref="IConfirmingDeviceAdministration.SetAdcCalibrationSlopeAsync"/> when that matters.
         /// </remarks>
         void SetAdcCalibrationSlope(int channelNumber, double calM);
 
@@ -188,7 +213,8 @@ namespace Daqifi.Core.Device
         /// <remarks>
         /// <b>RAM only</b> (firmware primitive <c>CONFigure:ADC:chanCALB</c>). The value is lost on reboot unless
         /// persisted with <see cref="SaveAdcCalibration"/> (user bank) or <see cref="SaveFactoryAdcCalibration"/>
-        /// (factory bank).
+        /// (factory bank). Fire-and-forget: a device that refuses this reports nothing — use
+        /// <see cref="IConfirmingDeviceAdministration.SetAdcCalibrationOffsetAsync"/> when that matters.
         /// </remarks>
         void SetAdcCalibrationOffset(int channelNumber, double calB);
 
@@ -198,6 +224,8 @@ namespace Daqifi.Core.Device
         /// <remarks>
         /// Firmware primitive <c>CONFigure:ADC:SAVEFcal</c>. Contrast with <see cref="SaveAdcCalibration"/>, which
         /// writes the user bank. Which bank the device applies is chosen with <see cref="UseAdcCalibration"/>.
+        /// Fire-and-forget: a device that refuses this reports nothing — use
+        /// <see cref="IConfirmingDeviceAdministration.SaveFactoryAdcCalibrationAsync"/> when that matters.
         /// </remarks>
         void SaveFactoryAdcCalibration();
 
@@ -206,6 +234,8 @@ namespace Daqifi.Core.Device
         /// </summary>
         /// <remarks>
         /// The inverse of <see cref="SaveFactoryAdcCalibration"/> (firmware primitive <c>CONFigure:ADC:LOADFcal</c>).
+        /// Fire-and-forget: a device that refuses this reports nothing — use
+        /// <see cref="IConfirmingDeviceAdministration.LoadFactoryAdcCalibrationAsync"/> when that matters.
         /// </remarks>
         void LoadFactoryAdcCalibration();
 
@@ -216,7 +246,8 @@ namespace Daqifi.Core.Device
         /// <remarks>
         /// <b>Persisted</b> (firmware primitive <c>CONFigure:ADC:USECal</c>). The choice is written to NVM, the
         /// runtime coefficients are immediately reloaded from the selected bank, and that bank is loaded on every
-        /// subsequent boot. Values other than 0 or 1 are rejected.
+        /// subsequent boot. Values other than 0 or 1 are rejected. Fire-and-forget: a device that refuses this
+        /// reports nothing — use <see cref="IConfirmingDeviceAdministration.UseAdcCalibrationAsync"/> when that matters.
         /// </remarks>
         void UseAdcCalibration(int bank);
 
@@ -225,7 +256,8 @@ namespace Daqifi.Core.Device
         /// </summary>
         /// <remarks>
         /// A thin wrapper over the firmware NVM primitive (<c>CONFigure:VOLTage:SAVE</c>). Pair with
-        /// <see cref="LoadVoltagePrecision"/> to restore it.
+        /// <see cref="LoadVoltagePrecision"/> to restore it. Fire-and-forget: a device that refuses this
+        /// reports nothing — use <see cref="IConfirmingDeviceAdministration.SaveVoltagePrecisionAsync"/> when that matters.
         /// </remarks>
         void SaveVoltagePrecision();
 
@@ -234,6 +266,8 @@ namespace Daqifi.Core.Device
         /// </summary>
         /// <remarks>
         /// The inverse of <see cref="SaveVoltagePrecision"/> (firmware primitive <c>CONFigure:VOLTage:LOAD</c>).
+        /// Fire-and-forget: a device that refuses this reports nothing — use
+        /// <see cref="IConfirmingDeviceAdministration.LoadVoltagePrecisionAsync"/> when that matters.
         /// </remarks>
         void LoadVoltagePrecision();
     }

--- a/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
@@ -1,5 +1,8 @@
+using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,6 +23,13 @@ namespace Daqifi.Core.Device.Internal
     /// state — the two exceptions being <see cref="Reboot"/>'s local teardown and
     /// <see cref="SetFriendlyNameAsync"/>'s optimistic metadata write, both of which go back through
     /// the host rather than being done here.
+    /// </para>
+    /// <para>
+    /// Each of those commands also has a confirming <c>...Async</c> twin here, which sends the same
+    /// primitive and then reads the device's SCPI error queue so a refusal cannot pass for a success
+    /// (see <see cref="SendConfirmedAsync"/>). The two shapes are kept side by side deliberately: the
+    /// <c>void</c> ones stay usable mid-stream and cost one write, while the confirming ones need
+    /// text exchanges and the device's full attention.
     /// </para>
     /// <para>
     /// Everything reaches the device through <see cref="IDeviceOperationHost"/>, so each command
@@ -104,10 +114,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.SetAdcCalibrationSlope" />
         internal void SetAdcCalibrationSlope(int channelNumber, double calM)
         {
-            if (channelNumber < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
-            }
+            ValidateChannelNumber(channelNumber);
 
             if (!_host.IsConnected)
             {
@@ -120,10 +127,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.SetAdcCalibrationOffset" />
         internal void SetAdcCalibrationOffset(int channelNumber, double calB)
         {
-            if (channelNumber < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
-            }
+            ValidateChannelNumber(channelNumber);
 
             if (!_host.IsConnected)
             {
@@ -158,10 +162,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.UseAdcCalibration" />
         internal void UseAdcCalibration(int bank)
         {
-            if (bank is < 0 or > 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bank), bank, "Calibration bank must be 0 (factory) or 1 (user).");
-            }
+            ValidateBank(bank);
 
             if (!_host.IsConnected)
             {
@@ -191,6 +192,173 @@ namespace Daqifi.Core.Device.Internal
             }
 
             _host.Send(ScpiMessageProducer.LoadVoltagePrecision);
+        }
+
+        #region Confirming variants
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.SaveAdcCalibrationAsync" />
+        internal Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default)
+            => SendConfirmedAsync(ScpiMessageProducer.SaveAdcCalibration, cancellationToken);
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.LoadAdcCalibrationAsync" />
+        internal Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default)
+            => SendConfirmedAsync(ScpiMessageProducer.LoadAdcCalibration, cancellationToken);
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.SetAdcCalibrationSlopeAsync" />
+        internal Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default)
+        {
+            ValidateChannelNumber(channelNumber);
+
+            return SendConfirmedAsync(ScpiMessageProducer.SetAdcCalibrationSlope(channelNumber, calM), cancellationToken);
+        }
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.SetAdcCalibrationOffsetAsync" />
+        internal Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default)
+        {
+            ValidateChannelNumber(channelNumber);
+
+            return SendConfirmedAsync(ScpiMessageProducer.SetAdcCalibrationOffset(channelNumber, calB), cancellationToken);
+        }
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.SaveFactoryAdcCalibrationAsync" />
+        internal Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default)
+            => SendConfirmedAsync(ScpiMessageProducer.SaveFactoryAdcCalibration, cancellationToken);
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.LoadFactoryAdcCalibrationAsync" />
+        internal Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default)
+            => SendConfirmedAsync(ScpiMessageProducer.LoadFactoryAdcCalibration, cancellationToken);
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.UseAdcCalibrationAsync" />
+        internal Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default)
+        {
+            ValidateBank(bank);
+
+            return SendConfirmedAsync(ScpiMessageProducer.UseAdcCalibration(bank), cancellationToken);
+        }
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.SaveVoltagePrecisionAsync" />
+        internal Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default)
+            => SendConfirmedAsync(ScpiMessageProducer.SaveVoltagePrecision, cancellationToken);
+
+        /// <inheritdoc cref="IConfirmingDeviceAdministration.LoadVoltagePrecisionAsync" />
+        internal Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default)
+            => SendConfirmedAsync(ScpiMessageProducer.LoadVoltagePrecision, cancellationToken);
+
+        /// <summary>
+        /// Sends one administration command and reads the device's verdict on it, throwing
+        /// <see cref="DeviceCommandFailedException"/> unless the device confirms it accepted the
+        /// command.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Two steps, and the first is what makes the second mean anything. The device's SCPI error
+        /// queue is FIFO and can already hold entries left by earlier commands or by the connect
+        /// sequence, so a single <c>SYSTem:ERRor?</c> after the command could just as easily pop
+        /// somebody else's failure — the same trap documented on the SD listing's terminator, which
+        /// is why that one is read as a liveness marker and never classified. Draining the queue
+        /// first removes the ambiguity: the entry popped afterwards is this command's own, or the
+        /// queue is clean and the command was accepted.
+        /// </para>
+        /// <para>
+        /// The command and its <c>SYSTem:ERRor?</c> query go out in one text exchange, so no other
+        /// exchange can interleave between them. The drain necessarily runs in exchanges of its own
+        /// beforehand, so a caller driving the same device from another thread can still slip a
+        /// command into that gap; these are administration operations that already assume one caller
+        /// at a time.
+        /// </para>
+        /// <para>
+        /// Side effect worth knowing about: the drain discards whatever the queue held. A caller who
+        /// wants those entries should read them with
+        /// <see cref="DaqifiDevice.DrainErrorQueueAsync"/> before calling this.
+        /// </para>
+        /// </remarks>
+        private async Task SendConfirmedAsync(IOutboundMessage<string> command, CancellationToken cancellationToken)
+        {
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await _host.DrainErrorQueueAsync(ErrorQueueDrainCap, cancellationToken).ConfigureAwait(false);
+
+            var lines = await _host.ExecuteTextCommandAsync(
+                () =>
+                {
+                    _host.Send(command);
+                    _host.Send(ScpiMessageProducer.GetSystemError);
+                },
+                responseTimeoutMs: ConfirmationResponseTimeoutMs,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            ThrowIfNotAccepted(command.Data, lines);
+        }
+
+        /// <summary>
+        /// Reads the device's verdict out of a confirming exchange's response and throws unless it is
+        /// an accepted command.
+        /// </summary>
+        /// <remarks>
+        /// Three outcomes, and only one of them returns. A volunteered <c>**ERROR: ...</c> line is the
+        /// device complaining about the command as it processed it; the <c>SYSTem:ERRor?</c> reply is
+        /// the queue's verdict, authoritative because the drain left the queue empty; and no readable
+        /// reply at all means the command's outcome is simply unknown, which is not a success and must
+        /// not be reported as one.
+        /// </remarks>
+        private static void ThrowIfNotAccepted(string command, IReadOnlyList<string> lines)
+        {
+            var volunteeredError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
+            if (volunteeredError != null)
+            {
+                ScpiResponseClassifier.TryExtractErrorCode(volunteeredError, out var volunteeredCode);
+                throw new DeviceCommandFailedException(command, volunteeredCode, volunteeredError);
+            }
+
+            var reply = lines.LastOrDefault(ScpiResponseClassifier.IsSystemErrorReplyLine)?.Trim();
+            if (reply == null || !ScpiResponseClassifier.TryParseSystemErrorReplyCode(reply, out var code))
+            {
+                throw new DeviceCommandFailedException(command, reply);
+            }
+
+            if (code != 0)
+            {
+                throw new DeviceCommandFailedException(command, code, reply);
+            }
+        }
+
+        /// <summary>
+        /// Cap on the pre-send drain. Far smaller than
+        /// <see cref="DaqifiDevice.DrainErrorQueueAsync"/>'s own default because each iteration is a
+        /// full text exchange and a healthy device converges on the first one; a queue deeper than
+        /// this is a device with bigger problems than the command about to be sent, and the
+        /// confirmation below will say so rather than wait it out.
+        /// </summary>
+        private const int ErrorQueueDrainCap = 16;
+
+        /// <summary>
+        /// Time allowed for the first line of a confirming exchange's response. Generous because the
+        /// commands being confirmed include NVM writes (<c>SAVEcal</c>, <c>SAVEFcal</c>,
+        /// <c>VOLTage:SAVE</c>), which the device does not answer until the write is done.
+        /// </summary>
+        private const int ConfirmationResponseTimeoutMs = 3000;
+
+        #endregion
+
+        private static void ValidateChannelNumber(int channelNumber)
+        {
+            if (channelNumber < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
+            }
+        }
+
+        private static void ValidateBank(int bank)
+        {
+            if (bank is < 0 or > 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bank), bank, "Calibration bank must be 0 (factory) or 1 (user).");
+            }
         }
     }
 }

--- a/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
@@ -309,11 +309,14 @@ namespace Daqifi.Core.Device.Internal
         /// not be reported as one.
         /// </para>
         /// <para>
-        /// A code is only ever reported when one was actually parsed. <c>ERROR</c> lines that carry no
-        /// readable code — a bare <c>ERROR</c>, or <c>ERROR: something non-numeric</c>, both of which
+        /// A code is only ever reported when one was actually parsed <i>and</i> is non-zero, which is
+        /// what makes <see cref="DeviceCommandFailedException.ErrorCode"/> safe to branch on. Two cases
+        /// keep it that way: <c>ERROR</c> lines carrying no readable code — a bare <c>ERROR</c>, or
+        /// <c>ERROR: something non-numeric</c>, both of which
         /// <see cref="ScpiResponseClassifier.IsScpiErrorLine"/> matches — are a refusal whose code is
-        /// unknown, so they take the null-code path. Reporting them as code <c>0</c> would name the one
-        /// value SCPI reserves for "no error".
+        /// unknown, so they take the null-code path rather than being reported under the one value SCPI
+        /// reserves for "no error"; and an <c>ERROR</c>-shaped line that does say <c>0</c> is not
+        /// treated as a refusal at all.
         /// </para>
         /// </remarks>
         private static void ThrowIfNotAccepted(string command, IReadOnlyList<string> lines)
@@ -321,9 +324,21 @@ namespace Daqifi.Core.Device.Internal
             var volunteeredError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
             if (volunteeredError != null)
             {
-                throw ScpiResponseClassifier.TryExtractErrorCode(volunteeredError, out var volunteeredCode)
-                    ? new DeviceCommandFailedException(command, volunteeredCode, volunteeredError)
-                    : new DeviceCommandFailedException(command, volunteeredError);
+                if (!ScpiResponseClassifier.TryExtractErrorCode(volunteeredError, out var volunteeredCode))
+                {
+                    // A refusal whose code cannot be read is still a refusal.
+                    throw new DeviceCommandFailedException(command, volunteeredError);
+                }
+
+                if (volunteeredCode != 0)
+                {
+                    throw new DeviceCommandFailedException(command, volunteeredCode, volunteeredError);
+                }
+
+                // Code 0 is "no error" — a line that says so is not evidence of a refusal, whatever
+                // shape it arrived in. A device that answers the queue read as `**ERROR: 0,"No error"`
+                // rather than the bare form would otherwise be reported as having rejected a command
+                // it accepted. Fall through and let the queue verdict decide.
             }
 
             var reply = lines.LastOrDefault(ScpiResponseClassifier.IsSystemErrorReplyLine)?.Trim();

--- a/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
@@ -290,6 +290,7 @@ namespace Daqifi.Core.Device.Internal
                     _host.Send(ScpiMessageProducer.GetSystemError);
                 },
                 responseTimeoutMs: ConfirmationResponseTimeoutMs,
+                completionTimeoutMs: ConfirmationCompletionTimeoutMs,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             ThrowIfNotAccepted(command.Data, lines);
@@ -300,19 +301,29 @@ namespace Daqifi.Core.Device.Internal
         /// an accepted command.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Three outcomes, and only one of them returns. A volunteered <c>**ERROR: ...</c> line is the
         /// device complaining about the command as it processed it; the <c>SYSTem:ERRor?</c> reply is
         /// the queue's verdict, authoritative because the drain left the queue empty; and no readable
         /// reply at all means the command's outcome is simply unknown, which is not a success and must
         /// not be reported as one.
+        /// </para>
+        /// <para>
+        /// A code is only ever reported when one was actually parsed. <c>ERROR</c> lines that carry no
+        /// readable code — a bare <c>ERROR</c>, or <c>ERROR: something non-numeric</c>, both of which
+        /// <see cref="ScpiResponseClassifier.IsScpiErrorLine"/> matches — are a refusal whose code is
+        /// unknown, so they take the null-code path. Reporting them as code <c>0</c> would name the one
+        /// value SCPI reserves for "no error".
+        /// </para>
         /// </remarks>
         private static void ThrowIfNotAccepted(string command, IReadOnlyList<string> lines)
         {
             var volunteeredError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
             if (volunteeredError != null)
             {
-                ScpiResponseClassifier.TryExtractErrorCode(volunteeredError, out var volunteeredCode);
-                throw new DeviceCommandFailedException(command, volunteeredCode, volunteeredError);
+                throw ScpiResponseClassifier.TryExtractErrorCode(volunteeredError, out var volunteeredCode)
+                    ? new DeviceCommandFailedException(command, volunteeredCode, volunteeredError)
+                    : new DeviceCommandFailedException(command, volunteeredError);
             }
 
             var reply = lines.LastOrDefault(ScpiResponseClassifier.IsSystemErrorReplyLine)?.Trim();
@@ -342,6 +353,31 @@ namespace Daqifi.Core.Device.Internal
         /// <c>VOLTage:SAVE</c>), which the device does not answer until the write is done.
         /// </summary>
         private const int ConfirmationResponseTimeoutMs = 3000;
+
+        /// <summary>
+        /// Inactivity window that ends a confirming exchange, in milliseconds.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Deliberately longer than the 250ms default, and set for the same reason the SD listing
+        /// raises its own (<c>SD_LIST_COMPLETION_TIMEOUT_MS</c>): both exchanges are only complete once
+        /// a trailing <c>SYSTem:ERRor?</c> reply has been seen, and the exchange switches from
+        /// <see cref="ConfirmationResponseTimeoutMs"/> to this window as soon as <i>any</i> line
+        /// arrives. On a device that echoes commands, that first line is the echo, so this window — not
+        /// the response timeout — is what has to cover the gap between the echo and the verdict. With
+        /// the 250ms default, a merely-slow verdict would read as a missing one and fail a command the
+        /// device had accepted.
+        /// </para>
+        /// <para>
+        /// It does not have to cover an NVM write on its own: a device that says nothing until the
+        /// write finishes is still in the first phase, which
+        /// <see cref="ConfirmationResponseTimeoutMs"/> covers. Should a device ever both echo and then
+        /// take longer than this to answer, the result is a spurious "not confirmed" — loud and
+        /// retryable, which is the failure direction this whole surface is built to prefer over a
+        /// silent false success.
+        /// </para>
+        /// </remarks>
+        private const int ConfirmationCompletionTimeoutMs = 1000;
 
         #endregion
 

--- a/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
@@ -321,6 +321,11 @@ namespace Daqifi.Core.Device.Internal
         /// </remarks>
         private static void ThrowIfNotAccepted(string command, IReadOnlyList<string> lines)
         {
+            // An error-shaped line that reports code 0 is not a refusal, but it is still something the
+            // device said. Held onto so that if no bare verdict turns up either, the failure can carry
+            // it rather than claim the device was silent.
+            string? codeZeroLine = null;
+
             var volunteeredError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
             if (volunteeredError != null)
             {
@@ -339,10 +344,21 @@ namespace Daqifi.Core.Device.Internal
                 // shape it arrived in. A device that answers the queue read as `**ERROR: 0,"No error"`
                 // rather than the bare form would otherwise be reported as having rejected a command
                 // it accepted. Fall through and let the queue verdict decide.
+                codeZeroLine = volunteeredError;
             }
 
             var reply = lines.LastOrDefault(ScpiResponseClassifier.IsSystemErrorReplyLine)?.Trim();
-            if (reply == null || !ScpiResponseClassifier.TryParseSystemErrorReplyCode(reply, out var code))
+            if (reply == null)
+            {
+                // Nothing in the bare verdict shape. Report what the device did say, if anything: the
+                // code-0 constructor normalises the code away but keeps the line, which is the whole
+                // point of carrying it this far.
+                throw codeZeroLine != null
+                    ? new DeviceCommandFailedException(command, 0, codeZeroLine)
+                    : new DeviceCommandFailedException(command);
+            }
+
+            if (!ScpiResponseClassifier.TryParseSystemErrorReplyCode(reply, out var code))
             {
                 throw new DeviceCommandFailedException(command, reply);
             }

--- a/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
@@ -407,6 +407,17 @@ namespace Daqifi.Core.Device.Internal
         /// retryable, which is the failure direction this whole surface is built to prefer over a
         /// silent false success.
         /// </para>
+        /// <para>
+        /// <b>Measured on the bench Nyquist (fw 3.7.2, USB CDC):</b> this firmware does <i>not</i> echo
+        /// commands, and every line it has to say arrives within ~20 ms of the first — a refusal's two
+        /// lines land essentially together. So on that path the window is pure trailing latency and
+        /// 250 ms would have sufficed. It is kept at 1000 ms as headroom for the cases the bench could
+        /// not cover: WiFi, whose gaps are the documented reason the SD listing raised its own window,
+        /// and the NVM writers (<c>SAVEcal</c> and friends), which are destructive to a calibrated
+        /// unit and so were never sent. Tightening this is a reasonable future change once one of
+        /// those has evidence behind it — the cost it buys is quantified on
+        /// <see cref="IConfirmingDeviceAdministration"/>.
+        /// </para>
         /// </remarks>
         private const int ConfirmationCompletionTimeoutMs = 1000;
 

--- a/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
+++ b/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
@@ -94,6 +94,15 @@ namespace Daqifi.Core.Device.Internal
             Func<Task>? finalizeAsync = null);
 #pragma warning restore CA1068
 
+        /// <inheritdoc cref="DaqifiDevice.DrainErrorQueueAsync"/>
+        /// <remarks>
+        /// Needed by the confirming administration commands, which drain the queue before they send so
+        /// the entry they pop afterwards is their own command's and not an older one's.
+        /// </remarks>
+        Task<IReadOnlyList<string>> DrainErrorQueueAsync(
+            int maxIterations = 256,
+            CancellationToken cancellationToken = default);
+
         /// <inheritdoc cref="DaqifiDevice.ExecuteRawCaptureAsync"/>
         Task ExecuteRawCaptureAsync(
             Func<Stream, CancellationToken, Task> rawAction,

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -140,6 +140,28 @@ namespace Daqifi.Core.Device
                    && trimmed[trimmed.Length - 1] == '"';
         }
 
+        /// <summary>
+        /// Parses the numeric code out of a <c>SYSTem:ERRor?</c> reply — <c>0</c> from
+        /// <c>0,"No error"</c>, <c>-200</c> from <c>-200,"Execution error"</c>. Pair it with
+        /// <see cref="IsSystemErrorReplyLine"/>, which decides whether a line is such a reply at all;
+        /// this only reads the code out of one that is.
+        /// </summary>
+        /// <remarks>
+        /// Distinct from <see cref="TryExtractErrorCode"/>, which parses the <c>**ERROR: -200,...</c>
+        /// form the device volunteers alongside a command's output: that one requires the <c>ERROR</c>
+        /// token, and the error-queue reply carries the bare code.
+        /// </remarks>
+        /// <param name="line">The candidate <c>SYSTem:ERRor?</c> reply line.</param>
+        /// <param name="code">The parsed code when the method returns <c>true</c>; otherwise 0.</param>
+        /// <returns><c>true</c> if a numeric code was read; otherwise <c>false</c>.</returns>
+        internal static bool TryParseSystemErrorReplyCode(string line, out int code)
+        {
+            var trimmed = line.Trim();
+            var commaIndex = trimmed.IndexOf(',');
+            var codeSpan = (commaIndex >= 0 ? trimmed[..commaIndex] : trimmed).Trim();
+            return int.TryParse(codeSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out code);
+        }
+
         private static int SkipSpaces(string value, int index)
         {
             while (index < value.Length && (value[index] == ' ' || value[index] == '\t'))


### PR DESCRIPTION
## What

The ADC-calibration and voltage-precision commands on `IStreamingDevice` are fire-and-forget: they send a SCPI primitive and parse no reply. A device that refuses the command is indistinguishable from one that carried it out.

This adds `IConfirmingDeviceAdministration` — a confirming `...Async` twin for each of the nine commands that sends the same primitive and then reads the device's SCPI error queue, throwing `DeviceCommandFailedException` unless the device confirms it accepted the command.

## Why

Bench evidence on a real Nyquist running fw 3.7.2 ([posted on #344](https://github.com/daqifi/daqifi-core/issues/344#issuecomment-5200780816)): on a unit whose user calibration bank was never written, `CONFigure:ADC:LOADcal` answers `-200,"Execution error"` — and `LoadAdcCalibration()` returns normally.

A control run sending the identical raw primitive produced the same `-200` byte for byte, so the firmware is behaving as designed and Core's delegation is faithful. What was missing was any way for the caller to find out: "load the user calibration bank" was a silent no-op that reported success.

## Design decisions

**Throwing, not a result object.** A result a caller can ignore reintroduces the original bug in a subtler form. `DeviceCommandFailedException` carries `Command`, `ErrorCode` and `DeviceResponse`, so a caller who wants to branch on the refusal can catch and read the device's own code.

**A null `ErrorCode` means "unknown", not "fine".** If no readable verdict comes back the command may or may not have been applied. That is not a success, so it also throws — but with a null code, because a refusal will be refused again while an unanswered query usually means the link needs attention first.

**The queue is drained before the command is sent.** The device's error queue is FIFO and can already hold entries from earlier commands or the connect sequence, so a single `SYSTem:ERRor?` afterwards could pop somebody else's failure. This is the same trap already documented on the SD listing's terminator, which is why that one is read as a liveness marker and never classified. Draining first is what makes the verdict attributable. Side effect, documented on the API: the drain discards what the queue held, so a caller who wants those entries should read them with `DrainErrorQueueAsync` first.

**Additive throughout.** The `void` commands are untouched, on the wire and in signature. The confirming ones live on a separate interface rather than as new `IStreamingDevice` members so existing implementers keep compiling — adding them to `IStreamingDevice` broke every test fake that implements it, which is a fair preview of what it would do downstream. This follows the capability-slice shape the device already uses (`INetworkConfigurable`, `ISdCardOperations`, `ILanChipInfoProvider`, `IDeviceDiagnostics`):

```csharp
if (device is IConfirmingDeviceAdministration admin)
{
    await admin.LoadAdcCalibrationAsync(cancellationToken);
}
```

Confirmation costs text exchanges rather than a single write, so the `void` commands remain the right choice mid-stream or when a silent no-op is acceptable. Their docs now state the silence explicitly and point at the twin.

## Tests

- Confirming path per operation: drain → command + `SYSTem:ERRor?` in one exchange, asserted **in order** (the drain happening before the exchange is the point, not just that it happens).
- The headline case: `-200,"Execution error"` surfaces as `DeviceCommandFailedException` with `ErrorCode == -200` and the device's own line.
- Volunteered `**ERROR: ...` lines, unreadable verdicts (empty response, no queue reply), extra output ahead of a clean verdict.
- Guards: disconnected and pre-cancelled both throw having touched nothing — not even the drain.
- Argument validation throws before any device contact, `ParamName` preserved.
- `TryParseSystemErrorReplyCode` in `ScpiResponseClassifier`, including the overflow and wrong-form cases.
- The nine new entry points added to the existing `DeviceNotConnectedExceptionTests` guard theory.

Full suite green on **net9.0 and net10.0** (2765 passed each). Five `FirmwareUpdateServiceTests.UpdateWifiModuleAsync_*` tests fail, but they fail identically on a clean checkout of `origin/main` at 7965b26 — verified in a separate worktree. Pre-existing and unrelated to this change.

Not bench-tested: the confirming path has no hardware evidence yet. The behavior it reacts to does — that is what motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)