### PR TITLE
test: stop the wall-clock-tight unit tests racing a stalled CI runner

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -283,6 +283,18 @@ public class SerialDeviceFinderTests
 
     // --- #294: hang immunity -------------------------------------------------
 
+    // Choosing hardTimeoutMs: a sweep waits roughly this long for its hung port, so a
+    // small value keeps the test quick — but every probe, healthy ones included, is
+    // dispatched through Task.Run and must be given a thread-pool thread before it can
+    // complete. That handoff races Task.Delay(PortProbeHardTimeoutMs), and a probe still
+    // waiting for a thread when the ceiling expires is abandoned rather than reported.
+    // Under a saturated pool, thread injection is throttled to roughly one new thread per
+    // second, so the handoff alone can outlast a few-hundred-ms ceiling.
+    //
+    // So: a test that asserts a healthy device IS discovered needs a ceiling well clear of
+    // that scheduling latency — use ~2000ms, and expect the test to cost about that. A test
+    // that only asserts how often a wedged port was probed can stay short, since it is not
+    // depending on any probe winning the race.
     private static SerialDeviceFinder CreateFinderWithProbes(
         string[] ports,
         Func<string, CancellationToken, Task<IDeviceInfo?>> probe,
@@ -323,7 +335,15 @@ public class SerialDeviceFinderTests
             (port, _) => port == "COM_HUNG"
                 ? hungForever.Task
                 : Task.FromResult<IDeviceInfo?>(FakeDevice(port)),
-            hardTimeoutMs: 300);
+            // 2000, not 300: the healthy probe is dispatched with Task.Run, so it has to be
+            // handed a thread-pool thread before it can complete, and it races
+            // Task.Delay(PortProbeHardTimeoutMs) to do it. Once the pool is saturated,
+            // thread injection is throttled to roughly one new thread per second, so a
+            // few-hundred-ms ceiling can expire before COM_OK's probe delegate ever starts
+            // — and an unstarted probe is abandoned, leaving this assertion looking at an
+            // empty collection. 300ms lost that race on CI. See the matching comment on
+            // CreateFinderWithProbes.
+            hardTimeoutMs: 2000);
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var devices = (await finder.DiscoverAsync(CancellationToken.None)).ToList();
@@ -412,7 +432,10 @@ public class SerialDeviceFinderTests
                 }
                 return Task.FromResult<IDeviceInfo?>(FakeDevice(port));
             },
-            hardTimeoutMs: 200);
+            // 2000: the Assert.Single calls below need COM_OK's probe to win its race
+            // against the hard timeout. Only the first sweep pays the wait — the second
+            // finds the port quarantined and skips it.
+            hardTimeoutMs: 2000);
 
         var firstSweep = (await finder.DiscoverAsync(CancellationToken.None)).ToList();
         var secondSweep = (await finder.DiscoverAsync(CancellationToken.None)).ToList();
@@ -448,13 +471,16 @@ public class SerialDeviceFinderTests
             return Task.FromResult<IDeviceInfo?>(FakeDevice(port));
         };
 
-        using (var first = CreateFinderWithProbes(new[] { "COM_HUNG_X", "COM_OK_X" }, probe, hardTimeoutMs: 200))
+        // 2000 on both: each Assert.Single needs COM_OK_X's probe to be scheduled before the
+        // hard timeout fires. Only the first instance actually waits it out; the second finds
+        // COM_HUNG_X quarantined and skips it.
+        using (var first = CreateFinderWithProbes(new[] { "COM_HUNG_X", "COM_OK_X" }, probe, hardTimeoutMs: 2000))
         {
             Assert.Equal("COM_OK_X", Assert.Single(await first.DiscoverAsync(CancellationToken.None)).PortName);
         }
 
         // Fresh instance, same process: the wedged port must stay quarantined.
-        using (var second = CreateFinderWithProbes(new[] { "COM_HUNG_X", "COM_OK_X" }, probe, hardTimeoutMs: 200))
+        using (var second = CreateFinderWithProbes(new[] { "COM_HUNG_X", "COM_OK_X" }, probe, hardTimeoutMs: 2000))
         {
             Assert.Equal("COM_OK_X", Assert.Single(await second.DiscoverAsync(CancellationToken.None)).PortName);
         }
@@ -523,8 +549,11 @@ public class SerialDeviceFinderTests
             return Task.FromResult<IDeviceInfo?>(FakeDevice(port));
         };
 
-        using var finderA = CreateFinderWithProbes(new[] { "COM_HUNG_CONC", "COM_OK_CONC" }, probe, hardTimeoutMs: 400);
-        using var finderB = CreateFinderWithProbes(new[] { "COM_HUNG_CONC", "COM_OK_CONC" }, probe, hardTimeoutMs: 400);
+        // 2000: the Assert.Contains below needs at least one sweep to actually report
+        // COM_OK_CONC, which means its probe has to be scheduled before that sweep's hard
+        // timeout. Two concurrent sweeps make the pool contention worse, not better.
+        using var finderA = CreateFinderWithProbes(new[] { "COM_HUNG_CONC", "COM_OK_CONC" }, probe, hardTimeoutMs: 2000);
+        using var finderB = CreateFinderWithProbes(new[] { "COM_HUNG_CONC", "COM_OK_CONC" }, probe, hardTimeoutMs: 2000);
 
         var results = await Task.WhenAll(
             Task.Run(() => finderA.DiscoverAsync(CancellationToken.None)),

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2902,9 +2902,18 @@ public class FirmwareUpdateServiceTests
             probeCallCount++;
             return Task.FromResult(probeCallCount >= 3);
         };
-        // Readiness budget must be strictly less than JumpingToApplicationTimeout
-        // (CreateFastOptions uses 2s) — the probe succeeds within 50ms anyway.
-        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(1);
+        // Both budgets are deliberately generous. What this test asserts is behavioural
+        // — the probe is polled until it returns true, and Complete is held back until
+        // then — so the budgets exist only to stop a hung probe from hanging the suite,
+        // never as a deadline the assertions depend on. The probe succeeds after two
+        // 10ms retry delays, so the headroom costs nothing in the normal case: it just
+        // stops a stalled CI runner from failing a behavioural assertion on wall clock.
+        // A 1s budget here did exactly that — a loaded runner got only 2 of the 3
+        // probes away inside the second, and the timeout fired one probe short. The
+        // readiness budget still stays strictly below JumpingToApplicationTimeout, which
+        // FirmwareUpdateServiceOptions.Validate requires whenever a probe is set.
+        options.JumpingToApplicationTimeout = TimeSpan.FromSeconds(60);
+        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(30);
         options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
 
         var service = new FirmwareUpdateService(
@@ -3014,7 +3023,13 @@ public class FirmwareUpdateServiceTests
                 ? Task.FromException<bool>(new OperationCanceledException("probe-internal-cancel"))
                 : Task.FromResult(true);
         };
-        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(1);
+        // Generous budgets for the same reason as
+        // UpdateFirmwareAsync_PostReconnectReadinessProbe_AwaitedBeforeComplete: the
+        // assertion is that the retry happens and the update still completes, not that
+        // it completes inside a deadline. Leaving a 1s budget here makes a behavioural
+        // test fail whenever the runner stalls long enough to eat the third probe.
+        options.JumpingToApplicationTimeout = TimeSpan.FromSeconds(60);
+        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(30);
         options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
 
         var service = new FirmwareUpdateService(

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2912,8 +2912,14 @@ public class FirmwareUpdateServiceTests
         // probes away inside the second, and the timeout fired one probe short. The
         // readiness budget still stays strictly below JumpingToApplicationTimeout, which
         // FirmwareUpdateServiceOptions.Validate requires whenever a probe is set.
-        options.JumpingToApplicationTimeout = TimeSpan.FromSeconds(60);
-        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(30);
+        //
+        // 10s/15s rather than something enormous: these also bound how long a real
+        // regression in the JumpingToApp state takes to surface, so the aim is comfortably
+        // clear of a stalled runner without going so far that a genuine hang is slow to
+        // diagnose. 10s is an order of magnitude past the ~1s stall that broke the 1s
+        // budget, and ~300x what the probe actually needs.
+        options.JumpingToApplicationTimeout = TimeSpan.FromSeconds(15);
+        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(10);
         options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
 
         var service = new FirmwareUpdateService(
@@ -3028,8 +3034,8 @@ public class FirmwareUpdateServiceTests
         // assertion is that the retry happens and the update still completes, not that
         // it completes inside a deadline. Leaving a 1s budget here makes a behavioural
         // test fail whenever the runner stalls long enough to eat the third probe.
-        options.JumpingToApplicationTimeout = TimeSpan.FromSeconds(60);
-        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(30);
+        options.JumpingToApplicationTimeout = TimeSpan.FromSeconds(15);
+        options.PostReconnectReadinessTimeout = TimeSpan.FromSeconds(10);
         options.PostReconnectReadinessRetryDelay = TimeSpan.FromMilliseconds(10);
 
         var service = new FirmwareUpdateService(


### PR DESCRIPTION
Two unrelated tests were failing PRs that had nothing to do with either of them. Both are pre-existing flakes on `main` — both fail on net9.0 while **net10.0 passes the same test in the same run**, which is the signature of a starved runner rather than a regression.

## 1. Post-reconnect readiness probe (hit [#452](https://github.com/daqifi/daqifi-core/pull/452))

```
System.TimeoutException : Device did not become application-ready within 00:00:01 (probes executed: 2).
```

`UpdateFirmwareAsync_PostReconnectReadinessProbe_AwaitedBeforeComplete` and `UpdateFirmwareAsync_PostReconnectProbeThrowsOwnOCE_RetriesAndCompletes` configure a probe that reports not-ready twice then ready, and assert `probeCallCount == 3` with `CurrentState == Complete`. Neither assertion is about *how long* readiness takes — the budget only exists so a hung probe can't hang the suite. A 1s budget for a ~30ms need was not enough margin: the runner got 2 of the 3 probes away inside the second and the timeout fired one probe short.

Budgets raised to 10s readiness / 15s `JumpingToApplicationTimeout` (both must move together — `Validate` requires readiness to stay strictly below the outer state timeout whenever a probe is set).

## 2. Hung-port discovery sweeps (hit [#453](https://github.com/daqifi/daqifi-core/pull/453))

```
DiscoverAsync_HungPort_TimesOutAndStillReturnsHealthyDevices
Assert.Single() Failure: The collection was empty
```

`#453` touches the live-stream device tests and nothing in discovery.

Every probe — healthy ones included — is dispatched through `Task.Run`, so it must be handed a thread-pool thread before it can complete. That handoff races `Task.Delay(PortProbeHardTimeoutMs)`, and `SerialDeviceFinder` **abandons** a probe still waiting for a thread when the ceiling expires. That is precisely an empty result for `COM_OK`. Under a saturated pool, thread injection is throttled to roughly one new thread per second, so a 300ms ceiling can expire before the delegate ever starts.

The file already half-knew this. The cross-sweep tests were relaxed to `hungProbeCalls <= 1` with the comment *"under thread-pool contention the hung probe may not have STARTED before the first sweep's hard timeout fires"* — but the healthy-device assertions were left racing the same clock.

Ceiling raised to 2000ms on the four sites that assert a healthy device **is** reported, matching what `DiscoverAsync_HungPort_HealthyDeviceEventFiresBeforeSweepSettles` already used. `DiscoverAsync_QuarantineTtl_AllowsPeriodicRetry` keeps its 100ms — it only counts probes of a wedged port and depends on the short window.

`CreateFinderWithProbes` now documents the constraint so the next test picks a value deliberately rather than picking the smallest number that passed locally.

## Scope

Tests only — no production code changed. The abandon-on-timeout behaviour in `SerialDeviceFinder` is correct and deliberate (#294); the tests were just holding it to a stopwatch.

## Verification

- Full solution green on net9.0 and net10.0 (2703 passed each, 0 failed).
- Suite cost: about +7s, from the raised discovery ceilings. The readiness changes cost nothing — that probe still succeeds after two 10ms delays.

**Not reproduced locally.** A 12-core dev box does not starve the .NET thread pool the way a 2-core runner running 2700 parallel tests does; the unfixed discovery test still passes here under 6x CPU oversubscription. The diagnosis rests on the failure signature (an empty collection means the probe never completed), the abandon-on-timeout code path, and the net9.0/net10.0 split — not on a local repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)