### PR TITLE
ci: run on merge_group so a merge queue can gate main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,20 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
+  # Required for the merge queue. A queued PR is tested on a merge_group ref that
+  # contains main's tip plus everything ahead of it in the queue — the state the
+  # commit will actually land in, which a pull_request run cannot see. Without this
+  # trigger the required "build" check never reports for a merge group and every
+  # queued PR sits until it is timed out of the queue.
+  merge_group:
+
+  # Backstop only. The queue tests the real post-merge state, so this should not be
+  # what catches a break — but main can still move without passing through a queue
+  # (a ruleset bypass, an admin push), and #444/#445 showed how expensive an
+  # unnoticed red main is: five later PRs failed on inherited breakage, and CI that
+  # only ran on pull_request had no run on main to point at.
+  push:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
**This must land before the merge queue is enabled.** Turning the queue on first would stall every open PR.

## Why

A queued PR is tested on a `merge_group` ref containing `main`'s tip plus everything ahead of it in the queue — the state the commit will *actually* land in. A `pull_request` run cannot see that.

That gap is exactly what broke `main` earlier today. [#445](https://github.com/daqifi/daqifi-core/pull/445) and [#444](https://github.com/daqifi/daqifi-core/pull/444) merged 63 seconds apart, each tested against a `main` that did not contain the other — #444 on a **nine-hour-old** check whose base never included #445. Verified after the fact:

| commit | contents | result |
|---|---|---|
| `da35eff` | main after **#445 only** | green (108 tests) |
| `7965b26` | main after **#445 + #444** | **red** (5 failures) |

Neither PR was broken. The combination was. Five later PRs then inherited the breakage and failed for reasons that had nothing to do with their own changes.

The `main` ruleset already requires up-to-date branches (`strict: true`), but the `daqifi-core` team holds `bypass_mode: always`, so it did not apply. A merge queue closes this properly: it re-tests each entry against the real post-merge state instead of trusting a stale green check.

## What changes

- **`merge_group`** — required for the queue. Without it the required `build` check never reports for a merge group, and queued PRs sit until they're timed out of the queue.
- **`push: [main]`** — backstop only. The queue makes it largely redundant, but `main` can still move without passing through a queue (ruleset bypass, admin push), and today showed the cost of an unnoticed red `main`: CI running only on `pull_request` left no run on `main` to point at.

No job or step changes; the required check context stays `build`.

## Queue settings to apply after this merges

Matching the repo's existing config (squash-only, `PR_TITLE`/`BLANK`):

- merge method: **SQUASH**
- grouping: **ALLGREEN**
- required check: **build**

🤖 Generated with [Claude Code](https://claude.com/claude-code)