### PR TITLE
feat(device): modernize device interfaces — async + CancellationToken on IStreamingDevice, disposability on IDevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ if (device is IStreamingDevice streamingDevice)
 }
 ```
 
+Every `IStreamingDevice` method above (and the rest of the channel/PWM/analog-output/reboot surface)
+has a cancellable `...Async` twin declared on the interface — see
+[IStreamingDevice](docs/DEVICE_INTERFACES.md#istreamingdevice) for the full list.
+
 ### PWM output
 
 PWM runs on capable DIO pins (`IDigitalChannel.IsPwmCapable` — channels 0, 3, 4, 5, 6 and 7 on

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -46,7 +46,13 @@ The base interface for all DAQiFi devices, providing fundamental connection and 
 - `IpAddress` - Network address (for WiFi devices)
 - `IsConnected` - Connection status
 - `Status` - Detailed connection status (Disconnected, Connecting, Connected, Lost)
-- `Connect()` / `Disconnect()` - Connection management
+- `Connect()` / `Disconnect()` - Blocking connection management
+- `ConnectAsync(CancellationToken)` / `DisconnectAsync(CancellationToken)` - Non-blocking, cancellable
+  connection management. These are genuine interface members, not default-interface-method shims over
+  the blocking calls — every implementer honors the token.
+- `IAsyncDisposable.DisposeAsync()` - `IDevice` extends `IAsyncDisposable`, so any consumer coding
+  against the interface (not just the concrete `DaqifiDevice`) can tear a device down with
+  `await using`/`await device.DisposeAsync()` — no cast required.
 - `Send<T>(IOutboundMessage<T>)` - Send commands to device
 - `StatusChanged` event - Connection status notifications
 - `MessageReceived` event - Incoming data notifications
@@ -58,6 +64,29 @@ Extends `IDevice` with data streaming functionality for devices that support con
 starting/stopping a stream, per-channel enable/disable, digital I/O, PWM, and analog output.
 `DaqifiStreamingDevice` implements it in this library — see [DaqifiStreamingDevice](#daqifistreamingdevice)
 below.
+
+Every one of those operations — plus `Reboot()` — has an `...Async(CancellationToken)` twin declared
+directly on the interface, so a consumer holding only an `IStreamingDevice` reference gets the same
+cancellable API surface as one holding the concrete `DaqifiStreamingDevice`:
+
+```csharp
+if (device is IStreamingDevice streamingDevice)
+{
+    await streamingDevice.EnableChannelAsync(channel, cancellationToken);
+    await streamingDevice.StartStreamingAsync(cancellationToken);
+}
+```
+
+The synchronous methods (`StartStreaming()`, `EnableChannel()`, etc.) remain, unchanged, for existing
+callers — the `Async` members are additive, not a replacement. Unlike `Connect`/`Disconnect`, most of
+this surface has no genuine async machinery underneath: `DaqifiStreamingDevice`'s streaming/channel/DIO
+/PWM/output/reboot commands are fire-and-forget writes with nothing to await, so the `Async` twin is a
+thin, cancellable wrapper around the same single write.
+
+`IStreamingDevice` also extends `IConfirmingDeviceAdministration`, so the confirming calibration calls
+(`SaveAdcCalibrationAsync`, `LoadAdcCalibrationAsync`, `SetAdcCalibrationSlopeAsync`, and the rest —
+each sends the same firmware primitive as its `void` counterpart and then confirms the device accepted
+it) are reachable directly off an `IStreamingDevice` reference too, with no separate cast needed.
 
 ## Implementation Classes
 
@@ -434,6 +463,16 @@ never throws `OperationCanceledException`, because a teardown abandoned part-way
 device in an indeterminate state. On return the device is always disconnected.
 
 The synchronous `Connect`, `Disconnect` and `Dispose` remain, unchanged, for existing callers.
+
+`ConnectAsync` and `DisconnectAsync` are declared directly on `IDevice` (not default-interface-method
+shims over `Connect`/`Disconnect`), and `IDevice` extends `IAsyncDisposable`, so all three are reachable
+through the interface with no cast to `DaqifiDevice`:
+
+```csharp
+IDevice device = await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
+await device.DisconnectAsync(cancellationToken);
+await device.DisposeAsync();
+```
 
 ### Error Handling
 
@@ -860,6 +899,16 @@ if (device is IStreamingDevice streamingDevice)
 > Channel objects passed to the enable/disable and DIO methods must belong to the device's
 > `Channels` collection (so the internal state and bitmask stay in sync). Analog-output (DAC)
 > channels are not part of `Channels`, so `SetAnalogOutput` takes a channel number directly.
+
+Every method above has a cancellable `...Async` twin (`EnableChannelsAsync`, `DisableChannelAsync`,
+`SetDioValueAsync`, `SetPwmEnabledAsync`, `SetAnalogOutputAsync`, `RebootAsync`, and the rest), declared
+directly on `IStreamingDevice`:
+
+```csharp
+await streamingDevice.EnableChannelsAsync(new[] { ai0, ai2 }, cancellationToken);
+await streamingDevice.SetDioValueAsync(dio1, true, cancellationToken);
+await streamingDevice.RebootAsync(cancellationToken);
+```
 
 ## SCPI Commands
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAsyncSurfaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAsyncSurfaceTests.cs
@@ -1,0 +1,425 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    /// <summary>
+    /// Unit tests for the async-with-<see cref="CancellationToken"/> surface added to
+    /// <see cref="IStreamingDevice"/> and <see cref="IDevice"/> by issue #460: each
+    /// <c>...Async</c> twin honors an already-cancelled token before doing anything, and
+    /// otherwise performs exactly what its synchronous counterpart does.
+    /// </summary>
+    public class DaqifiStreamingDeviceAsyncSurfaceTests
+    {
+        private static TestableDaqifiStreamingDevice CreateConnectedDevice(int analogChannels = 4, int digitalChannels = 4)
+        {
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = (uint)analogChannels,
+                AnalogInRes = 65535,
+                DigitalPortNum = (uint)digitalChannels
+            });
+            device.Connect();
+            device.SentMessages.Clear();
+            return device;
+        }
+
+        private static IChannel AnalogChannelAt(DaqifiStreamingDevice device, int channelNumber) =>
+            device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == channelNumber);
+
+        private static IChannel DigitalChannelAt(DaqifiStreamingDevice device, int channelNumber) =>
+            device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == channelNumber);
+
+        private static CancellationToken CanceledToken()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            return cts.Token;
+        }
+
+        #region Streaming
+
+        [Fact]
+        public async Task StartStreamingAsync_SendsStartStreamingCommand()
+        {
+            var device = CreateConnectedDevice();
+
+            await device.StartStreamingAsync();
+
+            Assert.True(device.IsStreaming);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.StartStreaming(device.StreamingFrequency).Data, sent.Data);
+        }
+
+        [Fact]
+        public async Task StopStreamingAsync_SendsStopStreamingCommand()
+        {
+            var device = CreateConnectedDevice();
+            device.StartStreaming();
+            device.SentMessages.Clear();
+
+            await device.StopStreamingAsync();
+
+            Assert.False(device.IsStreaming);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.StopStreaming.Data, sent.Data);
+        }
+
+        [Fact]
+        public async Task StartStreamingAsync_CanceledToken_ThrowsWithoutSending()
+        {
+            var device = CreateConnectedDevice();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => device.StartStreamingAsync(CanceledToken()));
+
+            Assert.False(device.IsStreaming);
+            Assert.Empty(device.SentMessages);
+        }
+
+        #endregion
+
+        #region Channel management
+
+        [Fact]
+        public async Task EnableChannelAsync_Analog_SetsIsEnabledAndSendsBitmask()
+        {
+            var device = CreateConnectedDevice();
+            var channel = AnalogChannelAt(device, 0);
+
+            await device.EnableChannelAsync(channel);
+
+            Assert.True(channel.IsEnabled);
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.EnableAdcChannels("1").Data, sent.Data);
+        }
+
+        [Fact]
+        public async Task EnableChannelsAsync_SendsAtMostOneCommandPerChannelType()
+        {
+            var device = CreateConnectedDevice();
+            var channels = new[] { AnalogChannelAt(device, 0), DigitalChannelAt(device, 0) };
+
+            await device.EnableChannelsAsync(channels);
+
+            Assert.True(channels[0].IsEnabled);
+            Assert.True(channels[1].IsEnabled);
+            Assert.Equal(2, device.SentMessages.Count);
+        }
+
+        [Fact]
+        public async Task DisableChannelAsync_ClearsIsEnabled()
+        {
+            var device = CreateConnectedDevice();
+            var channel = AnalogChannelAt(device, 0);
+            device.EnableChannel(channel);
+            device.SentMessages.Clear();
+
+            await device.DisableChannelAsync(channel);
+
+            Assert.False(channel.IsEnabled);
+        }
+
+        [Fact]
+        public async Task DisableAllChannelsAsync_ClearsEveryChannel()
+        {
+            var device = CreateConnectedDevice();
+            device.EnableChannel(AnalogChannelAt(device, 0));
+            device.EnableChannel(DigitalChannelAt(device, 0));
+            device.SentMessages.Clear();
+
+            await device.DisableAllChannelsAsync();
+
+            Assert.All(device.Channels, c => Assert.False(c.IsEnabled));
+        }
+
+        [Fact]
+        public async Task EnableChannelAsync_CanceledToken_ThrowsWithoutEnabling()
+        {
+            var device = CreateConnectedDevice();
+            var channel = AnalogChannelAt(device, 0);
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => device.EnableChannelAsync(channel, CanceledToken()));
+
+            Assert.False(channel.IsEnabled);
+            Assert.Empty(device.SentMessages);
+        }
+
+        #endregion
+
+        #region DIO
+
+        [Fact]
+        public async Task SetDioDirectionAsync_SetsDirection()
+        {
+            var device = CreateConnectedDevice();
+            var channel = DigitalChannelAt(device, 0);
+
+            await device.SetDioDirectionAsync(channel, ChannelDirection.Output);
+
+            Assert.Equal(ChannelDirection.Output, channel.Direction);
+        }
+
+        [Fact]
+        public async Task SetDioValueAsync_SendsExpectedCommand()
+        {
+            var device = CreateConnectedDevice();
+            var channel = DigitalChannelAt(device, 0);
+            device.SetDioDirection(channel, ChannelDirection.Output);
+            device.SentMessages.Clear();
+
+            await device.SetDioValueAsync(channel, true);
+
+            Assert.Single(device.SentMessages);
+        }
+
+        #endregion
+
+        #region PWM
+
+        [Fact]
+        public async Task SetPwmFrequencyAsync_UpdatesPwmFrequencyHz()
+        {
+            var device = CreateConnectedDevice();
+
+            await device.SetPwmFrequencyAsync(1000);
+
+            Assert.Equal(1000, device.PwmFrequencyHz);
+        }
+
+        [Fact]
+        public async Task SetPwmDutyCycleAsync_AndSetPwmEnabledAsync_SendCommands()
+        {
+            var device = CreateConnectedDevice();
+            var channel = DigitalChannelAt(device, 0);
+            device.SetDioDirection(channel, ChannelDirection.Output);
+            device.SentMessages.Clear();
+
+            await device.SetPwmDutyCycleAsync(channel, 50);
+            await device.SetPwmEnabledAsync(channel, true);
+
+            Assert.Equal(2, device.SentMessages.Count);
+        }
+
+        #endregion
+
+        #region Analog output and reboot
+
+        [Fact]
+        public async Task SetAnalogOutputAsync_SendsCommand()
+        {
+            var device = CreateConnectedDevice();
+
+            await device.SetAnalogOutputAsync(0, 1.5);
+
+            Assert.NotEmpty(device.SentMessages);
+        }
+
+        [Fact]
+        public async Task RebootAsync_SendsRebootCommandAndDisconnects()
+        {
+            var device = CreateConnectedDevice();
+
+            await device.RebootAsync();
+
+            var sent = Assert.Single(device.SentMessages);
+            Assert.Equal(ScpiMessageProducer.RebootDevice.Data, sent.Data);
+            Assert.False(device.IsConnected);
+        }
+
+        [Fact]
+        public async Task RebootAsync_CanceledToken_ThrowsWithoutDisconnecting()
+        {
+            var device = CreateConnectedDevice();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => device.RebootAsync(CanceledToken()));
+
+            Assert.True(device.IsConnected);
+            Assert.Empty(device.SentMessages);
+        }
+
+        #endregion
+
+        #region IDevice.ConnectAsync / DisconnectAsync are genuine members, not DIM shims
+
+        [Fact]
+        public async Task IDevice_ConnectAsync_DisconnectAsync_AreCallableThroughTheInterface()
+        {
+            IDevice device = new TestableDaqifiStreamingDevice("TestDevice");
+
+            await device.ConnectAsync();
+            Assert.True(device.IsConnected);
+
+            await device.DisconnectAsync();
+            Assert.False(device.IsConnected);
+        }
+
+        #endregion
+
+        #region IDevice : IAsyncDisposable
+
+        [Fact]
+        public async Task IDevice_IsAsyncDisposable_AndDisposeAsyncDisconnects()
+        {
+            IDevice device = new TestableDaqifiStreamingDevice("TestDevice");
+            await device.ConnectAsync();
+
+            await device.DisposeAsync();
+
+            Assert.False(device.IsConnected);
+        }
+
+        #endregion
+
+        #region IStreamingDevice default Async implementations (no override) still work
+
+        [Fact]
+        public async Task IStreamingDevice_DefaultAsyncStartStreaming_DelegatesToSyncMethod()
+        {
+            // MinimalStreamingDevice implements only the synchronous members, relying entirely on
+            // IStreamingDevice's default-interface-method bodies for the Async twins. Reached only
+            // through the interface type, matching how a consumer coding against IStreamingDevice
+            // would call it.
+            IStreamingDevice device = new MinimalStreamingDevice();
+
+            await device.StartStreamingAsync();
+
+            Assert.True(device.IsStreaming);
+        }
+
+        [Fact]
+        public async Task IStreamingDevice_DefaultAsyncStartStreaming_CanceledToken_DoesNotStart()
+        {
+            IStreamingDevice device = new MinimalStreamingDevice();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => device.StartStreamingAsync(CanceledToken()));
+
+            Assert.False(device.IsStreaming);
+        }
+
+        [Fact]
+        public async Task IStreamingDevice_ExtendsIConfirmingDeviceAdministration()
+        {
+            IStreamingDevice device = new MinimalStreamingDevice();
+            Assert.IsAssignableFrom<IConfirmingDeviceAdministration>(device);
+
+            // Reachable directly, no cast needed.
+            await device.SaveAdcCalibrationAsync();
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The smallest possible <see cref="IStreamingDevice"/> implementer: every member not
+        /// exercised by these tests is a no-op, and none of the new <c>...Async</c> members are
+        /// overridden — every one of them must resolve to the interface's default implementation.
+        /// </summary>
+        private sealed class MinimalStreamingDevice : IStreamingDevice
+        {
+            public string Name => "Minimal";
+            public IPAddress? IpAddress => null;
+            public bool IsConnected { get; private set; } = true;
+            public ConnectionStatus Status => IsConnected ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+            public int StreamingFrequency { get; set; }
+            public bool IsStreaming { get; private set; }
+            public int PwmFrequencyHz => 0;
+
+            public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
+            public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
+            public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred { add { } remove { } }
+
+            public void Connect() => IsConnected = true;
+            public void Disconnect() => IsConnected = false;
+
+            public Task ConnectAsync(CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Connect();
+                return Task.CompletedTask;
+            }
+
+            public Task DisconnectAsync(CancellationToken cancellationToken = default)
+            {
+                Disconnect();
+                return Task.CompletedTask;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                Disconnect();
+                return ValueTask.CompletedTask;
+            }
+
+            public void Send<T>(IOutboundMessage<T> message) { }
+
+            public void StartStreaming() => IsStreaming = true;
+            public void StopStreaming() => IsStreaming = false;
+            public void EnableChannel(IChannel channel) { }
+            public void EnableChannels(IEnumerable<IChannel> channels) { }
+            public void DisableChannel(IChannel channel) { }
+            public void DisableAllChannels() { }
+            public void SetDioDirection(IChannel channel, ChannelDirection direction) { }
+            public void SetDioValue(IChannel channel, bool value) { }
+            public void SetPwmEnabled(IChannel channel, bool enabled) { }
+            public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent) { }
+            public void SetPwmFrequency(int frequencyHz) { }
+            public void SetAnalogOutput(int channelNumber, double voltage) { }
+            public void Reboot() => Disconnect();
+
+            public void SaveAdcCalibration() { }
+            public void LoadAdcCalibration() { }
+            public void SetAdcCalibrationSlope(int channelNumber, double calM) { }
+            public void SetAdcCalibrationOffset(int channelNumber, double calB) { }
+            public void SaveFactoryAdcCalibration() { }
+            public void LoadFactoryAdcCalibration() { }
+            public void UseAdcCalibration(int bank) { }
+            public void SaveVoltagePrecision() { }
+            public void LoadVoltagePrecision() { }
+
+            public Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveAdcCalibration(); return Task.CompletedTask; }
+            public Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadAdcCalibration(); return Task.CompletedTask; }
+            public Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default) { SetAdcCalibrationSlope(channelNumber, calM); return Task.CompletedTask; }
+            public Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default) { SetAdcCalibrationOffset(channelNumber, calB); return Task.CompletedTask; }
+            public Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveFactoryAdcCalibration(); return Task.CompletedTask; }
+            public Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadFactoryAdcCalibration(); return Task.CompletedTask; }
+            public Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default) { UseAdcCalibration(bank); return Task.CompletedTask; }
+            public Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default) { SaveVoltagePrecision(); return Task.CompletedTask; }
+            public Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default) { LoadVoltagePrecision(); return Task.CompletedTask; }
+        }
+
+        /// <summary>
+        /// A testable <see cref="DaqifiStreamingDevice"/> that captures sent messages instead of
+        /// writing to a transport, mirroring the pattern in <see cref="DaqifiStreamingDeviceTests"/>.
+        /// </summary>
+        private sealed class TestableDaqifiStreamingDevice : DaqifiStreamingDevice
+        {
+            public List<IOutboundMessage<string>> SentMessages { get; } = new();
+
+            public TestableDaqifiStreamingDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)
+            {
+            }
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                // Capture instead of sending so tests run without a real connection.
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    SentMessages.Add(stringMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAsyncSurfaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAsyncSurfaceTests.cs
@@ -250,6 +250,19 @@ namespace Daqifi.Core.Tests.Device
             Assert.Empty(device.SentMessages);
         }
 
+        [Fact]
+        public async Task RebootAsync_CanceledToken_OnDisconnectedDevice_ThrowsOperationCanceled_NotDeviceNotConnected()
+        {
+            // Cancellation must win over connection validation — matching every other ...Async
+            // member — so a caller can tell "this call was cancelled" apart from "the device
+            // wasn't connected" even when both are true at once.
+            var device = new TestableDaqifiStreamingDevice("TestDevice");
+            Assert.False(device.IsConnected);
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => device.RebootAsync(CanceledToken()));
+        }
+
         #endregion
 
         #region IDevice.ConnectAsync / DisconnectAsync are genuine members, not DIM shims

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAsyncSurfaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAsyncSurfaceTests.cs
@@ -261,6 +261,9 @@ namespace Daqifi.Core.Tests.Device
 
             await Assert.ThrowsAsync<OperationCanceledException>(
                 () => device.RebootAsync(CanceledToken()));
+
+            Assert.False(device.IsConnected);
+            Assert.Empty(device.SentMessages);
         }
 
         #endregion

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -4071,6 +4071,25 @@ public class FirmwareUpdateServiceTests
         public void Connect() => IsConnected = true;
         public void Disconnect() => IsConnected = false;
 
+        public Task ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Connect();
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken = default)
+        {
+            Disconnect();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disconnect();
+            return ValueTask.CompletedTask;
+        }
+
         public void Send<T>(IOutboundMessage<T> message)
         {
             if (message is IOutboundMessage<string> textMessage && textMessage.Data == "SYSTem:COMMunicate:LAN:APPLY")
@@ -4102,6 +4121,16 @@ public class FirmwareUpdateServiceTests
         public void SaveFactoryAdcCalibration() { }
         public void LoadFactoryAdcCalibration() { }
         public void UseAdcCalibration(int bank) { }
+
+        public Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadAdcCalibration(); return Task.CompletedTask; }
+        public Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default) { SetAdcCalibrationSlope(channelNumber, calM); return Task.CompletedTask; }
+        public Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default) { SetAdcCalibrationOffset(channelNumber, calB); return Task.CompletedTask; }
+        public Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default) { UseAdcCalibration(bank); return Task.CompletedTask; }
+        public Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default) { SaveVoltagePrecision(); return Task.CompletedTask; }
+        public Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default) { LoadVoltagePrecision(); return Task.CompletedTask; }
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
@@ -4175,6 +4204,26 @@ public class FirmwareUpdateServiceTests
         public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred { add { } remove { } }
         public void Connect() => IsConnected = true;
         public void Disconnect() => IsConnected = false;
+
+        public Task ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Connect();
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken = default)
+        {
+            Disconnect();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disconnect();
+            return ValueTask.CompletedTask;
+        }
+
         public void Send<T>(IOutboundMessage<T> message) { }
         public void StartStreaming() => IsStreaming = true;
         public void StopStreaming() => IsStreaming = false;
@@ -4199,6 +4248,17 @@ public class FirmwareUpdateServiceTests
         public void SaveFactoryAdcCalibration() { }
         public void LoadFactoryAdcCalibration() { }
         public void UseAdcCalibration(int bank) { }
+
+        public Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadAdcCalibration(); return Task.CompletedTask; }
+        public Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default) { SetAdcCalibrationSlope(channelNumber, calM); return Task.CompletedTask; }
+        public Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default) { SetAdcCalibrationOffset(channelNumber, calB); return Task.CompletedTask; }
+        public Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default) { UseAdcCalibration(bank); return Task.CompletedTask; }
+        public Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default) { SaveVoltagePrecision(); return Task.CompletedTask; }
+        public Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default) { LoadVoltagePrecision(); return Task.CompletedTask; }
+
         public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
             await Task.Delay(_attemptLatency, cancellationToken).ConfigureAwait(false);
@@ -4946,6 +5006,25 @@ public class FirmwareUpdateServiceTests
             StatusChanged?.Invoke(this, new DeviceStatusEventArgs(_status));
         }
 
+        public Task ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Connect();
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken = default)
+        {
+            Disconnect();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disconnect();
+            return ValueTask.CompletedTask;
+        }
+
         public void Send<T>(IOutboundMessage<T> message)
         {
             if (message is IOutboundMessage<string> textMessage)
@@ -4986,6 +5065,16 @@ public class FirmwareUpdateServiceTests
         public void SaveFactoryAdcCalibration() { }
         public void LoadFactoryAdcCalibration() { }
         public void UseAdcCalibration(int bank) { }
+
+        public Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadAdcCalibration(); return Task.CompletedTask; }
+        public Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default) { SetAdcCalibrationSlope(channelNumber, calM); return Task.CompletedTask; }
+        public Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default) { SetAdcCalibrationOffset(channelNumber, calB); return Task.CompletedTask; }
+        public Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default) { UseAdcCalibration(bank); return Task.CompletedTask; }
+        public Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default) { SaveVoltagePrecision(); return Task.CompletedTask; }
+        public Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default) { LoadVoltagePrecision(); return Task.CompletedTask; }
     }
 
     private sealed class FakeLanChipInfoStreamingDevice : IStreamingDevice, ILanChipInfoProvider
@@ -5062,6 +5151,25 @@ public class FirmwareUpdateServiceTests
             StatusChanged?.Invoke(this, new DeviceStatusEventArgs(_status));
         }
 
+        public Task ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Connect();
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken = default)
+        {
+            Disconnect();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disconnect();
+            return ValueTask.CompletedTask;
+        }
+
         public void Send<T>(IOutboundMessage<T> message)
         {
             if (message is IOutboundMessage<string> textMessage)
@@ -5101,6 +5209,16 @@ public class FirmwareUpdateServiceTests
         public void SaveFactoryAdcCalibration() { }
         public void LoadFactoryAdcCalibration() { }
         public void UseAdcCalibration(int bank) { }
+
+        public Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadAdcCalibration(); return Task.CompletedTask; }
+        public Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default) { SetAdcCalibrationSlope(channelNumber, calM); return Task.CompletedTask; }
+        public Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default) { SetAdcCalibrationOffset(channelNumber, calB); return Task.CompletedTask; }
+        public Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default) { UseAdcCalibration(bank); return Task.CompletedTask; }
+        public Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default) { SaveVoltagePrecision(); return Task.CompletedTask; }
+        public Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default) { LoadVoltagePrecision(); return Task.CompletedTask; }
 
         public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Daqifi.Core.Tests/Firmware/LanChipInfoProviderExtensionsTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/LanChipInfoProviderExtensionsTests.cs
@@ -489,6 +489,25 @@ public class LanChipInfoProviderExtensionsTests
 
         public void Disconnect() => IsConnected = false;
 
+        public Task ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Connect();
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync(CancellationToken cancellationToken = default)
+        {
+            Disconnect();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disconnect();
+            return ValueTask.CompletedTask;
+        }
+
         public void Send<T>(IOutboundMessage<T> message)
         {
             if (ThrowOnSend)
@@ -529,5 +548,15 @@ public class LanChipInfoProviderExtensionsTests
         public void SaveFactoryAdcCalibration() { }
         public void LoadFactoryAdcCalibration() { }
         public void UseAdcCalibration(int bank) { }
+
+        public Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadAdcCalibration(); return Task.CompletedTask; }
+        public Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default) { SetAdcCalibrationSlope(channelNumber, calM); return Task.CompletedTask; }
+        public Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default) { SetAdcCalibrationOffset(channelNumber, calB); return Task.CompletedTask; }
+        public Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { SaveFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default) { LoadFactoryAdcCalibration(); return Task.CompletedTask; }
+        public Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default) { UseAdcCalibration(bank); return Task.CompletedTask; }
+        public Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default) { SaveVoltagePrecision(); return Task.CompletedTask; }
+        public Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default) { LoadVoltagePrecision(); return Task.CompletedTask; }
     }
 }

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -859,12 +859,33 @@ namespace Daqifi.Core.Device
         /// <inheritdoc />
         public void Reboot() => _administration.Reboot();
 
-        /// <inheritdoc cref="IStreamingDevice.RebootAsync" />
-        public Task RebootAsync(CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Reboots the device and disconnects from it, without blocking the calling thread.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="IStreamingDevice.RebootAsync"/>'s default implementation, this override
+        /// does not call the blocking <see cref="Reboot"/>: that path tears down through
+        /// <see cref="DaqifiDevice.Disconnect"/>, which can stall the caller for the full teardown
+        /// wait (up to <see cref="DaqifiDevice.TextExchangeTeardownWait"/>) — exactly the freeze the
+        /// async surface exists to avoid. This sends the same reboot command and then awaits
+        /// <see cref="DaqifiDevice.DisconnectAsync"/> instead, so the local teardown is genuinely
+        /// asynchronous.
+        /// </remarks>
+        /// <inheritdoc cref="IStreamingDevice.RebootAsync" path="/param|/returns|/exception" />
+        public async Task RebootAsync(CancellationToken cancellationToken = default)
         {
+            if (!IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
-            Reboot();
-            return Task.CompletedTask;
+
+            Send(ScpiMessageProducer.RebootDevice);
+
+            // The device drops its link while restarting, so tear down the local connection —
+            // without blocking the caller, unlike Reboot()'s synchronous Disconnect().
+            await DisconnectAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -26,7 +26,7 @@ namespace Daqifi.Core.Device
     /// Represents a DAQiFi device that supports data streaming functionality.
     /// Extends the base DaqifiDevice with streaming-specific operations.
     /// </summary>
-    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, IConfirmingDeviceAdministration, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost
+    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost
     {
         /// <summary>
         /// Response window allowed for the USB stream-interface command sent during
@@ -303,6 +303,22 @@ namespace Daqifi.Core.Device
 
             IsStreaming = false;
             Send(ScpiMessageProducer.StopStreaming);
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.StartStreamingAsync" />
+        public Task StartStreamingAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StartStreaming();
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc cref="IStreamingDevice.StopStreamingAsync" />
+        public Task StopStreamingAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StopStreaming();
+            return Task.CompletedTask;
         }
 
         #region Session state tracking for commands sent directly (issue #379)
@@ -675,21 +691,69 @@ namespace Daqifi.Core.Device
         /// <inheritdoc />
         public void EnableChannel(IChannel channel) => _channelControl.EnableChannel(channel);
 
+        /// <inheritdoc cref="IStreamingDevice.EnableChannelAsync" />
+        public Task EnableChannelAsync(IChannel channel, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnableChannel(channel);
+            return Task.CompletedTask;
+        }
+
         /// <inheritdoc />
         public void EnableChannels(IEnumerable<IChannel> channels) => _channelControl.EnableChannels(channels);
+
+        /// <inheritdoc cref="IStreamingDevice.EnableChannelsAsync" />
+        public Task EnableChannelsAsync(IEnumerable<IChannel> channels, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnableChannels(channels);
+            return Task.CompletedTask;
+        }
 
         /// <inheritdoc />
         public void DisableChannel(IChannel channel) => _channelControl.DisableChannel(channel);
 
+        /// <inheritdoc cref="IStreamingDevice.DisableChannelAsync" />
+        public Task DisableChannelAsync(IChannel channel, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DisableChannel(channel);
+            return Task.CompletedTask;
+        }
+
         /// <inheritdoc />
         public void DisableAllChannels() => _channelControl.DisableAllChannels();
+
+        /// <inheritdoc cref="IStreamingDevice.DisableAllChannelsAsync" />
+        public Task DisableAllChannelsAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DisableAllChannels();
+            return Task.CompletedTask;
+        }
 
         /// <inheritdoc />
         public void SetDioDirection(IChannel channel, ChannelDirection direction)
             => _channelControl.SetDioDirection(channel, direction);
 
+        /// <inheritdoc cref="IStreamingDevice.SetDioDirectionAsync" />
+        public Task SetDioDirectionAsync(IChannel channel, ChannelDirection direction, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetDioDirection(channel, direction);
+            return Task.CompletedTask;
+        }
+
         /// <inheritdoc />
         public void SetDioValue(IChannel channel, bool value) => _channelControl.SetDioValue(channel, value);
+
+        /// <inheritdoc cref="IStreamingDevice.SetDioValueAsync" />
+        public Task SetDioValueAsync(IChannel channel, bool value, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetDioValue(channel, value);
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// The lowest PWM frequency the firmware reproduces correctly. Below this the firmware's
@@ -719,12 +783,36 @@ namespace Daqifi.Core.Device
         /// <inheritdoc />
         public void SetPwmEnabled(IChannel channel, bool enabled) => _channelControl.SetPwmEnabled(channel, enabled);
 
+        /// <inheritdoc cref="IStreamingDevice.SetPwmEnabledAsync" />
+        public Task SetPwmEnabledAsync(IChannel channel, bool enabled, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetPwmEnabled(channel, enabled);
+            return Task.CompletedTask;
+        }
+
         /// <inheritdoc />
         public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent)
             => _channelControl.SetPwmDutyCycle(channel, dutyCyclePercent);
 
+        /// <inheritdoc cref="IStreamingDevice.SetPwmDutyCycleAsync" />
+        public Task SetPwmDutyCycleAsync(IChannel channel, int dutyCyclePercent, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetPwmDutyCycle(channel, dutyCyclePercent);
+            return Task.CompletedTask;
+        }
+
         /// <inheritdoc />
         public void SetPwmFrequency(int frequencyHz) => _channelControl.SetPwmFrequency(frequencyHz);
+
+        /// <inheritdoc cref="IStreamingDevice.SetPwmFrequencyAsync" />
+        public Task SetPwmFrequencyAsync(int frequencyHz, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetPwmFrequency(frequencyHz);
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Sets and persists the device's user-defined friendly name to NVM, then optimistically
@@ -760,8 +848,24 @@ namespace Daqifi.Core.Device
         public void SetAnalogOutput(int channelNumber, double voltage)
             => _channelControl.SetAnalogOutput(channelNumber, voltage);
 
+        /// <inheritdoc cref="IStreamingDevice.SetAnalogOutputAsync" />
+        public Task SetAnalogOutputAsync(int channelNumber, double voltage, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetAnalogOutput(channelNumber, voltage);
+            return Task.CompletedTask;
+        }
+
         /// <inheritdoc />
         public void Reboot() => _administration.Reboot();
+
+        /// <inheritdoc cref="IStreamingDevice.RebootAsync" />
+        public Task RebootAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Reboot();
+            return Task.CompletedTask;
+        }
 
         /// <inheritdoc />
         public void SaveAdcCalibration() => _administration.SaveAdcCalibration();

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -874,12 +874,15 @@ namespace Daqifi.Core.Device
         /// <inheritdoc cref="IStreamingDevice.RebootAsync" path="/param|/returns|/exception" />
         public async Task RebootAsync(CancellationToken cancellationToken = default)
         {
+            // Cancellation is checked before validation, matching every other ...Async member on
+            // this class: a pre-cancelled token must surface as OperationCanceledException even on
+            // a disconnected device, not be masked by DeviceNotConnectedException.
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (!IsConnected)
             {
                 throw new DeviceNotConnectedException();
             }
-
-            cancellationToken.ThrowIfCancellationRequested();
 
             Send(ScpiMessageProducer.RebootDevice);
 

--- a/src/Daqifi.Core/Device/IConfirmingDeviceAdministration.cs
+++ b/src/Daqifi.Core/Device/IConfirmingDeviceAdministration.cs
@@ -22,12 +22,14 @@ namespace Daqifi.Core.Device
     /// owes the caller is a way to find out.
     /// </para>
     /// <para>
-    /// This is a separate interface rather than more members on <see cref="IStreamingDevice"/> so
-    /// existing implementers of that interface keep compiling, and it follows the same shape as the
-    /// other capability slices this device exposes
+    /// <see cref="IStreamingDevice"/> extends this interface, so any implementer of it gets the
+    /// confirming calibration calls directly — no cast needed. It remains a separate interface
+    /// (rather than folding the members straight into <see cref="IStreamingDevice"/>) because it
+    /// follows the same shape as the other capability slices this device exposes
     /// (<see cref="Network.INetworkConfigurable"/>, <see cref="SdCard.ISdCardOperations"/>,
-    /// <see cref="Firmware.ILanChipInfoProvider"/>, <see cref="Diagnostics.IDeviceDiagnostics"/>) — test for it
-    /// before use:
+    /// <see cref="Firmware.ILanChipInfoProvider"/>, <see cref="Diagnostics.IDeviceDiagnostics"/>), some
+    /// of which are implemented independently of <see cref="IStreamingDevice"/>. A caller holding only
+    /// a bare <see cref="IDevice"/> still needs the type test before use:
     /// </para>
     /// <code>
     /// if (device is IConfirmingDeviceAdministration admin)

--- a/src/Daqifi.Core/Device/IDevice.cs
+++ b/src/Daqifi.Core/Device/IDevice.cs
@@ -11,7 +11,13 @@ namespace Daqifi.Core.Device
     /// <summary>
     /// Base interface for all DAQiFi devices.
     /// </summary>
-    public interface IDevice
+    /// <remarks>
+    /// Extends <see cref="IAsyncDisposable"/> so a consumer holding only this interface — the point
+    /// of coding against it in the first place — can tear a device down without a cast to
+    /// <see cref="DaqifiDevice"/>. Implement it the way <see cref="DaqifiDevice.DisposeAsync"/> does:
+    /// disconnect, then release resources, guarded so it is safe to call more than once.
+    /// </remarks>
+    public interface IDevice : IAsyncDisposable
     {
         /// <summary>
         /// Gets the name of the device.
@@ -77,44 +83,27 @@ namespace Daqifi.Core.Device
         /// is signalled.
         /// </summary>
         /// <remarks>
-        /// The default implementation simply calls <see cref="Connect"/> on the calling thread, so
-        /// an existing <see cref="IDevice"/> implementation keeps compiling and working unchanged —
-        /// it just cannot honor the token beyond the check made before the attempt starts.
-        /// <see cref="DaqifiDevice"/> overrides it with a genuinely asynchronous, cancellable
-        /// implementation.
+        /// A genuine member, not a default-interface-method shim over <see cref="Connect"/> — every
+        /// implementer must honor the token, not merely check it before the attempt starts. See
+        /// <see cref="DaqifiDevice.ConnectAsync"/> for the reference implementation.
         /// </remarks>
         /// <param name="cancellationToken">A cancellation token to observe while connecting.</param>
         /// <returns>A task representing the asynchronous connect operation.</returns>
         /// <exception cref="OperationCanceledException">Thrown when the attempt is canceled.</exception>
-        Task ConnectAsync(CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            Connect();
-            return Task.CompletedTask;
-        }
+        Task ConnectAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Disconnects from the device without blocking the calling thread.
         /// </summary>
         /// <remarks>
-        /// The default implementation simply calls <see cref="Disconnect"/> on the calling thread,
-        /// so an existing <see cref="IDevice"/> implementation keeps compiling and working
-        /// unchanged. <see cref="DaqifiDevice"/> overrides it with a genuinely asynchronous
-        /// implementation; see that override for what the token does — teardown always runs to
-        /// completion, so cancellation shortens the wait rather than aborting the disconnect.
+        /// A genuine member, not a default-interface-method shim over <see cref="Disconnect"/>. See
+        /// <see cref="DaqifiDevice.DisconnectAsync"/> for the reference implementation and for what
+        /// the token does there — teardown always runs to completion, so cancellation shortens the
+        /// wait rather than aborting the disconnect; other implementers may choose differently.
         /// </remarks>
-        /// <param name="cancellationToken">
-        /// A cancellation token to observe while disconnecting. Ignored by this default
-        /// implementation: aborting a teardown part-way would leave the device in an
-        /// indeterminate state, which is worse than finishing it.
-        /// </param>
+        /// <param name="cancellationToken">A cancellation token to observe while disconnecting.</param>
         /// <returns>A task representing the asynchronous disconnect operation.</returns>
-        Task DisconnectAsync(CancellationToken cancellationToken = default)
-        {
-            _ = cancellationToken;
-            Disconnect();
-            return Task.CompletedTask;
-        }
+        Task DisconnectAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sends a message to the device.

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -1,12 +1,25 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Daqifi.Core.Channel;
+
+#nullable enable
 
 namespace Daqifi.Core.Device
 {
     /// <summary>
     /// Represents a device that supports data streaming.
     /// </summary>
-    public interface IStreamingDevice : IDevice
+    /// <remarks>
+    /// Extends <see cref="IConfirmingDeviceAdministration"/> so the calibration operations are
+    /// available with a <see cref="CancellationToken"/> directly on this interface, with no cast
+    /// needed — see that interface for why the confirming calibration calls exist alongside the
+    /// <c>void</c> ones declared here. The streaming/channel/DIO/PWM/output/reboot operations below
+    /// each carry an <c>...Async</c> twin for the same reason; unlike calibration, the concrete
+    /// device runs no async machinery under those today, so the default implementation is a thin,
+    /// cancellable wrapper over the synchronous call — see the remarks on <see cref="StartStreamingAsync"/>.
+    /// </remarks>
+    public interface IStreamingDevice : IDevice, IConfirmingDeviceAdministration
     {
         /// <summary>
         /// Gets or sets the streaming frequency in Hz.
@@ -24,9 +37,42 @@ namespace Daqifi.Core.Device
         void StartStreaming();
 
         /// <summary>
+        /// Starts streaming data from the device without blocking the calling thread.
+        /// </summary>
+        /// <remarks>
+        /// The default implementation is a thin, cancellable wrapper over <see cref="StartStreaming"/>:
+        /// it checks <paramref name="cancellationToken"/> once and then performs the same single,
+        /// fire-and-forget write — there is no underlying text exchange to await. Implementers whose
+        /// transport genuinely awaits (e.g. a confirming variant) should override it.
+        /// </remarks>
+        /// <param name="cancellationToken">A cancellation token to observe before starting.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task StartStreamingAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StartStreaming();
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Stops streaming data from the device.
         /// </summary>
         void StopStreaming();
+
+        /// <summary>
+        /// Stops streaming data from the device without blocking the calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="cancellationToken">A cancellation token to observe before stopping.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task StopStreamingAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            StopStreaming();
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Enables a single channel and reconfigures the device accordingly.
@@ -40,6 +86,22 @@ namespace Daqifi.Core.Device
         void EnableChannel(IChannel channel);
 
         /// <summary>
+        /// Enables a single channel and reconfigures the device accordingly, without blocking the
+        /// calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="channel">The channel to enable. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task EnableChannelAsync(IChannel channel, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnableChannel(channel);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Enables multiple channels in a single operation, sending at most one command per channel type.
         /// </summary>
         /// <param name="channels">The channels to enable. Each must belong to this device's <c>Channels</c> collection.</param>
@@ -49,6 +111,21 @@ namespace Daqifi.Core.Device
         /// analog channels and the global DIO enable for digital channels. The input is enumerated once.
         /// </remarks>
         void EnableChannels(IEnumerable<IChannel> channels);
+
+        /// <summary>
+        /// Enables multiple channels in a single operation, without blocking the calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="channels">The channels to enable. Each must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task EnableChannelsAsync(IEnumerable<IChannel> channels, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnableChannels(channels);
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Disables a single channel and reconfigures the device accordingly.
@@ -62,9 +139,39 @@ namespace Daqifi.Core.Device
         void DisableChannel(IChannel channel);
 
         /// <summary>
+        /// Disables a single channel and reconfigures the device accordingly, without blocking the
+        /// calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="channel">The channel to disable. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task DisableChannelAsync(IChannel channel, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DisableChannel(channel);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Disables all channels on the device.
         /// </summary>
         void DisableAllChannels();
+
+        /// <summary>
+        /// Disables all channels on the device, without blocking the calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task DisableAllChannelsAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DisableAllChannels();
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Sets the direction (input or output) of a digital I/O channel.
@@ -74,11 +181,45 @@ namespace Daqifi.Core.Device
         void SetDioDirection(IChannel channel, ChannelDirection direction);
 
         /// <summary>
+        /// Sets the direction (input or output) of a digital I/O channel, without blocking the
+        /// calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="direction">The direction to apply. Must be <see cref="ChannelDirection.Input"/> or <see cref="ChannelDirection.Output"/>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SetDioDirectionAsync(IChannel channel, ChannelDirection direction, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetDioDirection(channel, direction);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Sets the output state (high or low) of a digital I/O channel.
         /// </summary>
         /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
         /// <param name="value"><c>true</c> to drive the output high; <c>false</c> to drive it low.</param>
         void SetDioValue(IChannel channel, bool value);
+
+        /// <summary>
+        /// Sets the output state (high or low) of a digital I/O channel, without blocking the
+        /// calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="value"><c>true</c> to drive the output high; <c>false</c> to drive it low.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SetDioValueAsync(IChannel channel, bool value, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetDioValue(channel, value);
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Enables or disables PWM output on a PWM-capable digital channel.
@@ -99,6 +240,25 @@ namespace Daqifi.Core.Device
         void SetPwmEnabled(IChannel channel, bool enabled);
 
         /// <summary>
+        /// Enables or disables PWM output on a PWM-capable digital channel, without blocking the
+        /// calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.
+        /// Enabling requires <see cref="Channel.IDigitalChannel.IsPwmCapable"/>; disabling is accepted on any
+        /// digital channel.</param>
+        /// <param name="enabled"><c>true</c> to start PWM output; <c>false</c> to stop it.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SetPwmEnabledAsync(IChannel channel, bool enabled, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetPwmEnabled(channel, enabled);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Sets the PWM duty cycle of a PWM-capable digital channel.
         /// </summary>
         /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection
@@ -107,6 +267,25 @@ namespace Daqifi.Core.Device
         /// because the firmware stores but never applies it (the old duty keeps toggling); stop the output
         /// with <see cref="SetPwmEnabled"/> instead.</param>
         void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent);
+
+        /// <summary>
+        /// Sets the PWM duty cycle of a PWM-capable digital channel, without blocking the calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection
+        /// and be <see cref="Channel.IDigitalChannel.IsPwmCapable"/>.</param>
+        /// <param name="dutyCyclePercent">The duty cycle in whole percent, 1-100. A duty of 0 is rejected
+        /// because the firmware stores but never applies it (the old duty keeps toggling); stop the output
+        /// with <see cref="SetPwmEnabled"/> instead.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SetPwmDutyCycleAsync(IChannel channel, int dutyCyclePercent, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetPwmDutyCycle(channel, dutyCyclePercent);
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Sets the PWM frequency, in hertz, for the whole device.
@@ -119,6 +298,22 @@ namespace Daqifi.Core.Device
         /// each enabled channel's duty cycle.
         /// </remarks>
         void SetPwmFrequency(int frequencyHz);
+
+        /// <summary>
+        /// Sets the PWM frequency, in hertz, for the whole device, without blocking the calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="frequencyHz">The frequency in hertz, 6-50000. Values below 6 Hz are rejected because
+        /// the firmware's 16-bit period register silently wraps for them, producing a kilohertz-range output.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SetPwmFrequencyAsync(int frequencyHz, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetPwmFrequency(frequencyHz);
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Gets the last PWM frequency commanded through <see cref="SetPwmFrequency"/> this
@@ -142,6 +337,24 @@ namespace Daqifi.Core.Device
         void SetAnalogOutput(int channelNumber, double voltage);
 
         /// <summary>
+        /// Sets the analog output (DAC) voltage of a channel and applies it immediately, without
+        /// blocking the calling thread.
+        /// </summary>
+        /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
+        /// <param name="channelNumber">The analog output channel number. DAC channels are addressed by
+        /// number; they are not part of the <c>Channels</c> collection (which holds analog inputs).</param>
+        /// <param name="voltage">The output voltage, in volts. Must be a finite number.</param>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task SetAnalogOutputAsync(int channelNumber, double voltage, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SetAnalogOutput(channelNumber, voltage);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Reboots the device and disconnects from it.
         /// </summary>
         /// <remarks>
@@ -149,6 +362,26 @@ namespace Daqifi.Core.Device
         /// drops its link while restarting. Reconnect once the device is back online.
         /// </remarks>
         void Reboot();
+
+        /// <summary>
+        /// Reboots the device and disconnects from it, without blocking the calling thread.
+        /// </summary>
+        /// <remarks>
+        /// The default implementation is a thin, cancellable wrapper over <see cref="Reboot"/>: it
+        /// checks <paramref name="cancellationToken"/> once and then performs the same fire-and-forget
+        /// reboot command followed by a synchronous local teardown. Implementers whose disconnect is
+        /// itself genuinely asynchronous (see <see cref="IDevice.DisconnectAsync"/>) should override
+        /// this to await it instead.
+        /// </remarks>
+        /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        Task RebootAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Reboot();
+            return Task.CompletedTask;
+        }
 
         // -----------------------------------------------------------------
         // ADC calibration and voltage precision.

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -15,9 +15,12 @@ namespace Daqifi.Core.Device
     /// available with a <see cref="CancellationToken"/> directly on this interface, with no cast
     /// needed — see that interface for why the confirming calibration calls exist alongside the
     /// <c>void</c> ones declared here. The streaming/channel/DIO/PWM/output/reboot operations below
-    /// each carry an <c>...Async</c> twin for the same reason; unlike calibration, the concrete
-    /// device runs no async machinery under those today, so the default implementation is a thin,
-    /// cancellable wrapper over the synchronous call — see the remarks on <see cref="StartStreamingAsync"/>.
+    /// each carry an <c>...Async</c> twin for the same reason. Most of them have no genuine async
+    /// machinery underneath today, so the default implementation is a thin, cancellable wrapper over
+    /// the synchronous call — see the remarks on <see cref="StartStreamingAsync"/>. Reboot is the
+    /// exception: its teardown is a real, potentially-blocking wait, so
+    /// <see cref="DaqifiStreamingDevice.RebootAsync"/> overrides the default to await
+    /// <see cref="IDevice.DisconnectAsync"/> instead of calling <see cref="Reboot"/>.
     /// </remarks>
     public interface IStreamingDevice : IDevice, IConfirmingDeviceAdministration
     {


### PR DESCRIPTION
## Summary

Closes #460. Follow-on to #333 (not yet merged): that ticket promotes missing members and fixes factory return types; this one is the *shape* of the contracts — the three inconsistencies the issue calls out.

1. **`IStreamingDevice` async surface.** Every streaming/channel/DIO/PWM/analog-output/reboot method now has a cancellable `...Async` twin declared directly on the interface (`StartStreamingAsync`, `EnableChannelAsync`, `SetDioValueAsync`, `SetPwmEnabledAsync`, `SetAnalogOutputAsync`, `RebootAsync`, …). `IStreamingDevice` also now extends `IConfirmingDeviceAdministration`, so the confirming ADC-calibration/voltage-precision calls are reachable directly off an `IStreamingDevice` reference — no separate cast.
2. **`IDevice.ConnectAsync`/`DisconnectAsync` are genuine abstract members now**, not default-interface-method shims that quietly wrapped `Connect()`/`Disconnect()`. Every implementer must honor the `CancellationToken` itself.
3. **`IDevice` extends `IAsyncDisposable`.** A consumer holding only the interface can now `await using`/`await device.DisposeAsync()` without a cast to `DaqifiDevice`.

Sync methods are unchanged and remain the primary API for existing callers — nothing was removed.

## Design notes

- Most of the new `...Async` surface (streaming/channel/DIO/PWM/output/reboot) has **no genuine async machinery underneath today** — `DaqifiStreamingDevice`'s implementations are fire-and-forget synchronous writes. So the interface's default-interface-method body for each is a thin, cancellable wrapper over the sync call — that's an honest implementation of what's actually happening, not a stopgap (unlike the old `ConnectAsync`/`DisconnectAsync` shims, which hid genuinely async machinery that already existed in `DaqifiDevice`). `DaqifiStreamingDevice` also implements each of these explicitly as a regular class member (not relying purely on the DIM default), so they're callable directly on the concrete type the same way the existing sync methods are — a DIM-only default is only reachable through the interface type.
- Calibration is different: `DaqifiStreamingDevice` already runs real async machinery for those (drain-error-queue + confirm), on `IConfirmingDeviceAdministration`. Making `IStreamingDevice` extend that interface (rather than duplicating differently-behaved members with the same names) reuses it directly with zero code changes to the concrete class.

## Breaking changes

Any `IDevice`/`IStreamingDevice` implementer outside this repo needs to add:
- `ConnectAsync`, `DisconnectAsync` (previously optional via DIM)
- `DisposeAsync` (`IAsyncDisposable`)
- The 9 `IConfirmingDeviceAdministration` calibration members (previously only reachable via `is IConfirmingDeviceAdministration` cast)

Per the issue, batch this into the same release note as #333 when both ship.

## Testing

- Updated the five `IStreamingDevice` test fakes in `FirmwareUpdateServiceTests.cs` / `LanChipInfoProviderExtensionsTests.cs` for the new interface shape.
- Added `DaqifiStreamingDeviceAsyncSurfaceTests.cs`: delegation + cancellation behavior for the new `...Async` methods, `IDevice.ConnectAsync`/`DisconnectAsync` reachable through the interface, `IDevice : IAsyncDisposable`, and a minimal `IStreamingDevice` implementer proving the default-interface-method bodies work when reached only through the interface type.
- `dotnet build` — solution builds clean (0 warnings, 0 errors).
- `dotnet test` — full suite passes: 2846 passed, 2 skipped (real-hardware tests), 0 failed, both net9.0 and net10.0. Plus `Daqifi.Mcp.Tests` (23 passed).
- `dotnet format --verify-no-changes` — no new formatting issues introduced (pre-existing drift in files this PR doesn't touch).

No bench hardware test was needed: this PR only reshapes interface contracts and adds thin wrappers over already-tested code paths (`DaqifiStreamingDevice`'s sync methods, `DaqifiDevice`'s existing `ConnectAsync`/`DisconnectAsync`/`DisposeAsync`), all covered by the unit suite above.

## Docs

- [docs/DEVICE_INTERFACES.md](docs/DEVICE_INTERFACES.md) — `IDevice`/`IStreamingDevice` core-interface sections, the "Connecting and disconnecting without blocking" section, and Channel Management examples.
- [README.md](README.md) — pointer to the async surface from the Digital output quick recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)