### PR TITLE
feat(device): eliminate the DaqifiStreamingDevice downcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ dotnet add package Daqifi.Core
 using Daqifi.Core.Device;
 using Daqifi.Core.Channel;
 
-// Connect — transport and device initialization handled for you. The factory returns the base
-// DaqifiDevice type, but the constructed instance is always a DaqifiStreamingDevice.
-await using var device = (DaqifiStreamingDevice)await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
+// Connect — transport and device initialization handled for you.
+await using var device = await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
 
 // Subscribe to decoded, per-channel samples
 var ai0 = device.GetChannelsSnapshot().First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
@@ -174,23 +173,17 @@ using var customFinder = new WiFiDeviceFinder(discoveryPort: 12345);
 Digital channels default to inputs. Flip one to output and drive it — the level is applied
 immediately, and flipping back to input releases the pin to high-impedance.
 
-`DaqifiDeviceFactory` returns the base `DaqifiDevice` type, so pattern-match to `IStreamingDevice`
-to reach these members — the same way as `INetworkConfigurable` below.
-
 ```csharp
 using Daqifi.Core.Channel;
 
-if (device is IStreamingDevice streamingDevice)
-{
-    var channels = device.GetChannelsSnapshot();
-    var dio3 = channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 3);
+var channels = device.GetChannelsSnapshot();
+var dio3 = channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 3);
 
-    streamingDevice.SetDioDirection(dio3, ChannelDirection.Output);
-    streamingDevice.SetDioValue(dio3, true);   // drive high
-    streamingDevice.SetDioValue(dio3, false);  // drive low
+device.SetDioDirection(dio3, ChannelDirection.Output);
+device.SetDioValue(dio3, true);   // drive high
+device.SetDioValue(dio3, false);  // drive low
 
-    streamingDevice.SetDioDirection(dio3, ChannelDirection.Input); // back to a streamed input
-}
+device.SetDioDirection(dio3, ChannelDirection.Input); // back to a streamed input
 ```
 
 Every `IStreamingDevice` method above (and the rest of the channel/PWM/analog-output/reboot surface)
@@ -206,43 +199,37 @@ one hardware timer drives them all.
 ```csharp
 using Daqifi.Core.Channel;
 
-if (device is IStreamingDevice streamingDevice)
-{
-    var pwm = device.GetChannelsSnapshot()
-        .OfType<IDigitalChannel>()
-        .First(c => c.IsPwmCapable);
+var pwm = device.GetChannelsSnapshot()
+    .OfType<IDigitalChannel>()
+    .First(c => c.IsPwmCapable);
 
-    streamingDevice.SetPwmDutyCycle(pwm, 25);  // 1-100 percent
-    streamingDevice.SetPwmFrequency(1000);     // 6-50000 Hz, applies to every PWM channel
-    streamingDevice.SetPwmEnabled(pwm, true);  // start
+device.SetPwmDutyCycle(pwm, 25);  // 1-100 percent
+device.SetPwmFrequency(1000);     // 6-50000 Hz, applies to every PWM channel
+device.SetPwmEnabled(pwm, true);  // start
 
-    streamingDevice.SetPwmDutyCycle(pwm, 75);  // duty changes take effect live
+device.SetPwmDutyCycle(pwm, 75);  // duty changes take effect live
 
-    streamingDevice.SetPwmEnabled(pwm, false); // stop — the pin is left high-impedance
-}
+device.SetPwmEnabled(pwm, false); // stop — the pin is left high-impedance
 ```
 
 ### Network configuration
 
-Devices implementing `INetworkConfigurable` accept programmatic WiFi and LAN configuration. `Mode`, `Ssid`, and `Password` are always applied on every call; only `StaticIP`, `SubnetMask`, and `Gateway` honor `null` as "leave unchanged" — so DHCP-only callers can omit the static-IP fields without affecting their DHCP setup.
+`DaqifiStreamingDevice` implements `INetworkConfigurable` for programmatic WiFi and LAN configuration. `Mode`, `Ssid`, and `Password` are always applied on every call; only `StaticIP`, `SubnetMask`, and `Gateway` honor `null` as "leave unchanged" — so DHCP-only callers can omit the static-IP fields without affecting their DHCP setup.
 
 ```csharp
 using System.Net;
 using Daqifi.Core.Device.Network;
 
-if (device is INetworkConfigurable networkDevice)
+var config = new NetworkConfiguration
 {
-    var config = new NetworkConfiguration
-    {
-        Ssid       = "MyNetwork",
-        Password   = "secret",
-        Mode       = WifiMode.ExistingNetwork,
-        StaticIP   = IPAddress.Parse("192.168.1.42"),
-        SubnetMask = IPAddress.Parse("255.255.255.0"),
-        Gateway    = IPAddress.Parse("192.168.1.1"),
-    };
-    await networkDevice.UpdateNetworkConfigurationAsync(config);
-}
+    Ssid       = "MyNetwork",
+    Password   = "secret",
+    Mode       = WifiMode.ExistingNetwork,
+    StaticIP   = IPAddress.Parse("192.168.1.42"),
+    SubnetMask = IPAddress.Parse("255.255.255.0"),
+    Gateway    = IPAddress.Parse("192.168.1.1"),
+};
+await device.UpdateNetworkConfigurationAsync(config);
 ```
 
 ### Firmware updates

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -103,7 +103,8 @@ The primary device class that provides:
 ### DaqifiStreamingDevice
 
 Extends `DaqifiDevice` with the full streaming/configuration surface — this is the class
-`DaqifiDeviceFactory` actually constructs for a connection. It implements:
+`DaqifiDeviceFactory` constructs for a connection, and the type its `Connect*` methods return
+directly (no cast required). It implements:
 
 - `IStreamingDevice` — streaming start/stop, channel enable/disable, digital I/O, PWM, analog output
   (see [Channel Management](#channel-management) below)
@@ -764,9 +765,7 @@ never sets that local state, so `SampleReceived` would not fire.
 using Daqifi.Core.Channel;
 using Daqifi.Core.Device;
 
-// DaqifiDeviceFactory methods return the base DaqifiDevice type, but the constructed instance is
-// always a DaqifiStreamingDevice — cast (or pattern-match with `is`) to reach its streaming API.
-await using var device = (DaqifiStreamingDevice)await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
+await using var device = await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
 
 var ai0 = device.GetChannelsSnapshot().First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
 ai0.SampleReceived += (sender, e) =>
@@ -798,7 +797,7 @@ cancellation and backpressure instead of hand-building an event/queue bridge. Ea
 the decoded `IDataSample` with the `IChannel` that produced it.
 
 ```csharp
-await using var device = (DaqifiStreamingDevice)await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
+await using var device = await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
 
 device.EnableChannels(device.GetChannelsSnapshot().Where(c => c.Type == ChannelType.Analog));
 device.StreamingFrequency = 100; // Hz
@@ -854,46 +853,43 @@ Console.WriteLine($"Received {sampleCount} samples");
 or disabling analog channels recomputes the full `ENAble:VOLTage:DC` bitmask internally; digital
 channels are toggled via the global DIO enable.
 
-`DaqifiDeviceFactory` returns the base `DaqifiDevice` type, so pattern-match to `IStreamingDevice`
-to reach these members — the same way as `INetworkConfigurable` below.
+`Channels`, along with the rest of the members below, is declared directly on `IStreamingDevice`
+(#333) — no cast to the concrete device type needed, whether `device` came from
+`DaqifiDeviceFactory` or is held only as an `IStreamingDevice` reference.
 
 ```csharp
 using Daqifi.Core.Channel;
 
-if (device is IStreamingDevice streamingDevice)
-{
-    // Channels are populated after a status message is received from the device.
-    // Channels itself lives on the DaqifiDevice base class, so it's read from `device`.
-    var ai0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
-    var ai2 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 2);
+// Channels are populated after a status message is received from the device.
+var ai0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+var ai2 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 2);
 
-    // Enable analog input channels (the device receives the combined bitmask, e.g. "5").
-    streamingDevice.EnableChannels(new[] { ai0, ai2 });
+// Enable analog input channels (the device receives the combined bitmask, e.g. "5").
+device.EnableChannels(new[] { ai0, ai2 });
 
-    // Disable a single channel — the recomputed mask reflects the remaining enabled channels.
-    streamingDevice.DisableChannel(ai0);
+// Disable a single channel — the recomputed mask reflects the remaining enabled channels.
+device.DisableChannel(ai0);
 
-    // Turn everything off.
-    streamingDevice.DisableAllChannels();
+// Turn everything off.
+device.DisableAllChannels();
 
-    // Digital I/O: set direction and drive an output.
-    var dio1 = device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
-    streamingDevice.SetDioDirection(dio1, ChannelDirection.Output);
-    streamingDevice.SetDioValue(dio1, true); // drive high
+// Digital I/O: set direction and drive an output.
+var dio1 = device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
+device.SetDioDirection(dio1, ChannelDirection.Output);
+device.SetDioValue(dio1, true); // drive high
 
-    // PWM on a capable channel (IDigitalChannel.IsPwmCapable). Duty is per channel; the
-    // frequency is device-wide because one hardware timer drives every PWM channel.
-    var pwm = device.Channels.OfType<IDigitalChannel>().First(c => c.IsPwmCapable);
-    streamingDevice.SetPwmDutyCycle(pwm, 25);  // 1-100 %
-    streamingDevice.SetPwmFrequency(1000);     // 6-50000 Hz, shared by all PWM channels
-    streamingDevice.SetPwmEnabled(pwm, true);  // start; SetPwmEnabled(pwm, false) stops (pin goes high-impedance)
+// PWM on a capable channel (IDigitalChannel.IsPwmCapable). Duty is per channel; the
+// frequency is device-wide because one hardware timer drives every PWM channel.
+var pwm = device.Channels.OfType<IDigitalChannel>().First(c => c.IsPwmCapable);
+device.SetPwmDutyCycle(pwm, 25);  // 1-100 %
+device.SetPwmFrequency(1000);     // 6-50000 Hz, shared by all PWM channels
+device.SetPwmEnabled(pwm, true);  // start; SetPwmEnabled(pwm, false) stops (pin goes high-impedance)
 
-    // Analog output (NQ3 only) — addressed by channel number; staged value is applied immediately.
-    streamingDevice.SetAnalogOutput(0, 2.5); // DAC channel 0 to 2.5 V
+// Analog output (NQ3 only) — addressed by channel number; staged value is applied immediately.
+device.SetAnalogOutput(0, 2.5); // DAC channel 0 to 2.5 V
 
-    // Reboot the device (also disconnects, since the device drops its link while restarting).
-    streamingDevice.Reboot();
-}
+// Reboot the device (also disconnects, since the device drops its link while restarting).
+device.Reboot();
 ```
 
 > Channel objects passed to the enable/disable and DIO methods must belong to the device's
@@ -937,40 +933,37 @@ logging and diagnostics SCPI surface — the system log, runtime log levels, SCP
 error-queue depth, and streaming/memory performance counters. These values originate **on the
 device**; this is not a client-side instrumentation framework.
 
-`DaqifiDeviceFactory` returns the base `DaqifiDevice` type, so pattern-match to `IDeviceDiagnostics`
-to reach these members — the same way as `INetworkConfigurable` below.
+`DaqifiDeviceFactory` returns `DaqifiStreamingDevice` directly, which implements
+`IDeviceDiagnostics` — no cast needed to reach these members.
 
 ```csharp
 using Daqifi.Core.Device.Diagnostics;
 
 await using var device = await DaqifiDeviceFactory.ConnectTcpAsync("192.168.1.100", 9760);
 
-if (device is IDeviceDiagnostics diagnostics)
-{
-    // System log (reading the log also clears the device buffer).
-    IReadOnlyList<SystemLogEntry> log = await diagnostics.GetSystemLogAsync();
-    foreach (var entry in log) Console.WriteLine(entry.Message);
-    await diagnostics.ClearSystemLogAsync();
+// System log (reading the log also clears the device buffer).
+IReadOnlyList<SystemLogEntry> log = await device.GetSystemLogAsync();
+foreach (var entry in log) Console.WriteLine(entry.Message);
+await device.ClearSystemLogAsync();
 
-    // Runtime log levels (0 = None, 1 = Error, 2 = Info, 3 = Debug). The returned
-    // setting reflects the level actually applied, which a module's ceiling may cap.
-    LogLevelSetting applied = await diagnostics.SetLogLevelAsync("STREAM", 2);
-    Console.WriteLine($"{applied.Module}: {applied.Level} (ceiling {applied.Ceiling})");
+// Runtime log levels (0 = None, 1 = Error, 2 = Info, 3 = Debug). The returned
+// setting reflects the level actually applied, which a module's ceiling may cap.
+LogLevelSetting applied = await device.SetLogLevelAsync("STREAM", 2);
+Console.WriteLine($"{applied.Module}: {applied.Level} (ceiling {applied.Ceiling})");
 
-    // SCPI command history (oldest first — the device numbers lines backwards from
-    // the present, so the newest command is last) and error-queue depth (non-destructive).
-    IReadOnlyList<string> history = await diagnostics.GetCommandHistoryAsync();
-    int queuedErrors = await diagnostics.GetSystemErrorCountAsync();
+// SCPI command history (oldest first — the device numbers lines backwards from
+// the present, so the newest command is last) and error-queue depth (non-destructive).
+IReadOnlyList<string> history = await device.GetCommandHistoryAsync();
+int queuedErrors = await device.GetSystemErrorCountAsync();
 
-    // Performance counters. Headline fields are typed (nullable when the running
-    // firmware doesn't emit them); the full set is available via Values.
-    StreamStats stream = await diagnostics.GetStreamStatsAsync();
-    Console.WriteLine($"Samples: {stream.TotalSamplesStreamed}, dropped: {stream.QueueDroppedSamples}");
+// Performance counters. Headline fields are typed (nullable when the running
+// firmware doesn't emit them); the full set is available via Values.
+StreamStats stream = await device.GetStreamStatsAsync();
+Console.WriteLine($"Samples: {stream.TotalSamplesStreamed}, dropped: {stream.QueueDroppedSamples}");
 
-    MemoryDiagnostics mem = await diagnostics.GetMemoryDiagnosticsAsync();
-    Console.WriteLine($"Heap free: {mem.HeapFree}/{mem.HeapTotal}");
-    foreach (var (key, value) in mem.Values) Console.WriteLine($"{key} = {value}");
-}
+MemoryDiagnostics mem = await device.GetMemoryDiagnosticsAsync();
+Console.WriteLine($"Heap free: {mem.HeapFree}/{mem.HeapTotal}");
+foreach (var (key, value) in mem.Values) Console.WriteLine($"{key} = {value}");
 ```
 
 Notes:

--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -853,16 +853,19 @@ Console.WriteLine($"Received {sampleCount} samples");
 or disabling analog channels recomputes the full `ENAble:VOLTage:DC` bitmask internally; digital
 channels are toggled via the global DIO enable.
 
-`Channels`, along with the rest of the members below, is declared directly on `IStreamingDevice`
-(#333) — no cast to the concrete device type needed, whether `device` came from
-`DaqifiDeviceFactory` or is held only as an `IStreamingDevice` reference.
+`Channels`/`GetChannelsSnapshot()`, along with the rest of the members below, are declared directly
+on `IStreamingDevice` (#333) — no cast to the concrete device type needed, whether `device` came
+from `DaqifiDeviceFactory` or is held only as an `IStreamingDevice` reference.
 
 ```csharp
 using Daqifi.Core.Channel;
 
-// Channels are populated after a status message is received from the device.
-var ai0 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
-var ai2 = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 2);
+// Channels are populated after a status message is received from the device. Channels itself is
+// a live view that can be repopulated concurrently on the consumer thread, so a snapshot (rather
+// than the live property) is what's safe to run LINQ queries against off that thread.
+var channels = device.GetChannelsSnapshot();
+var ai0 = channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+var ai2 = channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 2);
 
 // Enable analog input channels (the device receives the combined bitmask, e.g. "5").
 device.EnableChannels(new[] { ai0, ai2 });
@@ -874,13 +877,13 @@ device.DisableChannel(ai0);
 device.DisableAllChannels();
 
 // Digital I/O: set direction and drive an output.
-var dio1 = device.Channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
+var dio1 = channels.First(c => c.Type == ChannelType.Digital && c.ChannelNumber == 1);
 device.SetDioDirection(dio1, ChannelDirection.Output);
 device.SetDioValue(dio1, true); // drive high
 
 // PWM on a capable channel (IDigitalChannel.IsPwmCapable). Duty is per channel; the
 // frequency is device-wide because one hardware timer drives every PWM channel.
-var pwm = device.Channels.OfType<IDigitalChannel>().First(c => c.IsPwmCapable);
+var pwm = channels.OfType<IDigitalChannel>().First(c => c.IsPwmCapable);
 device.SetPwmDutyCycle(pwm, 25);  // 1-100 %
 device.SetPwmFrequency(1000);     // 6-50000 Hz, shared by all PWM channels
 device.SetPwmEnabled(pwm, true);  // start; SetPwmEnabled(pwm, false) stops (pin goes high-impedance)

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceFactoryTests.cs
@@ -577,6 +577,60 @@ public class DaqifiDeviceFactoryTests
 
     #endregion
 
+    #region Return Type Tests
+
+    // The constructed instance was always a DaqifiStreamingDevice; every public Connect* method
+    // returned the base DaqifiDevice type anyway, forcing every caller to cast (#333). These pin
+    // the narrower return type at the reflection level so a regression is caught even though the
+    // actual connect path needs live hardware to exercise end to end.
+    [Theory]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectTcp), new[] { typeof(string), typeof(int), typeof(DeviceConnectionOptions) })]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectTcp), new[] { typeof(IPAddress), typeof(int), typeof(DeviceConnectionOptions) })]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectSerial), new[] { typeof(string), typeof(DeviceConnectionOptions) })]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectSerial), new[] { typeof(string), typeof(int), typeof(DeviceConnectionOptions) })]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectFromDeviceInfo), new[] { typeof(IDeviceInfo), typeof(DeviceConnectionOptions) })]
+    public void SyncConnectMethod_ReturnsDaqifiStreamingDevice(string methodName, Type[] parameterTypes)
+    {
+        var method = typeof(DaqifiDeviceFactory).GetMethod(methodName, parameterTypes);
+        Assert.NotNull(method);
+        Assert.Equal(typeof(DaqifiStreamingDevice), method!.ReturnType);
+    }
+
+    [Theory]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectTcpAsync), new[] { typeof(string), typeof(int), typeof(DeviceConnectionOptions), typeof(CancellationToken) })]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectTcpAsync), new[] { typeof(IPAddress), typeof(int), typeof(DeviceConnectionOptions), typeof(CancellationToken) })]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectSerialAsync), new[] { typeof(string), typeof(DeviceConnectionOptions), typeof(CancellationToken) })]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectSerialAsync), new[] { typeof(string), typeof(int), typeof(DeviceConnectionOptions), typeof(CancellationToken) })]
+    [InlineData(nameof(DaqifiDeviceFactory.ConnectFromDeviceInfoAsync), new[] { typeof(IDeviceInfo), typeof(DeviceConnectionOptions), typeof(CancellationToken) })]
+    public void AsyncConnectMethod_ReturnsTaskOfDaqifiStreamingDevice(string methodName, Type[] parameterTypes)
+    {
+        var method = typeof(DaqifiDeviceFactory).GetMethod(methodName, parameterTypes);
+        Assert.NotNull(method);
+        Assert.Equal(typeof(Task<DaqifiStreamingDevice>), method!.ReturnType);
+    }
+
+    [Fact]
+    public void DiscoverAndConnectAsync_ReturnsTaskOfDaqifiStreamingDevice()
+    {
+        var method = typeof(DaqifiDeviceFactory).GetMethod(nameof(DaqifiDeviceFactory.DiscoverAndConnectAsync));
+        Assert.NotNull(method);
+        Assert.Equal(typeof(Task<DaqifiStreamingDevice>), method!.ReturnType);
+    }
+
+    [Fact]
+    public void IStreamingDevice_ExposesChannelsAndMetadataDirectly()
+    {
+        // Promoted onto the interface (#333) so a caller holding only IStreamingDevice can obtain
+        // a channel to pass into the interface's own enable/disable/DIO/PWM methods, without a
+        // cast to the concrete device type.
+        Assert.NotNull(typeof(IStreamingDevice).GetProperty(nameof(IStreamingDevice.Channels)));
+        Assert.NotNull(typeof(IStreamingDevice).GetProperty(nameof(IStreamingDevice.Metadata)));
+        Assert.NotNull(typeof(IStreamingDevice).GetMethod(nameof(IStreamingDevice.GetChannelsSnapshot)));
+        Assert.NotNull(typeof(IStreamingDevice).GetEvent(nameof(IStreamingDevice.ChannelsPopulated)));
+    }
+
+    #endregion
+
     #region Test Helpers
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAsyncSurfaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAsyncSurfaceTests.cs
@@ -349,6 +349,9 @@ namespace Daqifi.Core.Tests.Device
             public IPAddress? IpAddress => null;
             public bool IsConnected { get; private set; } = true;
             public ConnectionStatus Status => IsConnected ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+            public DeviceMetadata Metadata { get; } = new();
+            public IReadOnlyList<IChannel> Channels => Array.Empty<IChannel>();
+            public IReadOnlyList<IChannel> GetChannelsSnapshot() => Array.Empty<IChannel>();
             public int StreamingFrequency { get; set; }
             public bool IsStreaming { get; private set; }
             public int PwmFrequencyHz => 0;
@@ -356,6 +359,7 @@ namespace Daqifi.Core.Tests.Device
             public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
             public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
             public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred { add { } remove { } }
+            public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated { add { } remove { } }
 
             public void Connect() => IsConnected = true;
             public void Disconnect() => IsConnected = false;

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -4063,11 +4063,15 @@ public class FirmwareUpdateServiceTests
         public IPAddress? IpAddress => null;
         public bool IsConnected { get; private set; }
         public ConnectionStatus Status => ConnectionStatus.Connected;
+        public DeviceMetadata Metadata { get; } = new();
+        public IReadOnlyList<IChannel> Channels => Array.Empty<IChannel>();
+        public IReadOnlyList<IChannel> GetChannelsSnapshot() => Array.Empty<IChannel>();
         public int StreamingFrequency { get; set; }
         public bool IsStreaming { get; private set; }
         public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
         public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred { add { } remove { } }
+        public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated { add { } remove { } }
         public void Connect() => IsConnected = true;
         public void Disconnect() => IsConnected = false;
 
@@ -4197,11 +4201,15 @@ public class FirmwareUpdateServiceTests
         public IPAddress? IpAddress => null;
         public bool IsConnected { get; private set; }
         public ConnectionStatus Status => ConnectionStatus.Connected;
+        public DeviceMetadata Metadata { get; } = new();
+        public IReadOnlyList<IChannel> Channels => Array.Empty<IChannel>();
+        public IReadOnlyList<IChannel> GetChannelsSnapshot() => Array.Empty<IChannel>();
         public int StreamingFrequency { get; set; }
         public bool IsStreaming { get; private set; }
         public event EventHandler<DeviceStatusEventArgs>? StatusChanged { add { } remove { } }
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived { add { } remove { } }
         public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred { add { } remove { } }
+        public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated { add { } remove { } }
         public void Connect() => IsConnected = true;
         public void Disconnect() => IsConnected = false;
 
@@ -4956,6 +4964,9 @@ public class FirmwareUpdateServiceTests
         public IPAddress? IpAddress => null;
         public bool IsConnected { get; private set; }
         public ConnectionStatus Status => _status;
+        public DeviceMetadata Metadata { get; } = new();
+        public IReadOnlyList<IChannel> Channels => Array.Empty<IChannel>();
+        public IReadOnlyList<IChannel> GetChannelsSnapshot() => Array.Empty<IChannel>();
         public int StreamingFrequency { get; set; }
         public bool IsStreaming { get; private set; }
 
@@ -4979,6 +4990,12 @@ public class FirmwareUpdateServiceTests
         }
 
         public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated
         {
             add { }
             remove { }
@@ -5113,6 +5130,9 @@ public class FirmwareUpdateServiceTests
         public IPAddress? IpAddress => null;
         public bool IsConnected { get; private set; }
         public ConnectionStatus Status => _status;
+        public DeviceMetadata Metadata { get; } = new();
+        public IReadOnlyList<IChannel> Channels => Array.Empty<IChannel>();
+        public IReadOnlyList<IChannel> GetChannelsSnapshot() => Array.Empty<IChannel>();
         public int StreamingFrequency { get; set; }
         public bool IsStreaming { get; private set; }
 
@@ -5132,6 +5152,12 @@ public class FirmwareUpdateServiceTests
         }
 
         public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated
         {
             add { }
             remove { }

--- a/src/Daqifi.Core.Tests/Firmware/LanChipInfoProviderExtensionsTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/LanChipInfoProviderExtensionsTests.cs
@@ -464,6 +464,9 @@ public class LanChipInfoProviderExtensionsTests
         public IPAddress? IpAddress => null;
         public bool IsConnected { get; set; } = true;
         public ConnectionStatus Status => IsConnected ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        public DeviceMetadata Metadata { get; } = new();
+        public IReadOnlyList<IChannel> Channels => Array.Empty<IChannel>();
+        public IReadOnlyList<IChannel> GetChannelsSnapshot() => Array.Empty<IChannel>();
         public int StreamingFrequency { get; set; }
         public bool IsStreaming { get; private set; }
 
@@ -480,6 +483,12 @@ public class LanChipInfoProviderExtensionsTests
         }
 
         public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated
         {
             add { }
             remove { }

--- a/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceFactory.cs
@@ -41,11 +41,11 @@ public static class DaqifiDeviceFactory
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when host is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when port is not between 1 and 65535.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiDevice> ConnectTcpAsync(
+    public static async Task<DaqifiStreamingDevice> ConnectTcpAsync(
         string host,
         int port,
         DeviceConnectionOptions? options = null,
@@ -74,11 +74,11 @@ public static class DaqifiDeviceFactory
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when ipAddress is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when port is not between 1 and 65535.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiDevice> ConnectTcpAsync(
+    public static async Task<DaqifiStreamingDevice> ConnectTcpAsync(
         IPAddress ipAddress,
         int port,
         DeviceConnectionOptions? options = null,
@@ -106,9 +106,9 @@ public static class DaqifiDeviceFactory
     /// <param name="host">The hostname or IP address string to connect to.</param>
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when host is null or empty.</exception>
-    public static DaqifiDevice ConnectTcp(
+    public static DaqifiStreamingDevice ConnectTcp(
         string host,
         int port,
         DeviceConnectionOptions? options = null)
@@ -122,9 +122,9 @@ public static class DaqifiDeviceFactory
     /// <param name="ipAddress">The IP address to connect to.</param>
     /// <param name="port">The TCP port to connect to.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when ipAddress is null.</exception>
-    public static DaqifiDevice ConnectTcp(
+    public static DaqifiStreamingDevice ConnectTcp(
         IPAddress ipAddress,
         int port,
         DeviceConnectionOptions? options = null)
@@ -138,10 +138,10 @@ public static class DaqifiDeviceFactory
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static Task<DaqifiDevice> ConnectSerialAsync(
+    public static Task<DaqifiStreamingDevice> ConnectSerialAsync(
         string portName,
         DeviceConnectionOptions? options = null,
         CancellationToken cancellationToken = default)
@@ -156,11 +156,11 @@ public static class DaqifiDeviceFactory
     /// <param name="baudRate">The baud rate for the serial connection.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when baudRate is less than or equal to zero.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiDevice> ConnectSerialAsync(
+    public static async Task<DaqifiStreamingDevice> ConnectSerialAsync(
         string portName,
         int baudRate,
         DeviceConnectionOptions? options = null,
@@ -195,9 +195,9 @@ public static class DaqifiDeviceFactory
     /// </summary>
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
-    public static DaqifiDevice ConnectSerial(
+    public static DaqifiStreamingDevice ConnectSerial(
         string portName,
         DeviceConnectionOptions? options = null)
     {
@@ -210,10 +210,10 @@ public static class DaqifiDeviceFactory
     /// <param name="portName">The name of the serial port (e.g., "COM3", "/dev/ttyUSB0").</param>
     /// <param name="baudRate">The baud rate for the serial connection.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when portName is null or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when baudRate is less than or equal to zero.</exception>
-    public static DaqifiDevice ConnectSerial(
+    public static DaqifiStreamingDevice ConnectSerial(
         string portName,
         int baudRate,
         DeviceConnectionOptions? options = null)
@@ -227,12 +227,12 @@ public static class DaqifiDeviceFactory
     /// <param name="deviceInfo">The device information from discovery.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when deviceInfo is null.</exception>
     /// <exception cref="ArgumentException">Thrown when deviceInfo is missing required fields (IPAddress or Port for WiFi connections).</exception>
     /// <exception cref="NotSupportedException">Thrown when the connection type is not supported (e.g., Serial, HID).</exception>
     /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
-    public static async Task<DaqifiDevice> ConnectFromDeviceInfoAsync(
+    public static async Task<DaqifiStreamingDevice> ConnectFromDeviceInfoAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options = null,
         CancellationToken cancellationToken = default)
@@ -271,11 +271,11 @@ public static class DaqifiDeviceFactory
     /// </summary>
     /// <param name="deviceInfo">The device information from discovery.</param>
     /// <param name="options">Optional connection options. If null, uses default options.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when deviceInfo is null.</exception>
     /// <exception cref="ArgumentException">Thrown when deviceInfo is missing required fields (IPAddress or Port for WiFi connections).</exception>
     /// <exception cref="NotSupportedException">Thrown when the connection type is not supported (e.g., Serial, HID).</exception>
-    public static DaqifiDevice ConnectFromDeviceInfo(
+    public static DaqifiStreamingDevice ConnectFromDeviceInfo(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options = null)
     {
@@ -298,10 +298,10 @@ public static class DaqifiDeviceFactory
     /// is created and disposed internally.
     /// </param>
     /// <param name="cancellationToken">A cancellation token to cancel discovery and connection.</param>
-    /// <returns>A connected and optionally initialized <see cref="DaqifiDevice"/>.</returns>
+    /// <returns>A connected and optionally initialized <see cref="DaqifiStreamingDevice"/>.</returns>
     /// <exception cref="InvalidOperationException">Thrown when no matching device is discovered.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels the operation.</exception>
-    public static async Task<DaqifiDevice> DiscoverAndConnectAsync(
+    public static async Task<DaqifiStreamingDevice> DiscoverAndConnectAsync(
         Func<IDeviceInfo, bool>? filter = null,
         TimeSpan? timeout = null,
         DeviceConnectionOptions? options = null,
@@ -349,7 +349,7 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Connects to a WiFi device using the provided device info.
     /// </summary>
-    private static async Task<DaqifiDevice> ConnectWiFiDeviceAsync(
+    private static async Task<DaqifiStreamingDevice> ConnectWiFiDeviceAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options,
         CancellationToken cancellationToken)
@@ -402,7 +402,7 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Connects to a serial device using the provided device info.
     /// </summary>
-    private static async Task<DaqifiDevice> ConnectSerialDeviceAsync(
+    private static async Task<DaqifiStreamingDevice> ConnectSerialDeviceAsync(
         IDeviceInfo deviceInfo,
         DeviceConnectionOptions? options,
         CancellationToken cancellationToken)
@@ -454,12 +454,12 @@ public static class DaqifiDeviceFactory
     /// <summary>
     /// Internal method that handles the actual connection logic with a transport.
     /// </summary>
-    private static async Task<DaqifiDevice> ConnectWithTransportAsync(
+    private static async Task<DaqifiStreamingDevice> ConnectWithTransportAsync(
         IStreamTransport transport,
         DeviceConnectionOptions options,
         CancellationToken cancellationToken)
     {
-        DaqifiDevice? device = null;
+        DaqifiStreamingDevice? device = null;
 
         try
         {

--- a/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
+++ b/src/Daqifi.Core/Device/DaqifiDeviceRegistry.cs
@@ -96,8 +96,13 @@ public sealed class DaqifiDeviceRegistry : IDisposable
     /// </param>
     internal DaqifiDeviceRegistry(DeviceConnector? connector)
     {
-        _connector = connector ?? ((info, options, cancellationToken) =>
-            DaqifiDeviceFactory.ConnectFromDeviceInfoAsync(info, options, cancellationToken));
+        // Async, not a direct method-group forward: DaqifiDeviceFactory.ConnectFromDeviceInfoAsync
+        // returns Task<DaqifiStreamingDevice> (#333), one step narrower than this delegate's
+        // Task<DaqifiDevice> — the implicit reference conversion on the awaited result only applies
+        // to an async method's return statement, not to the Task instance itself.
+        _connector = connector ?? (async (info, options, cancellationToken) =>
+            await DaqifiDeviceFactory.ConnectFromDeviceInfoAsync(info, options, cancellationToken)
+                .ConfigureAwait(false));
     }
 
     #endregion

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,37 @@ namespace Daqifi.Core.Device
     /// </remarks>
     public interface IStreamingDevice : IDevice, IConfirmingDeviceAdministration
     {
+        /// <summary>
+        /// Gets the device metadata containing part number, firmware version, capabilities, etc.
+        /// </summary>
+        DeviceMetadata Metadata { get; }
+
+        /// <summary>
+        /// Gets the collection of channels populated from device status messages. Every
+        /// enable/disable/DIO/PWM method below documents that the channel it is given "must belong
+        /// to this device's <c>Channels</c> collection" — this member is what makes that
+        /// requirement satisfiable from an <see cref="IStreamingDevice"/> reference alone, with no
+        /// cast to the concrete device type (#333).
+        /// </summary>
+        /// <remarks>
+        /// This is a live view over the backing collection; callers that fold over channels off the
+        /// consumer thread should prefer <see cref="GetChannelsSnapshot"/> instead, for the same
+        /// reason documented there.
+        /// </remarks>
+        IReadOnlyList<IChannel> Channels { get; }
+
+        /// <summary>
+        /// Returns a point-in-time snapshot of the channel collection, safe to enumerate even when
+        /// a status message repopulates the collection concurrently on the consumer thread.
+        /// </summary>
+        /// <returns>A lock-protected copy of the current channel collection.</returns>
+        IReadOnlyList<IChannel> GetChannelsSnapshot();
+
+        /// <summary>
+        /// Occurs when channels have been populated from a device status message.
+        /// </summary>
+        event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated;
+
         /// <summary>
         /// Gets or sets the streaming frequency in Hz.
         /// </summary>

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -574,6 +574,14 @@ public sealed class DaqifiAgent
         return registration.Device;
     }
 
+    // #333 promoted Channels/Metadata/GetChannelsSnapshot/ChannelsPopulated onto IStreamingDevice
+    // and narrowed DaqifiDeviceFactory's return type, but this cast is a different one: it exists
+    // because DaqifiDeviceRegistry (this._registry) is deliberately typed over the base DaqifiDevice
+    // — its public Register(DaqifiDevice, ...) accepts any manually-constructed DaqifiDevice, not
+    // only ones this factory built — so a registered handle's static type here is never narrower
+    // than that. Every device this agent actually connects is in practice a DaqifiStreamingDevice,
+    // so the runtime check below always succeeds; it stays a check rather than an assumption because
+    // the registry's contract doesn't guarantee it.
     private (DaqifiDevice device, IStreamingDevice streaming) RequireStreaming(string deviceId)
     {
         var device = Require(deviceId);


### PR DESCRIPTION
## Summary

`DaqifiDeviceFactory`'s eight public `Connect*`/`DiscoverAndConnectAsync` methods were typed `Task<DaqifiDevice>` / `DaqifiDevice`, but the constructed instance was always a `DaqifiStreamingDevice` — every caller had to cast or pattern-match (`if (device is IStreamingDevice streamingDevice)`) to reach streaming, SD-card, network, or diagnostics operations. The README explained the downcast twice, `docs/DEVICE_INTERFACES.md` pattern-matched it in four sections, and the in-repo MCP consumer wrapped it in `RequireStreaming`/`RequireSdCard` helpers.

Worse, `IStreamingDevice`'s own docs said a channel argument "must belong to this device's `Channels` collection," but neither `IDevice` nor `IStreamingDevice` exposed `Channels`, `GetChannelsSnapshot()`, or `Metadata` — a consumer holding only the interface couldn't obtain a channel to pass into the interface's own methods.

## Changes

Following the issue's proposed "simplest path":

1. **`DaqifiDeviceFactory`** — narrowed every `Connect*`/`DiscoverAndConnectAsync` return type from `DaqifiDevice` to `DaqifiStreamingDevice`. Source-compatible: existing `DaqifiDevice`-typed call sites still compile via implicit upcast. **Binary break** — worth calling out in release notes.
2. **`IStreamingDevice`** — promoted `Channels`, `GetChannelsSnapshot()`, `Metadata`, and the `ChannelsPopulated` event onto the interface. `DaqifiStreamingDevice` already satisfies these via its `DaqifiDevice` base class, so no implementation changes were needed — this is purely a contract widening.
3. **`DaqifiDeviceRegistry`** — its internal `DeviceConnector` delegate stays typed over the base `DaqifiDevice` (its public `Register(DaqifiDevice, ...)` deliberately accepts any manually-constructed `DaqifiDevice`, not only ones the factory built — see the "Manual Device Connection (Advanced)" doc section), so the connector lambda needed a small async adjustment to bridge `Task<DaqifiStreamingDevice>` → `Task<DaqifiDevice>`.
4. **MCP (`DaqifiAgent.RequireStreaming`)** — for the same reason as #3, this keeps its runtime `IStreamingDevice` check; I documented why in a comment rather than removing it, since the registry's contract doesn't statically guarantee every registered device is a `DaqifiStreamingDevice` even though in practice it always is. Fully eliminating it would mean retyping `DaqifiDeviceRegistry` itself, which is a real design change beyond this issue's proposed scope (and would break the registry's legitimate "register any manually-connected `DaqifiDevice`" use case) — flagging this as a candidate follow-up rather than doing it here.
5. **Docs** — `README.md` and `docs/DEVICE_INTERFACES.md`: removed the cast/pattern-match advice from every example that connects through the factory (digital output, PWM, network configuration, channel management, device diagnostics). The "Manual Device Connection (Advanced)" section, which constructs a plain `DaqifiDevice` directly rather than through the factory, is unchanged since it doesn't get the narrowed type.

## Testing

- Reflection-based regression tests pinning the factory's return types and the new `IStreamingDevice` members (`DaqifiDeviceFactoryTests.cs`)
- Updated 6 test-only fake `IStreamingDevice` implementers across 3 files to satisfy the widened interface
- Full `Daqifi.Core.Tests` suite: 2867 passed
- Full `Daqifi.Mcp.Tests` suite: 36 passed

Fixes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)