### PR TITLE
test(firmware): reconcile the WiFi update SCPI sequence expectations (part of #269)

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1673,8 +1673,8 @@ public class FirmwareUpdateServiceTests
         // Pins that the settle genuinely sits BETWEEN the transparent-mode exit and the LAN
         // restore, not before the exit or after the whole recovery block: cancellation is raised
         // from inside the transparent-mode Send, so only a wait positioned between the two can
-        // stop LAN:ENAbled/APPLY/SAVE from going out. Also proves the wait observes the caller's
-        // token rather than sleeping through a cancel.
+        // stop the LAN:ENAbled/SAVE restore from going out. Also proves the wait observes the
+        // caller's token rather than sleeping through a cancel.
         using var cts = new CancellationTokenSource();
         var device = new FakeStreamingDevice("COM33");
         device.OnCommandSent = command =>
@@ -1725,11 +1725,18 @@ public class FirmwareUpdateServiceTests
             Directory.Delete(firmwareDir, recursive: true);
         }
 
+        // The restore is what the settle holds back, and the restore is LAN:ENAbled + LAN:SAVE —
+        // neither appears. The trailing pair is not the restore resuming: it is the failure
+        // recovery, which the cancel itself arms and which walks the device out of bridge mode
+        // with its own transparent-mode exit and a LAN:APPLY kick. It deliberately persists
+        // nothing, so a canceled flash still cannot write a network configuration.
         Assert.Equal(
             [
                 "SYSTem:POWer:STATe 1",
                 "SYSTem:COMMUnicate:LAN:FWUpdate",
-                "SYSTem:USB:SetTransparentMode 0"
+                "SYSTem:USB:SetTransparentMode 0",
+                "SYSTem:USB:SetTransparentMode 0",
+                "SYSTem:COMMunicate:LAN:APPLY"
             ],
             device.SentCommands);
     }
@@ -2086,8 +2093,11 @@ public class FirmwareUpdateServiceTests
             // twin: hand the port back to the SCPI console, then kick the WiFi manager out of its
             // bridge-mode state machine. Deliberately no LAN:ENAbled/SAVE — persisting a network
             // configuration off the back of a flash that did not complete is not this step's job.
+            // The leading power-on is prep's, not the recovery's: LAN commands are rejected while
+            // the WINC is unpowered, so LAN:FWUpdate has to be preceded by it.
             Assert.Equal(
                 [
+                    "SYSTem:POWer:STATe 1",
                     "SYSTem:COMMUnicate:LAN:FWUpdate",
                     "SYSTem:USB:SetTransparentMode 0",
                     "SYSTem:COMMunicate:LAN:APPLY"
@@ -2142,6 +2152,7 @@ public class FirmwareUpdateServiceTests
 
             Assert.Equal(
                 [
+                    "SYSTem:POWer:STATe 1",
                     "SYSTem:COMMUnicate:LAN:FWUpdate",
                     "SYSTem:USB:SetTransparentMode 0",
                     "SYSTem:COMMunicate:LAN:APPLY"
@@ -2198,6 +2209,7 @@ public class FirmwareUpdateServiceTests
 
             Assert.Equal(
                 [
+                    "SYSTem:POWer:STATe 1",
                     "SYSTem:COMMUnicate:LAN:FWUpdate",
                     "SYSTem:USB:SetTransparentMode 0",
                     "SYSTem:COMMunicate:LAN:APPLY"
@@ -2260,7 +2272,14 @@ public class FirmwareUpdateServiceTests
             // The flash failure, not the recovery's timeout, is what the caller sees.
             Assert.Equal(FirmwareUpdateState.Programming, exception.FailedState);
 
-            Assert.Equal(["SYSTem:COMMUnicate:LAN:FWUpdate"], device.SentCommands);
+            // Prep's power-on and LAN:FWUpdate, and nothing after them: the recovery gave up in the
+            // reconnect wait, so neither half of the bridge exit was sent down a dead transport.
+            Assert.Equal(
+                [
+                    "SYSTem:POWer:STATe 1",
+                    "SYSTem:COMMUnicate:LAN:FWUpdate"
+                ],
+                device.SentCommands);
             Assert.True(device.ConnectAttempts >= 1);
         }
         finally

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -1673,8 +1673,8 @@ public class FirmwareUpdateServiceTests
         // Pins that the settle genuinely sits BETWEEN the transparent-mode exit and the LAN
         // restore, not before the exit or after the whole recovery block: cancellation is raised
         // from inside the transparent-mode Send, so only a wait positioned between the two can
-        // stop the LAN:ENAbled/SAVE restore from going out. Also proves the wait observes the
-        // caller's token rather than sleeping through a cancel.
+        // stop LAN:ENAbled/APPLY/SAVE from going out. Also proves the wait observes the caller's
+        // token rather than sleeping through a cancel.
         using var cts = new CancellationTokenSource();
         var device = new FakeStreamingDevice("COM33");
         device.OnCommandSent = command =>
@@ -1725,11 +1725,12 @@ public class FirmwareUpdateServiceTests
             Directory.Delete(firmwareDir, recursive: true);
         }
 
-        // The restore is what the settle holds back, and the restore is LAN:ENAbled + LAN:SAVE —
-        // neither appears. The trailing pair is not the restore resuming: it is the failure
-        // recovery, which the cancel itself arms and which walks the device out of bridge mode
-        // with its own transparent-mode exit and a LAN:APPLY kick. It deliberately persists
-        // nothing, so a canceled flash still cannot write a network configuration.
+        // The restore is LAN:ENAbled -> APPLY -> SAVE, and the settle holds back all three: not one
+        // of them is here. The APPLY below is a different command with a different job — the
+        // failure recovery's bridge-exit kick, which the cancel itself arms. Two things tell it
+        // apart from a restore that leaked half way out: it re-sends the transparent-mode exit
+        // ahead of itself, and it is never accompanied by ENAbled or SAVE. It persists nothing,
+        // so a canceled flash still cannot write a network configuration.
         Assert.Equal(
             [
                 "SYSTem:POWer:STATe 1",


### PR DESCRIPTION
## Problem

Five `FirmwareUpdateServiceTests` fail on a clean checkout of `main` (7965b26), on both `net9.0` and `net10.0`:

- `UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresAfterReconnect_StillFinishesTheBridgeExit`
- `UpdateWifiModuleAsync_WhenCanceledAfterEnteringUpdateMode_StillTakesDeviceBackOut`
- `UpdateWifiModuleAsync_WhenFlashToolFails_TakesDeviceBackOutOfLanUpdateMode`
- `UpdateWifiModuleAsync_WhenCanceledDuringTransparentModeExitSettle_LeavesLanRestoreUnsent`
- `UpdateWifiModuleAsync_WhenRecoveryBudgetExpiresWaitingForReconnect_SendsNoBridgeExit`

## Bisect

| Tree | Result |
|---|---|
| #445 branch head (`1967c2ee`) | Passed — 108/108 |
| #444 branch head (`06bcf8ae`) | Passed — 111/111 |
| `da35eff` — #445 merged | Passed — 108/108 |
| `7965b26` — #444 merged | **Failed — 5/116** |

Both PRs branched from the same base (`4b8eed2`) and were green there. They touched different regions of `WifiModuleUpdater.cs`, so git merged them with no textual conflict — but each changed the SCPI traffic the other's tests assert on. `7965b26` is the commit that broke it only because it merged second.

## Which side is wrong

The test expectations, on both sides. Neither production behavior is changed here.

**#444 → breaks #445's four recovery tests.** Prep now powers the WINC on before `LAN:FWUpdate`, because LAN commands are rejected (`-200`) while the module is unpowered, so the mode command would silently not take. That prepends `SYSTem:POWer:STATe 1` to every sequence those four tests pin. The behavior is deliberate, hardware-backed, and separately covered by #444's own toggle tests (`PowerOnWifiModuleBeforeLanUpdateMode` on/off) and by the success-path sequence assertion, all of which still pass.

**#445 → breaks #444's settle-placement test.** A failed *or canceled* flash now walks the device back out of bridge mode, so the cancel path gains a second transparent-mode exit and a `LAN:APPLY` kick. That is the entire point of #445 — a canceled flash mid-bridge is the most likely way to strand the module — and the recovery deliberately omits `LAN:ENAbled`/`LAN:SAVE` so it cannot persist a configuration off a flash that did not complete. The redundant `SetTransparentMode 0` is a documented no-op; the `LAN:APPLY` is genuinely needed, because at the cancel point the console has been handed back but the WiFi manager has not been kicked out of its bridge-mode state machine — the one state worse than either end of the sequence.

`UpdateWifiModuleAsync_WhenCanceledDuringTransparentModeExitSettle_LeavesLanRestoreUnsent` still proves what its name and comment claim: the restore is `LAN:ENAbled` + `LAN:SAVE`, and neither is sent. Only the trailing recovery pair is new, and the comment now says so.

## Verification

Full solution, both TFMs:

- `Daqifi.Core.Tests` — 2703 passed, 0 failed, 2 skipped (net9.0 and net10.0)
- `Daqifi.Mcp.Tests` — 23 passed, 0 failed
- 0 build warnings

Tests only; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)