### PR TITLE
fix(device): Send() racing a disconnect now fails typed, not with an NRE

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceSendDisconnectRaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceSendDisconnectRaceTests.cs
@@ -152,8 +152,13 @@ public class DaqifiDeviceSendDisconnectRaceTests
         using var device = new DaqifiDevice("Racing Device", transport);
         device.Connect();
 
-        var failures = new List<Exception>();
-        var failureGate = new object();
+        // Only the first untyped failure is kept. It is the one that fails the test, and holding on
+        // to every teardown exception a four-second loop produces would have the test allocating
+        // harder than the race it is trying to lose. Typed failures are counted rather than stored:
+        // the count is diagnostic only, since whether a given run actually hits the race is not
+        // something a test can schedule.
+        Exception? untyped = null;
+        var typedFailures = 0;
         var sends = 0;
         var stop = false;
 
@@ -166,12 +171,17 @@ public class DaqifiDeviceSendDisconnectRaceTests
                     device.Send(ScpiMessageProducer.GetDeviceInfo);
                     Interlocked.Increment(ref sends);
                 }
+                catch (DeviceNotConnectedException)
+                {
+                    // The expected way to lose this race, and the whole point of the fix.
+                    Interlocked.Increment(ref typedFailures);
+                }
                 catch (Exception ex)
                 {
-                    lock (failureGate)
-                    {
-                        failures.Add(ex);
-                    }
+                    // First one wins and ends the run: it already fails the test, and letting the
+                    // loop carry on only buries it under thousands more of the same.
+                    Interlocked.CompareExchange(ref untyped, ex, null);
+                    Volatile.Write(ref stop, true);
                 }
 
                 // Keeps the producer's unbounded queue from being the thing under test.
@@ -184,7 +194,10 @@ public class DaqifiDeviceSendDisconnectRaceTests
 
         var cycles = 0;
         var clock = Stopwatch.StartNew();
-        while (cycles < MaxStressCycles && clock.Elapsed < StressBudget)
+
+        // The sender raises `stop` the moment something untyped escapes, so a failing run reports in
+        // milliseconds instead of burning the whole budget cycling a device nobody is sending to.
+        while (cycles < MaxStressCycles && clock.Elapsed < StressBudget && !Volatile.Read(ref stop))
         {
             device.Disconnect();
             device.Connect();
@@ -198,21 +211,17 @@ public class DaqifiDeviceSendDisconnectRaceTests
         Assert.True(cycles > 0, "No disconnect/reconnect cycles ran.");
         Assert.True(Volatile.Read(ref sends) > 0, "No sends were attempted.");
 
-        List<Exception> observed;
-        lock (failureGate)
-        {
-            observed = failures.ToList();
-        }
-
         // Asserted as a negative on purpose: whether a given run wins or loses the race is not
         // something a test can schedule, so this pins "no untyped failure can escape" rather than
-        // "the race happened". Before the fix, a long enough run produced both of these.
-        Assert.DoesNotContain(observed, ex => ex is NullReferenceException);
-
-        var untyped = observed.FirstOrDefault(ex => ex is not DeviceNotConnectedException);
+        // "the race happened". Before the fix, a long enough run produced both a
+        // NullReferenceException, from dereferencing the field teardown had just nulled, and a bare
+        // InvalidOperationException from the stopped producer; either one lands here. Read plainly —
+        // Thread.Join already published everything the sender wrote.
+        var escaped = untyped;
         Assert.True(
-            untyped == null,
-            $"Send surfaced an untyped failure while racing teardown: {untyped?.GetType().Name}: {untyped?.Message}");
+            escaped == null,
+            $"Send surfaced an untyped failure while racing teardown (after {typedFailures} typed "
+            + $"failure(s)): {escaped?.GetType().Name}: {escaped?.Message}");
 
         device.Disconnect();
     }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceSendDisconnectRaceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceSendDisconnectRaceTests.cs
@@ -1,0 +1,391 @@
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using System.Diagnostics;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Coverage for <see cref="DaqifiDevice.Send{T}"/> racing a teardown (#497).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The contract under test: a send that loses a race against <c>Disconnect</c>, <c>Dispose</c> or an
+/// auto-reconnect fails as <see cref="DeviceNotConnectedException"/> with
+/// <see cref="DeviceNotConnectedException.IsShuttingDown"/> set — never as a
+/// <see cref="NullReferenceException"/> from a half-torn-down field, and never as a bare
+/// <see cref="InvalidOperationException"/> whose message names an internal producer lifecycle
+/// method. Both outcomes were reachable before: the send path null-checked the mutable
+/// <c>_messageProducer</c> field and then dereferenced it (two reads, teardown could land between
+/// them), and winning that check still left the producer free to stop before the message was
+/// queued.
+/// </para>
+/// <para>
+/// The race itself cannot be scheduled, so it is covered from both ends: the translation is pinned
+/// deterministically through the internal seam (including against a real
+/// <see cref="MessageProducer{T}"/>, so a change to what it throws is caught here), and the real
+/// race is run as a stress loop that asserts the negative.
+/// </para>
+/// </remarks>
+public class DaqifiDeviceSendDisconnectRaceTests
+{
+    /// <summary>How long the disconnect/reconnect stress loop is allowed to run.</summary>
+    private static readonly TimeSpan StressBudget = TimeSpan.FromSeconds(4);
+
+    /// <summary>Upper bound on stress cycles, so a fast machine stops early instead of spinning.</summary>
+    private const int MaxStressCycles = 25;
+
+    // ── Translation: the producer reports a teardown ────────────────────────────────────────
+
+    [Fact]
+    public void SendViaProducer_WhenProducerIsNotRunning_ThrowsDeviceNotConnected()
+    {
+        // The exact exception MessageProducer.Send raises once Stop/StopSafely has run.
+        var stopped = new InvalidOperationException("Message producer is not running. Call Start() first.");
+        var producer = new ThrowingProducer(stopped);
+
+        var ex = Assert.Throws<DeviceNotConnectedException>(
+            () => DaqifiDevice.SendViaProducer(producer, ScpiMessageProducer.GetDeviceInfo));
+
+        Assert.True(ex.IsShuttingDown, "A producer stopped by teardown is a shutdown, not a plain 'never connected'.");
+        Assert.Same(stopped, ex.InnerException);
+    }
+
+    [Fact]
+    public void SendViaProducer_WhenProducerIsDisposed_ThrowsDeviceNotConnected()
+    {
+        // ObjectDisposedException derives from InvalidOperationException, so this also pins the
+        // order of the two catch blocks: a broader-first ordering would report the disposed
+        // producer as merely "no longer running".
+        var disposed = new ObjectDisposedException("MessageProducer");
+        var producer = new ThrowingProducer(disposed);
+
+        var ex = Assert.Throws<DeviceNotConnectedException>(
+            () => DaqifiDevice.SendViaProducer(producer, ScpiMessageProducer.GetDeviceInfo));
+
+        Assert.True(ex.IsShuttingDown);
+        Assert.Same(disposed, ex.InnerException);
+        Assert.Contains("disposed", ex.Message);
+    }
+
+    [Fact]
+    public void SendViaProducer_WhenProducerThrowsDeviceNotConnected_RethrowsItUnchanged()
+    {
+        // Already the failure this would translate to; re-wrapping would bury the producer's own
+        // wording one level deeper for no gain.
+        var original = new DeviceNotConnectedException("producer said so", isShuttingDown: true);
+        var producer = new ThrowingProducer(original);
+
+        var ex = Assert.Throws<DeviceNotConnectedException>(
+            () => DaqifiDevice.SendViaProducer(producer, ScpiMessageProducer.GetDeviceInfo));
+
+        Assert.Same(original, ex);
+    }
+
+    [Fact]
+    public void SendViaProducer_DoesNotTranslateFailuresThatAreNotTeardowns()
+    {
+        // The translation is scoped to lifecycle failures. An I/O fault is a real fault and must
+        // keep its type, or callers lose the ability to tell a dead link from a closed one.
+        var faulted = new IOException("stream fault");
+        var producer = new ThrowingProducer(faulted);
+
+        var ex = Assert.Throws<IOException>(
+            () => DaqifiDevice.SendViaProducer(producer, ScpiMessageProducer.GetDeviceInfo));
+
+        Assert.Same(faulted, ex);
+    }
+
+    [Fact]
+    public void SendViaProducer_OnTheHappyPath_HandsTheMessageToTheProducer()
+    {
+        var producer = new ThrowingProducer(failure: null);
+
+        // Held in a local: ScpiMessageProducer.GetDeviceInfo builds a fresh message per access.
+        var message = ScpiMessageProducer.GetDeviceInfo;
+
+        DaqifiDevice.SendViaProducer(producer, message);
+
+        Assert.Single(producer.Sent);
+        Assert.Same(message, producer.Sent[0]);
+    }
+
+    // ── Translation: pinned against the real producer ───────────────────────────────────────
+
+    [Fact]
+    public void SendViaProducer_AgainstARealStoppedProducer_ThrowsDeviceNotConnected()
+    {
+        using var sink = new NullSinkStream();
+        using var producer = new MessageProducer<string>(sink);
+        producer.Start();
+        producer.StopSafely();
+
+        var ex = Assert.Throws<DeviceNotConnectedException>(
+            () => DaqifiDevice.SendViaProducer(producer, ScpiMessageProducer.GetDeviceInfo));
+
+        Assert.True(ex.IsShuttingDown);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void SendViaProducer_AgainstARealDisposedProducer_ThrowsDeviceNotConnected()
+    {
+        using var sink = new NullSinkStream();
+        var producer = new MessageProducer<string>(sink);
+        producer.Start();
+        producer.Dispose();
+
+        var ex = Assert.Throws<DeviceNotConnectedException>(
+            () => DaqifiDevice.SendViaProducer(producer, ScpiMessageProducer.GetDeviceInfo));
+
+        Assert.True(ex.IsShuttingDown);
+        Assert.IsType<ObjectDisposedException>(ex.InnerException);
+    }
+
+    // ── The real race ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Send_RacingRepeatedDisconnectAndReconnect_OnlySurfacesTypedFailures()
+    {
+        using var transport = new SinkTransport();
+        using var device = new DaqifiDevice("Racing Device", transport);
+        device.Connect();
+
+        var failures = new List<Exception>();
+        var failureGate = new object();
+        var sends = 0;
+        var stop = false;
+
+        var sender = new Thread(() =>
+        {
+            while (!Volatile.Read(ref stop))
+            {
+                try
+                {
+                    device.Send(ScpiMessageProducer.GetDeviceInfo);
+                    Interlocked.Increment(ref sends);
+                }
+                catch (Exception ex)
+                {
+                    lock (failureGate)
+                    {
+                        failures.Add(ex);
+                    }
+                }
+
+                // Keeps the producer's unbounded queue from being the thing under test.
+                Thread.Yield();
+            }
+        })
+        { IsBackground = true };
+
+        sender.Start();
+
+        var cycles = 0;
+        var clock = Stopwatch.StartNew();
+        while (cycles < MaxStressCycles && clock.Elapsed < StressBudget)
+        {
+            device.Disconnect();
+            device.Connect();
+            cycles++;
+        }
+
+        Volatile.Write(ref stop, true);
+        Assert.True(sender.Join(TimeSpan.FromSeconds(10)), "The sender thread did not stop.");
+
+        // The loop has to have actually run, or the assertions below are vacuous.
+        Assert.True(cycles > 0, "No disconnect/reconnect cycles ran.");
+        Assert.True(Volatile.Read(ref sends) > 0, "No sends were attempted.");
+
+        List<Exception> observed;
+        lock (failureGate)
+        {
+            observed = failures.ToList();
+        }
+
+        // Asserted as a negative on purpose: whether a given run wins or loses the race is not
+        // something a test can schedule, so this pins "no untyped failure can escape" rather than
+        // "the race happened". Before the fix, a long enough run produced both of these.
+        Assert.DoesNotContain(observed, ex => ex is NullReferenceException);
+
+        var untyped = observed.FirstOrDefault(ex => ex is not DeviceNotConnectedException);
+        Assert.True(
+            untyped == null,
+            $"Send surfaced an untyped failure while racing teardown: {untyped?.GetType().Name}: {untyped?.Message}");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public void Send_WhenConnected_StillReachesTheWire()
+    {
+        // The snapshot must not have cost the common path: a connected device's string message
+        // still goes through the queued producer rather than the direct-write fallback.
+        using var transport = new SinkTransport();
+        using var device = new DaqifiDevice("Happy Device", transport);
+        device.Connect();
+
+        device.Send(ScpiMessageProducer.GetDeviceInfo);
+
+        Assert.True(
+            SpinWait.SpinUntil(() => transport.BytesWritten > 0, TimeSpan.FromSeconds(5)),
+            "A message sent on a connected device never reached the stream.");
+
+        device.Disconnect();
+    }
+
+    // ── Test doubles ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A producer that either records what it was handed or throws a caller-supplied failure, so
+    /// the translation can be driven through every branch without scheduling a race.
+    /// </summary>
+    private sealed class ThrowingProducer : IMessageProducer<string>
+    {
+        private readonly Exception? _failure;
+
+        public ThrowingProducer(Exception? failure) => _failure = failure;
+
+        public List<IOutboundMessage<string>> Sent { get; } = new();
+
+        /// <summary>
+        /// Never raised — this double fails synchronously out of <see cref="Send"/>, which is the
+        /// whole point of it. Declared with explicit accessors so it needs no backing field.
+        /// </summary>
+        public event EventHandler<MessageSendFailedEventArgs<string>>? SendFailed
+        {
+            add { }
+            remove { }
+        }
+
+        public int QueuedMessageCount => 0;
+
+        public bool IsRunning => _failure == null;
+
+        public void Send(IOutboundMessage<string> message)
+        {
+            if (_failure != null)
+            {
+                throw _failure;
+            }
+
+            Sent.Add(message);
+        }
+
+        public void Start()
+        {
+        }
+
+        public void Stop()
+        {
+        }
+
+        public bool StopSafely(int timeoutMs = 1000) => true;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// A write-only stream that counts bytes and keeps none of them, so a stress loop's traffic
+    /// cannot itself become the memory or contention under test.
+    /// </summary>
+    private sealed class NullSinkStream : Stream
+    {
+        private long _bytesWritten;
+
+        public long BytesWritten => Interlocked.Read(ref _bytesWritten);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            // Nothing ever arrives; back off so the consumer's reader loop does not spin a core.
+            Thread.Sleep(5);
+            return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            Interlocked.Add(ref _bytesWritten, count);
+    }
+
+    /// <summary>
+    /// Transport over a <see cref="NullSinkStream"/> that can be connected and disconnected
+    /// repeatedly, which is what makes the device rebuild and re-null its message pumps the way an
+    /// auto-reconnect does.
+    /// </summary>
+    private sealed class SinkTransport : IStreamTransport
+    {
+        private readonly NullSinkStream _stream = new();
+        private bool _isConnected;
+        private bool _disposed;
+
+        public long BytesWritten => _stream.BytesWritten;
+
+        public Stream Stream => _disposed
+            ? throw new ObjectDisposedException(nameof(SinkTransport))
+            : _stream;
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "Sink: Connected" : "Sink: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SinkTransport));
+            }
+
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().Wait();
+
+        public void Disconnect() => DisconnectAsync().Wait();
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _isConnected = false;
+            _disposed = true;
+            _stream.Dispose();
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1787,7 +1787,12 @@ namespace Daqifi.Core.Device
         /// </remarks>
         /// <typeparam name="T">The type of the message data payload.</typeparam>
         /// <param name="message">The message to send to the device.</param>
-        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceNotConnectedException">
+        /// Thrown when the device is not connected. Also thrown, with
+        /// <see cref="DeviceNotConnectedException.IsShuttingDown"/> set, when a disconnect, dispose
+        /// or auto-reconnect on another thread tears the send path down after this call has passed
+        /// its connectivity guard — an ordinary race a long-lived sender should expect, not a defect.
+        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// Thrown when the device is connected but has no transport or stream to send on
         /// (e.g. the producer-less <see cref="DaqifiDevice(string, IPAddress, ILogger)"/> constructor).
@@ -1819,11 +1824,20 @@ namespace Daqifi.Core.Device
         /// </summary>
         private void SendNow<T>(IOutboundMessage<T> message)
         {
+            // Snapshotted once, for the reason TextExchangeEngine.SuspendInboundConsumer snapshots
+            // the consumer: the field behind it is mutable and teardown nulls it
+            // (StopMessagePumps) from another thread, under no lock this path takes. Null-checking
+            // the field and then dereferencing it reads it twice, and a teardown landing between
+            // the two reads throws NullReferenceException out of a public API. The window is not
+            // limited to a user-initiated Disconnect() — every auto-reconnect attempt goes through
+            // DisconnectCore(Retrying) and nulls the field the same way (issue #497).
+            var producer = _messageProducer;
+
             // Use the queued message producer when available and the message is string-based;
             // this is the common path (SCPI text commands).
-            if (_messageProducer != null && message is IOutboundMessage<string> stringMessage)
+            if (producer != null && message is IOutboundMessage<string> stringMessage)
             {
-                _messageProducer.Send(stringMessage);
+                SendViaProducer(producer, stringMessage);
                 return;
             }
 
@@ -1846,6 +1860,68 @@ namespace Daqifi.Core.Device
             lock (_directWriteGate)
             {
                 stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+
+        /// <summary>
+        /// Hands a message to the queued producer, reporting a producer that teardown has already
+        /// stopped or disposed as the same typed failure every other guard on this device reports.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Snapshotting the field closes the null-dereference half of the disconnect race; this
+        /// closes the other half. Winning the snapshot only means the reference was still there —
+        /// teardown can have stopped or disposed that very instance a moment later, and the send
+        /// then fails inside the producer. Untranslated, callers would see a bare
+        /// <see cref="InvalidOperationException"/> whose message names an internal lifecycle method
+        /// ("Call Start() first"), or an <see cref="ObjectDisposedException"/> naming an internal
+        /// type — both indistinguishable, without matching on message text, from a genuine
+        /// application defect. That is exactly the distinction
+        /// <see cref="DeviceNotConnectedException"/> was introduced to make (#395), so this reports
+        /// the ordinary, expected condition it is, with
+        /// <see cref="DeviceNotConnectedException.IsShuttingDown"/> set.
+        /// </para>
+        /// <para>
+        /// The original is kept as <see cref="Exception.InnerException"/> so the race stays
+        /// diagnosable, and a <see cref="DeviceNotConnectedException"/> from the producer itself is
+        /// let through unwrapped — it already says what this would say.
+        /// </para>
+        /// <para>
+        /// Internal rather than private so the translation can be tested against a producer that
+        /// throws on demand. Hitting these branches through the public API means winning a race
+        /// against teardown, which no test can schedule reliably; the stress test that exercises the
+        /// real race can only assert the negative (no untyped exception escaped).
+        /// </para>
+        /// </remarks>
+        internal static void SendViaProducer(IMessageProducer<string> producer, IOutboundMessage<string> message)
+        {
+            try
+            {
+                producer.Send(message);
+            }
+            catch (DeviceNotConnectedException)
+            {
+                // Already the failure this method would translate to. Rethrown unchanged so the
+                // producer's own wording and IsShuttingDown value survive.
+                throw;
+            }
+            catch (ObjectDisposedException ex)
+            {
+                // Checked before InvalidOperationException: ObjectDisposedException derives from it,
+                // so the broader filter below would otherwise swallow this case first.
+                throw new DeviceNotConnectedException(
+                    "The message could not be sent because the device's message producer has been "
+                    + "disposed; a disconnect or dispose completed while this send was in flight.",
+                    ex,
+                    isShuttingDown: true);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new DeviceNotConnectedException(
+                    "The message could not be sent because the device's message producer is no "
+                    + "longer running; a disconnect or reconnect is in flight.",
+                    ex,
+                    isShuttingDown: true);
             }
         }
 


### PR DESCRIPTION
Closes #497.

**Not merging — this is for your review.**

## What was wrong

Disconnect a device while anything was still sending to it and `Send` could throw a `NullReferenceException` straight out of a public API. Lose the same race a fraction later and you instead got a bare `InvalidOperationException` reading *"Message producer is not running. Call Start() first."* — an internal lifecycle detail, not something a caller can act on.

Either way you did **not** get `DeviceNotConnectedException`, which is the exception this library tells you to catch for exactly this situation. So an ordinary shutdown surfaced as a confusing crash, and there was no way to tell it apart from a real defect in your own code without matching on message text.

It was also not limited to you calling `Disconnect()`. Every auto-reconnect attempt tears the send path down the same way, so any long-lived sender — a telemetry loop, a UI poll — was exposed on every reconnect, including ones it never asked for.

## How it was fixed

`SendNow` now reads the message producer **once** into a local, instead of null-checking the field and then dereferencing it a second time. That closes the `NullReferenceException` window by construction. If teardown gets to the producer after that read, the resulting failure is translated into `DeviceNotConnectedException` with `IsShuttingDown` set — so a shutdown race reports as a shutdown race.

Things you may want to push back on:

- **The translation is exception-type-based.** It catches what a stopped or disposed producer throws. Non-lifecycle failures (an `IOException`, say) keep their own type, and a `DeviceNotConnectedException` from the producer is rethrown untouched, so this cannot mask a real fault — but it does depend on the producer's choice of exception type. Tests pin that against the real `MessageProducer<string>`, so a change there fails here rather than silently escaping.
- **`ObjectDisposedException` must be caught before `InvalidOperationException`,** since it derives from it. That ordering is load-bearing and a test pins it, but it is the kind of thing a future edit can quietly break.
- **`SendViaProducer` is `internal`, not private,** purely so the translation can be driven deterministically in tests. Same seam the registry already uses for `DeviceConnector`.
- **This is not a lock.** A lock spanning the send path and teardown would fix the race structurally, but it puts contention on the hot send path and risks deadlock against the locks teardown already takes. Snapshot-and-translate was the smaller change.

## Verification

- **Proved the test catches the bug:** with the fix temporarily reverted, the stress test reproduced the raw `InvalidOperationException` on **5 of 5 runs**, within ~25 reconnect cycles each. The `NullReferenceException` half is a far narrower window, so the stress test asserts the negative (nothing untyped escapes) rather than claiming to schedule that race; the snapshot is correct by inspection.
- **9 new tests** in `DaqifiDeviceSendDisconnectRaceTests.cs`, driving every branch of the translation against both a throwing double and a real `MessageProducer<string>` (stopped and disposed), plus the reconnect stress loop and a happy-path guard.
- **Full suite green on net9.0** (2902 Core + 43 Mcp) **and net10.0** (2902) — 0 failures.
- **Bench-validated** on the real Nyquist over `/dev/cu.usbmodem1101` (fw 3.7.2), non-destructive: two full connect → configure → stream → disconnect cycles, exit 0, 396 samples each (the expected count at this unit's known 79.4% clock ratio). No regression on the common path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
