### PR TITLE
chore(scpi): single-source SCPI wire strings in ScpiMessageProducer

### DIFF
--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -391,6 +391,36 @@ public class ScpiMessageProducer
     public static IOutboundMessage<string> GetStreamInterface => new ScpiMessage("SYSTem:STReam:INTerface?");
 
     /// <summary>
+    /// The wire command <see cref="StartStreaming"/> emits, without its frequency argument. Exposed so
+    /// callers that must recognize this command from raw command text — e.g.
+    /// <see cref="Device.Internal.SessionCommandInterpreter"/> — have a single source of truth instead
+    /// of a second, driftable copy of the literal.
+    /// </summary>
+    internal const string StartStreamingCommand = "SYSTem:StartStreamData";
+
+    /// <summary>
+    /// The wire command <see cref="StopStreaming"/> emits. See <see cref="StartStreamingCommand"/> for why
+    /// this is exposed.
+    /// </summary>
+    internal const string StopStreamingCommand = "SYSTem:StopStreamData";
+
+    /// <summary>
+    /// The wire command <see cref="EnableAdcChannels"/> emits, without its bitmask argument. See
+    /// <see cref="StartStreamingCommand"/> for why this is exposed.
+    /// </summary>
+    internal const string EnableAdcChannelsCommand = "ENAble:VOLTage:DC";
+
+    /// <summary>
+    /// The wire command <see cref="SetProtobufStreamFormat"/>/<see cref="SetJsonStreamFormat"/>/
+    /// <see cref="SetCsvStreamFormat"/> emit, without their format argument. Exposed so other call sites
+    /// that need to set a stream format not covered by those three fixed properties — e.g.
+    /// <see cref="Device.SdCard.SdCardOperations"/>, which selects the format from a caller-supplied
+    /// <see cref="Device.SdCard.SdCardLogFormat"/> — compose the same command via <see cref="SetStreamFormat"/>
+    /// instead of re-declaring the literal.
+    /// </summary>
+    internal const string StreamFormatCommand = "SYSTem:STReam:FORmat";
+
+    /// <summary>
     /// Creates a command message to start data streaming at the specified frequency.
     /// </summary>
     /// <param name="frequency">The streaming frequency in Hz.</param>
@@ -407,7 +437,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> StartStreaming(int frequency)
     {
-        return new ScpiMessage($"SYSTem:StartStreamData {frequency}");
+        return new ScpiMessage($"{StartStreamingCommand} {frequency}");
     }
 
     /// <summary>
@@ -417,7 +447,7 @@ public class ScpiMessageProducer
     /// Command: SYSTem:StopStreamData
     /// Example: messageProducer.Send(ScpiMessageProducer.StopStreaming);
     /// </remarks>
-    public static IOutboundMessage<string> StopStreaming => new ScpiMessage("SYSTem:StopStreamData");
+    public static IOutboundMessage<string> StopStreaming => new ScpiMessage(StopStreamingCommand);
 
     /// <summary>
     /// Creates a command message to set the stream format to Protocol Buffer.
@@ -427,7 +457,7 @@ public class ScpiMessageProducer
     /// Command: SYSTem:STReam:FORmat 0
     /// Example: messageProducer.Send(ScpiMessageProducer.SetProtobufStreamFormat);
     /// </remarks>
-    public static IOutboundMessage<string> SetProtobufStreamFormat => new ScpiMessage("SYSTem:STReam:FORmat 0");
+    public static IOutboundMessage<string> SetProtobufStreamFormat => SetStreamFormat(0);
 
     /// <summary>
     /// Creates a command message to set the stream format to JSON.
@@ -437,7 +467,7 @@ public class ScpiMessageProducer
     /// Command: SYSTem:STReam:FORmat 1
     /// Example: messageProducer.Send(ScpiMessageProducer.SetJsonStreamFormat);
     /// </remarks>
-    public static IOutboundMessage<string> SetJsonStreamFormat => new ScpiMessage("SYSTem:STReam:FORmat 1");
+    public static IOutboundMessage<string> SetJsonStreamFormat => SetStreamFormat(1);
 
     /// <summary>
     /// Creates a command message to set the stream format to CSV.
@@ -447,7 +477,7 @@ public class ScpiMessageProducer
     /// Command: SYSTem:STReam:FORmat 2
     /// Example: messageProducer.Send(ScpiMessageProducer.SetCsvStreamFormat);
     /// </remarks>
-    public static IOutboundMessage<string> SetCsvStreamFormat => new ScpiMessage("SYSTem:STReam:FORmat 2");
+    public static IOutboundMessage<string> SetCsvStreamFormat => SetStreamFormat(2);
 
     /// <summary>
     /// Creates a query message to get the current stream format.
@@ -460,7 +490,21 @@ public class ScpiMessageProducer
     /// Command: SYSTem:STReam:FORmat?
     /// Example: messageProducer.Send(ScpiMessageProducer.GetStreamFormat);
     /// </remarks>
-    public static IOutboundMessage<string> GetStreamFormat => new ScpiMessage("SYSTem:STReam:FORmat?");
+    public static IOutboundMessage<string> GetStreamFormat => new ScpiMessage($"{StreamFormatCommand}?");
+
+    /// <summary>
+    /// Creates a command message to set the stream format to the given integer code.
+    /// </summary>
+    /// <param name="format">The wire format code (0 = Protobuf, 1 = JSON, 2 = CSV).</param>
+    /// <remarks>
+    /// Internal escape hatch for callers whose format comes from a domain enum rather than one of the
+    /// three fixed properties above — see <see cref="StreamFormatCommand"/>.
+    /// Command: SYSTem:STReam:FORmat format
+    /// </remarks>
+    internal static IOutboundMessage<string> SetStreamFormat(int format)
+    {
+        return new ScpiMessage($"{StreamFormatCommand} {format}");
+    }
 
     /// <summary>
     /// Creates a command message to enable ADC channels using a decimal bitmask.
@@ -484,7 +528,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> EnableAdcChannels(string channelSetString)
     {
-        return new ScpiMessage($"ENAble:VOLTage:DC {channelSetString}");
+        return new ScpiMessage($"{EnableAdcChannelsCommand} {channelSetString}");
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/Internal/SessionCommandInterpreter.cs
+++ b/src/Daqifi.Core/Device/Internal/SessionCommandInterpreter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using Daqifi.Core.Communication.Producers;
 
 #nullable enable
 
@@ -132,15 +133,6 @@ namespace Daqifi.Core.Device.Internal
     /// </remarks>
     internal static class SessionCommandInterpreter
     {
-        /// <summary>The command <see cref="Communication.Producers.ScpiMessageProducer.StartStreaming"/> emits.</summary>
-        internal const string StartStreamingCommand = "SYSTem:StartStreamData";
-
-        /// <summary>The command <see cref="Communication.Producers.ScpiMessageProducer.StopStreaming"/> emits.</summary>
-        internal const string StopStreamingCommand = "SYSTem:StopStreamData";
-
-        /// <summary>The command <see cref="Communication.Producers.ScpiMessageProducer.EnableAdcChannels"/> emits.</summary>
-        internal const string EnableAdcChannelsCommand = "ENAble:VOLTage:DC";
-
         /// <summary>
         /// Decides what <paramref name="command"/> means for the streaming session.
         /// </summary>
@@ -184,19 +176,19 @@ namespace Daqifi.Core.Device.Internal
 
             var trimmed = command!.Trim();
 
-            if (trimmed.StartsWith(StopStreamingCommand, StringComparison.OrdinalIgnoreCase))
+            if (trimmed.StartsWith(ScpiMessageProducer.StopStreamingCommand, StringComparison.OrdinalIgnoreCase))
             {
                 return SessionCommandEffect.StopStreaming;
             }
 
-            if (trimmed.StartsWith(StartStreamingCommand, StringComparison.OrdinalIgnoreCase))
+            if (trimmed.StartsWith(ScpiMessageProducer.StartStreamingCommand, StringComparison.OrdinalIgnoreCase))
             {
-                return InterpretStreamingStart(trimmed.AsSpan(StartStreamingCommand.Length), maxSamplingRate);
+                return InterpretStreamingStart(trimmed.AsSpan(ScpiMessageProducer.StartStreamingCommand.Length), maxSamplingRate);
             }
 
-            if (trimmed.StartsWith(EnableAdcChannelsCommand, StringComparison.OrdinalIgnoreCase))
+            if (trimmed.StartsWith(ScpiMessageProducer.EnableAdcChannelsCommand, StringComparison.OrdinalIgnoreCase))
             {
-                return InterpretAdcEnableMask(trimmed.AsSpan(EnableAdcChannelsCommand.Length));
+                return InterpretAdcEnableMask(trimmed.AsSpan(ScpiMessageProducer.EnableAdcChannelsCommand.Length));
             }
 
             return SessionCommandEffect.None;

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -621,8 +621,8 @@ namespace Daqifi.Core.Device.SdCard
 
             ValidateSdCardFileName(logFileName);
 
-            // SdCardLogFormat integer values map 1:1 to SYSTem:STReam:FORmat SCPI arguments
-            var formatCommand = new ScpiMessage($"SYSTem:STReam:FORmat {(int)format}");
+            // SdCardLogFormat integer values map 1:1 to the SYSTem:STReam:FORmat SCPI argument
+            var formatCommand = ScpiMessageProducer.SetStreamFormat((int)format);
 
             // SD card and LAN share the SPI bus on the hardware, so LAN must be
             // disabled before the SD card can be used.


### PR DESCRIPTION
## Summary
`ScpiMessageProducer` is meant to be the single source of truth for SCPI wire strings, but three command strings had escaped it:

- `SessionCommandInterpreter` re-declared `StartStreamingCommand`/`StopStreamingCommand`/`EnableAdcChannelsCommand` as its own internal consts, duplicating the literals baked into `ScpiMessageProducer.StartStreaming`/`StopStreaming`/`EnableAdcChannels`.
- `SdCardOperations` built `new ScpiMessage($"SYSTem:STReam:FORmat {(int)format}")` inline, duplicating the literal used by `SetProtobufStreamFormat`/`SetJsonStreamFormat`/`SetCsvStreamFormat`.

## Changes
- `ScpiMessageProducer` now exposes internal constants (`StartStreamingCommand`, `StopStreamingCommand`, `EnableAdcChannelsCommand`, `StreamFormatCommand`) and a new internal `SetStreamFormat(int format)` composer; the existing public members now build off these instead of inline literals.
- `SessionCommandInterpreter` no longer re-declares the command strings — it references `ScpiMessageProducer`'s constants directly.
- `SdCardOperations` composes its stream-format command via `ScpiMessageProducer.SetStreamFormat((int)format)` instead of building a `ScpiMessage` inline.

Pure refactor — no wire format change, no behavior change.

## Testing
- `dotnet build` — succeeds, 0 warnings
- `dotnet test` (full suite, net9.0 + net10.0) — 2826 passed, 0 failed, 2 skipped (pre-existing)
- No bench test: this only consolidates string literals that already produce identical wire output; the change is provably behavior-preserving from source inspection and the existing test suite (which exercises the affected command strings) stayed green.

Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)