### PR TITLE
fix(mcp): raise discover_devices timeout floor from 250ms to 1000ms

### DIFF
--- a/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
+++ b/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
@@ -66,6 +66,35 @@ public class DaqifiAgentTests
         Assert.Contains("discover_devices", ex.Message);
     }
 
+    // The serial identify handshake measures ~830 ms on real hardware (#448); a timeout below the
+    // floor returns an empty list before the device could ever answer, indistinguishable from "no
+    // device attached". These pin the clamp directly rather than through a real discovery run.
+    [Theory]
+    [InlineData(0)]
+    [InlineData(250)]   // the old floor — must no longer be honored
+    [InlineData(999)]
+    public void ClampDiscoveryTimeout_BelowFloor_ClampsToFloor(int timeoutMs)
+    {
+        Assert.Equal(
+            TimeSpan.FromMilliseconds(DaqifiAgent.MinDiscoveryTimeoutMs),
+            DaqifiAgent.ClampDiscoveryTimeout(timeoutMs));
+    }
+
+    [Theory]
+    [InlineData(1000)]
+    [InlineData(2000)]
+    [InlineData(30_000)]
+    public void ClampDiscoveryTimeout_WithinRange_IsUnchanged(int timeoutMs)
+    {
+        Assert.Equal(TimeSpan.FromMilliseconds(timeoutMs), DaqifiAgent.ClampDiscoveryTimeout(timeoutMs));
+    }
+
+    [Fact]
+    public void ClampDiscoveryTimeout_AboveCeiling_ClampsTo30Seconds()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(30), DaqifiAgent.ClampDiscoveryTimeout(60_000));
+    }
+
     [Fact]
     public async Task Disconnect_UnknownDevice_ReturnsMessageRatherThanThrows()
     {

--- a/src/Daqifi.Mcp/Daqifi.Mcp.csproj
+++ b/src/Daqifi.Mcp/Daqifi.Mcp.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Daqifi.Mcp.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -81,9 +81,10 @@ public sealed class DaqifiAgent
     /// Clamps a caller-supplied discovery timeout to <c>[<see cref="MinDiscoveryTimeoutMs"/>, 30_000]</c>
     /// ms. The floor is derived from measurement, not a guess: the serial identify handshake takes
     /// ~830 ms on real hardware, so anything below ~1000 ms returns empty before the device can
-    /// ever answer — indistinguishable from "nothing is attached" (#448). Successful discovery
-    /// still returns as soon as the device responds; this floor only rejects budgets that could
-    /// never have succeeded.
+    /// ever answer — indistinguishable from "nothing is attached" (#448). Serial probing can settle
+    /// and return before the full budget; <see cref="WiFiDeviceFinder"/> listens for the whole
+    /// window regardless (its receive loop runs until the timeout cancels it), so this floor mainly
+    /// rejects budgets that could never have succeeded rather than guaranteeing an early return.
     /// </summary>
     internal static TimeSpan ClampDiscoveryTimeout(int timeoutMs) =>
         TimeSpan.FromMilliseconds(Math.Clamp(timeoutMs, MinDiscoveryTimeoutMs, 30_000));

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -69,6 +69,25 @@ public sealed class DaqifiAgent
     /// <summary>Presence-only marker value for the two "commanded" tables above.</summary>
     private static readonly object PwmCommandedMarker = new();
 
+    /// <summary>
+    /// Floor for <see cref="DiscoverAsync"/>'s <c>timeoutMs</c> clamp. Bench-measured: the serial
+    /// identify handshake takes ~830 ms on real hardware, so this is that plus ~20% margin — a
+    /// timeout below it can never succeed and returns an empty list indistinguishable from "no
+    /// device attached" (#448). Was 250 ms, which is below the handshake time on every run.
+    /// </summary>
+    internal const int MinDiscoveryTimeoutMs = 1000;
+
+    /// <summary>
+    /// Clamps a caller-supplied discovery timeout to <c>[<see cref="MinDiscoveryTimeoutMs"/>, 30_000]</c>
+    /// ms. The floor is derived from measurement, not a guess: the serial identify handshake takes
+    /// ~830 ms on real hardware, so anything below ~1000 ms returns empty before the device can
+    /// ever answer — indistinguishable from "nothing is attached" (#448). Successful discovery
+    /// still returns as soon as the device responds; this floor only rejects budgets that could
+    /// never have succeeded.
+    /// </summary>
+    internal static TimeSpan ClampDiscoveryTimeout(int timeoutMs) =>
+        TimeSpan.FromMilliseconds(Math.Clamp(timeoutMs, MinDiscoveryTimeoutMs, 30_000));
+
     public DaqifiAgent(ServerOptions options, ILogger<DaqifiAgent>? logger = null)
     {
         _options = options;
@@ -80,7 +99,7 @@ public sealed class DaqifiAgent
     public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverAsync(
         int timeoutMs, bool wifi, bool serial, CancellationToken cancellationToken)
     {
-        var timeout = TimeSpan.FromMilliseconds(Math.Clamp(timeoutMs, 250, 30_000));
+        var timeout = ClampDiscoveryTimeout(timeoutMs);
         var infos = new List<IDeviceInfo>();
 
         if (wifi)

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -18,7 +18,7 @@ public static class DaqifiTools
     [Description("Discover DAQiFi devices on USB/serial and WiFi. Returns a list whose device_id values are used by the other tools. Call this first.")]
     public static Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevices(
         DaqifiAgent agent,
-        [Description("Discovery timeout in milliseconds (default 2000; clamped to 250..30000).")] int timeoutMs = 2000,
+        [Description("Discovery timeout in milliseconds (default 2000; clamped to 1000..30000). The floor is bench-measured: the serial identify handshake takes ~830 ms, so a lower budget returns an empty list before a device could ever answer — indistinguishable from none being attached. Successful calls return as soon as a device responds, not at the full timeout.")] int timeoutMs = 2000,
         [Description("Include WiFi/network discovery (default true).")] bool wifi = true,
         [Description("Include USB/serial discovery (default true).")] bool serial = true,
         CancellationToken cancellationToken = default)

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -18,7 +18,7 @@ public static class DaqifiTools
     [Description("Discover DAQiFi devices on USB/serial and WiFi. Returns a list whose device_id values are used by the other tools. Call this first.")]
     public static Task<IReadOnlyList<DiscoveredDevice>> DiscoverDevices(
         DaqifiAgent agent,
-        [Description("Discovery timeout in milliseconds (default 2000; clamped to 1000..30000). The floor is bench-measured: the serial identify handshake takes ~830 ms, so a lower budget returns an empty list before a device could ever answer — indistinguishable from none being attached. Successful calls return as soon as a device responds, not at the full timeout.")] int timeoutMs = 2000,
+        [Description("Discovery timeout in milliseconds (default 2000; clamped to 1000..30000). The floor is bench-measured: the serial identify handshake takes ~830 ms, so a lower budget returns an empty list before a device could ever answer — indistinguishable from none being attached. Serial probing can return before the full timeout once probes settle; WiFi discovery listens for replies for the whole window regardless, so a wifi=true call (the default) generally takes close to the full budget either way.")] int timeoutMs = 2000,
         [Description("Include WiFi/network discovery (default true).")] bool wifi = true,
         [Description("Include USB/serial discovery (default true).")] bool serial = true,
         CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

`DaqifiAgent.DiscoverAsync` clamped the caller's `timeoutMs` to a 250 ms floor, but the serial identify handshake takes ~830 ms on real hardware. Every value in the lower two-thirds of the advertised `250..30000` range — including the floor itself — returned an **empty list**, silently indistinguishable from "no device is plugged in".

Confirmed on bench hardware (Nq1, fw 3.7.2, USB CDC) in #448: 16/16 successful runs returned in 0.80–0.86 s regardless of a 900 ms or 2000 ms budget (the device answers as soon as it's ready, not at the timeout), while every run below ~830 ms failed at exactly its timeout.

## Fix

- Raise `DaqifiAgent.MinDiscoveryTimeoutMs` from 250 to 1000 (measured ~830 ms + ~20% margin).
- Update the `discover_devices` tool description to match and explain why.
- Extract the clamp into `DaqifiAgent.ClampDiscoveryTimeout` — there was no test for the clamp before; this makes it directly unit-testable without spinning up real device finders.

The secondary "distinguish timeout from no-device" and "call out the ~1ms claim-skip window" suggestions from the issue are left for a follow-up if it comes up again — this fix addresses the actual bug (a floor that could never succeed).

## Testing

- New tests: `ClampDiscoveryTimeout_BelowFloor_ClampsToFloor`, `ClampDiscoveryTimeout_WithinRange_IsUnchanged`, `ClampDiscoveryTimeout_AboveCeiling_ClampsTo30Seconds`
- Full `Daqifi.Mcp.Tests` suite: 43 passed
- Full `Daqifi.Core.Tests` suite: 2853 passed

Fixes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)