### PR TITLE
fix(transport): a throwing StatusChanged subscriber no longer kills auto-reconnect or leaks the port handle

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -650,6 +650,14 @@ device.StatusChanged += (_, e) =>
 };
 ```
 
+Because that callback runs on a background thread, a UI handler that touches a bound control from it
+throws — so the raise is isolated. A `StatusChanged` subscriber that throws cannot stop the
+transition, cannot stop automatic reconnection from starting, and cannot keep the transport from
+releasing its handle; the exception is reported on `ErrorOccurred` as
+`DeviceErrorSource.StatusNotification` and written to the device logger. Isolation is per raise, not
+per subscriber: the first handler to throw ends that one notification for the rest of the invocation
+list.
+
 Custom transports can opt into the same escalation by implementing `ITransportHealthSink`; the
 reader and writer loops report every read/write outcome to a transport that does.
 
@@ -1136,6 +1144,7 @@ device.ErrorOccurred += (_, e) =>
 |---|---|
 | `MessageConsumer` | A read from the transport stream failed, a frame could not be parsed, or a `MessageReceived` subscriber threw |
 | `StreamDecode` | A streaming frame could not be decoded into channel samples. That frame is dropped; the stream continues |
+| `StatusNotification` | A `StatusChanged` subscriber threw. The status transition itself still completed |
 
 ### Observational, never escalating
 

--- a/src/Daqifi.Core.Tests/Communication/Transport/DropPathSubscriberIsolationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/DropPathSubscriberIsolationTests.cs
@@ -1,0 +1,175 @@
+using Daqifi.Core.Communication.Transport;
+using System.IO.Ports;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Daqifi.Core.Tests.Communication.Transport;
+
+/// <summary>
+/// Issue #494: the drop path hands the connection handle to <c>Dispose</c> only after
+/// <see cref="IStreamTransport.StatusChanged"/> has been raised. A subscriber that throws used to
+/// unwind past that dispose — and because the field had already been nulled, a later
+/// <c>Disconnect()</c>/<c>Dispose()</c> skipped it too, so the OS handle stayed claimed for the
+/// life of the process (on serial, re-plugging the device then fails with "Access is denied").
+/// </summary>
+/// <remarks>
+/// A WPF/WinForms consumer touching a bound property from the handler is the realistic source: the
+/// event is documented as firing on a background thread, so a cross-thread
+/// <see cref="InvalidOperationException"/> is the exception these tests use.
+/// </remarks>
+public class DropPathSubscriberIsolationTests
+{
+    [Fact]
+    public void SerialTransport_WhenAStatusSubscriberThrowsOnAnIoFaultDrop_ThePortIsStillDisposed()
+    {
+        using var transport = new SerialStreamTransport("/dev/ttyTest494", livenessCheckInterval: TimeSpan.Zero);
+        var port = new DisposalTrackingSerialPort();
+        transport.SetSerialPortForTesting(port);
+
+        transport.StatusChanged += (_, e) =>
+        {
+            if (!e.IsConnected)
+            {
+                throw new InvalidOperationException("the calling thread cannot access this object");
+            }
+        };
+
+        transport.StartDropDetection();
+
+        // The reader loop escalates an unbroken run of failures into a drop.
+        for (var i = 0; i < TransportConnectionWatchdog.ConsecutiveFaultThreshold; i++)
+        {
+            transport.ReportIoFault(new IOException("device gone"));
+        }
+
+        Assert.True(port.IsDisposed, "the throwing subscriber leaked the serial port handle");
+        Assert.False(transport.IsConnected);
+    }
+
+    [Fact]
+    public void SerialTransport_WhenAStatusSubscriberThrowsOnAPresenceDrop_ThePortIsStillDisposed()
+    {
+        // The unplug path proper: the presence poll notices the port is gone. It is also the path
+        // where the subscriber exception is least visible — the watchdog's poll loop absorbs it —
+        // so the handle release cannot be left depending on the subscriber behaving.
+        var present = true;
+        using var transport = new SerialStreamTransport("/dev/ttyTest494", livenessCheckInterval: TimeSpan.FromHours(1))
+        {
+            PortPresenceProbe = _ => Volatile.Read(ref present)
+        };
+
+        var port = new DisposalTrackingSerialPort();
+        transport.SetSerialPortForTesting(port);
+
+        transport.StatusChanged += (_, e) =>
+        {
+            if (!e.IsConnected)
+            {
+                throw new InvalidOperationException("the calling thread cannot access this object");
+            }
+        };
+
+        transport.StartDropDetection();
+        Assert.True(transport.IsLivenessMonitorActive);
+
+        Volatile.Write(ref present, false);
+        for (var i = 0; i < TransportConnectionWatchdog.PresenceMissThreshold; i++)
+        {
+            transport.PollLivenessForTesting();
+        }
+
+        Assert.True(port.IsDisposed, "the throwing subscriber leaked the serial port handle");
+    }
+
+    [Fact]
+    public void SerialTransport_AThrowingStatusSubscriber_DoesNotEscapeIntoTheReportingLoop()
+    {
+        // ReportIoFault is called from the reader and writer loops. Rethrowing here would only put
+        // the subscriber's exception somewhere those loops have to absorb it again, so the drop
+        // path swallows it — the device-level StatusChanged, which is where real consumers
+        // subscribe, is the surface that reports it (DaqifiDevice raises ErrorOccurred).
+        using var transport = new SerialStreamTransport("/dev/ttyTest494", livenessCheckInterval: TimeSpan.Zero);
+        transport.SetSerialPortForTesting(new DisposalTrackingSerialPort());
+        transport.StatusChanged += (_, _) => throw new InvalidOperationException("a badly behaved subscriber");
+
+        transport.StartDropDetection();
+
+        var escaped = Record.Exception(() =>
+        {
+            for (var i = 0; i < TransportConnectionWatchdog.ConsecutiveFaultThreshold; i++)
+            {
+                transport.ReportIoFault(new IOException("device gone"));
+            }
+        });
+
+        Assert.Null(escaped);
+        Assert.False(transport.IsConnected);
+    }
+
+    [Fact]
+    public void TcpTransport_WhenAStatusSubscriberThrows_TheSocketIsStillReleased()
+    {
+        using var listener = new LoopbackListener();
+        using var transport = new TcpStreamTransport(IPAddress.Loopback, listener.Port);
+
+        transport.StatusChanged += (_, e) =>
+        {
+            if (!e.IsConnected)
+            {
+                throw new InvalidOperationException("the calling thread cannot access this object");
+            }
+        };
+
+        transport.Connect();
+        using var server = listener.AcceptOne();
+
+        for (var i = 0; i < TransportConnectionWatchdog.ConsecutiveFaultThreshold; i++)
+        {
+            transport.ReportIoFault(new IOException("peer gone"));
+        }
+
+        Assert.False(transport.IsConnected);
+
+        // Proof the handle was actually released rather than merely dropped from the field: the
+        // peer sees the FIN, which only arrives when the client socket is closed.
+        server.Client.ReceiveTimeout = 5000;
+        Assert.Equal(0, server.Client.Receive(new byte[1]));
+    }
+
+    /// <summary>
+    /// A loopback TCP listener on an OS-assigned port, so these tests never collide with each other
+    /// or with anything else on the machine.
+    /// </summary>
+    private sealed class LoopbackListener : IDisposable
+    {
+        private readonly TcpListener _listener;
+
+        public LoopbackListener()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        }
+
+        public int Port { get; }
+
+        public TcpClient AcceptOne() => _listener.AcceptTcpClient();
+
+        public void Dispose() => _listener.Stop();
+    }
+
+    /// <summary>
+    /// A <see cref="SerialPort"/> that records whether it was disposed, so "the handle was
+    /// released" is asserted directly rather than inferred.
+    /// </summary>
+    private sealed class DisposalTrackingSerialPort : SerialPort
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Communication/Transport/DropPathSubscriberIsolationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/DropPathSubscriberIsolationTests.cs
@@ -197,9 +197,7 @@ public class DropPathSubscriberIsolationTests
 
         Assert.Null(escaped);
         Assert.False(transport.IsConnected);
-
-        server.Client.ReceiveTimeout = 5000;
-        Assert.Equal(0, server.Client.Receive(new byte[1]));
+        AssertPeerObservedTheSocketClose(server);
     }
 
     [Fact]
@@ -225,11 +223,36 @@ public class DropPathSubscriberIsolationTests
         }
 
         Assert.False(transport.IsConnected);
+        AssertPeerObservedTheSocketClose(server);
+    }
 
-        // Proof the handle was actually released rather than merely dropped from the field: the
-        // peer sees the FIN, which only arrives when the client socket is closed.
+    /// <summary>
+    /// Asserts the peer saw the client socket actually close, which is the proof the handle was
+    /// released rather than merely dropped from its field.
+    /// </summary>
+    /// <remarks>
+    /// A graceful close (the expected case here — nothing is ever sent to this client, so its
+    /// receive buffer is empty at close) surfaces as a zero-byte read. A close that the stack turns
+    /// into a reset instead is equally good proof, so it is accepted rather than left as a source of
+    /// platform flakiness. What must not be accepted is a <see cref="SocketError.TimedOut"/>: that
+    /// is precisely the symptom of the leak these tests exist to catch, since a socket still held
+    /// open sends the peer neither a FIN nor an RST.
+    /// </remarks>
+    private static void AssertPeerObservedTheSocketClose(TcpClient server)
+    {
         server.Client.ReceiveTimeout = 5000;
-        Assert.Equal(0, server.Client.Receive(new byte[1]));
+
+        int read;
+        try
+        {
+            read = server.Client.Receive(new byte[1]);
+        }
+        catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+        {
+            return;
+        }
+
+        Assert.Equal(0, read);
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Communication/Transport/DropPathSubscriberIsolationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/DropPathSubscriberIsolationTests.cs
@@ -144,6 +144,65 @@ public class DropPathSubscriberIsolationTests
     }
 
     [Fact]
+    public void SerialTransport_WhenTheSubscribersExceptionCannotRenderItself_TheDropPathIsStillContained()
+    {
+        // The exception being traced came out of consumer code as surely as the subscriber did, so
+        // rendering it is not a safe operation either. Composing the trace message outside the guard
+        // let a throwing ToString() escape the catch that exists to contain the subscriber — the
+        // handle still went out in the finally, but the watchdog/reader thread was disrupted anyway,
+        // which is the very thing the isolation is for.
+        using var transport = new SerialStreamTransport("/dev/ttyTest494", livenessCheckInterval: TimeSpan.Zero);
+        var port = new DisposalTrackingSerialPort();
+        transport.SetSerialPortForTesting(port);
+        transport.StatusChanged += (_, _) => throw new UnrenderableException();
+
+        transport.StartDropDetection();
+
+        var escaped = Record.Exception(() =>
+        {
+            for (var i = 0; i < TransportConnectionWatchdog.ConsecutiveFaultThreshold; i++)
+            {
+                transport.ReportIoFault(new IOException("device gone"));
+            }
+        });
+
+        Assert.Null(escaped);
+        Assert.True(port.IsDisposed);
+        Assert.False(transport.IsConnected);
+    }
+
+    [Fact]
+    public void TcpTransport_WhenTheSubscribersExceptionCannotRenderItself_TheDropPathIsStillContained()
+    {
+        using var listener = new LoopbackListener();
+        using var transport = new TcpStreamTransport(IPAddress.Loopback, listener.Port);
+        transport.StatusChanged += (_, e) =>
+        {
+            if (!e.IsConnected)
+            {
+                throw new UnrenderableException();
+            }
+        };
+
+        transport.Connect();
+        using var server = listener.AcceptOne();
+
+        var escaped = Record.Exception(() =>
+        {
+            for (var i = 0; i < TransportConnectionWatchdog.ConsecutiveFaultThreshold; i++)
+            {
+                transport.ReportIoFault(new IOException("peer gone"));
+            }
+        });
+
+        Assert.Null(escaped);
+        Assert.False(transport.IsConnected);
+
+        server.Client.ReceiveTimeout = 5000;
+        Assert.Equal(0, server.Client.Receive(new byte[1]));
+    }
+
+    [Fact]
     public void TcpTransport_WhenAStatusSubscriberThrows_TheSocketIsStillReleased()
     {
         using var listener = new LoopbackListener();
@@ -193,6 +252,15 @@ public class DropPathSubscriberIsolationTests
         public TcpClient AcceptOne() => _listener.AcceptTcpClient();
 
         public void Dispose() => _listener.Stop();
+    }
+
+    /// <summary>
+    /// An exception that throws while being rendered — the shape a consumer's own exception type can
+    /// take when its <see cref="object.ToString"/> (or a property it reads) is itself buggy.
+    /// </summary>
+    private sealed class UnrenderableException : Exception
+    {
+        public override string ToString() => throw new InvalidOperationException("cannot render");
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Communication/Transport/DropPathSubscriberIsolationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/DropPathSubscriberIsolationTests.cs
@@ -1,4 +1,5 @@
 using Daqifi.Core.Communication.Transport;
+using System.Diagnostics;
 using System.IO.Ports;
 using System.Net;
 using System.Net.Sockets;
@@ -104,6 +105,42 @@ public class DropPathSubscriberIsolationTests
 
         Assert.Null(escaped);
         Assert.False(transport.IsConnected);
+    }
+
+    [Fact]
+    public void SerialTransport_AThrowingStatusSubscriber_IsTracedRatherThanSwallowedSilently()
+    {
+        // These transports carry no ILogger, so the best-effort trace DeviceFinderBase uses for the
+        // same situation is the only diagnosability a bare-transport consumer gets. The listener is
+        // synchronized and only asserted with Contains, so traffic from tests running in parallel
+        // can neither corrupt it nor fail this.
+        using var transport = new SerialStreamTransport("/dev/ttyTest494", livenessCheckInterval: TimeSpan.Zero);
+        transport.SetSerialPortForTesting(new DisposalTrackingSerialPort());
+        transport.StatusChanged += (_, _) => throw new InvalidOperationException("a badly behaved subscriber");
+
+        var captured = new StringWriter();
+        var listener = new TextWriterTraceListener(TextWriter.Synchronized(captured));
+        Trace.Listeners.Add(listener);
+        try
+        {
+            transport.StartDropDetection();
+
+            for (var i = 0; i < TransportConnectionWatchdog.ConsecutiveFaultThreshold; i++)
+            {
+                transport.ReportIoFault(new IOException("device gone"));
+            }
+
+            Trace.Flush();
+        }
+        finally
+        {
+            Trace.Listeners.Remove(listener);
+            listener.Dispose();
+        }
+
+        var traced = captured.ToString();
+        Assert.Contains(nameof(SerialStreamTransport), traced);
+        Assert.Contains("a badly behaved subscriber", traced);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/DeviceReconnectTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceReconnectTests.cs
@@ -1119,6 +1119,30 @@ public class DeviceReconnectTests
     }
 
     [Fact]
+    public async Task AThrowingStatusSubscriber_DoesNotStopTheLoopFromStarting()
+    {
+        // Issue #494. Raising Lost and starting the loop happen back to back on the thread that
+        // detected the drop, so an escaping StatusChanged exception used to skip
+        // BeginReconnectIfEnabled entirely — ReconnectOptions.Enabled silently did nothing, and the
+        // exception was swallowed by the background loop it unwound into. The subscriber here
+        // throws on every transition, so the loop's own Retrying/Connected raises are covered too.
+        using var transport = new ScriptedReconnectTransport();
+        using var device = new ScriptedStreamingDevice("Badly Observed Device", transport);
+        device.ReconnectOptions = FastPolicy();
+
+        ConnectAndInitialize(device);
+        device.StatusChanged += (_, _) =>
+            throw new InvalidOperationException("the calling thread cannot access this object");
+
+        var reconnected = WaitFor<ReconnectedEventArgs>(h => device.Reconnected += h);
+        transport.SimulateDrop();
+
+        var result = await reconnected;
+        Assert.Equal(1, result.AttemptNumber);
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+    }
+
+    [Fact]
     public async Task ASecondDropAfterARecovery_StartsAFreshLoop()
     {
         using var transport = new ScriptedReconnectTransport();

--- a/src/Daqifi.Core.Tests/Device/DeviceStatusChangedIsolationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceStatusChangedIsolationTests.cs
@@ -1,0 +1,163 @@
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Issue #494: <see cref="DaqifiDevice.StatusChanged"/> is raised on whichever thread observed the
+/// change, so a UI consumer touching a bound property from the handler throws a cross-thread
+/// <see cref="InvalidOperationException"/> out of a library event. That exception used to escape the
+/// status transition and take everything that runs after it with it — most damagingly the reconnect
+/// start — and then vanish into a background loop's catch, leaving a dead device and no error.
+/// </summary>
+public class DeviceStatusChangedIsolationTests
+{
+    [Fact]
+    public void AThrowingSubscriber_DoesNotEscapeConnect()
+    {
+        using var transport = new DroppableTransport();
+        using var device = new DaqifiDevice("Badly Observed Device", transport);
+
+        device.StatusChanged += (_, _) => throw new InvalidOperationException("the calling thread cannot access this object");
+
+        var escaped = Record.Exception(() => device.Connect());
+
+        Assert.Null(escaped);
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+        Assert.True(device.IsConnected);
+    }
+
+    [Fact]
+    public void AThrowingSubscriber_DoesNotEscapeDisconnect()
+    {
+        using var transport = new DroppableTransport();
+        using var device = new DaqifiDevice("Badly Observed Device", transport);
+
+        device.Connect();
+        device.StatusChanged += (_, _) => throw new InvalidOperationException("the calling thread cannot access this object");
+
+        var escaped = Record.Exception(() => device.Disconnect());
+
+        Assert.Null(escaped);
+        Assert.Equal(ConnectionStatus.Disconnected, device.Status);
+    }
+
+    [Fact]
+    public void AThrowingSubscriber_OnADrop_LeavesTheDeviceReportingLost()
+    {
+        using var transport = new DroppableTransport();
+        using var device = new DaqifiDevice("Badly Observed Device", transport);
+
+        device.Connect();
+        device.StatusChanged += (_, _) => throw new InvalidOperationException("the calling thread cannot access this object");
+
+        transport.SimulateDrop();
+
+        Assert.Equal(ConnectionStatus.Lost, device.Status);
+        Assert.False(device.IsConnected);
+    }
+
+    [Fact]
+    public void AThrowingSubscriber_IsReportedOnErrorOccurred()
+    {
+        // The failure has to be visible somewhere. ErrorOccurred is the library's existing "a
+        // background callback failed" surface (issue #378), and it also writes to the device logger.
+        using var transport = new DroppableTransport();
+        using var device = new DaqifiDevice("Badly Observed Device", transport);
+
+        var thrown = new InvalidOperationException("the calling thread cannot access this object");
+        var errors = new List<DeviceErrorEventArgs>();
+        device.ErrorOccurred += (_, e) =>
+        {
+            lock (errors)
+            {
+                errors.Add(e);
+            }
+        };
+
+        // Subscribed after the connect so the drop is the only transition the subscriber sees.
+        device.Connect();
+        device.StatusChanged += (_, _) => throw thrown;
+
+        transport.SimulateDrop();
+
+        lock (errors)
+        {
+            var error = Assert.Single(errors);
+            Assert.Equal(DeviceErrorSource.StatusNotification, error.Source);
+            Assert.Same(thrown, error.Error);
+        }
+    }
+
+    [Fact]
+    public void AThrowingErrorSubscriber_OnTopOfAThrowingStatusSubscriber_StillDoesNotEscape()
+    {
+        // The report of a failed notification must not itself become an escaping failure.
+        using var transport = new DroppableTransport();
+        using var device = new DaqifiDevice("Doubly Badly Observed Device", transport);
+
+        device.StatusChanged += (_, _) => throw new InvalidOperationException("a badly behaved status subscriber");
+        device.ErrorOccurred += (_, _) => throw new InvalidOperationException("a badly behaved error subscriber");
+
+        var escaped = Record.Exception(() => device.Connect());
+
+        Assert.Null(escaped);
+        Assert.Equal(ConnectionStatus.Connected, device.Status);
+    }
+
+    /// <summary>
+    /// A transport over an in-memory stream that can report an unexpected drop on command, which is
+    /// all these tests need from it.
+    /// </summary>
+    private sealed class DroppableTransport : IStreamTransport
+    {
+        private readonly MemoryStream _stream = new();
+        private bool _isConnected;
+        private bool _disposed;
+
+        public Stream Stream => _disposed
+            ? throw new ObjectDisposedException(nameof(DroppableTransport))
+            : _stream;
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => IsConnected ? "Droppable: Connected" : "Droppable: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().GetAwaiter().GetResult();
+
+        public void Disconnect() => DisconnectAsync().GetAwaiter().GetResult();
+
+        /// <summary>Reports an unexpected drop, the way a watchdog would.</summary>
+        public void SimulateDrop()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(
+                false, ConnectionInfo, new TransportNotConnectedException("the device went away")));
+        }
+
+        public void Dispose()
+        {
+            _isConnected = false;
+            _disposed = true;
+            _stream.Dispose();
+        }
+    }
+}

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -632,8 +632,7 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
             // disturbing them. A DaqifiDevice surfaces its own StatusChanged subscriber failures on
             // ErrorOccurred; this transport carries no logger, so a consumer working against a bare
             // transport gets the same best-effort trace DeviceFinderBase gives its event raises.
-            SafeTrace(
-                $"[{nameof(SerialStreamTransport)}] a {nameof(StatusChanged)} subscriber threw while a dropped connection was being reported: {ex}");
+            SafeTrace(ex);
         }
         finally
         {
@@ -649,8 +648,8 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     }
 
     /// <summary>
-    /// Writes a diagnostic line, swallowing anything a misbehaving
-    /// <see cref="System.Diagnostics.TraceListener"/> throws.
+    /// Writes the diagnostic line for a <see cref="StatusChanged"/> subscriber failure, swallowing
+    /// anything a misbehaving <see cref="System.Diagnostics.TraceListener"/> throws.
     /// </summary>
     /// <remarks>
     /// <see cref="System.Diagnostics.Trace"/> dispatches to listeners the consumer installed, so it
@@ -659,17 +658,26 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     /// anyway. Same guarantee as <c>DeviceFinderBase.RaiseIsolated</c> and
     /// <c>DaqifiStreamingDevice.SafeTrace</c>; this transport has no <c>ILogger</c>, hence the local
     /// twin rather than a shared one.
+    /// <para>
+    /// The message is composed <em>inside</em> the guard rather than passed in ready-made, because
+    /// <paramref name="subscriberFailure"/> came out of consumer code too: rendering an exception
+    /// whose <see cref="object.ToString"/> or <see cref="Exception.Message"/> throws would otherwise
+    /// escape the <c>catch</c> from the interpolation itself and leave the drop path exactly as
+    /// disrupted as an unguarded raise.
+    /// </para>
     /// </remarks>
-    /// <param name="message">The diagnostic line to write.</param>
-    private static void SafeTrace(string message)
+    /// <param name="subscriberFailure">The exception the subscriber threw.</param>
+    private static void SafeTrace(Exception subscriberFailure)
     {
         try
         {
-            System.Diagnostics.Trace.WriteLine(message);
+            System.Diagnostics.Trace.WriteLine(
+                $"[{nameof(SerialStreamTransport)}] a {nameof(StatusChanged)} subscriber threw while a dropped connection was being reported: {subscriberFailure}");
         }
         catch
         {
-            // A trace listener that throws is not permitted to affect the drop path.
+            // A trace listener — or an exception that cannot render itself — is not permitted to
+            // affect the drop path.
         }
     }
 

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -621,7 +621,7 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
         {
             OnStatusChanged(false, error);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             // A subscriber that throws must not cost us the port handle (issue #494). The reference
             // has already been taken out of the field, so if this unwound past the dispose below,
@@ -630,7 +630,10 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
             // "Access is denied". Not rethrown: the callers of this are a watchdog timer thread and
             // the reader/writer loops, all of which already absorb it, so propagating only risks
             // disturbing them. A DaqifiDevice surfaces its own StatusChanged subscriber failures on
-            // ErrorOccurred; a consumer that subscribes to a bare transport owns its handler.
+            // ErrorOccurred; this transport carries no logger, so a consumer working against a bare
+            // transport gets the same best-effort trace DeviceFinderBase gives its event raises.
+            SafeTrace(
+                $"[{nameof(SerialStreamTransport)}] a {nameof(StatusChanged)} subscriber threw while a dropped connection was being reported: {ex}");
         }
         finally
         {
@@ -642,6 +645,31 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
             {
                 // The device is already gone; failing to close its handle changes nothing.
             }
+        }
+    }
+
+    /// <summary>
+    /// Writes a diagnostic line, swallowing anything a misbehaving
+    /// <see cref="System.Diagnostics.TraceListener"/> throws.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="System.Diagnostics.Trace"/> dispatches to listeners the consumer installed, so it
+    /// is consumer code and can throw like any other. A listener throwing out of the <c>catch</c>
+    /// that was containing a bad subscriber would defeat the containment and cost the port handle
+    /// anyway. Same guarantee as <c>DeviceFinderBase.RaiseIsolated</c> and
+    /// <c>DaqifiStreamingDevice.SafeTrace</c>; this transport has no <c>ILogger</c>, hence the local
+    /// twin rather than a shared one.
+    /// </remarks>
+    /// <param name="message">The diagnostic line to write.</param>
+    private static void SafeTrace(string message)
+    {
+        try
+        {
+            System.Diagnostics.Trace.WriteLine(message);
+        }
+        catch
+        {
+            // A trace listener that throws is not permitted to affect the drop path.
         }
     }
 

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -617,15 +617,31 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
         // so it happens after the notification.
         var port = Interlocked.Exchange(ref _serialPort, null);
 
-        OnStatusChanged(false, error);
-
         try
         {
-            port?.Dispose();
+            OnStatusChanged(false, error);
         }
         catch (Exception)
         {
-            // The device is already gone; failing to close its handle changes nothing.
+            // A subscriber that throws must not cost us the port handle (issue #494). The reference
+            // has already been taken out of the field, so if this unwound past the dispose below,
+            // Disconnect() and Dispose() would both find null and skip it too — the OS port would
+            // stay claimed for the life of the process and re-plugging the device would fail with
+            // "Access is denied". Not rethrown: the callers of this are a watchdog timer thread and
+            // the reader/writer loops, all of which already absorb it, so propagating only risks
+            // disturbing them. A DaqifiDevice surfaces its own StatusChanged subscriber failures on
+            // ErrorOccurred; a consumer that subscribes to a bare transport owns its handler.
+        }
+        finally
+        {
+            try
+            {
+                port?.Dispose();
+            }
+            catch (Exception)
+            {
+                // The device is already gone; failing to close its handle changes nothing.
+            }
         }
     }
 

--- a/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
@@ -409,12 +409,15 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
         {
             OnStatusChanged(false, error);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             // A subscriber that throws must not cost us the socket (issue #494). The references have
             // already been taken out of their fields, so if this unwound past the dispose below,
             // Disconnect() and Dispose() would both find null and skip them too, leaking the socket
-            // for the life of the process. Not rethrown: see SerialStreamTransport.HandleConnectionLost.
+            // for the life of the process. Not rethrown, and traced best-effort because this
+            // transport carries no logger: see SerialStreamTransport.HandleConnectionLost.
+            SafeTrace(
+                $"[{nameof(TcpStreamTransport)}] a {nameof(StatusChanged)} subscriber threw while a dropped connection was being reported: {ex}");
         }
         finally
         {
@@ -427,6 +430,24 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
             {
                 // The peer is already gone; failing to close the socket changes nothing.
             }
+        }
+    }
+
+    /// <summary>
+    /// Writes a diagnostic line, swallowing anything a misbehaving
+    /// <see cref="System.Diagnostics.TraceListener"/> throws. See
+    /// <c>SerialStreamTransport.SafeTrace</c> for why the trace itself has to be contained.
+    /// </summary>
+    /// <param name="message">The diagnostic line to write.</param>
+    private static void SafeTrace(string message)
+    {
+        try
+        {
+            System.Diagnostics.Trace.WriteLine(message);
+        }
+        catch
+        {
+            // A trace listener that throws is not permitted to affect the drop path.
         }
     }
 

--- a/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
@@ -416,8 +416,7 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
             // Disconnect() and Dispose() would both find null and skip them too, leaking the socket
             // for the life of the process. Not rethrown, and traced best-effort because this
             // transport carries no logger: see SerialStreamTransport.HandleConnectionLost.
-            SafeTrace(
-                $"[{nameof(TcpStreamTransport)}] a {nameof(StatusChanged)} subscriber threw while a dropped connection was being reported: {ex}");
+            SafeTrace(ex);
         }
         finally
         {
@@ -434,20 +433,23 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
     }
 
     /// <summary>
-    /// Writes a diagnostic line, swallowing anything a misbehaving
-    /// <see cref="System.Diagnostics.TraceListener"/> throws. See
-    /// <c>SerialStreamTransport.SafeTrace</c> for why the trace itself has to be contained.
+    /// Writes the diagnostic line for a <see cref="StatusChanged"/> subscriber failure, swallowing
+    /// anything a misbehaving <see cref="System.Diagnostics.TraceListener"/> throws. See
+    /// <c>SerialStreamTransport.SafeTrace</c> for why the trace itself — and the composition of its
+    /// message from a consumer-supplied exception — has to be contained.
     /// </summary>
-    /// <param name="message">The diagnostic line to write.</param>
-    private static void SafeTrace(string message)
+    /// <param name="subscriberFailure">The exception the subscriber threw.</param>
+    private static void SafeTrace(Exception subscriberFailure)
     {
         try
         {
-            System.Diagnostics.Trace.WriteLine(message);
+            System.Diagnostics.Trace.WriteLine(
+                $"[{nameof(TcpStreamTransport)}] a {nameof(StatusChanged)} subscriber threw while a dropped connection was being reported: {subscriberFailure}");
         }
         catch
         {
-            // A trace listener that throws is not permitted to affect the drop path.
+            // A trace listener — or an exception that cannot render itself — is not permitted to
+            // affect the drop path.
         }
     }
 

--- a/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
@@ -405,16 +405,28 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
         var stream = Interlocked.Exchange(ref _networkStream, null);
         var client = Interlocked.Exchange(ref _tcpClient, null);
 
-        OnStatusChanged(false, error);
-
         try
         {
-            stream?.Dispose();
-            client?.Dispose();
+            OnStatusChanged(false, error);
         }
         catch (Exception)
         {
-            // The peer is already gone; failing to close the socket changes nothing.
+            // A subscriber that throws must not cost us the socket (issue #494). The references have
+            // already been taken out of their fields, so if this unwound past the dispose below,
+            // Disconnect() and Dispose() would both find null and skip them too, leaking the socket
+            // for the life of the process. Not rethrown: see SerialStreamTransport.HandleConnectionLost.
+        }
+        finally
+        {
+            try
+            {
+                stream?.Dispose();
+                client?.Dispose();
+            }
+            catch (Exception)
+            {
+                // The peer is already gone; failing to close the socket changes nothing.
+            }
         }
     }
 

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -475,15 +475,58 @@ namespace Daqifi.Core.Device
             {
                 if (_status == value) return;
                 _status = value;
-                StatusChanged?.Invoke(this, new DeviceStatusEventArgs(_status));
+                RaiseStatusChanged(_status);
             }
         }
 
         /// <summary>
         /// Occurs when the device status changes.
         /// </summary>
+        /// <remarks>
+        /// Raised on whichever thread observed the change — for a drop, a background watchdog or
+        /// reader thread. A subscriber that throws (a UI framework's cross-thread
+        /// <see cref="InvalidOperationException"/> is the usual one) is isolated: the exception is
+        /// reported on <see cref="ErrorOccurred"/> as
+        /// <see cref="DeviceErrorSource.StatusNotification"/> and the transition completes
+        /// regardless.
+        /// </remarks>
         public event EventHandler<DeviceStatusEventArgs>? StatusChanged;
-        
+
+        /// <summary>
+        /// Raises <see cref="StatusChanged"/>, isolating everything downstream of the transition
+        /// from a subscriber that throws — the same guarantee <see cref="RaiseDeviceError"/>,
+        /// <see cref="RaiseReconnectEvent{TArgs}"/> and <c>SendFailed</c> already give.
+        /// </summary>
+        /// <remarks>
+        /// The drop path is what makes this load-bearing (issue #494). A drop runs
+        /// <c>transport.HandleConnectionLost</c> → <see cref="OnTransportStatusChanged"/> →
+        /// <c>Status = Lost</c> → this event → <c>BeginReconnectIfEnabled</c>, all on one thread.
+        /// An escaping subscriber exception used to skip the reconnect start entirely (so
+        /// <see cref="ReconnectOptions.Enabled"/> silently did nothing) and unwind back into the
+        /// transport before it had released the port handle, leaving the OS port claimed until the
+        /// process exited. It then vanished into a background loop's catch, so the consumer saw a
+        /// dead, unreconnectable device with no error at all.
+        /// </remarks>
+        private void RaiseStatusChanged(ConnectionStatus status)
+        {
+            var handler = StatusChanged;
+            if (handler == null)
+            {
+                return;
+            }
+
+            try
+            {
+                handler(this, new DeviceStatusEventArgs(status));
+            }
+            catch (Exception ex)
+            {
+                // Logs and raises ErrorOccurred, both isolated: a status change is never allowed to
+                // fail, so this must not throw either.
+                RaiseDeviceError(DeviceErrorSource.StatusNotification, ex);
+            }
+        }
+
         /// <summary>
         /// Occurs when a message is received from the device.
         /// </summary>

--- a/src/Daqifi.Core/Device/DeviceErrorSource.cs
+++ b/src/Daqifi.Core/Device/DeviceErrorSource.cs
@@ -44,4 +44,15 @@ public enum DeviceErrorSource
     /// stopping on request is not a failure.
     /// </remarks>
     Reconnect = 3,
+
+    /// <summary>
+    /// A <see cref="DaqifiDevice.StatusChanged"/> subscriber threw while being notified of a
+    /// connection-status transition (issue #494).
+    /// </summary>
+    /// <remarks>
+    /// The transition itself already happened and is not rolled back; this reports only that one
+    /// consumer callback failed. A cross-thread UI exception is the common cause, since the event
+    /// is raised on whichever background thread observed the change.
+    /// </remarks>
+    StatusNotification = 4,
 }


### PR DESCRIPTION
## What was wrong

Pull the USB cable on a device whose `StatusChanged` handler throws — the classic case being a WPF or WinForms app that updates a bound property from the handler, which throws a cross-thread `InvalidOperationException` because the event is documented as firing on a background thread — and three things went wrong at once, silently:

- **Automatic reconnection never started.** `ReconnectOptions.Enabled` did nothing at all, because the exception escaped the `Lost` notification and skipped the reconnect start that runs right after it.
- **The serial port (or socket) stayed claimed for the life of the process.** The transport nulls its handle field *before* notifying, so unwinding past the dispose meant a later `Disconnect()`/`Dispose()` found null and skipped it too. Re-plugging the device then fails with "Access is denied".
- **Nothing was reported.** The exception disappeared into a background watchdog's catch, so the consumer was left with a dead, unreconnectable device and no error anywhere.

## How it was fixed

`StatusChanged` was the last event on that path still raised unguarded — `ErrorOccurred`, `SendFailed`, the reconnect events and the classified-message events are all already isolated. It now goes through the same kind of guard: the transition always completes, whatever happens after it still runs, and the subscriber's exception is reported on `ErrorOccurred` (and the device logger) under a new `DeviceErrorSource.StatusNotification`. Both transports additionally dispose their handle in a `finally`, so a consumer subscribed directly to a bare transport can't leak it either.

Things you may want to push back on:

- **Isolation is per raise, not per subscriber.** The first handler to throw still ends that one notification for the rest of the invocation list. That matches every other raiser in the class; making it per-subscriber would be a behaviour change beyond the issue.
- **It applies to every transition, not just `Lost`.** A throwing subscriber used to make `Connect()` itself throw *after* the device was fully connected, which is the same bug wearing a different hat.
- **`DeviceErrorSource` gains a member** (`StatusNotification = 4`). Additive, but it is a public enum.
- **The transports swallow rather than rethrow.** Their callers are a watchdog timer thread and the reader/writer loops, all of which already absorb exceptions, so rethrowing would only relocate it. The device layer is where the failure is actually surfaced; the transports, which carry no `ILogger`, additionally emit the same best-effort `Trace` line `DeviceFinderBase` uses for its isolated raises, so a bare-transport consumer isn't left with silence.

## Verification

- 13 new tests across the drop path (serial I/O-fault and presence-poll drops, TCP over a real loopback socket where the peer observing the close proves the handle was really released, and an exception whose own `ToString()` throws) and the device (connect/disconnect/drop, the `ErrorOccurred` report, a throwing `ErrorOccurred` handler on top of a throwing `StatusChanged` one, and the reconnect loop starting and completing). Each was re-run against the un-fixed code first — **all failed** — so they pin the bug rather than the fix.
- Full suite green on **net9.0** (2915 Core + 43 Mcp) and **net10.0** (2915), 0 failures, 0 warnings.
- Bench, fw 3.7.2 on `/dev/cu.usbmodem1101`: four connect → status → stream → disconnect cycles across the review rounds, exit 0, 1186–1187 samples in 3 s at 500 Hz (this unit's known ~79% clock ratio), clean `Disconnected` transition through the new raise path. Non-destructive; serial only.

closes #494

Not merging — for review.
