### PR TITLE
chore(device): add BootloaderSessionDevice so Core owns the bootloader stand-in

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -115,6 +115,32 @@ directly (no cast required). It implements:
 - `IDeviceDiagnostics` — system log, runtime log levels, command history, and performance counters
   (see [Device Diagnostics](#device-diagnostics) below)
 
+### BootloaderSessionDevice
+
+Stands in for a device that is **already sitting in its bootloader**, so a manual bootloader-only
+firmware update can go through the same `IFirmwareUpdateService` entry points as a normal update.
+Every operation is a no-op and every collection is empty — a device in bootloader mode has no SCPI
+transport to talk to.
+
+```csharp
+await using var session = new BootloaderSessionDevice("DAQiFi Bootloader");
+await firmwareUpdateService.UpdateFirmwareAsync(session, hexFilePath, progress);
+```
+
+Three of its behaviours are load-bearing rather than incidental, because the PIC32 update flow
+touches the device before it ever reaches the bootloader:
+
+| Member | Value | Why |
+|--------|-------|-----|
+| `IsConnected` | starts `true` | The flow rejects a disconnected device before it starts |
+| `IsStreaming` | always `false` | Lets the flow skip its `StopStreaming()` call |
+| `Send(...)` | discards silently | The flow sends force-bootloader unconditionally; throwing would abort a valid update |
+
+Prefer this over hand-writing an `IStreamingDevice` stub in your own application. It is the only
+hand-written implementation of that interface shipped with the product, so a member added to
+`IStreamingDevice` is resolved here — in the change that adds it — instead of breaking your build on
+your next Core upgrade.
+
 ### DaqifiDeviceFactory
 
 Static factory class for simplified device connections:

--- a/src/Daqifi.Core.Tests/Device/BootloaderSessionDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/BootloaderSessionDeviceTests.cs
@@ -307,16 +307,62 @@ public class BootloaderSessionDeviceTests
                     $"{target.Name} threw {ex.InnerException?.GetType().Name}: {ex.InnerException?.Message}");
             }
 
-            // Observe returned tasks so a faulted one is not silently dropped.
-            switch (result)
-            {
-                case Task task:
-                    await task;
-                    break;
-                case ValueTask valueTask:
-                    await valueTask;
-                    break;
-            }
+            await ObserveAsync(result);
+        }
+    }
+
+    /// <summary>
+    /// Awaits whatever a reflected member returned, so a faulted result is surfaced rather than
+    /// silently dropped.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Task{TResult}"/> needs no special case — it derives from <see cref="Task"/>.
+    /// <see cref="ValueTask{TResult}"/> does: it is a distinct struct with no non-generic base, so
+    /// without the third branch a future member returning one could fault unobserved while the
+    /// sweep still passed.
+    /// </remarks>
+    private static async Task ObserveAsync(object? result)
+    {
+        switch (result)
+        {
+            case Task task:
+                await task;
+                break;
+            case ValueTask valueTask:
+                await valueTask;
+                break;
+            default:
+                if (result?.GetType() is { IsGenericType: true } type
+                    && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
+                {
+                    await (Task)type.GetMethod(nameof(ValueTask<int>.AsTask))!.Invoke(result, null)!;
+                }
+
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Guards the sweep's own result-observing logic: each awaitable shape a member could return
+    /// must surface a fault, or the sweep would report success over a throwing member.
+    /// </summary>
+    [Fact]
+    public async Task ObserveAsync_SurfacesFaults_ForEveryAwaitableShape()
+    {
+        var boom = new InvalidOperationException("boom");
+
+        object[] faulted =
+        [
+            Task.FromException(boom),
+            Task.FromException<int>(boom),
+            new ValueTask(Task.FromException(boom)),
+            new ValueTask<int>(Task.FromException<int>(boom)),
+        ];
+
+        foreach (var result in faulted)
+        {
+            var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => ObserveAsync(result));
+            Assert.Equal("boom", thrown.Message);
         }
     }
 

--- a/src/Daqifi.Core.Tests/Device/BootloaderSessionDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/BootloaderSessionDeviceTests.cs
@@ -1,0 +1,324 @@
+using System.Reflection;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
+using Daqifi.Core.Firmware;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Covers <see cref="BootloaderSessionDevice"/>: the three behaviours the PIC32 update flow
+/// depends on, the no-op contract for everything else, and a reflection sweep that keeps the type
+/// honest as <see cref="IStreamingDevice"/> grows (daqifi-core#477).
+/// </summary>
+public class BootloaderSessionDeviceTests
+{
+    #region Contract required by the PIC32 update flow
+
+    [Fact]
+    public void FreshInstance_SatisfiesEnsureDeviceConnected()
+    {
+        var device = new BootloaderSessionDevice();
+
+        // The real guard the update flow opens with. A stand-in that reported IsConnected == false
+        // would throw here and fail the update before it started.
+        var exception = Record.Exception(() => FirmwareUpdateContext.EnsureDeviceConnected(device));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void AfterDisconnect_FailsEnsureDeviceConnected()
+    {
+        var device = new BootloaderSessionDevice();
+        device.Disconnect();
+
+        // The mirror of the above: once the flow has torn the session down, the guard must reject
+        // it, so a second update attempt on a spent instance surfaces as a clear error.
+        Assert.Throws<InvalidOperationException>(() => FirmwareUpdateContext.EnsureDeviceConnected(device));
+    }
+
+    [Fact]
+    public void IsStreaming_IsAlwaysFalse()
+    {
+        // The flow only calls StopStreaming() when this is true.
+        Assert.False(new BootloaderSessionDevice().IsStreaming);
+    }
+
+    [Fact]
+    public void Send_DiscardsSilently()
+    {
+        var device = new BootloaderSessionDevice();
+
+        // The flow sends this unconditionally; throwing would abort a valid update.
+        var exception = Record.Exception(() => device.Send(ScpiMessageProducer.ForceBootloader));
+
+        Assert.Null(exception);
+    }
+
+    #endregion
+
+    #region Connection state
+
+    [Fact]
+    public void NewInstance_IsConnected()
+    {
+        var device = new BootloaderSessionDevice();
+
+        Assert.True(device.IsConnected);
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+    }
+
+    [Fact]
+    public void Disconnect_TransitionsAndRaisesStatusChangedOnce()
+    {
+        var device = new BootloaderSessionDevice();
+        var statuses = new List<ConnectionStatus>();
+        device.StatusChanged += (_, e) => statuses.Add(e.Status);
+
+        device.Disconnect();
+
+        Assert.False(device.IsConnected);
+        Assert.Equal(ConnectionStatus.Disconnected, device.Status);
+        Assert.Equal([ConnectionStatus.Disconnected], statuses);
+    }
+
+    [Fact]
+    public void Disconnect_WhenAlreadyDisconnected_DoesNotRaiseAgain()
+    {
+        var device = new BootloaderSessionDevice();
+        device.Disconnect();
+
+        var raised = 0;
+        device.StatusChanged += (_, _) => raised++;
+        device.Disconnect();
+
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public void Connect_WhenAlreadyConnected_DoesNotRaise()
+    {
+        var device = new BootloaderSessionDevice();
+        var raised = 0;
+        device.StatusChanged += (_, _) => raised++;
+
+        device.Connect();
+
+        Assert.True(device.IsConnected);
+        Assert.Equal(0, raised);
+    }
+
+    [Fact]
+    public void Reconnect_AfterDisconnect_RaisesConnected()
+    {
+        var device = new BootloaderSessionDevice();
+        device.Disconnect();
+
+        var statuses = new List<ConnectionStatus>();
+        device.StatusChanged += (_, e) => statuses.Add(e.Status);
+        device.Connect();
+
+        Assert.True(device.IsConnected);
+        Assert.Equal([ConnectionStatus.Connected], statuses);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisconnectsAndIsIdempotent()
+    {
+        var device = new BootloaderSessionDevice();
+        var raised = 0;
+        device.StatusChanged += (_, _) => raised++;
+
+        await device.DisposeAsync();
+        await device.DisposeAsync();
+
+        Assert.False(device.IsConnected);
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public async Task ConcurrentDisconnects_RaiseStatusChangedExactlyOnce()
+    {
+        var device = new BootloaderSessionDevice();
+        var raised = 0;
+        device.StatusChanged += (_, _) => Interlocked.Increment(ref raised);
+
+        // A dialog's teardown can race the update flow's own Disconnect(). Only one of them
+        // performed the transition, so only one notification is owed.
+        await Task.WhenAll(Enumerable.Range(0, 32).Select(_ => Task.Run(device.Disconnect)));
+
+        Assert.False(device.IsConnected);
+        Assert.Equal(1, Volatile.Read(ref raised));
+    }
+
+    #endregion
+
+    #region Naming
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Name_FallsBackToDefault_WhenNotSupplied(string? name)
+    {
+        Assert.Equal(BootloaderSessionDevice.DefaultName, new BootloaderSessionDevice(name).Name);
+    }
+
+    [Fact]
+    public void Name_UsesSuppliedValue()
+    {
+        Assert.Equal("Nyquist 1", new BootloaderSessionDevice("Nyquist 1").Name);
+    }
+
+    #endregion
+
+    #region Channels, metadata, and defaults
+
+    [Fact]
+    public void Channels_AndSnapshot_AreEmpty()
+    {
+        var device = new BootloaderSessionDevice();
+
+        Assert.Empty(device.Channels);
+        Assert.Empty(device.GetChannelsSnapshot());
+    }
+
+    [Fact]
+    public void Metadata_IsNonNull()
+    {
+        // Callers read this without a guard, so it must never be null.
+        Assert.NotNull(new BootloaderSessionDevice().Metadata);
+    }
+
+    [Fact]
+    public void IpAddress_IsNull()
+    {
+        Assert.Null(new BootloaderSessionDevice().IpAddress);
+    }
+
+    [Fact]
+    public void PwmFrequencyHz_ReportsTheCommandableDefault()
+    {
+        // Not 0: the interface documents this as a commandable frequency, and 0 is not one.
+        Assert.Equal(DaqifiStreamingDevice.DefaultPwmFrequencyHz, new BootloaderSessionDevice().PwmFrequencyHz);
+    }
+
+    [Fact]
+    public void StreamingFrequency_RoundTrips()
+    {
+        var device = new BootloaderSessionDevice { StreamingFrequency = 42 };
+
+        Assert.Equal(42, device.StreamingFrequency);
+    }
+
+    #endregion
+
+    #region Cancellation
+
+    [Fact]
+    public async Task AsyncMembers_HonorAnAlreadyCancelledToken()
+    {
+        var device = new BootloaderSessionDevice();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var token = cts.Token;
+
+        var calls = new Func<Task>[]
+        {
+            () => device.ConnectAsync(token),
+            () => device.DisconnectAsync(token),
+            () => device.SaveAdcCalibrationAsync(token),
+            () => device.LoadAdcCalibrationAsync(token),
+            () => device.SetAdcCalibrationSlopeAsync(0, 1.0, token),
+            () => device.SetAdcCalibrationOffsetAsync(0, 1.0, token),
+            () => device.SaveFactoryAdcCalibrationAsync(token),
+            () => device.LoadFactoryAdcCalibrationAsync(token),
+            () => device.UseAdcCalibrationAsync(0, token),
+            () => device.SaveVoltagePrecisionAsync(token),
+            () => device.LoadVoltagePrecisionAsync(token),
+        };
+
+        foreach (var call in calls)
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(call);
+        }
+    }
+
+    [Fact]
+    public async Task ConnectAsync_WithCancelledToken_LeavesStateUntouched()
+    {
+        var device = new BootloaderSessionDevice();
+        device.Disconnect();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => device.ConnectAsync(cts.Token));
+
+        Assert.False(device.IsConnected);
+    }
+
+    #endregion
+
+    #region Future-widening guard
+
+    /// <summary>
+    /// Invokes every member of the <see cref="IStreamingDevice"/> surface — including the members it
+    /// inherits — and asserts none of them throws.
+    /// </summary>
+    /// <remarks>
+    /// This is the test that earns the type its place in Core. A member added to
+    /// <see cref="IStreamingDevice"/> later must be implemented here as a no-op like the rest; if
+    /// someone instead leaves it throwing <see cref="NotImplementedException"/>, this fails in
+    /// Core's own CI rather than in a downstream app's firmware-update dialog.
+    /// </remarks>
+    [Fact]
+    public async Task EveryInterfaceMember_IsInvokableWithoutThrowing()
+    {
+        var device = new BootloaderSessionDevice();
+        var surface = new[] { typeof(IStreamingDevice) }
+            .Concat(typeof(IStreamingDevice).GetInterfaces())
+            .SelectMany(i => i.GetMethods())
+            .ToList();
+
+        // Guards the sweep itself: if the reflection walk silently stopped finding members, the
+        // test would pass while covering nothing.
+        Assert.True(surface.Count > 50, $"Expected the interface surface to be large; found {surface.Count}.");
+
+        foreach (var method in surface)
+        {
+            var target = method.IsGenericMethodDefinition
+                ? method.MakeGenericMethod(typeof(string))
+                : method;
+
+            var args = target.GetParameters()
+                .Select(p => p.ParameterType.IsValueType
+                    ? Activator.CreateInstance(p.ParameterType)
+                    : null)
+                .ToArray();
+
+            object? result;
+            try
+            {
+                result = target.Invoke(device, args);
+            }
+            catch (TargetInvocationException ex)
+            {
+                throw new Xunit.Sdk.XunitException(
+                    $"{target.Name} threw {ex.InnerException?.GetType().Name}: {ex.InnerException?.Message}");
+            }
+
+            // Observe returned tasks so a faulted one is not silently dropped.
+            switch (result)
+            {
+                case Task task:
+                    await task;
+                    break;
+                case ValueTask valueTask:
+                    await valueTask;
+                    break;
+            }
+        }
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core/Device/BootloaderSessionDevice.cs
+++ b/src/Daqifi.Core/Device/BootloaderSessionDevice.cs
@@ -1,0 +1,475 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// Stands in for a device that is <b>already sitting in its bootloader</b>, so a manual
+/// bootloader-only firmware update can be driven through the same
+/// <see cref="Firmware.IFirmwareUpdateService"/> entry points as a normal update.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A device in bootloader mode has no SCPI transport: it does not answer commands, stream data, or
+/// emit status messages. Every operation on this type is therefore a no-op, and every collection is
+/// empty. It exists purely so a recovery/update dialog has something satisfying
+/// <see cref="IStreamingDevice"/> to pass to
+/// <see cref="Firmware.IFirmwareUpdateService.UpdateFirmwareAsync(IStreamingDevice, string, IProgress{Firmware.FirmwareUpdateProgress}?, string?, CancellationToken)"/>.
+/// </para>
+/// <para>
+/// Three of those behaviours are load-bearing rather than incidental, because the PIC32 update flow
+/// touches the device before it ever reaches the bootloader:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="IsConnected"/> starts <c>true</c>. The flow opens with
+/// <c>EnsureDeviceConnected</c>, which throws <see cref="InvalidOperationException"/> on a
+/// disconnected device — a stand-in reporting <c>false</c> would fail the update before it began.
+/// </description></item>
+/// <item><description>
+/// <see cref="IsStreaming"/> is always <c>false</c>, so the flow skips its
+/// <see cref="StopStreaming"/> call.
+/// </description></item>
+/// <item><description>
+/// <see cref="Send{T}"/> silently discards. The flow sends the force-bootloader command; a device
+/// already in the bootloader cannot receive it, and throwing here would abort a valid update.
+/// </description></item>
+/// </list>
+/// <para>
+/// Safe to use from multiple threads. Every operation but connect/disconnect is stateless, and
+/// those two use an atomic compare-and-set so <see cref="StatusChanged"/> is raised exactly once
+/// per real transition — a dialog tearing the session down can race the update flow's own
+/// <see cref="Disconnect"/> without producing a duplicate or a missed notification.
+/// </para>
+/// <para>
+/// This type lives in Core rather than in each consuming application on purpose. It is the only
+/// hand-written implementation of <see cref="IStreamingDevice"/> that ships with the product, so
+/// keeping it here means a member added to that interface is resolved once, in the change that adds
+/// it, and is caught by this repository's build rather than surfacing later as a break in a
+/// downstream app (daqifi-core#477).
+/// </para>
+/// </remarks>
+public sealed class BootloaderSessionDevice : IStreamingDevice
+{
+    /// <summary>
+    /// Name used when the caller supplies none.
+    /// </summary>
+    public const string DefaultName = "DAQiFi Bootloader";
+
+    // 1 = connected. An int rather than a bool so the connect/disconnect transition can be an
+    // atomic compare-and-set: StatusChanged must be raised exactly once per real transition even if
+    // a dialog's teardown races the update flow's own Disconnect().
+    private int _isConnected = Connected;
+
+    private const int Connected = 1;
+    private const int NotConnected = 0;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BootloaderSessionDevice"/> class, already in the
+    /// connected state.
+    /// </summary>
+    /// <param name="name">
+    /// A display name for the session. Falls back to <see cref="DefaultName"/> when null, empty, or
+    /// whitespace.
+    /// </param>
+    public BootloaderSessionDevice(string? name = null)
+    {
+        Name = string.IsNullOrWhiteSpace(name) ? DefaultName : name;
+    }
+
+    #region IDevice
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <summary>
+    /// Always <c>null</c>: a bootloader session is reached over USB HID, never over the network.
+    /// </summary>
+    public IPAddress? IpAddress => null;
+
+    /// <inheritdoc />
+    public bool IsConnected => Volatile.Read(ref _isConnected) == Connected;
+
+    /// <inheritdoc />
+    public ConnectionStatus Status => IsConnected
+        ? ConnectionStatus.Connected
+        : ConnectionStatus.Disconnected;
+
+    /// <summary>
+    /// Raised by <see cref="Connect"/> and <see cref="Disconnect"/>. This is the one event this type
+    /// actually raises — the device itself produces nothing to report.
+    /// </summary>
+    public event EventHandler<DeviceStatusEventArgs>? StatusChanged;
+
+    /// <summary>
+    /// Never raised: a device in bootloader mode emits no protocol messages. Declared with no-op
+    /// accessors so that contract is explicit in the code rather than an unused-field warning.
+    /// </summary>
+    public event EventHandler<MessageReceivedEventArgs>? MessageReceived
+    {
+        add { }
+        remove { }
+    }
+
+    /// <summary>
+    /// Never raised: this type owns no transport or background threads, so it has no failures of its
+    /// own to report. Update failures surface through
+    /// <see cref="Firmware.FirmwareUpdateProgress"/> and
+    /// <see cref="Firmware.FirmwareUpdateException"/> instead.
+    /// </summary>
+    public event EventHandler<DeviceErrorEventArgs>? ErrorOccurred
+    {
+        add { }
+        remove { }
+    }
+
+    /// <summary>
+    /// Marks the session connected, raising <see cref="StatusChanged"/> if it was not already.
+    /// Opens no transport — there is nothing to open.
+    /// </summary>
+    public void Connect() => SetConnected(true);
+
+    /// <summary>
+    /// Marks the session disconnected, raising <see cref="StatusChanged"/> if it was not already.
+    /// Closes no transport — there is nothing to close.
+    /// </summary>
+    public void Disconnect() => SetConnected(false);
+
+    /// <inheritdoc cref="Connect" />
+    /// <param name="cancellationToken">Observed before the state change is applied.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        Connect();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc cref="Disconnect" />
+    /// <param name="cancellationToken">Observed before the state change is applied.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        Disconnect();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Silently discards <paramref name="message"/>. See the remarks on the type: the PIC32 update
+    /// flow sends the force-bootloader command unconditionally, and a device already in the
+    /// bootloader has no command channel to receive it.
+    /// </summary>
+    /// <typeparam name="T">The message payload type.</typeparam>
+    /// <param name="message">The message to discard.</param>
+    public void Send<T>(IOutboundMessage<T> message)
+    {
+    }
+
+    /// <summary>
+    /// Marks the session disconnected. Idempotent, and releases nothing — this type holds no
+    /// unmanaged resources.
+    /// </summary>
+    /// <returns>A completed task.</returns>
+    public ValueTask DisposeAsync()
+    {
+        Disconnect();
+        return default;
+    }
+
+    #endregion
+
+    #region Channels and metadata
+
+    /// <summary>
+    /// An empty metadata record. A bootloader session reports no part number, firmware version, or
+    /// capabilities; the instance is non-null so callers can read it without a guard.
+    /// </summary>
+    public DeviceMetadata Metadata { get; } = new();
+
+    /// <summary>
+    /// Always empty: channels are populated from device status messages, which a bootloader session
+    /// never emits.
+    /// </summary>
+    public IReadOnlyList<IChannel> Channels => Array.Empty<IChannel>();
+
+    /// <inheritdoc cref="Channels" />
+    /// <returns>An empty list.</returns>
+    public IReadOnlyList<IChannel> GetChannelsSnapshot() => Array.Empty<IChannel>();
+
+    /// <summary>
+    /// Never raised: see <see cref="Channels"/>.
+    /// </summary>
+    public event EventHandler<ChannelsPopulatedEventArgs>? ChannelsPopulated
+    {
+        add { }
+        remove { }
+    }
+
+    #endregion
+
+    #region Streaming
+
+    /// <summary>
+    /// Stored but never acted on, so a caller that round-trips the value sees what it set.
+    /// </summary>
+    public int StreamingFrequency { get; set; } = 1;
+
+    /// <summary>
+    /// Always <c>false</c>. See the remarks on the type: the update flow calls
+    /// <see cref="StopStreaming"/> only when this is <c>true</c>.
+    /// </summary>
+    public bool IsStreaming => false;
+
+    /// <summary>No-op: a bootloader session cannot stream.</summary>
+    public void StartStreaming()
+    {
+    }
+
+    /// <summary>No-op: a bootloader session cannot stream.</summary>
+    public void StopStreaming()
+    {
+    }
+
+    #endregion
+
+    #region Channel, DIO, PWM, and analog output control
+
+    // All no-ops: these drive hardware through the SCPI command channel, which a device in
+    // bootloader mode does not expose. They accept any argument rather than validating it —
+    // a stand-in that threw would turn a harmless call into an update failure.
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channel">Ignored.</param>
+    public void EnableChannel(IChannel channel)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channels">Ignored.</param>
+    public void EnableChannels(IEnumerable<IChannel> channels)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channel">Ignored.</param>
+    public void DisableChannel(IChannel channel)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    public void DisableAllChannels()
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channel">Ignored.</param>
+    /// <param name="direction">Ignored.</param>
+    public void SetDioDirection(IChannel channel, ChannelDirection direction)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channel">Ignored.</param>
+    /// <param name="value">Ignored.</param>
+    public void SetDioValue(IChannel channel, bool value)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channel">Ignored.</param>
+    /// <param name="enabled">Ignored.</param>
+    public void SetPwmEnabled(IChannel channel, bool enabled)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channel">Ignored.</param>
+    /// <param name="dutyCyclePercent">Ignored.</param>
+    public void SetPwmDutyCycle(IChannel channel, int dutyCyclePercent)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="frequencyHz">Ignored.</param>
+    public void SetPwmFrequency(int frequencyHz)
+    {
+    }
+
+    /// <summary>
+    /// Always <see cref="DaqifiStreamingDevice.DefaultPwmFrequencyHz"/>. Nothing is ever commanded
+    /// through <see cref="SetPwmFrequency"/> here, so this reports the same default a real device
+    /// reports before its first PWM command rather than a 0 that is not a commandable frequency.
+    /// </summary>
+    public int PwmFrequencyHz => DaqifiStreamingDevice.DefaultPwmFrequencyHz;
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channelNumber">Ignored.</param>
+    /// <param name="voltage">Ignored.</param>
+    public void SetAnalogOutput(int channelNumber, double voltage)
+    {
+    }
+
+    /// <summary>
+    /// No-op: the device is already in its bootloader, which is where a reboot would be trying to
+    /// leave it from.
+    /// </summary>
+    public void Reboot()
+    {
+    }
+
+    #endregion
+
+    #region ADC calibration and voltage precision
+
+    // No-ops for the same reason as the control members above. The confirming twins complete
+    // successfully rather than throwing DeviceCommandFailedException: there is no device to refuse
+    // the command, so there is no failure to report.
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    public void SaveAdcCalibration()
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    public void LoadAdcCalibration()
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channelNumber">Ignored.</param>
+    /// <param name="calM">Ignored.</param>
+    public void SetAdcCalibrationSlope(int channelNumber, double calM)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="channelNumber">Ignored.</param>
+    /// <param name="calB">Ignored.</param>
+    public void SetAdcCalibrationOffset(int channelNumber, double calB)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    public void SaveFactoryAdcCalibration()
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    public void LoadFactoryAdcCalibration()
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    /// <param name="bank">Ignored.</param>
+    public void UseAdcCalibration(int bank)
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    public void SaveVoltagePrecision()
+    {
+    }
+
+    /// <summary>No-op: see the remarks on this type.</summary>
+    public void LoadVoltagePrecision()
+    {
+    }
+
+    /// <inheritdoc cref="SaveAdcCalibration" />
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task SaveAdcCalibrationAsync(CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    /// <inheritdoc cref="LoadAdcCalibration" />
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task LoadAdcCalibrationAsync(CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    /// <inheritdoc cref="SetAdcCalibrationSlope" />
+    /// <param name="channelNumber">Ignored.</param>
+    /// <param name="calM">Ignored.</param>
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task SetAdcCalibrationSlopeAsync(int channelNumber, double calM, CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    /// <inheritdoc cref="SetAdcCalibrationOffset" />
+    /// <param name="channelNumber">Ignored.</param>
+    /// <param name="calB">Ignored.</param>
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task SetAdcCalibrationOffsetAsync(int channelNumber, double calB, CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    /// <inheritdoc cref="SaveFactoryAdcCalibration" />
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task SaveFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    /// <inheritdoc cref="LoadFactoryAdcCalibration" />
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task LoadFactoryAdcCalibrationAsync(CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    /// <inheritdoc cref="UseAdcCalibration" />
+    /// <param name="bank">Ignored.</param>
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task UseAdcCalibrationAsync(int bank, CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    /// <inheritdoc cref="SaveVoltagePrecision" />
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task SaveVoltagePrecisionAsync(CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    /// <inheritdoc cref="LoadVoltagePrecision" />
+    /// <param name="cancellationToken">Observed before completing.</param>
+    /// <returns>A completed task, or a cancelled one if <paramref name="cancellationToken"/> was already signalled.</returns>
+    public Task LoadVoltagePrecisionAsync(CancellationToken cancellationToken = default)
+        => Completed(cancellationToken);
+
+    #endregion
+
+    private static Task Completed(CancellationToken cancellationToken)
+        => cancellationToken.IsCancellationRequested
+            ? Task.FromCanceled(cancellationToken)
+            : Task.CompletedTask;
+
+    private void SetConnected(bool connected)
+    {
+        var desired = connected ? Connected : NotConnected;
+        if (Interlocked.Exchange(ref _isConnected, desired) == desired)
+        {
+            // Already in this state — not a transition, so nothing to announce.
+            return;
+        }
+
+        // Raised outside any lock, and reporting the transition this call performed rather than
+        // re-reading the field, so a concurrent flip cannot make the notification lie about which
+        // transition fired.
+        var status = connected ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        StatusChanged?.Invoke(this, new DeviceStatusEventArgs(status));
+    }
+}


### PR DESCRIPTION
## Summary

`daqifi-desktop` and `daqifi-avalonia` each carry a hand-written no-op `IStreamingDevice` for their manual bootloader-only firmware update dialogs. They are the same file — stripped of comments the two copies differ by 15 lines, and that delta is pure version drift (desktop, on Core 1.4.0, has `ErrorOccurred` and the `add {}/remove {}` accessor style; Avalonia, on 1.3.0, does not).

Core owns `IStreamingDevice`, but the only hand-written implementers live downstream. So every widening of that interface is a source break that surfaces later, in two repositories, and is invisible from inside this one — Core's own tests and the MCP consumer all work with the concrete `DaqifiStreamingDevice`. Measured against each app's current `origin/main`:

| Adapter | vs v1.3.0 | vs v1.4.0 | vs v1.5.0 | vs #476 |
|---|---|---|---|---|
| daqifi-desktop | 0 | **0** (its pin) | 12 | 16 |
| daqifi-avalonia | **0** (its pin) | 1 | 13 | 17 |

v1.5.0 added 12 members in one release (`ConnectAsync`/`DisconnectAsync`, `DisposeAsync`, 9 × `IConfirmingDeviceAdministration.*Async`); #476 added 4 more. Neither flagged the break.

This PR moves the stand-in into Core, so a member added to `IStreamingDevice` is resolved once — in the change that adds it — and caught by this repository's build.

## Changes

**`BootloaderSessionDevice`** (`src/Daqifi.Core/Device/`) — a sealed, no-op `IStreamingDevice` for a device that is already sitting in its bootloader.

Three of its behaviours are load-bearing rather than incidental, because `Pic32FirmwareUpdater.RunUpdateAsync` touches the device before it ever reaches the bootloader. All three are documented on the type and covered by tests:

| Member | Value | Why |
|---|---|---|
| `IsConnected` | starts `true` | The flow opens with `FirmwareUpdateContext.EnsureDeviceConnected`, which throws on a disconnected device |
| `IsStreaming` | always `false` | Lets the flow skip its `StopStreaming()` call |
| `Send(...)` | discards silently | The flow sends `ForceBootloader` unconditionally; throwing would abort a valid update |

Connect/disconnect use an atomic compare-and-set, so `StatusChanged` fires exactly once per real transition when a dialog's teardown races the update flow's own `Disconnect()`.

Two smaller judgement calls, both departures from what the apps do today:

- **`PwmFrequencyHz` reports `DaqifiStreamingDevice.DefaultPwmFrequencyHz`, not `0`.** The apps return 0 citing a "none commanded this session" sentinel, but that comment predates the current contract — `IStreamingDevice` now documents this as defaulting to a commandable frequency, and 0 is not one.
- **`Metadata` is a real empty instance, not `null!`.** Callers read it without a guard.

**Docs** — a `BootloaderSessionDevice` subsection under Implementation Classes in `docs/DEVICE_INTERFACES.md`, including the load-bearing table and a note steering consumers away from hand-rolling their own stub.

## Testing

- 24 unit tests. The load-bearing behaviours are tested against the **real** internal guard (`FirmwareUpdateContext.EnsureDeviceConnected`) rather than a restatement of it.
- A reflection sweep invokes every member of the `IStreamingDevice` surface — including inherited `IDevice`, `IConfirmingDeviceAdministration`, and `IAsyncDisposable` members — and asserts none throws. This is the guard that earns the type its place in Core: a member added later must be implemented here as a no-op, or CI fails.
  - **Verified non-vacuous by mutation**: making `DisableAllChannels()` throw `NotImplementedException` does fail the sweep. The test also asserts the discovered surface is >50 methods, so a reflection walk that silently stopped finding members can't pass while covering nothing.
- Full `Daqifi.Core.Tests`: 2890 passed, 2 skipped. Full `Daqifi.Mcp.Tests`: 43 passed.
- Clean build on both target frameworks with `TreatWarningsAsErrors=true` and XML doc generation on, so every `cref` in the new docs resolves.

**No bench test.** The change is purely additive — one new file plus a docs section, touching no existing code path — and nothing in Core constructs or calls this type. Exercising it for real means driving a manual bootloader update dialog, which lives in the apps and cannot consume this until it ships. The apps' existing adapters, whose behaviour this reproduces, are the field-proven reference.

## Follow-up (not in this PR)

The consumer-side deletions in #477 land after this is released, as part of each app's Core version bump — they can't compile against an unreleased Core. Desktop's next bump is a 16-member adapter update either way; 12 of those are already on `main` from v1.5.0 independent of this change.

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)
