### PR TITLE
fix(device): block digital writes while PWM is active on the channel

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceChannelManagementTests.cs
@@ -418,6 +418,21 @@ namespace Daqifi.Core.Tests.Device
             Assert.Throws<ArgumentException>(() => device.SetDioDirection(foreign, ChannelDirection.Output));
         }
 
+        [Fact]
+        public void SetDioDirection_WhilePwmEnabled_ThrowsInvalidOperationException()
+        {
+            // The firmware silently ignores direction/state writes while PWM is running the pin
+            // (#449) — Core rejects rather than mirroring a level the pin doesn't have.
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = (IDigitalChannel)DigitalChannelAt(device, 4);
+            device.SetPwmEnabled(channel, true);
+            device.SentMessages.Clear();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => device.SetDioDirection(channel, ChannelDirection.Output));
+            Assert.Contains("SetPwmEnabled", ex.Message);
+            Assert.Empty(device.SentMessages);
+        }
+
         #endregion
 
         #region SetDioValue
@@ -465,6 +480,23 @@ namespace Daqifi.Core.Tests.Device
             var foreign = new DigitalChannel(1); // correctly typed, but not a member of Channels
 
             Assert.Throws<ArgumentException>(() => device.SetDioValue(foreign, true));
+        }
+
+        [Fact]
+        public void SetDioValue_WhilePwmEnabled_ThrowsInvalidOperationExceptionAndDoesNotMirrorOutputValue()
+        {
+            // The firmware ignores the write entirely; Core must not report success or mirror a
+            // level the pin does not actually have (#449).
+            var device = CreateConnectedDevice(digitalChannels: 8);
+            var channel = (IDigitalChannel)DigitalChannelAt(device, 4);
+            device.SetPwmEnabled(channel, true);
+            device.SentMessages.Clear();
+            var outputValueBeforeAttempt = channel.OutputValue;
+
+            var ex = Assert.Throws<InvalidOperationException>(() => device.SetDioValue(channel, !outputValueBeforeAttempt));
+            Assert.Contains("SetPwmEnabled", ex.Message);
+            Assert.Equal(outputValueBeforeAttempt, channel.OutputValue);
+            Assert.Empty(device.SentMessages);
         }
 
         #endregion

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -179,8 +179,13 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Sets the direction (input or output) of a digital I/O channel.
         /// </summary>
-        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.
+        /// Rejected if <see cref="Channel.IDigitalChannel.IsPwmEnabled"/> is <c>true</c> on this channel — see
+        /// <see cref="SetPwmEnabled"/>.</param>
         /// <param name="direction">The direction to apply. Must be <see cref="ChannelDirection.Input"/> or <see cref="ChannelDirection.Output"/>.</param>
+        /// <exception cref="InvalidOperationException">Thrown when PWM is enabled on <paramref name="channel"/>; the
+        /// firmware ignores direction writes while PWM drives the pin. Call <see cref="SetPwmEnabled"/> with
+        /// <c>enabled: false</c> first.</exception>
         void SetDioDirection(IChannel channel, ChannelDirection direction);
 
         /// <summary>
@@ -188,11 +193,16 @@ namespace Daqifi.Core.Device
         /// calling thread.
         /// </summary>
         /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
-        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.
+        /// Rejected if <see cref="Channel.IDigitalChannel.IsPwmEnabled"/> is <c>true</c> on this channel — see
+        /// <see cref="SetPwmEnabled"/>.</param>
         /// <param name="direction">The direction to apply. Must be <see cref="ChannelDirection.Input"/> or <see cref="ChannelDirection.Output"/>.</param>
         /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when PWM is enabled on <paramref name="channel"/>; the
+        /// firmware ignores direction writes while PWM drives the pin. Call <see cref="SetPwmEnabled"/> with
+        /// <c>enabled: false</c> first.</exception>
         Task SetDioDirectionAsync(IChannel channel, ChannelDirection direction, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -203,8 +213,13 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Sets the output state (high or low) of a digital I/O channel.
         /// </summary>
-        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.
+        /// Rejected if <see cref="Channel.IDigitalChannel.IsPwmEnabled"/> is <c>true</c> on this channel — see
+        /// <see cref="SetPwmEnabled"/>.</param>
         /// <param name="value"><c>true</c> to drive the output high; <c>false</c> to drive it low.</param>
+        /// <exception cref="InvalidOperationException">Thrown when PWM is enabled on <paramref name="channel"/>; the
+        /// firmware ignores state writes while PWM drives the pin. Call <see cref="SetPwmEnabled"/> with
+        /// <c>enabled: false</c> first.</exception>
         void SetDioValue(IChannel channel, bool value);
 
         /// <summary>
@@ -212,11 +227,16 @@ namespace Daqifi.Core.Device
         /// calling thread.
         /// </summary>
         /// <inheritdoc cref="StartStreamingAsync" path="/remarks" />
-        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.</param>
+        /// <param name="channel">The digital channel. Must belong to this device's <c>Channels</c> collection.
+        /// Rejected if <see cref="Channel.IDigitalChannel.IsPwmEnabled"/> is <c>true</c> on this channel — see
+        /// <see cref="SetPwmEnabled"/>.</param>
         /// <param name="value"><c>true</c> to drive the output high; <c>false</c> to drive it low.</param>
         /// <param name="cancellationToken">A cancellation token to observe before sending.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when PWM is enabled on <paramref name="channel"/>; the
+        /// firmware ignores state writes while PWM drives the pin. Call <see cref="SetPwmEnabled"/> with
+        /// <c>enabled: false</c> first.</exception>
         Task SetDioValueAsync(IChannel channel, bool value, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
@@ -185,7 +185,7 @@ namespace Daqifi.Core.Device.Internal
             if (channel is IDigitalChannel { IsPwmEnabled: true })
             {
                 throw new InvalidOperationException(
-                    $"Channel {channel.ChannelNumber} has PWM enabled; digital direction/state commands are ignored by the firmware while PWM is running. Call SetPwmEnabled(channel, false) first.");
+                    $"Channel {channel.ChannelNumber} has PWM enabled; digital direction/state commands are ignored by the firmware while PWM is running. Disable PWM on this channel first (SetPwmEnabled(channel, false); the MCP server exposes this as the disable_pwm tool).");
             }
         }
 

--- a/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
@@ -136,6 +136,7 @@ namespace Daqifi.Core.Device.Internal
             }
 
             EnsureChannelBelongs(channel);
+            EnsurePwmNotEnabled(channel);
 
             channel.Direction = direction;
             _host.Send(ScpiMessageProducer.SetDioPortDirection(
@@ -162,6 +163,7 @@ namespace Daqifi.Core.Device.Internal
             }
 
             EnsureChannelBelongs(channel);
+            EnsurePwmNotEnabled(channel);
 
             if (channel is IDigitalChannel digitalChannel)
             {
@@ -169,6 +171,22 @@ namespace Daqifi.Core.Device.Internal
             }
 
             _host.Send(ScpiMessageProducer.SetDioPortState(channel.ChannelNumber, value ? 1 : 0));
+        }
+
+        /// <summary>
+        /// Blocks digital direction/state writes while PWM is active on the channel. The firmware
+        /// silently ignores those commands once PWM is running the pin, but Core would otherwise
+        /// still mirror the commanded level/direction into local state — telling every caller the
+        /// pin is doing something it is not (#449). Symmetric with the capability guard in
+        /// <see cref="SetPwmEnabled"/>; the only way past this is <c>SetPwmEnabled(channel, false)</c>.
+        /// </summary>
+        private static void EnsurePwmNotEnabled(IChannel channel)
+        {
+            if (channel is IDigitalChannel { IsPwmEnabled: true })
+            {
+                throw new InvalidOperationException(
+                    $"Channel {channel.ChannelNumber} has PWM enabled; digital direction/state commands are ignored by the firmware while PWM is running. Call SetPwmEnabled(channel, false) first.");
+            }
         }
 
         /// <inheritdoc cref="IStreamingDevice.SetPwmEnabled" />

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -275,10 +275,14 @@ public sealed class DaqifiAgent
         RequireControl();
         var (device, streaming) = RequireStreaming(deviceId);
         var ch = RequireDigitalChannel(device, channel);
-        RequirePwmDisabled(ch);
 
+        // The PWM check runs inside the same exclusive section as the write it guards, so no
+        // concurrent tool call can toggle PWM between the check and the send (#473) — an outer,
+        // unlocked check would leave that race open and could let Core's SDK-oriented exception
+        // (naming SetPwmEnabled, not an MCP tool) leak through instead of this guard's message.
         return await device.RunExclusiveAsync(_ =>
         {
+            RequirePwmDisabled(ch);
             streaming.SetDioDirection(ch, parsed);
 
             return Task.FromResult(DigitalPinResult.From(deviceId, ch));
@@ -294,12 +298,14 @@ public sealed class DaqifiAgent
         RequireControl();
         var (device, streaming) = RequireStreaming(deviceId);
         var ch = RequireDigitalChannel(device, channel);
-        RequirePwmDisabled(ch);
 
         // Direction-then-value is the sequence that must not be split: another tool call landing
-        // between them could flip the pin back to input before the value is driven.
+        // between them could flip the pin back to input before the value is driven. The PWM check
+        // runs inside the same exclusive section for the same reason — see SetDigitalDirectionAsync.
         return await device.RunExclusiveAsync(_ =>
         {
+            RequirePwmDisabled(ch);
+
             if (ch.Direction != ChannelDirection.Output)
             {
                 streaming.SetDioDirection(ch, ChannelDirection.Output);

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -277,7 +277,7 @@ public sealed class DaqifiAgent
         var ch = RequireDigitalChannel(device, channel);
 
         // The PWM check runs inside the same exclusive section as the write it guards, so no
-        // concurrent tool call can toggle PWM between the check and the send (#473) — an outer,
+        // concurrent tool call can toggle PWM between the check and the send (#449) — an outer,
         // unlocked check would leave that race open and could let Core's SDK-oriented exception
         // (naming SetPwmEnabled, not an MCP tool) leak through instead of this guard's message.
         return await device.RunExclusiveAsync(_ =>

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -275,6 +275,7 @@ public sealed class DaqifiAgent
         RequireControl();
         var (device, streaming) = RequireStreaming(deviceId);
         var ch = RequireDigitalChannel(device, channel);
+        RequirePwmDisabled(ch);
 
         return await device.RunExclusiveAsync(_ =>
         {
@@ -293,6 +294,7 @@ public sealed class DaqifiAgent
         RequireControl();
         var (device, streaming) = RequireStreaming(deviceId);
         var ch = RequireDigitalChannel(device, channel);
+        RequirePwmDisabled(ch);
 
         // Direction-then-value is the sequence that must not be split: another tool call landing
         // between them could flip the pin back to input before the value is driven.
@@ -649,6 +651,22 @@ public sealed class DaqifiAgent
                 $"{string.Join(", ", digital.Select(c => c.ChannelNumber).OrderBy(n => n))}.");
         }
         return match;
+    }
+
+    /// <summary>
+    /// Fails fast with MCP-actionable guidance when PWM is enabled on <paramref name="channel"/>,
+    /// rather than letting the call reach Core and surface its SDK-oriented
+    /// <see cref="InvalidOperationException"/> message (which points at <c>SetPwmEnabled</c>, a
+    /// method MCP callers have no tool for) — see #449.
+    /// </summary>
+    private static void RequirePwmDisabled(IChannel channel)
+    {
+        if (channel is IDigitalChannel { IsPwmEnabled: true })
+        {
+            throw new InvalidOperationException(
+                $"Channel {channel.ChannelNumber} has PWM enabled; the firmware ignores digital direction/state " +
+                "commands while PWM is running. Call disable_pwm on this channel first.");
+        }
     }
 
     private static ChannelDirection ParseDirection(string? direction) => (direction ?? string.Empty).Trim().ToLowerInvariant() switch

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -75,7 +75,7 @@ public static class DaqifiTools
         => GuardAsync(() => agent.ConfigureDigitalChannelsAsync(deviceId, enabledChannels));
 
     [McpServerTool(Name = "set_digital_direction")]
-    [Description("Set a digital channel's direction: 'input' (high-impedance, sampled during streaming) or 'output' (driven by the device; set the level with set_digital_output).")]
+    [Description("Set a digital channel's direction: 'input' (high-impedance, sampled during streaming) or 'output' (driven by the device; set the level with set_digital_output). Rejected while PWM is enabled on the channel — call disable_pwm first.")]
     public static Task<DigitalPinResult> SetDigitalDirection(
         DaqifiAgent agent,
         [Description("The device_id to configure.")] string deviceId,
@@ -84,7 +84,7 @@ public static class DaqifiTools
         => GuardAsync(() => agent.SetDigitalDirectionAsync(deviceId, channel, direction));
 
     [McpServerTool(Name = "set_digital_output")]
-    [Description("Drive a digital channel high or low. If the channel is currently an input it is switched to output direction first, so one call is enough to drive a pin.")]
+    [Description("Drive a digital channel high or low. If the channel is currently an input it is switched to output direction first, so one call is enough to drive a pin. Rejected while PWM is enabled on the channel — call disable_pwm first.")]
     public static Task<DigitalPinResult> SetDigitalOutput(
         DaqifiAgent agent,
         [Description("The device_id to control.")] string deviceId,
@@ -93,7 +93,7 @@ public static class DaqifiTools
         => GuardAsync(() => agent.SetDigitalOutputAsync(deviceId, channel, high));
 
     [McpServerTool(Name = "set_pwm_output")]
-    [Description("Start PWM output on a PWM-capable digital channel (Nyquist: channels 0, 3, 4, 5, 6, 7). Sets the duty cycle, optionally the device-wide frequency, then enables the channel. The frequency is shared by ALL PWM channels (one hardware timer). While PWM runs, digital direction/state commands for the channel are ignored by the hardware.")]
+    [Description("Start PWM output on a PWM-capable digital channel (Nyquist: channels 0, 3, 4, 5, 6, 7). Sets the duty cycle, optionally the device-wide frequency, then enables the channel. The frequency is shared by ALL PWM channels (one hardware timer). While PWM runs, set_digital_direction/set_digital_output on the channel are rejected rather than silently ignored — call disable_pwm first to drive it digitally again.")]
     public static Task<PwmResult> SetPwmOutput(
         DaqifiAgent agent,
         [Description("The device_id to control.")] string deviceId,


### PR DESCRIPTION
## Summary

`SetDioValue`/`SetDioDirection` (and therefore the MCP `set_digital_output`/`set_digital_direction` tools) reported success and mirrored the commanded level/direction into local channel state **while PWM was active on that channel**, even though the firmware silently ignores the command. The pin keeps running its PWM waveform while every readable property in Core says it's a static driven level.

Confirmed on bench hardware (Nq1, fw 3.7.2, loopback rig) in #449: duty cycle and transition counts are unchanged after a "successful" digital write issued during PWM.

## Fix

Adds a guard symmetric to the one `SetPwmEnabled` already has for the non-capable-channel case: `SetDioValue`/`SetDioDirection` now throw `InvalidOperationException` when `IDigitalChannel.IsPwmEnabled` is `true`, pointing the caller at `SetPwmEnabled(channel, false)` (the existing recovery path). No local mirroring happens, no SCPI is sent.

Also updates the `set_digital_output`/`set_digital_direction`/`set_pwm_output` MCP tool descriptions to document the precondition, per the issue's suggestion.

## Testing

- `SetDioDirection_WhilePwmEnabled_ThrowsInvalidOperationException`
- `SetDioValue_WhilePwmEnabled_ThrowsInvalidOperationExceptionAndDoesNotMirrorOutputValue`
- Full `Daqifi.Core.Tests` suite: 2855 passed
- Full `Daqifi.Mcp.Tests` suite: 36 passed

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)