### PR TITLE
fix(consumers): stop routing the binary status frame to the text parser (part of #268)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/CompositeMessageParserBenchCaptureTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/CompositeMessageParserBenchCaptureTests.cs
@@ -1,0 +1,344 @@
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Messages;
+using Google.Protobuf;
+using System.Text;
+
+namespace Daqifi.Core.Tests.Communication.Consumers;
+
+/// <summary>
+/// Routing tests built from fixtures shaped like raw bytes captured off an Nq1 running
+/// firmware 3.7.2 over USB CDC (issue #268). Each fixture reproduces the byte statistics
+/// the real capture had — printable-ASCII ratio, null-byte ratio, frame sizes and framing
+/// — because those statistics are exactly what <see cref="CompositeMessageParser"/>
+/// classifies on. The shape assertions below are part of the test: if a fixture drifts
+/// away from the measured capture it stops standing in for the hardware and the routing
+/// assertion beneath it stops meaning anything.
+/// </summary>
+public class CompositeMessageParserBenchCaptureTests
+{
+    private static double PrintableRatio(byte[] data) =>
+        data.Count(b => b >= 32 && b <= 126) / (double)data.Length;
+
+    private static double NullRatio(byte[] data) =>
+        data.Count(b => b == 0) / (double)data.Length;
+
+    private static byte[] Delimited(DaqifiOutMessage message)
+    {
+        using var stream = new MemoryStream();
+        message.WriteDelimitedTo(stream);
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// A SYSTem:SYSInfoPB? reply: device identity, network configuration and per-channel
+    /// calibration. Sized and populated so the delimited frame matches the capture — a
+    /// two-byte "C8 04" varint prefix plus a 584-byte body — and lands on the capture's
+    /// byte statistics (24.0% printable, 40.5% null).
+    /// </summary>
+    private static DaqifiOutMessage BuildStatusMessage()
+    {
+        var status = new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceHwRev = "1.0",
+            DeviceFwRev = "3.7.2",
+            DeviceSn = 1234567,
+            DevicePort = 9760,
+            MacAddr = ByteString.CopyFrom(new byte[] { 0x00, 0x1E, 0xC0, 0x11, 0x22, 0x33 }),
+            IpAddr = ByteString.CopyFrom(new byte[] { 192, 168, 1, 42 }),
+            NetMask = ByteString.CopyFrom(new byte[] { 255, 255, 255, 0 }),
+            Gateway = ByteString.CopyFrom(new byte[] { 192, 168, 1, 1 }),
+            HostName = "DAQiFi",
+            Ssid = "bench-n",
+            SsidStrength = 72,
+            WifiSecurityMode = 3,
+            WifiInfMode = 1,
+            TimestampFreq = 50000,
+            AnalogInPortNum = 16,
+            AnalogInPortNumPriv = 2,
+            AnalogInPortType = ByteString.CopyFrom(new byte[] { 0x00, 0x00 }),
+            AnalogInPortRse = ByteString.CopyFrom(new byte[] { 0xFF, 0xFF }),
+            AnalogInPortEnabled = ByteString.CopyFrom(new byte[] { 0x01, 0x00 }),
+            AnalogInRes = 16,
+            AnalogInResPriv = 12,
+            DigitalPortNum = 16,
+            DigitalPortType = ByteString.CopyFrom(new byte[] { 0x00, 0x00 }),
+            DigitalPortDir = ByteString.CopyFrom(new byte[] { 0x00, 0x00 }),
+            AnalogOutPortNum = 0,
+            AnalogOutRes = 12,
+            IpAddrV6 = ByteString.CopyFrom(new byte[] { 0xFE, 0x80, 0, 0, 0, 0, 0, 0, 0x02, 0x1E, 0xC0, 0xFF, 0xFE, 0x11, 0x22, 0x33 }),
+            GatewayV6 = ByteString.CopyFrom(new byte[] { 0xFE, 0x80, 0, 0, 0, 0, 0, 0, 0x02, 0x1E, 0xC0, 0xFF, 0xFE, 0x11, 0x22, 0x01 }),
+            PrimaryDnsV6 = ByteString.CopyFrom(new byte[] { 0xFE, 0x80, 0, 0, 0, 0, 0, 0, 0x02, 0x1E, 0xC0, 0xFF, 0xFE, 0x11, 0x22, 0x02 }),
+            SecondaryDnsV6 = ByteString.CopyFrom(new byte[] { 0xFE, 0x80, 0, 0, 0, 0, 0, 0, 0x02, 0x1E, 0xC0, 0xFF, 0xFE, 0x11, 0x22, 0x03 }),
+            Eui64 = ByteString.CopyFrom(new byte[] { 0x02, 0x1E, 0xC0, 0xFF, 0xFE, 0x11, 0x22, 0x33 }),
+            SubPreLengthV6 = ByteString.CopyFrom(new byte[] { 64 }),
+            PwrStatus = 3,
+            BattStatus = 92,
+            TempStatus = 31,
+            DeviceStatus = 1,
+        };
+
+        for (var channel = 0; channel < 16; channel++)
+        {
+            status.AnalogInCalM.Add(1.0f);
+            status.AnalogInCalB.Add(0.0f);
+            status.AnalogInIntScaleM.Add(10.0f);
+            status.AnalogInPortAvRange.Add(10.0f);
+        }
+
+        // Private-channel calibration. The counts are what bring the encoded body to the
+        // captured 584 bytes at the captured printable/null mix.
+        for (var i = 0; i < 4; i++)
+        {
+            status.AnalogInPortAvRangePriv.Add(0.0f);
+        }
+
+        for (var i = 0; i < 15; i++)
+        {
+            status.AnalogInCalMPriv.Add(1.0f);
+        }
+
+        return status;
+    }
+
+    /// <summary>
+    /// The status reply exactly as it comes off the wire: the length-delimited protobuf
+    /// frame followed by the ASCII CRLF the device appends to its binary reply.
+    /// </summary>
+    private static byte[] BuildStatusReplyCapture() =>
+        Delimited(BuildStatusMessage()).Concat(Encoding.ASCII.GetBytes("\r\n")).ToArray();
+
+    /// <summary>
+    /// A stream of one analog channel at 10 Hz: 10-byte frames whose every byte is either
+    /// a varint continuation byte or a small value, so the buffer contains no null bytes
+    /// and no printable ASCII whatsoever.
+    /// </summary>
+    private static byte[] BuildSingleChannelStreamCapture()
+    {
+        var capture = new List<byte>();
+        for (uint sample = 0; sample < 15; sample++)
+        {
+            var frame = new DaqifiOutMessage { MsgTimeStamp = 100_000u + sample * 5_000u };
+            frame.AnalogInData.Add(20_000 + (int)sample * 37);
+            capture.AddRange(Delimited(frame));
+        }
+
+        return capture.ToArray();
+    }
+
+    /// <summary>
+    /// A stream of four analog channels at 100 Hz over ~3 s: 11-byte frames in which
+    /// channels resting near zero encode as null bytes, giving the capture's 16.6% null
+    /// and 8.3% printable mix.
+    /// </summary>
+    private static byte[] BuildFourChannelStreamCapture()
+    {
+        var capture = new List<byte>();
+        for (uint sample = 0; sample < 260; sample++)
+        {
+            var frame = new DaqifiOutMessage { MsgTimeStamp = 600_000u + sample * 500u };
+            frame.AnalogInData.Add(0);
+            frame.AnalogInData.Add(1 + (int)(sample % 3));
+            frame.AnalogInData.Add(sample % 6 == 0 ? 2 : 0);
+            frame.AnalogInData.Add(-1 - (int)(sample % 2));
+            capture.AddRange(Delimited(frame));
+        }
+
+        return capture.ToArray();
+    }
+
+    [Fact]
+    public void StatusReplyCapture_MatchesTheShapeMeasuredOnHardware()
+    {
+        var capture = BuildStatusReplyCapture();
+
+        // 2-byte varint prefix + 584-byte body + CRLF, as captured.
+        Assert.Equal(588, capture.Length);
+        Assert.Equal(new byte[] { 0xC8, 0x04 }, capture.Take(2));
+        Assert.Equal(new byte[] { 0x0D, 0x0A }, capture.Skip(586));
+
+        // The trailing CRLF sits on a buffer that is overwhelmingly binary: this is the
+        // exact combination the old line-ending heuristic read as text.
+        Assert.InRange(PrintableRatio(capture), 0.20, 0.28);
+        Assert.InRange(NullRatio(capture), 0.36, 0.45);
+    }
+
+    [Fact]
+    public void StatusReplyCapture_TerminatedWithCrlf_RoutesToProtobuf()
+    {
+        // Regression for issue #268 finding 2. The device terminates its *binary*
+        // SYSTem:SYSInfoPB? reply with an ASCII CRLF. The classifier used to accept any
+        // buffer ending in a line ending as text, so LineBasedMessageParser consumed all
+        // 588 bytes as a single garbage "line" and the protobuf frame was destroyed.
+
+        // Arrange
+        var parser = new CompositeMessageParser();
+        var capture = BuildStatusReplyCapture();
+
+        // Act
+        var messages = parser.ParseMessages(capture, out var consumedBytes).ToList();
+
+        // Assert
+        var message = Assert.IsType<DaqifiOutMessage>(Assert.Single(messages).Data);
+        Assert.Equal("Nq1", message.DevicePn);
+        Assert.Equal(1234567UL, message.DeviceSn);
+        Assert.Equal(16u, message.AnalogInPortNum);
+
+        // The frame is consumed; the trailing CRLF is left for the next read.
+        Assert.Equal(586, consumedBytes);
+    }
+
+    [Fact]
+    public void SingleChannelStreamCapture_HasNeitherNullNorPrintableBytes()
+    {
+        var capture = BuildSingleChannelStreamCapture();
+
+        Assert.Equal(150, capture.Length);
+        Assert.Equal(0.0, PrintableRatio(capture));
+        Assert.Equal(0.0, NullRatio(capture));
+    }
+
+    [Fact]
+    public void SingleChannelStreamCapture_WhereEveryRatioHeuristicAbstains_RoutesToProtobuf()
+    {
+        // One analog channel at 10 Hz produces frames with 0% null bytes and 0% printable
+        // ASCII, so the printable-ratio and null-ratio heuristics both abstain and the
+        // buffer classifies Uncertain. Uncertain must fall to protobuf first: a buffer
+        // that failed the printable test is not plausibly SCPI text, and handing it to
+        // the line parser risks losing frames to a stray CRLF-shaped byte pair.
+
+        // Arrange
+        var parser = new CompositeMessageParser();
+        var capture = BuildSingleChannelStreamCapture();
+
+        // Act
+        var messages = parser.ParseMessages(capture, out var consumedBytes).ToList();
+
+        // Assert
+        Assert.Equal(15, messages.Count);
+        Assert.All(messages, m => Assert.IsType<DaqifiOutMessage>(m.Data));
+        Assert.Equal(capture.Length, consumedBytes);
+
+        var timestamps = messages.Select(m => ((DaqifiOutMessage)m.Data).MsgTimeStamp).ToList();
+        Assert.Equal(100_000u, timestamps[0]);
+        Assert.Equal(timestamps.OrderBy(t => t), timestamps);
+    }
+
+    [Fact]
+    public void FourChannelStreamCapture_MatchesTheShapeMeasuredOnHardware()
+    {
+        var capture = BuildFourChannelStreamCapture();
+
+        Assert.Equal(11 * 260, capture.Length);
+        Assert.InRange(PrintableRatio(capture), 0.06, 0.11);
+        Assert.InRange(NullRatio(capture), 0.14, 0.19);
+    }
+
+    [Fact]
+    public void FourChannelStreamCapture_RoutesToProtobuf()
+    {
+        // Arrange
+        var parser = new CompositeMessageParser();
+        var capture = BuildFourChannelStreamCapture();
+
+        // Act
+        var messages = parser.ParseMessages(capture, out var consumedBytes).ToList();
+
+        // Assert
+        Assert.Equal(260, messages.Count);
+        Assert.All(messages, m => Assert.IsType<DaqifiOutMessage>(m.Data));
+        Assert.Equal(capture.Length, consumedBytes);
+        Assert.All(messages, m => Assert.Equal(4, ((DaqifiOutMessage)m.Data).AnalogInData.Count));
+    }
+
+    [Fact]
+    public void MultiLineScpiReply_RoutesToText()
+    {
+        // The SYSTem:INFO? style reply captured alongside the binary frames. Several
+        // CRLF-terminated key=value lines, each of which must arrive as its own string.
+
+        // Arrange
+        var parser = new CompositeMessageParser();
+        var capture = Encoding.ASCII.GetBytes(
+            "HeapTotal=75000\r\nHeapFree=7544\r\nStackTotal=8192\r\nStackFree=6120\r\n");
+
+        // Act
+        var messages = parser.ParseMessages(capture, out var consumedBytes).ToList();
+
+        // Assert
+        Assert.Equal(4, messages.Count);
+        Assert.All(messages, m => Assert.IsType<string>(m.Data));
+        Assert.Equal(
+            new[] { "HeapTotal=75000", "HeapFree=7544", "StackTotal=8192", "StackFree=6120" },
+            messages.Select(m => (string)m.Data));
+        Assert.Equal(capture.Length, consumedBytes);
+    }
+
+    [Fact]
+    public void ScpiErrorReply_RoutesToText()
+    {
+        // The negative control from the bench pass: SYSTem:NOTAREALCOMMAND? answered with
+        // an error line. The leading '*' is also the SCPI marker the classifier looks for.
+
+        // Arrange
+        var parser = new CompositeMessageParser();
+        var capture = Encoding.ASCII.GetBytes("**ERROR: -113, \"Undefined header\"\r\n");
+
+        // Act
+        var messages = parser.ParseMessages(capture, out var consumedBytes).ToList();
+
+        // Assert
+        var message = Assert.IsType<string>(Assert.Single(messages).Data);
+        Assert.Equal("**ERROR: -113, \"Undefined header\"", message);
+        Assert.Equal(capture.Length, consumedBytes);
+    }
+
+    [Theory]
+    [InlineData("0\r\n", "0")]                       // SYSTem:STReam:FORmat?
+    [InlineData("1\r\n", "1")]                       // SYSTem:STReam:INTerface?
+    [InlineData("7544\r\n", "7544")]                 // HeapFree
+    [InlineData("16\r\n", "16")]
+    [InlineData("0,\"No error\"\r\n", "0,\"No error\"")] // drained error queue
+    public void ShortScpiReply_RoutesToText(string reply, string expected)
+    {
+        // A short reply is mostly line ending by raw byte count — "0\r\n" is 33% printable
+        // — so scoring the line ending against printability drops these below the text
+        // threshold and hands them to the protobuf parser first, where a chance parse
+        // would consume the reply and destroy it. Line endings are framing, not content:
+        // by content these replies are 100% printable and must classify as text outright.
+
+        // Arrange
+        var parser = new CompositeMessageParser();
+        var capture = Encoding.ASCII.GetBytes(reply);
+
+        // Act
+        var messages = parser.ParseMessages(capture, out var consumedBytes).ToList();
+
+        // Assert
+        Assert.Equal(expected, Assert.IsType<string>(Assert.Single(messages).Data));
+        Assert.Equal(capture.Length, consumedBytes);
+    }
+
+    [Fact]
+    public void EchoedCommandAheadOfStatusFrame_RoutesToProtobuf()
+    {
+        // With echo on, the device puts the ASCII command in front of its binary reply and
+        // a "DAQIFI>" prompt behind it. The buffer then both starts with "SYST" and ends
+        // with a text-shaped tail while still being ~40% null bytes — the leading SCPI
+        // marker must not outrank that null density.
+
+        // Arrange
+        var parser = new CompositeMessageParser();
+        var capture = Encoding.ASCII.GetBytes("SYSTem:SYSInfoPB?\r\n")
+            .Concat(Delimited(BuildStatusMessage()))
+            .Concat(Encoding.ASCII.GetBytes("\r\nDAQIFI>"))
+            .ToArray();
+
+        // Act
+        var messages = parser.ParseMessages(capture, out _).ToList();
+
+        // Assert
+        var message = Assert.IsType<DaqifiOutMessage>(Assert.Single(messages).Data);
+        Assert.Equal("Nq1", message.DevicePn);
+    }
+}

--- a/src/Daqifi.Core/Communication/Consumers/CompositeMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/CompositeMessageParser.cs
@@ -6,6 +6,18 @@ namespace Daqifi.Core.Communication.Consumers;
 /// A composite message parser that attempts to parse messages using multiple parsers.
 /// This allows handling different message formats (text-based SCPI and binary protobuf) in the same stream.
 /// </summary>
+/// <remarks>
+/// Classification is content-based and therefore approximate: it weighs how much of a
+/// buffer is printable ASCII against how much of it is null bytes, and only consults
+/// surface features such as a leading SCPI marker once those ratios have abstained. A
+/// line ending is framing rather than content and is excluded from the printable ratio,
+/// so it neither argues for text nor against it. Buffers that satisfy neither ratio —
+/// real single-channel low-rate streaming frames contain no null bytes and no printable
+/// ASCII at all — are handed to the protobuf parser first and fall back to the text
+/// parser if it finds nothing. Code that already knows which format a link carries should
+/// use <see cref="LineBasedMessageParser"/> or <see cref="ProtobufMessageParser"/>
+/// directly rather than paying for the guess.
+/// </remarks>
 public class CompositeMessageParser : IMessageParser<object>
 {
     private readonly IMessageParser<string> _textParser;
@@ -42,65 +54,63 @@ public class CompositeMessageParser : IMessageParser<object>
         // Use improved heuristics to detect message type
         var messageTypeHint = DetectMessageType(data);
 
-        if (messageTypeHint == MessageTypeHint.LikelyProtobuf)
-        {
-            // Try protobuf parser first
-            var protobufMessages = _protobufParser.ParseMessages(data, out int protobufConsumed);
-            if (protobufMessages.Any())
-            {
-                foreach (var msg in protobufMessages)
-                {
-                    messages.Add(new ObjectInboundMessage(msg.Data));
-                }
-                consumedBytes = protobufConsumed;
-                return messages;
-            }
-        }
-
+        // Whichever parser the heuristics favour runs first; the other is the fallback
+        // for when that parser finds nothing. Routing the wrong way is not merely slow:
+        // LineBasedMessageParser will happily swallow an entire binary frame as one
+        // "line" and report it consumed, destroying the frame for good.
+        //
+        // Uncertain buffers try protobuf first. Uncertain means the buffer failed the
+        // printable-ratio test, so it is not plausibly SCPI text — and some real
+        // streaming shapes leave every ratio heuristic abstaining: a single analog
+        // channel at 10 Hz produces 10-byte frames containing neither a null byte nor
+        // a printable ASCII byte (measured on an Nq1 running fw 3.7.2, issue #268).
         if (messageTypeHint == MessageTypeHint.LikelyText)
         {
-            // Try text parser first
-            var textMessages = _textParser.ParseMessages(data, out int textConsumed);
-            if (textMessages.Any())
-            {
-                foreach (var msg in textMessages)
-                {
-                    messages.Add(new ObjectInboundMessage(msg.Data));
-                }
-                consumedBytes = textConsumed;
+            if (TryParse(_textParser, data, messages, ref consumedBytes))
                 return messages;
-            }
-        }
 
-        // If heuristics are uncertain or first attempt failed, try the other parser
-        if (messageTypeHint != MessageTypeHint.LikelyText)
+            TryParse(_protobufParser, data, messages, ref consumedBytes);
+        }
+        else
         {
-            var textMessages = _textParser.ParseMessages(data, out int textConsumed);
-            if (textMessages.Any())
-            {
-                foreach (var msg in textMessages)
-                {
-                    messages.Add(new ObjectInboundMessage(msg.Data));
-                }
-                consumedBytes = textConsumed;
+            if (TryParse(_protobufParser, data, messages, ref consumedBytes))
                 return messages;
-            }
-        }
 
-        if (messageTypeHint != MessageTypeHint.LikelyProtobuf)
-        {
-            var protobufMessages = _protobufParser.ParseMessages(data, out int protobufConsumed);
-            if (protobufMessages.Any())
-            {
-                foreach (var msg in protobufMessages)
-                {
-                    messages.Add(new ObjectInboundMessage(msg.Data));
-                }
-                consumedBytes = protobufConsumed;
-            }
+            TryParse(_textParser, data, messages, ref consumedBytes);
         }
 
         return messages;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="parser"/> over <paramref name="data"/> and appends whatever it
+    /// produced to <paramref name="messages"/>, reporting whether anything was parsed.
+    /// <paramref name="consumedBytes"/> is only updated when the parser produced at least
+    /// one message, so a parser that consumed bytes while finding nothing (the protobuf
+    /// parser resyncing over garbage, for instance) never hides those bytes from the
+    /// fallback parser.
+    /// </summary>
+    private static bool TryParse<T>(
+        IMessageParser<T> parser,
+        byte[] data,
+        List<IInboundMessage<object>> messages,
+        ref int consumedBytes)
+    {
+        var parsed = parser.ParseMessages(data, out var parserConsumed);
+
+        var parsedAny = false;
+        foreach (var msg in parsed)
+        {
+            messages.Add(new ObjectInboundMessage(msg.Data!));
+            parsedAny = true;
+        }
+
+        if (parsedAny)
+        {
+            consumedBytes = parserConsumed;
+        }
+
+        return parsedAny;
     }
 
     /// <summary>
@@ -114,6 +124,25 @@ public class CompositeMessageParser : IMessageParser<object>
     }
 
     /// <summary>
+    /// Minimum fraction of printable ASCII, measured over content bytes only, for a
+    /// buffer to be taken as text outright. See <see cref="MeasureRatios"/>.
+    /// </summary>
+    private const double TextPrintableRatio = 0.8;
+
+    /// <summary>
+    /// Minimum fraction of printable ASCII for a leading SCPI marker to count as
+    /// evidence of text. A marker on a buffer that is mostly non-printable is far
+    /// more likely to be an echoed command in front of a binary reply than a text
+    /// message.
+    /// </summary>
+    private const double MarkerPrintableRatio = 0.5;
+
+    /// <summary>
+    /// Fraction of null bytes above which a buffer is taken as binary.
+    /// </summary>
+    private const double BinaryNullRatio = 0.1;
+
+    /// <summary>
     /// Uses multiple heuristics to detect the likely message type.
     /// Goes beyond simple null byte detection to avoid false positives.
     /// </summary>
@@ -124,24 +153,32 @@ public class CompositeMessageParser : IMessageParser<object>
         if (data.Length == 0)
             return MessageTypeHint.Uncertain;
 
+        var (printableRatio, nullByteRatio) = MeasureRatios(data);
+
         // Heuristic 1: Check for printable ASCII (common in SCPI) - prioritize this
-        var printableRatio = data.Count(b => b >= 32 && b <= 126) / (double)data.Length;
-        if (printableRatio > 0.8) // More than 80% printable ASCII
+        if (printableRatio > TextPrintableRatio) // More than 80% printable ASCII
         {
             return MessageTypeHint.LikelyText;
         }
 
-        // Heuristic 2: Check for common text patterns (SCPI commands)
-        if (data.Length > 3 && IsLikelyTextCommand(data))
-        {
-            return MessageTypeHint.LikelyText;
-        }
-
-        // Heuristic 3: High ratio of null bytes suggests binary
-        var nullByteRatio = data.Count(b => b == 0) / (double)data.Length;
-        if (nullByteRatio > 0.1) // More than 10% null bytes
+        // Heuristic 2: High ratio of null bytes suggests binary.
+        //
+        // This must be tested before any surface-level text marker (heuristic 3).
+        // A DAQiFi device terminates its BINARY SYSTem:SYSInfoPB? reply with an
+        // ASCII CRLF, and with echo on it also prefixes the reply with the echoed
+        // command text — so both a leading "SYST" and a trailing CRLF appear on a
+        // buffer that is 40% null bytes. Measured on an Nq1 running fw 3.7.2, the
+        // real 588-byte status frame is 24% printable and 40.5% null (issue #268).
+        // Null density is the trustworthy signal; a text-shaped edge is not.
+        if (nullByteRatio > BinaryNullRatio) // More than 10% null bytes
         {
             return MessageTypeHint.LikelyProtobuf;
+        }
+
+        // Heuristic 3: Check for common text patterns (SCPI commands)
+        if (data.Length > 3 && printableRatio > MarkerPrintableRatio && StartsWithScpiMarker(data))
+        {
+            return MessageTypeHint.LikelyText;
         }
 
         // Heuristic 4: Check for protobuf-like patterns (be more conservative)
@@ -154,19 +191,74 @@ public class CompositeMessageParser : IMessageParser<object>
     }
 
     /// <summary>
-    /// Checks if the data looks like a text command (SCPI-style).
+    /// Measures the two signals the classifier weighs: what fraction of the buffer's
+    /// content bytes are printable ASCII, and what fraction of the whole buffer is null
+    /// bytes.
+    /// </summary>
+    /// <remarks>
+    /// Line endings and tabs are excluded from the printable ratio entirely — they
+    /// neither raise nor lower it. In a line-oriented text protocol a line ending is
+    /// framing, not content, so counting it against printability misjudges exactly the
+    /// replies that are shortest: "0\r\n" (the reply to SYSTem:STReam:FORmat?) is 33%
+    /// printable by raw count and 100% printable by content. Getting those wrong matters,
+    /// because a text buffer that fails this test is handed to the protobuf parser first,
+    /// where a chance parse would consume the reply and destroy it.
+    ///
+    /// Null bytes are measured over the whole buffer, since a null is never framing.
+    /// </remarks>
+    private static (double PrintableRatio, double NullByteRatio) MeasureRatios(byte[] data)
+    {
+        var contentBytes = 0;
+        var printableBytes = 0;
+        var nullBytes = 0;
+
+        foreach (var b in data)
+        {
+            if (b == 0)
+            {
+                nullBytes++;
+            }
+
+            if (b is 0x0D or 0x0A or 0x09) // CR, LF, TAB: framing, not content
+            {
+                continue;
+            }
+
+            contentBytes++;
+            if (b >= 32 && b <= 126)
+            {
+                printableBytes++;
+            }
+        }
+
+        // An all-line-ending buffer has no content to judge; report it as non-printable
+        // and let the remaining heuristics (or Uncertain) decide.
+        var printableRatio = contentBytes == 0 ? 0.0 : printableBytes / (double)contentBytes;
+        return (printableRatio, nullBytes / (double)data.Length);
+    }
+
+    /// <summary>
+    /// Checks whether the data opens with a marker characteristic of SCPI text.
     /// </summary>
     /// <param name="data">The data to check.</param>
     /// <returns>True if it looks like a text command.</returns>
-    private static bool IsLikelyTextCommand(byte[] data)
+    /// <remarks>
+    /// Deliberately looks only at the head of the buffer. An earlier version also
+    /// accepted any buffer ending in a line ending, which misrouted the binary
+    /// SYSTem:SYSInfoPB? reply — the device terminates that frame with an ASCII
+    /// CRLF — into <see cref="LineBasedMessageParser"/>, where the whole frame was
+    /// consumed as a single garbage line and the protobuf message was lost. A
+    /// trailing CRLF says nothing about a buffer that is 40% null bytes; the
+    /// printable- and null-ratio heuristics already classify those correctly.
+    /// </remarks>
+    private static bool StartsWithScpiMarker(byte[] data)
     {
-        // Check for common SCPI patterns
-        var text = System.Text.Encoding.ASCII.GetString(data, 0, Math.Min(data.Length, 10));
-        var fullText = System.Text.Encoding.ASCII.GetString(data);
-        
-        return text.StartsWith("*") || text.StartsWith("SYST") || text.StartsWith("CONF") || 
-               text.StartsWith("READ", StringComparison.OrdinalIgnoreCase) ||
-               fullText.EndsWith("\r\n") || fullText.EndsWith("\n");
+        var head = System.Text.Encoding.ASCII.GetString(data, 0, Math.Min(data.Length, 10));
+
+        return head.StartsWith("*", StringComparison.Ordinal) ||
+               head.StartsWith("SYST", StringComparison.OrdinalIgnoreCase) ||
+               head.StartsWith("CONF", StringComparison.OrdinalIgnoreCase) ||
+               head.StartsWith("READ", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes finding 2 of the hardware bench pass in https://github.com/daqifi/daqifi-core/issues/268#issuecomment-5202412946.

## The defect

A DAQiFi device terminates its **binary** `SYSTem:SYSInfoPB?` reply with an ASCII CRLF. `CompositeMessageParser.IsLikelyTextCommand` ended with:

```csharp
fullText.EndsWith("\r\n") || fullText.EndsWith("\n")
```

That clause outranked the printable- and null-ratio heuristics that had already classified the buffer correctly. The real 588-byte status frame — 24.0% printable, 40.5% null — classified `LikelyText`, `LineBasedMessageParser` ran first and consumed all 588 bytes as a single garbage "line", and the protobuf frame was destroyed.

No production code in this repo constructs `CompositeMessageParser` today (live paths use `ProtobufMessageParser` or `LineBasedMessageParser` directly), so this is a public exported API defect rather than a live one. I kept the class rather than deprecating it: the defect was two conditions in one method, and the fix is smaller than the removal would have been.

## The fix

**1. Line endings no longer vote for text.** The trailing-line-ending clause is gone; `IsLikelyTextCommand` becomes `StartsWithScpiMarker` and looks only at the head of the buffer. This also drops a full-buffer ASCII decode that ran on every call just to test a suffix.

**2. Line endings no longer count *against* text either.** The deleted clause was carrying a legitimate case — short replies. `"0\r\n"`, the reply to `SYSTem:STReam:FORmat?`, is **33% printable** by raw byte count, far below the 80% text threshold, yet entirely text:

| reply | raw printable | content-only printable |
|---|---|---|
| `0\r\n` | 33.3% | 100% |
| `7544\r\n` | 66.7% | 100% |
| `0,"No error"\r\n` | 85.7% | 100% |

A line ending is framing, not content, so CR/LF/TAB are now excluded from the printable ratio and neither help nor hurt. Without this, short replies would have fallen through to `Uncertain` and been handed to the protobuf parser first, surviving only because that parser happened to find nothing — and finding 1 of the same issue documents that it does not always find nothing. The measurement is now a single pass instead of two LINQ scans over every buffer.

**3. Ordering.** The null-byte check now runs *before* the SCPI-marker check, so an echoed `SYSTem:SYSInfoPB?` in front of a 40%-null binary reply cannot be read as text. And `Uncertain` buffers try protobuf before text — a real single-channel 10 Hz stream has **0% null bytes and 0% printable ASCII**, so every ratio heuristic abstains.

## Bench validation

Raw bytes captured off a real **Nq1 (fw 3.7.2)** over USB CDC via `SerialStreamTransport`, then replayed through `CompositeMessageParser`. Same harness, same device, A/B on the one commit:

| capture | bytes | printable | null | ends CRLF | before | after |
|---|---|---|---|---|---|---|
| `SYSInfoPB?` status | 588 | 24.0% | 40.5% | yes | ❌ `String`, 588 consumed | ✅ `DaqifiOutMessage`, 586 consumed |
| `**ERROR: -113, "Undefined header"` | 35 | 94.3% | 0% | yes | ✅ `String` | ✅ `String` |
| `STReam:FORmat?` | 3 | 33.3% | 0% | yes | ✅ `String` | ✅ `String` |
| `STReam:INTerface?` | 3 | 33.3% | 0% | yes | ✅ `String` | ✅ `String` |
| `ERRor:COUNt?` | 3 | 33.3% | 0% | yes | ✅ `String` | ✅ `String` |
| stream 1 ch @ 10 Hz | 210 | 0% | 0% | no | ✅ 21 × `DaqifiOutMessage` | ✅ 21 × `DaqifiOutMessage` |
| stream 4 ch @ 100 Hz | 2701 | 0% | 15.3% | no | ✅ 208 × `DaqifiOutMessage` | ✅ 208 × `DaqifiOutMessage` |

The captured status frame matched the issue's reported statistics exactly (588 bytes / 24.0% / 40.5%). Pre-fix, the mangled text output was visible in the dump — `C8-04-08-82-9C-B5-F3-05…` read back as `"…@HPd……"`.

Additionally fuzzed 8000 synthetic buffers (1–16 channels, 1–40 frames, resting channels producing nulls, digital data, half with the device's CRLF terminator):

- **before:** 2018/4000 protobuf buffers misrouted to `String` — i.e. *every* CRLF-terminated one; text 4000/4000 correct
- **after:** 0/4000 protobuf misroutes; text 4000/4000 correct

## Tests

14 new tests in `CompositeMessageParserBenchCaptureTests`. Fixtures are tuned to reproduce the captures' byte statistics, since those statistics are exactly what the classifier reads:

| fixture | real capture | fixture |
|---|---|---|
| status reply | 588 B, `C8 04` + 584 body + CRLF, 24.0% / 40.5% | 588 B, `C8 04` + 584 body + CRLF, 24.5% / 40.6% |
| 1 ch @ 10 Hz | 10-byte frames, 0% / 0% | 150 B, 10-byte frames, 0% / 0% |
| 4 ch @ 100 Hz | ~11-byte frames, 8.3% / 16.6% | 2860 B, 11-byte frames, 9.1% / 16.6% |

Each fixture has a companion test asserting its shape, so a fixture that drifts fails loudly instead of quietly ceasing to stand in for the hardware. Reverting only the source file makes the two regression tests fail as predicted (`Assert.IsType() Failure: Value is not the exact type`).

## Test run

All 97 `Communication.Consumers` tests green on net9.0 and net10.0.

The full suite is **not** fully green: 5 `FirmwareUpdateServiceTests` fail on both TFMs. They fail identically on unmodified `main` (verified by stashing and re-running) — expected-SCPI-sequence mismatches from 7965b26, unrelated to this change and not addressed here.

## Bench hygiene

Non-destructive throughout — queries plus two short streams. No reboot, format, firmware, SD or WiFi command. Device verified after: stream stopped, error queue drained to `0,"No error"` (the 2 entries were my own negative controls), `SYSInfoPB?` still answering with 588 bytes. Benign RAM-only residue: the analog enable mask is left at 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)