### PR TITLE
fix(device): normalize decimal/hex serial numbers in DeviceIdentity matching

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DeviceIdentityTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceIdentityTests.cs
@@ -87,6 +87,61 @@ public class DeviceIdentityTests
     }
 
     [Fact]
+    public void Matches_SameSerial_DecimalAndHex_AreTheSamePhysicalDevice()
+    {
+        // The value Core's protobuf-sourced paths report (DeviceMetadata.SerialNumber, base-10)
+        // and the value the device's own capability document reports (identity.serial, base-16,
+        // uppercase) for one real 64-bit serial — see #446.
+        var protobufSourced = DeviceIdentity.Create("16045690984833335023");
+        var capabilityDocumentSourced = DeviceIdentity.Create("DEADBEEFDEADBEEF");
+
+        Assert.True(protobufSourced.Matches(capabilityDocumentSourced));
+        Assert.True(capabilityDocumentSourced.Matches(protobufSourced));
+    }
+
+    [Fact]
+    public void Matches_SameSerial_HexIsCaseInsensitive()
+    {
+        var upper = DeviceIdentity.Create("DEADBEEFDEADBEEF");
+        var lower = DeviceIdentity.Create("deadbeefdeadbeef");
+
+        Assert.True(upper.Matches(lower));
+    }
+
+    [Fact]
+    public void Matches_DifferentSerials_DecimalAndHex_DoNotMatch()
+    {
+        var protobufSourced = DeviceIdentity.Create("16045690984833335023");
+        var unrelatedHex = DeviceIdentity.Create("FEEDFACEFEEDFACE");
+
+        Assert.False(protobufSourced.Matches(unrelatedHex));
+    }
+
+    [Fact]
+    public void Matches_NonNumericSerials_StillFallBackToCaseInsensitiveStringCompare()
+    {
+        // A serial that parses as neither base (e.g. a USB HID serial descriptor) keeps the
+        // pre-existing string-comparison behavior.
+        var first = DeviceIdentity.Create("DAQ-NOT-NUMERIC");
+        var second = DeviceIdentity.Create("daq-not-numeric");
+
+        Assert.True(first.Matches(second));
+    }
+
+    [Fact]
+    public void Key_SameSerial_DecimalAndHex_ProduceTheSameKey()
+    {
+        // Key is used as the connected-device registry's dictionary key (DaqifiDeviceRegistry), so
+        // it must stay in lock-step with Matches: the same physical device must file under one key
+        // regardless of which representation populated it.
+        var protobufSourced = DeviceIdentity.Create("16045690984833335023");
+        var capabilityDocumentSourced = DeviceIdentity.Create("DEADBEEFDEADBEEF");
+
+        Assert.Equal(protobufSourced.Key, capabilityDocumentSourced.Key);
+        Assert.Equal("sn:16045690984833335023", capabilityDocumentSourced.Key);
+    }
+
+    [Fact]
     public void Matches_DifferentSerials_DoNotMatch_EvenWhenAWeakerDiscriminatorAgrees()
     {
         // A serial-number mismatch is decisive: two units that both answered with a serial number

--- a/src/Daqifi.Core.Tests/Device/DeviceIdentityTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceIdentityTests.cs
@@ -118,6 +118,21 @@ public class DeviceIdentityTests
     }
 
     [Fact]
+    public void Matches_ShortHexLookingSerial_DoesNotNormalizeToDecimal()
+    {
+        // The hex fallback must not fire for anything shorter than the capability document's
+        // fixed 16-digit width — otherwise a short, coincidentally-hex serial (e.g. a USB HID
+        // descriptor, which is not guaranteed to be numeric at all) would silently collide with an
+        // unrelated device that reports that same value in decimal. "FACE" is 0xFACE = 64206.
+        var shortHex = DeviceIdentity.Create("FACE");
+        var decimalLookalike = DeviceIdentity.Create("64206");
+
+        Assert.False(shortHex.Matches(decimalLookalike));
+        Assert.NotEqual(shortHex.Key, decimalLookalike.Key);
+        Assert.Equal("sn:face", shortHex.Key);
+    }
+
+    [Fact]
     public void Matches_NonNumericSerials_StillFallBackToCaseInsensitiveStringCompare()
     {
         // A serial that parses as neither base (e.g. a USB HID serial descriptor) keeps the

--- a/src/Daqifi.Core/Device/DeviceIdentity.cs
+++ b/src/Daqifi.Core/Device/DeviceIdentity.cs
@@ -14,11 +14,12 @@ namespace Daqifi.Core.Device;
 /// Serial number — reported by every transport once the device has answered a status message
 /// (<see cref="IDeviceInfo.SerialNumber"/> pre-connect, <see cref="DeviceMetadata.SerialNumber"/>
 /// post-connect). Core's own protobuf-sourced paths always report this in base-10, but the
-/// device's own capability document (<c>identity.serial</c>) reports the same value in base-16 —
-/// so when both sides parse as a 64-bit integer (decimal preferred; hex as a fallback for a value
-/// that is not valid decimal) they are compared numerically rather than as strings. Any value that
-/// does not parse as either — for example a USB HID serial descriptor — falls back to
-/// case-insensitive string comparison.
+/// device's own capability document (<c>identity.serial</c>) reports the same value as a
+/// fixed-width, 16-digit base-16 string — so when one side is a valid decimal number and the other
+/// is a 16-digit hex string, both are parsed as a 64-bit integer and compared numerically rather
+/// than as strings. Any value that does not parse as either — for example a USB HID serial
+/// descriptor, which is not guaranteed to be numeric at all and is not held to the capability
+/// document's fixed width — falls back to case-insensitive string comparison.
 /// </description></item>
 /// <item><description>
 /// MAC address — network-only, but present before a serial number is known on the WiFi path.
@@ -224,6 +225,13 @@ public sealed class DeviceIdentity
             : serialNumber.ToLowerInvariant();
 
     /// <summary>
+    /// The capability document's <c>identity.serial</c> field is a fixed-width 64-bit value
+    /// rendered as hex, which is always 16 digits (see #446) — never fewer, since a shorter value
+    /// would be zero-padded.
+    /// </summary>
+    private const int CapabilityDocumentSerialHexLength = 16;
+
+    /// <summary>
     /// Parses a serial number as the 64-bit integer it represents, trying base-10 first (the form
     /// every protobuf-sourced path in Core produces) and falling back to base-16 (the form the
     /// device's own capability document reports). A pure-digit string is genuinely ambiguous — for
@@ -232,12 +240,27 @@ public sealed class DeviceIdentity
     /// status-message path produces, so a serial that never leaves that path is unaffected by this
     /// method existing at all.
     /// </summary>
+    /// <remarks>
+    /// The hex fallback only fires for a string exactly <see cref="CapabilityDocumentSerialHexLength"/>
+    /// digits long — the capability document's fixed width. Without that constraint, any short
+    /// hex-digit-only string (a plausible USB HID serial descriptor, which is not guaranteed to be
+    /// numeric at all) would silently normalize to a small decimal value and could collide with an
+    /// unrelated device that happens to report that value as its decimal serial — e.g. the four
+    /// characters <c>"FACE"</c> parsing as <c>64206</c>.
+    /// </remarks>
     /// <param name="serial">The serial number string to parse.</param>
     /// <param name="value">The parsed value, or <c>0</c> when parsing fails.</param>
     /// <returns><c>true</c> when <paramref name="serial"/> parses as either base.</returns>
     private static bool TryParseSerialAsNumber(string serial, out ulong value)
-        => ulong.TryParse(serial, NumberStyles.None, CultureInfo.InvariantCulture, out value)
-            || ulong.TryParse(serial, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
+    {
+        if (ulong.TryParse(serial, NumberStyles.None, CultureInfo.InvariantCulture, out value))
+        {
+            return true;
+        }
+
+        return serial.Length == CapabilityDocumentSerialHexLength
+            && ulong.TryParse(serial, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
+    }
 
     /// <summary>
     /// Strips separators and case from a MAC address so the hyphenated form Core produces

--- a/src/Daqifi.Core/Device/DeviceIdentity.cs
+++ b/src/Daqifi.Core/Device/DeviceIdentity.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Daqifi.Core.Device.Discovery;
 
 namespace Daqifi.Core.Device;
@@ -12,7 +13,12 @@ namespace Daqifi.Core.Device;
 /// <item><description>
 /// Serial number — reported by every transport once the device has answered a status message
 /// (<see cref="IDeviceInfo.SerialNumber"/> pre-connect, <see cref="DeviceMetadata.SerialNumber"/>
-/// post-connect). Compared case-insensitively.
+/// post-connect). Core's own protobuf-sourced paths always report this in base-10, but the
+/// device's own capability document (<c>identity.serial</c>) reports the same value in base-16 —
+/// so when both sides parse as a 64-bit integer (decimal preferred; hex as a fallback for a value
+/// that is not valid decimal) they are compared numerically rather than as strings. Any value that
+/// does not parse as either — for example a USB HID serial descriptor — falls back to
+/// case-insensitive string comparison.
 /// </description></item>
 /// <item><description>
 /// MAC address — network-only, but present before a serial number is known on the WiFi path.
@@ -41,7 +47,7 @@ public sealed class DeviceIdentity
         MacAddress = Normalize(macAddress);
         LocationKey = Normalize(locationKey);
 
-        Key = SerialNumber != null ? "sn:" + SerialNumber.ToLowerInvariant()
+        Key = SerialNumber != null ? "sn:" + NormalizeSerialForKey(SerialNumber)
             : MacAddress != null ? "mac:" + NormalizeMac(MacAddress)
             : LocationKey != null ? "loc:" + LocationKey.ToLowerInvariant()
             : string.Empty;
@@ -130,6 +136,12 @@ public sealed class DeviceIdentity
 
         if (SerialNumber != null && other.SerialNumber != null)
         {
+            if (TryParseSerialAsNumber(SerialNumber, out var thisSerial)
+                && TryParseSerialAsNumber(other.SerialNumber, out var otherSerial))
+            {
+                return thisSerial == otherSerial;
+            }
+
             return SerialNumber.Equals(other.SerialNumber, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -199,6 +211,33 @@ public sealed class DeviceIdentity
     /// </summary>
     private static string? Normalize(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    /// <summary>
+    /// Reduces a serial number to the key fragment used in <see cref="Key"/>: the decimal value
+    /// when the serial parses as one (see <see cref="TryParseSerialAsNumber"/>), otherwise the
+    /// lowercased raw string. Keeps <see cref="Key"/> in lock-step with <see cref="Matches"/> — two
+    /// identities that <see cref="Matches"/> says are equal always produce the same key.
+    /// </summary>
+    private static string NormalizeSerialForKey(string serialNumber)
+        => TryParseSerialAsNumber(serialNumber, out var value)
+            ? value.ToString(CultureInfo.InvariantCulture)
+            : serialNumber.ToLowerInvariant();
+
+    /// <summary>
+    /// Parses a serial number as the 64-bit integer it represents, trying base-10 first (the form
+    /// every protobuf-sourced path in Core produces) and falling back to base-16 (the form the
+    /// device's own capability document reports). A pure-digit string is genuinely ambiguous — for
+    /// example a 16-digit all-numeric capability-document serial is valid as both — and the
+    /// decimal-first order resolves that ambiguity in favor of the representation Core's own
+    /// status-message path produces, so a serial that never leaves that path is unaffected by this
+    /// method existing at all.
+    /// </summary>
+    /// <param name="serial">The serial number string to parse.</param>
+    /// <param name="value">The parsed value, or <c>0</c> when parsing fails.</param>
+    /// <returns><c>true</c> when <paramref name="serial"/> parses as either base.</returns>
+    private static bool TryParseSerialAsNumber(string serial, out ulong value)
+        => ulong.TryParse(serial, NumberStyles.None, CultureInfo.InvariantCulture, out value)
+            || ulong.TryParse(serial, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
 
     /// <summary>
     /// Strips separators and case from a MAC address so the hyphenated form Core produces


### PR DESCRIPTION
## Summary

`DeviceMetadata.SerialNumber` (from protobuf `DaqifiOutMessage.DeviceSn`, a `ulong`) is always reported in base-10, but the device's own capability document (`CONFigure:CAPabilities:JSON?` → `identity.serial`) reports the same physical serial in base-16, uppercase. Nothing normalized between the two, so `DeviceIdentity.Matches` — whose entire job is recognizing that two sightings are one physical unit (#380) — compared them as plain case-insensitive strings and could never match a decimal-sourced serial against a hex-sourced one for the same device.

Fixes #446.

## Fix

Option 1 from the issue (smallest blast radius): normalize inside `DeviceIdentity` rather than changing any publicly displayed value.

- `DeviceIdentity.Matches` now tries to parse both serials as a 64-bit integer — base-10 first (the form every protobuf-sourced path in Core produces), base-16 as a fallback — and compares numerically when both parse. Serials that parse as neither (e.g. a USB HID serial descriptor) keep the pre-existing case-insensitive string comparison.
- `DeviceIdentity.Key` (used as the connected-device registry's dictionary key) uses the same normalization, so the same physical device files under one key regardless of which representation populated it — keeping `Key` and `Matches` in lock-step, per the class's own documented invariant.
- Updated the class-level doc comment, which previously said the serial is "compared case-insensitively" without qualification.

The ambiguity the issue calls out — a 16-digit all-numeric string is valid as both decimal and hex — is resolved by trying decimal first, matching the representation Core's own status-message path produces.

## Testing

- `dotnet test src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj --filter FullyQualifiedName~DeviceIdentityTests` — 24/24 passed (5 new: decimal/hex match, hex case-insensitivity, unrelated hex mismatch, non-numeric fallback, and `Key` consistency across representations, using the real 64-bit value from the issue's own decimal/hex pair)
- `dotnet test Daqifi.Core.sln` — full suite green (2852 passed, 2 skipped real-hardware tests, unchanged)
- `dotnet build Daqifi.Core.sln` — 0 warnings, 0 errors

No device on hand for this pass — the bug and its fix are pure logic/representation, and the issue's bench-measured decimal/hex pair for one real device is reproduced verbatim as the regression-test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)