### PR TITLE
refactor(device): extract the text-exchange engine into a collaborator (part of #344)

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceOperationSerializationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceOperationSerializationTests.cs
@@ -356,6 +356,65 @@ public class DaqifiDeviceOperationSerializationTests
     }
 
     [Fact]
+    public async Task Send_FromInsideATextExchange_GoesStraightOut()
+    {
+        // The mirror of Send_FromTheOwningFlow_GoesStraightOut, for the lock acquisition the text
+        // exchange makes for itself rather than the one RunExclusiveAsync makes. Every text query
+        // depends on it: the setup action's whole job is to Send, and if the exchange's own flow
+        // does not register as the lock's owner then its command is parked by the very deferral it
+        // just switched on. The command reaches the device only after the exchange has closed, so
+        // the exchange collects nothing and reports an empty result — indistinguishable, from the
+        // caller's side, from a device that went silent.
+        //
+        // The claim is written into an AsyncLocal, which propagates from the writing frame to that
+        // frame's callees and no further. Sending from inside the setup action, after an await, is
+        // what pins both halves of that: the exchange's flow owns the lock, and the ownership
+        // survives the thread hop.
+        using var transport = new RecordingTransport();
+        using var device = new TextExchangeDevice("Self-sending Device", transport);
+        device.Connect();
+
+        await device.RunTextExchangeAsync(async _ =>
+        {
+            device.Send(ScpiMessageProducer.SetDioPortState(4, 1));
+
+            // Fails here, inside the exchange, if the send was parked — rather than passing later
+            // on the backlog the exchange flushes on its way out.
+            await WaitForWriteAsync(transport, "DIO:PORt:STATe");
+        }).WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task TextExchange_ReEnteredFromItsOwnSetupAction_IsRejected()
+    {
+        // DaqifiDeviceTextCommandLockTests covers this guard by planting the flag through
+        // reflection, which exercises only the reading half. This drives the real thing: the flag
+        // has to be written where the setup action can see it.
+        //
+        // Getting that wrong does not deadlock, which is what makes it worth pinning. The nested
+        // call would find the lock already held by its own flow, decline to wait for it, and run —
+        // a second consumer swap on a stream mid-swap, which is the framing corruption the guard
+        // was added to prevent. It fails silently, as mangled replies, not as a hang.
+        using var transport = new RecordingTransport();
+        using var device = new TextExchangeDevice("Re-entering Device", transport);
+        device.Connect();
+
+        Exception? nested = null;
+
+        await device.RunTextExchangeAsync(async ct =>
+        {
+            nested = await Record.ExceptionAsync(() => device.RunTextExchangeAsync(() => { }, ct));
+        }).WaitAsync(DeadlockBudget);
+
+        Assert.IsType<InvalidOperationException>(nested);
+        Assert.Contains("not re-entrant", nested!.Message);
+
+        device.Disconnect();
+    }
+
+    [Fact]
     public async Task TextExchange_CancelledWhileTheOutboundQueueDrains_DoesNotResubscribeTheConsumer()
     {
         // The drain added for #342 is the one step before the consumer swap that can throw. If it
@@ -834,6 +893,19 @@ public class DaqifiDeviceOperationSerializationTests
             CancellationToken cancellationToken = default) =>
             ExecuteTextCommandAsync(
                 setupAction,
+                responseTimeoutMs: 300,
+                completionTimeoutMs: 100,
+                cancellationToken: cancellationToken);
+
+        /// <summary>
+        /// The async-setup overload, so a test can observe the wire from <i>inside</i> the exchange
+        /// rather than only after it has closed.
+        /// </summary>
+        public Task<IReadOnlyList<string>> RunTextExchangeAsync(
+            Func<CancellationToken, Task> setupActionAsync,
+            CancellationToken cancellationToken = default) =>
+            ExecuteTextCommandAsync(
+                setupActionAsync,
                 responseTimeoutMs: 300,
                 completionTimeoutMs: 100,
                 cancellationToken: cancellationToken);

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -15,7 +15,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,7 +26,7 @@ namespace Daqifi.Core.Device
     /// Represents a DAQiFi device that can be connected to and communicated with.
     /// This is the base implementation of the IDevice interface.
     /// </summary>
-    public class DaqifiDevice : IDevice, IDisposable, IAsyncDisposable
+    public class DaqifiDevice : IDevice, IDisposable, IAsyncDisposable, ITextExchangeHost
     {
         /// <summary>
         /// Gets the name of the device.
@@ -610,6 +609,7 @@ namespace Daqifi.Core.Device
                 () => Name,
                 () => LifecycleLockTimeout,
                 () => TeardownLockTimeout);
+            _textExchange = new TextExchangeEngine(this);
         }
 
         /// <summary>
@@ -631,6 +631,7 @@ namespace Daqifi.Core.Device
                 () => Name,
                 () => LifecycleLockTimeout,
                 () => TeardownLockTimeout);
+            _textExchange = new TextExchangeEngine(this);
             _messageProducer = new MessageProducer<string>(stream);
             _messageProducer.SendFailed += OnMessageSendFailed;
             _directStream = stream;
@@ -653,6 +654,7 @@ namespace Daqifi.Core.Device
                 () => Name,
                 () => LifecycleLockTimeout,
                 () => TeardownLockTimeout);
+            _textExchange = new TextExchangeEngine(this);
             _transport = transport;
 
             // Subscribe to transport status changes
@@ -1860,95 +1862,11 @@ namespace Daqifi.Core.Device
         /// <returns>A task representing the asynchronous operation.</returns>
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the device has no transport-based connection.</exception>
-        protected virtual async Task ExecuteRawCaptureAsync(
+        protected virtual Task ExecuteRawCaptureAsync(
             Func<Stream, CancellationToken, Task> rawAction,
             CancellationToken cancellationToken = default)
         {
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            if (_transport == null)
-            {
-                throw new InvalidOperationException("ExecuteRawCaptureAsync requires a transport-based connection.");
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            try
-            {
-                // Stop the protobuf consumer so it doesn't compete for stream bytes
-                if (_messageConsumer != null)
-                {
-                    _messageConsumer.MessageReceived -= OnInboundMessageReceived;
-                    var stopped = _messageConsumer.StopSafely(timeoutMs: 1000);
-                    if (!stopped)
-                    {
-                        _messageConsumer.Stop();
-                    }
-                }
-
-                // Hand the stream to the caller for raw I/O
-                await rawAction(_transport.Stream, cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                RestartMessageConsumerAfterSwap();
-            }
-        }
-
-        /// <summary>
-        /// Restarts the protobuf consumer after a swap (raw capture or text exchange) has stopped it.
-        /// </summary>
-        /// <remarks>
-        /// The stop paths join the reader thread with a bounded timeout, so a reader parked in a slow
-        /// blocking <see cref="Stream.Read(byte[], int, int)"/> can still be alive here.
-        /// <see cref="StreamMessageConsumer{T}.Start"/> absorbs that case by waiting a grace period
-        /// for the stopped reader to exit, which is what keeps a normal connect from failing with
-        /// "a previous consumer thread has not yet exited" (issue #383).
-        /// <para>
-        /// If it still refuses, the reader's read is not returning at all — the stream is stuck.
-        /// Deliberately do <b>not</b> recover by binding a fresh consumer to that same stream: a new
-        /// instance would be a second concurrent reader on it, which is exactly the framing
-        /// corruption the guard exists to prevent, and it would block on the stuck stream anyway.
-        /// The consumer is left stopped; the operation's own failure (or the next
-        /// <see cref="Connect"/>) surfaces the problem honestly.
-        /// </para>
-        /// <para>
-        /// Never throws: it runs from <c>finally</c> blocks, where an exception would mask the real
-        /// failure already unwinding. The consumer is also snapshotted once up front — the
-        /// text-exchange path holds <c>_textExchangeLock</c> (which <see cref="Disconnect"/> waits
-        /// on), but the raw-capture path does not, so a concurrent teardown could otherwise null the
-        /// field between reads.
-        /// </para>
-        /// </remarks>
-        private void RestartMessageConsumerAfterSwap()
-        {
-            var consumer = _messageConsumer;
-            if (consumer == null)
-            {
-                return;
-            }
-
-            try
-            {
-                consumer.Start();
-                consumer.MessageReceived += OnInboundMessageReceived;
-            }
-            catch (ConsumerThreadNotExitedException ex)
-            {
-                SafeLog(() => _logger.LogError(
-                    ex,
-                    "The previous message consumer thread did not exit, so the consumer was left stopped. "
-                    + "The device stream appears stuck; a reconnect is required to resume inbound messages."));
-            }
-            catch (Exception ex)
-            {
-                // e.g. ObjectDisposedException from a concurrent Dispose(). Swallow rather than let
-                // it escape a finally block and replace the operation's real exception.
-                SafeLog(() => _logger.LogError(ex, "Failed to restart the message consumer after a stream swap."));
-            }
+            return _textExchange.ExecuteRawCaptureAsync(rawAction, cancellationToken);
         }
 
         /// <summary>
@@ -2069,7 +1987,7 @@ namespace Daqifi.Core.Device
                 cancellationToken);
         }
 
-        private async Task<IReadOnlyList<string>> ExecuteTextCommandCoreAsync(
+        private Task<IReadOnlyList<string>> ExecuteTextCommandCoreAsync(
             Func<CancellationToken, Task>? prepareAsync,
             Func<Task>? finalizeAsync,
             Func<CancellationToken, Task> setupActionAsync,
@@ -2077,361 +1995,97 @@ namespace Daqifi.Core.Device
             int completionTimeoutMs,
             CancellationToken cancellationToken)
         {
-            if (responseTimeoutMs <= 0)
-                throw new ArgumentOutOfRangeException(nameof(responseTimeoutMs), responseTimeoutMs, "Timeout must be positive.");
-            if (completionTimeoutMs <= 0)
-                throw new ArgumentOutOfRangeException(nameof(completionTimeoutMs), completionTimeoutMs, "Timeout must be positive.");
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Async-context re-entrancy detection: a setupAction that calls
-            // ExecuteTextCommandAsync on the same device would corrupt the
-            // consumer swap mid-flight. Surface as a clean exception rather
-            // than wedging on _textExchangeLock.WaitAsync() forever.
-            // AsyncLocal flows across await thread hops so this catches
-            // re-entry even when the inner call resumes on a different
-            // thread than the outer call.
-            if (_isInsideTextExchange.Value)
-            {
-                throw new InvalidOperationException(
-                    "ExecuteTextCommandAsync is not re-entrant on the same device; "
-                    + "do not call it from inside a setupAction callback.");
-            }
-
-            // The exchange runs under the device's operation lock. A flow that already owns it —
-            // one inside RunExclusiveAsync, typically — runs nested rather than waiting on a
-            // semaphore it is itself holding, and leaves the release to the owner.
-            var ownsLock = !HoldsOperationLock;
-            if (ownsLock)
-            {
-                try
-                {
-                    await _textExchangeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (ObjectDisposedException ex)
-                {
-                    // Dispose() raced ahead of us and disposed the semaphore.
-                    // Surface the same clean failure as the post-acquisition
-                    // _disposed check below, instead of leaking a low-level
-                    // teardown exception to callers. The original is kept as
-                    // InnerException so this rare race stays diagnosable.
-                    throw new DeviceNotConnectedException(
-                        "ExecuteTextCommandAsync cannot run because the device is disposed.",
-                        ex,
-                        isShuttingDown: true);
-                }
-
-                // Assigned in this frame, not in a helper: an async method's AsyncLocal writes flow
-                // forward to its callees but never back to its caller.
-                _operationLockGeneration.Value = Volatile.Read(ref _operationGeneration);
-                MarkOperationInFlight();
-            }
-
-            _isInsideTextExchange.Value = true;
-
-            // Whether the exchange got past validation and so owes its finalize phase, and whether
-            // it is on its way out normally rather than with an exception unwinding. Both are read
-            // only by the finalize block in the outer finally below.
-            var exchangeStarted = false;
-            var completedNormally = false;
-            try
-            {
-                // All validation runs INSIDE the lock so a competing thread
-                // calling DisconnectAsync() / Dispose() while we're blocked
-                // on WaitAsync() doesn't leave us with a stale _transport /
-                // _messageConsumer reference (closes the TOCTOU window
-                // documented in #186).
-                if (_disposed || _isDisconnecting)
-                {
-                    throw new DeviceNotConnectedException(
-                        "ExecuteTextCommandAsync cannot run while the device is "
-                        + "disposing or disconnecting.",
-                        isShuttingDown: true);
-                }
-
-                if (!IsConnected)
-                {
-                    throw new DeviceNotConnectedException();
-                }
-
-                if (_transport == null)
-                {
-                    throw new InvalidOperationException("ExecuteTextCommandAsync requires a transport-based connection.");
-                }
-
-                // The device-level IsConnected check above is status-based and can still report
-                // Connected when the underlying transport has dropped (e.g. a serial port closed
-                // by an unplug or a DTR-triggered MCU reset mid-connect). Detect that here and
-                // fail with the typed transport-disconnected exception, rather than dereferencing
-                // Stream below and surfacing the framework's raw "BaseStream is only available
-                // when the port is open." message (issue #238).
-                if (!_transport.IsConnected)
-                {
-                    throw new TransportNotConnectedException(
-                        "Device transport is no longer connected.");
-                }
-
-                // Past validation: from here on the exchange acts on the device, so its finalize
-                // phase (if any) is owed however this ends — including a prepare phase that failed
-                // part-way and left the device half-way into the state it was establishing.
-                exchangeStarted = true;
-
-                var sw = Stopwatch.StartNew();
-
-                // Prepare phase, if any. Deliberately here: inside the lock, so no competing text
-                // exchange can interleave between it and the setup action below and undo the state
-                // it establishes; and before the consumer swap, so the wait it typically needs
-                // cannot widen the stale-line boundary taken further down. Any device output it
-                // provokes goes to the protobuf consumer, which is still running at this point.
-                if (prepareAsync != null)
-                {
-                    await prepareAsync(cancellationToken).ConfigureAwait(false);
-
-                    SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Prepare phase completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));
-                }
-
-                // Let anything queued before this exchange opened reach the wire while the protobuf
-                // consumer is still the one reading, so its reply is not mistaken for an answer to
-                // a command this exchange is about to send (issue #342). New sends from other
-                // threads are already parked by this point, so the queue can only shrink.
-                //
-                // Deliberately OUTSIDE the swap's try/finally below: this is the one step here that
-                // can throw (a cancelled token) before the consumer has been stopped, and that
-                // finally restarts the consumer — which on a consumer that was never stopped means
-                // subscribing the inbound handler a second time and dispatching every frame twice.
-                await DrainOutboundQueueAsync(cancellationToken).ConfigureAwait(false);
-
-                var collectedLines = new List<string>();
-                var stream = _transport.Stream;
-                int? originalReadTimeout = null;
-
-                // Number of lines that were already in flight when this exchange opened — see the
-                // note at the point it is captured, below.
-                var staleLineCount = 0;
-
-                try
-                {
-                    if (stream.CanTimeout)
-                    {
-                        try
-                        {
-                            originalReadTimeout = stream.ReadTimeout;
-                            stream.ReadTimeout = Math.Min(500, Math.Max(100, responseTimeoutMs / 4));
-                        }
-                        catch
-                        {
-                            // Some streams may not allow setting read timeout; ignore.
-                            originalReadTimeout = null;
-                        }
-                    }
-
-                    // Stop the protobuf consumer so it doesn't compete for stream bytes.
-                    // The serial transport sets ReadTimeout=500ms after connect, so the
-                    // consumer thread's blocking Read will unblock within 500ms.
-                    if (_messageConsumer != null)
-                    {
-                        _messageConsumer.MessageReceived -= OnInboundMessageReceived;
-                        var stopped = _messageConsumer.StopSafely(timeoutMs: 1000);
-                        if (!stopped)
-                        {
-                            _messageConsumer.Stop();
-                        }
-                    }
-
-                    SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Protobuf consumer stopped at {ElapsedMs}ms", sw.ElapsedMilliseconds));
-
-                    // Create a temporary text consumer on the same stream
-                    using var textConsumer = new StreamMessageConsumer<string>(
-                        _transport.Stream,
-                        new LineBasedMessageParser(),
-                        healthSink: _transport as ITransportHealthSink);
-
-                    textConsumer.MessageReceived += (_, e) =>
-                    {
-                        collectedLines.Add(e.Message.Data);
-                    };
-
-                    // The protobuf consumer is stopped for the duration of this exchange, so
-                    // without this a read failure during a text command (an unplug mid-SD-listing,
-                    // say) would be the one background failure with nowhere to go (issue #378).
-                    //
-                    // Scoped rather than a bare '+=' because this consumer can outlive the block:
-                    // its stop and dispose are both time-bounded and may return with the reader
-                    // thread still parked in an un-returning read. A live thread roots the consumer,
-                    // which would root this device through the handler — retaining the whole object
-                    // graph and, worse, letting a zombie reader keep raising errors on a device that
-                    // has since been disconnected. 'using' disposes in reverse declaration order, so
-                    // this detaches before textConsumer itself is disposed, on every exit path
-                    // including a cancellation or a throwing setup action.
-                    using var textConsumerErrors = new ConsumerErrorSubscription(this, textConsumer);
-
-                    textConsumer.Start();
-                    // ConfigureAwait(false): the lock is held, so resuming on a captured
-                    // sync context (e.g. UI thread) would deadlock if that thread calls Disconnect().
-                    await Task.Delay(50, cancellationToken).ConfigureAwait(false);
-
-                    SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Text consumer started at {ElapsedMs}ms", sw.ElapsedMilliseconds));
-
-                    // Mark the boundary between "already in flight" and "answers to this exchange".
-                    // Anything captured before the setup action has sent anything is a late reply to
-                    // an EARLIER command, or line noise — never a response to a command this exchange
-                    // has yet to send. Those lines are dropped from the result below.
-                    //
-                    // Position matters as much as content: a caller that keys off response content —
-                    // e.g. the SD listing's end-of-listing terminator (#396) — would otherwise accept
-                    // a stale line as proof that the device answered a query it never even received,
-                    // and report a complete listing for a device that has gone silent.
-                    staleLineCount = collectedLines.Count;
-                    if (staleLineCount > 0)
-                    {
-                        SafeLog(() => _logger.LogDebug(
-                            "[ExecuteTextCommandAsync] Discarding {StaleLineCount} line(s) received before this exchange sent anything",
-                            staleLineCount));
-                    }
-
-                    // Execute the setup action (sends SCPI commands). ConfigureAwait(false)
-                    // matches the surrounding lock-protected awaits.
-                    await setupActionAsync(cancellationToken).ConfigureAwait(false);
-
-                    SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Setup action completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));
-
-                    // Wait for responses using a two-phase inactivity-based timeout:
-                    // Phase 1: Wait up to responseTimeoutMs for the first response.
-                    // Phase 2: After receiving data, wait completionTimeoutMs of inactivity to finish.
-                    var lastMessageTime = DateTime.UtcNow;
-                    var maxWait = TimeSpan.FromMilliseconds(responseTimeoutMs * 5);
-                    var startTime = DateTime.UtcNow;
-                    var hasReceivedAny = false;
-
-                    while (DateTime.UtcNow - startTime < maxWait)
-                    {
-                        var previousCount = collectedLines.Count;
-                        await Task.Delay(50, cancellationToken).ConfigureAwait(false);
-                        if (collectedLines.Count > previousCount)
-                        {
-                            lastMessageTime = DateTime.UtcNow;
-                            if (!hasReceivedAny)
-                            {
-                                hasReceivedAny = true;
-                                SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] First response at {ElapsedMs}ms", sw.ElapsedMilliseconds));
-                            }
-                        }
-
-                        var elapsed = DateTime.UtcNow - lastMessageTime;
-
-                        if (hasReceivedAny)
-                        {
-                            // Phase 2: short completion timeout after first data
-                            if (elapsed >= TimeSpan.FromMilliseconds(completionTimeoutMs))
-                            {
-                                break;
-                            }
-                        }
-                        else
-                        {
-                            // Phase 1: full initial timeout waiting for first data
-                            if (elapsed >= TimeSpan.FromMilliseconds(responseTimeoutMs))
-                            {
-                                break;
-                            }
-                        }
-                    }
-
-                    SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Collection complete at {ElapsedMs}ms, {LineCount} lines", sw.ElapsedMilliseconds, collectedLines.Count));
-
-                    // Stop the text consumer
-                    textConsumer.StopSafely();
-                }
-                finally
-                {
-                    if (originalReadTimeout.HasValue && stream.CanTimeout)
-                    {
-                        try
-                        {
-                            stream.ReadTimeout = originalReadTimeout.Value;
-                        }
-                        catch
-                        {
-                            // Ignore failures when restoring timeout.
-                        }
-                    }
-
-                    // Restart the protobuf consumer
-                    RestartMessageConsumerAfterSwap();
-
-                    SafeLog(() => _logger.LogDebug("[ExecuteTextCommandAsync] Total elapsed: {ElapsedMs}ms", sw.ElapsedMilliseconds));
-                }
-
-                // The text consumer is stopped by this point, so the list is no longer being
-                // appended to concurrently and can be re-projected safely.
-                var result = staleLineCount > 0
-                    ? collectedLines.Skip(staleLineCount).ToList()
-                    : collectedLines;
-
-                completedNormally = true;
-                return result;
-            }
-            finally
-            {
-                // Finalize phase, if any — the mirror of the prepare phase above, and deliberately
-                // still inside the lock: an exchange that switches shared device state on the way in
-                // has to switch it back before anything else can run, or the pairing is only half
-                // serialized (#407). It runs after the protobuf consumer has been restarted, just as
-                // the prepare phase ran before the consumer was swapped out.
-                // A failure here is never thrown from this point: doing so would abandon the rest of
-                // the finally, leaking the lock this exchange holds. It is held until after the
-                // release below and dealt with there.
-                Exception? finalizeFailure = null;
-                if (exchangeStarted && finalizeAsync != null)
-                {
-                    try
-                    {
-                        await finalizeAsync().ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        finalizeFailure = ex;
-                    }
-                }
-
-                _isInsideTextExchange.Value = false;
-
-                // Only the flow that took the lock releases it; a nested exchange leaves it to the
-                // RunExclusiveAsync block that owns it. Parked sends are flushed before the release
-                // so they are queued ahead of whatever runs next, and ReleaseOperationLock absorbs
-                // a Dispose that already tore the semaphore down (Dispose acquires the lock first,
-                // but proceeds anyway if that acquisition times out).
-                if (ownsLock)
-                {
-                    _operationLockGeneration.Value = 0;
-                    FlushDeferredSends();
-                    ReleaseOperationLock();
-                }
-
-                if (finalizeFailure != null)
-                {
-                    if (completedNormally)
-                    {
-                        // Nothing else is unwinding, so a failed restore is the only failure there
-                        // is. Surface it rather than report a success the device never got back
-                        // from — the caller's next command would run against the wrong state.
-                        // Rethrown only now, with the lock already released, so a failed restore
-                        // cannot also wedge the device.
-                        ExceptionDispatchInfo.Capture(finalizeFailure).Throw();
-                    }
-
-                    // Otherwise an exception is already on its way to the caller, and it is the one
-                    // that explains what went wrong. Replacing it with this one would lose the
-                    // diagnosis, so the cleanup failure is logged instead: cleanup never hides the
-                    // failure that caused the cleanup.
-                    SafeLog(() => _logger.LogError(
-                        finalizeFailure,
-                        "The text exchange's finalize phase failed while another failure was already "
-                        + "unwinding. The original failure is being surfaced to the caller; the device "
-                        + "may be left in the state the prepare phase established."));
-                }
-            }
+            return _textExchange.ExecuteAsync(
+                prepareAsync,
+                finalizeAsync,
+                setupActionAsync,
+                responseTimeoutMs,
+                completionTimeoutMs,
+                cancellationToken);
         }
+
+        /// <summary>
+        /// The text (SCPI) exchange primitive and the raw-capture swap it shares its consumer
+        /// handling with, extracted so this class delegates rather than hosts them (issue #344).
+        /// </summary>
+        private readonly TextExchangeEngine _textExchange;
+
+        #region ITextExchangeHost — the engine's view of this device
+
+        /// <inheritdoc />
+        bool ITextExchangeHost.IsConnected => IsConnected;
+
+        /// <inheritdoc />
+        bool ITextExchangeHost.IsShuttingDown => _disposed || _isDisconnecting;
+
+        /// <inheritdoc />
+        IStreamTransport? ITextExchangeHost.Transport => _transport;
+
+        /// <inheritdoc />
+        IMessageConsumer<DaqifiOutMessage>? ITextExchangeHost.MessageConsumer => _messageConsumer;
+
+        /// <inheritdoc />
+        void ITextExchangeHost.AttachInboundHandler(IMessageConsumer<DaqifiOutMessage> consumer) =>
+            consumer.MessageReceived += OnInboundMessageReceived;
+
+        /// <inheritdoc />
+        void ITextExchangeHost.DetachInboundHandler(IMessageConsumer<DaqifiOutMessage> consumer) =>
+            consumer.MessageReceived -= OnInboundMessageReceived;
+
+        /// <inheritdoc />
+        bool ITextExchangeHost.HoldsOperationLock => HoldsOperationLock;
+
+        /// <inheritdoc />
+        Task ITextExchangeHost.WaitForOperationLockAsync(CancellationToken cancellationToken) =>
+            _textExchangeLock.WaitAsync(cancellationToken);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Synchronous, and must stay that way: the <see cref="AsyncLocal{T}"/> write below flows
+        /// forward from whichever frame performs it. Called synchronously from the engine's own
+        /// frame it lands there, exactly as the inline assignment in
+        /// <see cref="RunExclusiveAsync{TResult}"/> does; behind an <c>await</c> it would land in a
+        /// frame nobody reads and the exchange would stop recognising its own ownership.
+        /// </remarks>
+        void ITextExchangeHost.EnterOperationLockOwnership()
+        {
+            _operationLockGeneration.Value = Volatile.Read(ref _operationGeneration);
+            MarkOperationInFlight();
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Synchronous for the same reason as <see cref="ITextExchangeHost.EnterOperationLockOwnership"/>.</remarks>
+        void ITextExchangeHost.ExitOperationLockOwnership()
+        {
+            _operationLockGeneration.Value = 0;
+            FlushDeferredSends();
+            ReleaseOperationLock();
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The setter is synchronous for the same reason as
+        /// <see cref="ITextExchangeHost.EnterOperationLockOwnership"/>: the re-entrancy guard only
+        /// works if the flag reaches the callbacks the engine invokes.
+        /// </remarks>
+        bool ITextExchangeHost.IsInsideTextExchange
+        {
+            get => _isInsideTextExchange.Value;
+            set => _isInsideTextExchange.Value = value;
+        }
+
+        /// <inheritdoc />
+        Task ITextExchangeHost.DrainOutboundQueueAsync(CancellationToken cancellationToken) =>
+            DrainOutboundQueueAsync(cancellationToken);
+
+        /// <inheritdoc />
+        IDisposable ITextExchangeHost.SubscribeConsumerErrors(IMessageConsumer<string> consumer) =>
+            new ConsumerErrorSubscription(this, consumer);
+
+        /// <inheritdoc />
+        ILogger ITextExchangeHost.Logger => _logger;
+
+        #endregion
 
         /// <summary>
         /// Pops <c>SYSTem:ERRor?</c> entries from the device until the queue reports

--- a/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
+++ b/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
@@ -1,0 +1,142 @@
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device.Protocol;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Internal
+{
+    /// <summary>
+    /// The slice of <see cref="DaqifiDevice"/> that <see cref="TextExchangeEngine"/> drives: the
+    /// state the exchange validates against, the consumer and transport bindings it swaps, and the
+    /// device's operation-lock protocol it takes part in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every member forwards to something the device already had. The device implements this
+    /// explicitly, so none of it widens the public API — the same arrangement
+    /// <see cref="IDeviceOperationHost"/> uses.
+    /// </para>
+    /// <para>
+    /// <b>Why some members are documented as "must not be async".</b> Three of them —
+    /// <see cref="EnterOperationLockOwnership"/>, <see cref="ExitOperationLockOwnership"/> and the
+    /// <see cref="IsInsideTextExchange"/> setter — write <see cref="AsyncLocal{T}"/> slots on the
+    /// device. An <see cref="AsyncLocal{T}"/> write propagates to the writing frame's <i>callees</i>,
+    /// never back to its caller once an <c>await</c> has established a boundary. These therefore
+    /// have to run synchronously on the engine's own frame: the engine writes them, and the engine
+    /// is what then invokes the caller's prepare / setup / finalize callbacks, which is precisely who
+    /// must observe them. Making any of them <c>async Task</c> would compile, pass a casual reading,
+    /// and silently stop the re-entrancy guard and the nested-lock detection from seeing anything —
+    /// turning a clean <see cref="InvalidOperationException"/> into a deadlock on a semaphore the
+    /// flow already holds. This is the same constraint the device's own
+    /// <c>RunExclusiveAsync</c> observes by assigning the slot inline rather than in a helper.
+    /// </para>
+    /// </remarks>
+    internal interface ITextExchangeHost
+    {
+        /// <inheritdoc cref="DaqifiDevice.IsConnected"/>
+        bool IsConnected { get; }
+
+        /// <summary>
+        /// True once the device is disposed or is tearing its connection down, in which case no
+        /// exchange may start.
+        /// </summary>
+        bool IsShuttingDown { get; }
+
+        /// <inheritdoc cref="DaqifiDevice.Transport"/>
+        IStreamTransport? Transport { get; }
+
+        /// <summary>
+        /// The protobuf consumer the exchange stops for the duration of the swap, or <c>null</c> on
+        /// a device that has none.
+        /// </summary>
+        IMessageConsumer<DaqifiOutMessage>? MessageConsumer { get; }
+
+        /// <summary>
+        /// Subscribes the device's inbound-message handler to <paramref name="consumer"/>.
+        /// </summary>
+        /// <remarks>
+        /// Attach and detach are the device's own because the handler is private to it. Routing them
+        /// through here rather than exposing the delegate keeps the subscription symmetric — the
+        /// engine cannot accidentally remove a differently-constructed equal delegate, or leave one
+        /// attached twice.
+        /// </remarks>
+        void AttachInboundHandler(IMessageConsumer<DaqifiOutMessage> consumer);
+
+        /// <summary>
+        /// Unsubscribes the device's inbound-message handler from <paramref name="consumer"/>.
+        /// </summary>
+        void DetachInboundHandler(IMessageConsumer<DaqifiOutMessage> consumer);
+
+        /// <summary>
+        /// True when the current logical flow already holds the device's operation lock — in any
+        /// session — and so must run nested rather than wait for a semaphore it is itself holding.
+        /// </summary>
+        bool HoldsOperationLock { get; }
+
+        /// <summary>
+        /// Waits for the device's operation lock.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately does <b>not</b> translate a disposed semaphore: it throws
+        /// <see cref="ObjectDisposedException"/> and lets the engine report the failure in its own
+        /// words, matching what callers of the text exchange have always seen.
+        /// </remarks>
+        /// <exception cref="ObjectDisposedException">Thrown when a concurrent dispose already tore the lock down.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when cancelled while waiting.</exception>
+        Task WaitForOperationLockAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Records that this flow now owns the operation lock, and starts deferring other threads'
+        /// sends behind it.
+        /// </summary>
+        /// <remarks>
+        /// <b>Must not be made async</b> — see the remarks on <see cref="ITextExchangeHost"/>.
+        /// </remarks>
+        void EnterOperationLockOwnership();
+
+        /// <summary>
+        /// Gives up ownership: clears this flow's claim, replays the sends parked while it ran, and
+        /// releases the lock.
+        /// </summary>
+        /// <remarks>
+        /// <b>Must not be made async</b> — see the remarks on <see cref="ITextExchangeHost"/>.
+        /// </remarks>
+        void ExitOperationLockOwnership();
+
+        /// <summary>
+        /// Whether the current logical flow is already inside a consumer swap. Set by the engine
+        /// around the exchange so a <c>setupAction</c> that re-enters is caught rather than wedging.
+        /// </summary>
+        /// <remarks>
+        /// <b>The setter must not be made async</b> — see the remarks on
+        /// <see cref="ITextExchangeHost"/>.
+        /// </remarks>
+        bool IsInsideTextExchange { get; set; }
+
+        /// <inheritdoc cref="DaqifiDevice.DrainOutboundQueueAsync"/>
+        Task DrainOutboundQueueAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Forwards the temporary text consumer's failures to the device's
+        /// <see cref="DaqifiDevice.ErrorOccurred"/> surface for the lifetime of the returned scope.
+        /// </summary>
+        /// <remarks>
+        /// Scoped rather than a bare subscription because the text consumer can outlive the exchange:
+        /// its stop and dispose are both time-bounded and may return with the reader thread still
+        /// parked in an un-returning read. A live thread roots the consumer, which would root the
+        /// device through the handler.
+        /// </remarks>
+        IDisposable SubscribeConsumerErrors(IMessageConsumer<string> consumer);
+
+        /// <summary>
+        /// The device's logger. The engine wraps every call to it, so a throwing logger cannot take
+        /// down an exchange.
+        /// </summary>
+        ILogger Logger { get; }
+    }
+}

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -1,0 +1,552 @@
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Transport;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Internal
+{
+    /// <summary>
+    /// Runs a text (SCPI) exchange on the device's stream: takes the operation lock, swaps the
+    /// protobuf consumer out for a line-based one, collects the reply lines, and puts everything
+    /// back — extracted from <see cref="DaqifiDevice"/> so the device delegates rather than hosts it
+    /// (issue #344).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the primitive nearly every non-streaming device operation is built on: the SD card
+    /// operations, the diagnostics, the LAN chip info and the confirming administration commands all
+    /// reach it through <see cref="IDeviceOperationHost.ExecuteTextCommandAsync"/>. It is also the
+    /// most order-sensitive code in the device — the prepare/finalize pairing, the outbound drain,
+    /// the stale-line boundary and the consumer restart each close a specific reported defect, and
+    /// the comments below say which. Read them before moving anything.
+    /// </para>
+    /// <para>
+    /// The engine holds no state of its own beyond its host. Everything it coordinates —
+    /// the operation lock, the re-entrancy flag, the consumer, the transport — belongs to the device
+    /// and is reached through <see cref="ITextExchangeHost"/>, whose remarks explain why three of
+    /// those members must stay synchronous.
+    /// </para>
+    /// </remarks>
+    internal sealed class TextExchangeEngine
+    {
+        private readonly ITextExchangeHost _host;
+
+        internal TextExchangeEngine(ITextExchangeHost host)
+        {
+            _host = host ?? throw new ArgumentNullException(nameof(host));
+        }
+
+        /// <summary>
+        /// Temporarily pauses the protobuf message consumer to allow raw byte access to the
+        /// underlying transport stream. The consumer is restored when the returned action completes
+        /// or is disposed.
+        /// </summary>
+        /// <param name="rawAction">
+        /// An async function that receives the transport stream and performs raw I/O.
+        /// The protobuf consumer will not read from the stream while this action is executing.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token to observe.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the device has no transport-based connection.</exception>
+        internal async Task ExecuteRawCaptureAsync(
+            Func<Stream, CancellationToken, Task> rawAction,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_host.IsConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+
+            var transport = _host.Transport;
+            if (transport == null)
+            {
+                throw new InvalidOperationException("ExecuteRawCaptureAsync requires a transport-based connection.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                // Stop the protobuf consumer so it doesn't compete for stream bytes
+                SuspendInboundConsumer();
+
+                // Hand the stream to the caller for raw I/O
+                await rawAction(transport.Stream, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                RestartMessageConsumerAfterSwap();
+            }
+        }
+
+        /// <summary>
+        /// Executes a text-based command by temporarily switching from the protobuf consumer to a
+        /// line-based text consumer, collecting text responses, then restoring the protobuf consumer.
+        /// </summary>
+        /// <remarks>
+        /// The parameter contract — including what the prepare and finalize phases guarantee — is
+        /// documented on <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>,
+        /// the seam callers actually use.
+        /// </remarks>
+        internal async Task<IReadOnlyList<string>> ExecuteAsync(
+            Func<CancellationToken, Task>? prepareAsync,
+            Func<Task>? finalizeAsync,
+            Func<CancellationToken, Task> setupActionAsync,
+            int responseTimeoutMs,
+            int completionTimeoutMs,
+            CancellationToken cancellationToken)
+        {
+            if (responseTimeoutMs <= 0)
+                throw new ArgumentOutOfRangeException(nameof(responseTimeoutMs), responseTimeoutMs, "Timeout must be positive.");
+            if (completionTimeoutMs <= 0)
+                throw new ArgumentOutOfRangeException(nameof(completionTimeoutMs), completionTimeoutMs, "Timeout must be positive.");
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Async-context re-entrancy detection: a setupAction that calls
+            // ExecuteTextCommandAsync on the same device would corrupt the
+            // consumer swap mid-flight. Surface as a clean exception rather
+            // than wedging on the operation lock forever.
+            // AsyncLocal flows across await thread hops so this catches
+            // re-entry even when the inner call resumes on a different
+            // thread than the outer call.
+            if (_host.IsInsideTextExchange)
+            {
+                throw new InvalidOperationException(
+                    "ExecuteTextCommandAsync is not re-entrant on the same device; "
+                    + "do not call it from inside a setupAction callback.");
+            }
+
+            // The exchange runs under the device's operation lock. A flow that already owns it —
+            // one inside RunExclusiveAsync, typically — runs nested rather than waiting on a
+            // semaphore it is itself holding, and leaves the release to the owner.
+            var ownsLock = !_host.HoldsOperationLock;
+            if (ownsLock)
+            {
+                try
+                {
+                    await _host.WaitForOperationLockAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    // Dispose() raced ahead of us and disposed the semaphore.
+                    // Surface the same clean failure as the post-acquisition
+                    // shutdown check below, instead of leaking a low-level
+                    // teardown exception to callers. The original is kept as
+                    // InnerException so this rare race stays diagnosable.
+                    throw new DeviceNotConnectedException(
+                        "ExecuteTextCommandAsync cannot run because the device is disposed.",
+                        ex,
+                        isShuttingDown: true);
+                }
+
+                // Claimed in this frame, not behind an await: an AsyncLocal write flows forward to
+                // this frame's callees but never back to its caller, and the callees are exactly who
+                // must see it. See the remarks on ITextExchangeHost.
+                _host.EnterOperationLockOwnership();
+            }
+
+            _host.IsInsideTextExchange = true;
+
+            // Whether the exchange got past validation and so owes its finalize phase, and whether
+            // it is on its way out normally rather than with an exception unwinding. Both are read
+            // only by the finalize block in the outer finally below.
+            var exchangeStarted = false;
+            var completedNormally = false;
+            try
+            {
+                // All validation runs INSIDE the lock so a competing thread
+                // calling DisconnectAsync() / Dispose() while we're blocked
+                // on the acquisition above doesn't leave us with a stale
+                // transport / consumer reference (closes the TOCTOU window
+                // documented in #186).
+                if (_host.IsShuttingDown)
+                {
+                    throw new DeviceNotConnectedException(
+                        "ExecuteTextCommandAsync cannot run while the device is "
+                        + "disposing or disconnecting.",
+                        isShuttingDown: true);
+                }
+
+                if (!_host.IsConnected)
+                {
+                    throw new DeviceNotConnectedException();
+                }
+
+                var transport = _host.Transport;
+                if (transport == null)
+                {
+                    throw new InvalidOperationException("ExecuteTextCommandAsync requires a transport-based connection.");
+                }
+
+                // The device-level IsConnected check above is status-based and can still report
+                // Connected when the underlying transport has dropped (e.g. a serial port closed
+                // by an unplug or a DTR-triggered MCU reset mid-connect). Detect that here and
+                // fail with the typed transport-disconnected exception, rather than dereferencing
+                // Stream below and surfacing the framework's raw "BaseStream is only available
+                // when the port is open." message (issue #238).
+                if (!transport.IsConnected)
+                {
+                    throw new TransportNotConnectedException(
+                        "Device transport is no longer connected.");
+                }
+
+                // Past validation: from here on the exchange acts on the device, so its finalize
+                // phase (if any) is owed however this ends — including a prepare phase that failed
+                // part-way and left the device half-way into the state it was establishing.
+                exchangeStarted = true;
+
+                var sw = Stopwatch.StartNew();
+
+                // Prepare phase, if any. Deliberately here: inside the lock, so no competing text
+                // exchange can interleave between it and the setup action below and undo the state
+                // it establishes; and before the consumer swap, so the wait it typically needs
+                // cannot widen the stale-line boundary taken further down. Any device output it
+                // provokes goes to the protobuf consumer, which is still running at this point.
+                if (prepareAsync != null)
+                {
+                    await prepareAsync(cancellationToken).ConfigureAwait(false);
+
+                    Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Prepare phase completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));
+                }
+
+                // Let anything queued before this exchange opened reach the wire while the protobuf
+                // consumer is still the one reading, so its reply is not mistaken for an answer to
+                // a command this exchange is about to send (issue #342). New sends from other
+                // threads are already parked by this point, so the queue can only shrink.
+                //
+                // Deliberately OUTSIDE the swap's try/finally below: this is the one step here that
+                // can throw (a cancelled token) before the consumer has been stopped, and that
+                // finally restarts the consumer — which on a consumer that was never stopped means
+                // subscribing the inbound handler a second time and dispatching every frame twice.
+                await _host.DrainOutboundQueueAsync(cancellationToken).ConfigureAwait(false);
+
+                var collectedLines = new List<string>();
+                var stream = transport.Stream;
+                int? originalReadTimeout = null;
+
+                // Number of lines that were already in flight when this exchange opened — see the
+                // note at the point it is captured, below.
+                var staleLineCount = 0;
+
+                try
+                {
+                    if (stream.CanTimeout)
+                    {
+                        try
+                        {
+                            originalReadTimeout = stream.ReadTimeout;
+                            stream.ReadTimeout = Math.Min(500, Math.Max(100, responseTimeoutMs / 4));
+                        }
+                        catch
+                        {
+                            // Some streams may not allow setting read timeout; ignore.
+                            originalReadTimeout = null;
+                        }
+                    }
+
+                    // Stop the protobuf consumer so it doesn't compete for stream bytes.
+                    // The serial transport sets ReadTimeout=500ms after connect, so the
+                    // consumer thread's blocking Read will unblock within 500ms.
+                    SuspendInboundConsumer();
+
+                    Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Protobuf consumer stopped at {ElapsedMs}ms", sw.ElapsedMilliseconds));
+
+                    // Create a temporary text consumer on the same stream
+                    using var textConsumer = new StreamMessageConsumer<string>(
+                        transport.Stream,
+                        new LineBasedMessageParser(),
+                        healthSink: transport as ITransportHealthSink);
+
+                    textConsumer.MessageReceived += (_, e) =>
+                    {
+                        collectedLines.Add(e.Message.Data);
+                    };
+
+                    // The protobuf consumer is stopped for the duration of this exchange, so
+                    // without this a read failure during a text command (an unplug mid-SD-listing,
+                    // say) would be the one background failure with nowhere to go (issue #378).
+                    //
+                    // Scoped rather than a bare '+=' because this consumer can outlive the block:
+                    // its stop and dispose are both time-bounded and may return with the reader
+                    // thread still parked in an un-returning read. A live thread roots the consumer,
+                    // which would root the device through the handler — retaining the whole object
+                    // graph and, worse, letting a zombie reader keep raising errors on a device that
+                    // has since been disconnected. 'using' disposes in reverse declaration order, so
+                    // this detaches before textConsumer itself is disposed, on every exit path
+                    // including a cancellation or a throwing setup action.
+                    using var textConsumerErrors = _host.SubscribeConsumerErrors(textConsumer);
+
+                    textConsumer.Start();
+                    // ConfigureAwait(false): the lock is held, so resuming on a captured
+                    // sync context (e.g. UI thread) would deadlock if that thread calls Disconnect().
+                    await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+
+                    Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Text consumer started at {ElapsedMs}ms", sw.ElapsedMilliseconds));
+
+                    // Mark the boundary between "already in flight" and "answers to this exchange".
+                    // Anything captured before the setup action has sent anything is a late reply to
+                    // an EARLIER command, or line noise — never a response to a command this exchange
+                    // has yet to send. Those lines are dropped from the result below.
+                    //
+                    // Position matters as much as content: a caller that keys off response content —
+                    // e.g. the SD listing's end-of-listing terminator (#396) — would otherwise accept
+                    // a stale line as proof that the device answered a query it never even received,
+                    // and report a complete listing for a device that has gone silent.
+                    staleLineCount = collectedLines.Count;
+                    if (staleLineCount > 0)
+                    {
+                        Log(logger => logger.LogDebug(
+                            "[ExecuteTextCommandAsync] Discarding {StaleLineCount} line(s) received before this exchange sent anything",
+                            staleLineCount));
+                    }
+
+                    // Execute the setup action (sends SCPI commands). ConfigureAwait(false)
+                    // matches the surrounding lock-protected awaits.
+                    await setupActionAsync(cancellationToken).ConfigureAwait(false);
+
+                    Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Setup action completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));
+
+                    // Wait for responses using a two-phase inactivity-based timeout:
+                    // Phase 1: Wait up to responseTimeoutMs for the first response.
+                    // Phase 2: After receiving data, wait completionTimeoutMs of inactivity to finish.
+                    var lastMessageTime = DateTime.UtcNow;
+                    var maxWait = TimeSpan.FromMilliseconds(responseTimeoutMs * 5);
+                    var startTime = DateTime.UtcNow;
+                    var hasReceivedAny = false;
+
+                    while (DateTime.UtcNow - startTime < maxWait)
+                    {
+                        var previousCount = collectedLines.Count;
+                        await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                        if (collectedLines.Count > previousCount)
+                        {
+                            lastMessageTime = DateTime.UtcNow;
+                            if (!hasReceivedAny)
+                            {
+                                hasReceivedAny = true;
+                                Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] First response at {ElapsedMs}ms", sw.ElapsedMilliseconds));
+                            }
+                        }
+
+                        var elapsed = DateTime.UtcNow - lastMessageTime;
+
+                        if (hasReceivedAny)
+                        {
+                            // Phase 2: short completion timeout after first data
+                            if (elapsed >= TimeSpan.FromMilliseconds(completionTimeoutMs))
+                            {
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            // Phase 1: full initial timeout waiting for first data
+                            if (elapsed >= TimeSpan.FromMilliseconds(responseTimeoutMs))
+                            {
+                                break;
+                            }
+                        }
+                    }
+
+                    Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Collection complete at {ElapsedMs}ms, {LineCount} lines", sw.ElapsedMilliseconds, collectedLines.Count));
+
+                    // Stop the text consumer
+                    textConsumer.StopSafely();
+                }
+                finally
+                {
+                    if (originalReadTimeout.HasValue && stream.CanTimeout)
+                    {
+                        try
+                        {
+                            stream.ReadTimeout = originalReadTimeout.Value;
+                        }
+                        catch
+                        {
+                            // Ignore failures when restoring timeout.
+                        }
+                    }
+
+                    // Restart the protobuf consumer
+                    RestartMessageConsumerAfterSwap();
+
+                    Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Total elapsed: {ElapsedMs}ms", sw.ElapsedMilliseconds));
+                }
+
+                // The text consumer is stopped by this point, so the list is no longer being
+                // appended to concurrently and can be re-projected safely.
+                var result = staleLineCount > 0
+                    ? collectedLines.Skip(staleLineCount).ToList()
+                    : collectedLines;
+
+                completedNormally = true;
+                return result;
+            }
+            finally
+            {
+                // Finalize phase, if any — the mirror of the prepare phase above, and deliberately
+                // still inside the lock: an exchange that switches shared device state on the way in
+                // has to switch it back before anything else can run, or the pairing is only half
+                // serialized (#407). It runs after the protobuf consumer has been restarted, just as
+                // the prepare phase ran before the consumer was swapped out.
+                // A failure here is never thrown from this point: doing so would abandon the rest of
+                // the finally, leaking the lock this exchange holds. It is held until after the
+                // release below and dealt with there.
+                Exception? finalizeFailure = null;
+                if (exchangeStarted && finalizeAsync != null)
+                {
+                    try
+                    {
+                        await finalizeAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        finalizeFailure = ex;
+                    }
+                }
+
+                _host.IsInsideTextExchange = false;
+
+                // Only the flow that took the lock releases it; a nested exchange leaves it to the
+                // RunExclusiveAsync block that owns it. Parked sends are flushed before the release
+                // so they are queued ahead of whatever runs next, and the release absorbs a Dispose
+                // that already tore the semaphore down (Dispose acquires the lock first, but
+                // proceeds anyway if that acquisition times out).
+                if (ownsLock)
+                {
+                    _host.ExitOperationLockOwnership();
+                }
+
+                if (finalizeFailure != null)
+                {
+                    if (completedNormally)
+                    {
+                        // Nothing else is unwinding, so a failed restore is the only failure there
+                        // is. Surface it rather than report a success the device never got back
+                        // from — the caller's next command would run against the wrong state.
+                        // Rethrown only now, with the lock already released, so a failed restore
+                        // cannot also wedge the device.
+                        ExceptionDispatchInfo.Capture(finalizeFailure).Throw();
+                    }
+
+                    // Otherwise an exception is already on its way to the caller, and it is the one
+                    // that explains what went wrong. Replacing it with this one would lose the
+                    // diagnosis, so the cleanup failure is logged instead: cleanup never hides the
+                    // failure that caused the cleanup.
+                    Log(logger => logger.LogError(
+                        finalizeFailure,
+                        "The text exchange's finalize phase failed while another failure was already "
+                        + "unwinding. The original failure is being surfaced to the caller; the device "
+                        + "may be left in the state the prepare phase established."));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Detaches the device's inbound handler and stops the protobuf consumer so it does not
+        /// compete for stream bytes while a swap is in progress.
+        /// </summary>
+        /// <remarks>
+        /// The consumer is snapshotted once. The field behind it is mutable — a teardown nulls it —
+        /// and the exchange's lock does not exclude teardown, which proceeds anyway once its bounded
+        /// courtesy wait expires. Re-reading it per step could therefore detach from one instance and
+        /// stop another, or dereference null. This mirrors what
+        /// <see cref="RestartMessageConsumerAfterSwap"/> already does for the same reason.
+        /// </remarks>
+        private void SuspendInboundConsumer()
+        {
+            var consumer = _host.MessageConsumer;
+            if (consumer == null)
+            {
+                return;
+            }
+
+            _host.DetachInboundHandler(consumer);
+            var stopped = consumer.StopSafely(timeoutMs: 1000);
+            if (!stopped)
+            {
+                consumer.Stop();
+            }
+        }
+
+        /// <summary>
+        /// Restarts the protobuf consumer after a swap (raw capture or text exchange) has stopped it.
+        /// </summary>
+        /// <remarks>
+        /// The stop paths join the reader thread with a bounded timeout, so a reader parked in a slow
+        /// blocking <see cref="Stream.Read(byte[], int, int)"/> can still be alive here.
+        /// <see cref="StreamMessageConsumer{T}.Start"/> absorbs that case by waiting a grace period
+        /// for the stopped reader to exit, which is what keeps a normal connect from failing with
+        /// "a previous consumer thread has not yet exited" (issue #383).
+        /// <para>
+        /// If it still refuses, the reader's read is not returning at all — the stream is stuck.
+        /// Deliberately do <b>not</b> recover by binding a fresh consumer to that same stream: a new
+        /// instance would be a second concurrent reader on it, which is exactly the framing
+        /// corruption the guard exists to prevent, and it would block on the stuck stream anyway.
+        /// The consumer is left stopped; the operation's own failure (or the next
+        /// <see cref="DaqifiDevice.Connect"/>) surfaces the problem honestly.
+        /// </para>
+        /// <para>
+        /// Never throws: it runs from <c>finally</c> blocks, where an exception would mask the real
+        /// failure already unwinding. The consumer is also snapshotted once up front — the
+        /// text-exchange path holds the operation lock (which <see cref="DaqifiDevice.Disconnect"/>
+        /// waits on), but the raw-capture path does not, so a concurrent teardown could otherwise
+        /// null the field between reads.
+        /// </para>
+        /// </remarks>
+        private void RestartMessageConsumerAfterSwap()
+        {
+            var consumer = _host.MessageConsumer;
+            if (consumer == null)
+            {
+                return;
+            }
+
+            try
+            {
+                consumer.Start();
+                _host.AttachInboundHandler(consumer);
+            }
+            catch (ConsumerThreadNotExitedException ex)
+            {
+                Log(logger => logger.LogError(
+                    ex,
+                    "The previous message consumer thread did not exit, so the consumer was left stopped. "
+                    + "The device stream appears stuck; a reconnect is required to resume inbound messages."));
+            }
+            catch (Exception ex)
+            {
+                // e.g. ObjectDisposedException from a concurrent Dispose(). Swallow rather than let
+                // it escape a finally block and replace the operation's real exception.
+                Log(logger => logger.LogError(ex, "Failed to restart the message consumer after a stream swap."));
+            }
+        }
+
+        /// <summary>
+        /// Logs through the device's logger without letting a throwing logger take down an exchange —
+        /// the same isolation <c>DaqifiDevice.SafeLog</c> gives the rest of the device.
+        /// </summary>
+        private void Log(Action<ILogger> logAction)
+        {
+            try
+            {
+                logAction(_host.Logger);
+            }
+            catch
+            {
+                // A logger that throws is not permitted to take down device operation.
+            }
+        }
+    }
+}


### PR DESCRIPTION
The next slice of #344. `ExecuteTextCommandCoreAsync` plus the raw-capture consumer swap were the largest remaining block in `DaqifiDevice` — and the primitive every non-streaming operation is built on: the SD card operations, the diagnostics, the LAN chip info and the confirming administration commands all reach it through `IDeviceOperationHost.ExecuteTextCommandAsync`.

They now live in `TextExchangeEngine`, reached through a new internal `ITextExchangeHost` that `DaqifiDevice` implements explicitly — the same arrangement `IDeviceOperationHost` already uses.

`DaqifiDevice.cs` **3,961 → 3,615** lines.

## No API change

The `ExecuteTextCommandAsync` overloads and `ExecuteRawCaptureAsync` keep their signatures and stay `virtual`, so the subclass and test-double overrides that intercept device I/O remain in the path.

Verified rather than asserted: I dumped the public + protected surface of both assemblies by reflection (`MetadataLoadContext`) and diffed against the merge base — **byte-identical**, 2,035 members.

## The subtle part, and why it needed new tests

Three host members write `AsyncLocal` slots: the operation-lock claim, its release, and the re-entrancy flag. An `AsyncLocal` write reaches the writing frame's *callees* and never its *caller*, so those members have to stay synchronous and be called from the engine's own frame — the engine is what then invokes the caller's prepare/setup/finalize callbacks, which are exactly who must observe them. This is the same constraint `RunExclusiveAsync` observes by assigning its slot inline instead of in a helper. Both the interface and the implementations say so, at length, because making one of them `async Task` would compile and read fine.

I checked whether that was actually covered by mutating each write to happen behind an `await`. **Both mutations left the entire suite green.** So two tests are added:

- **`Send_FromInsideATextExchange_GoesStraightOut`** — a send from the exchange's own setup action must reach the wire *during* the exchange, not be parked by the deferral the exchange just switched on. The existing suite had the `RunExclusiveAsync` half of this (`Send_FromTheOwningFlow_GoesStraightOut`) but not the exchange's own. Broken, the command reaches the device only after the exchange closes, so the exchange collects nothing and returns an empty result — indistinguishable from a silent device.
- **`TextExchange_ReEnteredFromItsOwnSetupAction_IsRejected`** — drives the real guard instead of planting the flag by reflection, which only exercised the reading half. Worth pinning because getting it wrong does *not* deadlock: the nested call finds the lock already held by its own flow, declines to wait for it, and runs a second consumer swap on a stream mid-swap — the framing corruption the guard exists to prevent, failing silently as mangled replies.

Each new test fails against its corresponding mutation and passes against the real thing.

## One intentional deviation from a pure move

`SuspendInboundConsumer` snapshots `_messageConsumer` once instead of reading it four times. The field is mutable and teardown proceeds once its bounded courtesy wait expires, so the original could detach one instance and stop another, or dereference null. This mirrors what `RestartMessageConsumerAfterSwap` next to it already did deliberately, and for the reason its remarks already gave. Flagging it because it is the one line that is not a mechanical redirection — happy to revert it to the literal original if you would rather keep this strictly pure.

Everything else is mechanical: `_transport` → a local captured once after validation (the field is `readonly`), `SafeLog(() => _logger…)` → the engine's own `Log`, and each piece of device state → its host member. I diffed the moved bodies against the originals comment-stripped to confirm nothing else changed.

## Testing

**2,893 passed / 0 failed / 2 skipped**, on net9.0 and net10.0.

**Bench-validated** on Nq1 (fw 3.7.2, USB, `/dev/cu.usbmodem1101`), non-destructive throughout — no flash, no format, no delete, no config write. The example CLI was built against this worktree's core and against a build of `origin/main`, and the two were compared on the same hardware:

| Path | Result |
|---|---|
| `--lan-chip-info` | ChipId 1377184, FW 19.7.7, build Mar 30 2022 — **byte-identical** to `origin/main` |
| `--sd-list` | 45 files with parsed dates — **byte-identical** (exercises the prepare/finalize SPI bus switch) |
| `--sd-storage` | free 7,799,816,192 / total 7,800,356,864 — **byte-identical**, and matches the values recorded on this card in #344 earlier |
| `--show-status` + stream | identical status line and identical sample count (46 @ 20 Hz/3 s); sample values differ only as live data does |

The LAN chip info run is the load-bearing one: it drives a complete real exchange through the extracted engine — lock acquisition, outbound drain, protobuf consumer stop, text consumer swap, stale-line boundary, setup send, two-phase collection, consumer restart, lock release — and parses a correct non-trivial answer.

**One anomaly, reported rather than explained.** The very first SD query of the session returned `SdCardNotPresentException` on a card that was demonstrably present. It did not reproduce in 9 further attempts on this branch or 4 on `origin/main`, including a deliberate stream-then-SD sequence (the known #703 buffer-collapse shape) run alternately on both builds 3× each — 6/6 identical. I could not attribute it to this change, and I could not explain it either; recording it so it is not lost.

## Notes

- Sequenced after #478, which is already in.
- The collaborators extracted by this ticket still have no direct unit tests (#464); the two tests here are on `DaqifiDevice`'s behaviour, not on `TextExchangeEngine` in isolation.

Part of #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)