### PR TITLE
fix(device): cap the backlog of sends parked during a long exclusive operation

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -1058,6 +1058,15 @@ other threads' text queries wait. Keep bodies short, and do not start background
 a `Task.Run` launched from the body inherits the flow's ownership of the lock, so its commands would
 *not* be deferred and could still interleave.
 
+The deferred backlog is capped at `DaqifiDevice.DefaultMaxDeferredSends` (1024) messages and
+overflows **drop-oldest**. This only matters for the genuinely long exclusive operations — an SD card
+download is allowed thirty minutes, a firmware update longer — where a UI or agent polling at even
+10 Hz would otherwise park tens of thousands of commands and then fire all of them at the device at
+once. Keeping the newest is the right way round for the level-setting commands that get parked ("set
+this pin", "set that duty cycle"), where a superseded instruction is worth less than the memory it
+costs. Discards are counted by `device.DroppedDeferredSendCount`; a non-zero and growing value means
+you are commanding faster than the operation in progress can let the commands out.
+
 `RunExclusiveAsync` is per device. Two devices always run in parallel — there is no global lock.
 
 ### 3. Connect / Disconnect / Dispose serialize themselves, but do not wait forever

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceOperationSerializationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceOperationSerializationTests.cs
@@ -468,8 +468,8 @@ public class DaqifiDeviceOperationSerializationTests
         using var device = new CappedDevice("Capped Device", transport, cap: 4);
         device.Connect();
 
-        var entered = new TaskCompletionSource();
-        var release = new TaskCompletionSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
         {
@@ -512,8 +512,8 @@ public class DaqifiDeviceOperationSerializationTests
         using var device = new CappedDevice("Uncapped-In-Practice Device", transport, cap: 8);
         device.Connect();
 
-        var entered = new TaskCompletionSource();
-        var release = new TaskCompletionSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
         {
@@ -554,8 +554,8 @@ public class DaqifiDeviceOperationSerializationTests
         using var device = new CappedDevice("Hammered Device", transport, cap: 4);
         device.Connect();
 
-        var entered = new TaskCompletionSource();
-        var release = new TaskCompletionSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
         {
@@ -596,8 +596,8 @@ public class DaqifiDeviceOperationSerializationTests
         using var device = new DaqifiDevice("Default Cap Device", transport);
         device.Connect();
 
-        var entered = new TaskCompletionSource();
-        var release = new TaskCompletionSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
         {
@@ -657,8 +657,8 @@ public class DaqifiDeviceOperationSerializationTests
 
         for (var round = 0; round < 2; round++)
         {
-            var entered = new TaskCompletionSource();
-            var release = new TaskCompletionSource();
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
             {

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceOperationSerializationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceOperationSerializationTests.cs
@@ -3,6 +3,7 @@ using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
+using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
@@ -456,6 +457,330 @@ public class DaqifiDeviceOperationSerializationTests
             .GetValue(consumer);
 
         return handler?.GetInvocationList().Length ?? 0;
+    }
+
+    // ── Issue #492: the parked backlog is capped ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Send_PastTheBacklogCap_DropsTheOldestAndReplaysTheNewestInOrder()
+    {
+        using var transport = new RecordingTransport();
+        using var device = new CappedDevice("Capped Device", transport, cap: 4);
+        device.Connect();
+
+        var entered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+        }));
+
+        await entered.Task.WaitAsync(DeadlockBudget);
+
+        await Task.Run(() =>
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                device.Send(new TaggedBinaryMessage($"m{i:00}"));
+            }
+        });
+
+        // Read while the operation still holds the device, so this is the backlog itself and not
+        // what survived a replay.
+        Assert.Equal(4, DeferredBacklogCount(device));
+        Assert.Equal(6, device.DroppedDeferredSendCount);
+
+        release.SetResult();
+        await operation.WaitAsync(DeadlockBudget);
+
+        await WaitForWriteAsync(transport, "m09");
+
+        // Drop-oldest: the four newest survive, still in the order they were sent.
+        Assert.Equal(new[] { "m06", "m07", "m08", "m09" }, TaggedWrites(transport));
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task Send_WithABacklogUnderTheCap_DropsNothing()
+    {
+        // The guard on the existing ordering guarantees: everything already tested here parks a
+        // handful of messages, and none of it may change because a cap now exists.
+        using var transport = new RecordingTransport();
+        using var device = new CappedDevice("Uncapped-In-Practice Device", transport, cap: 8);
+        device.Connect();
+
+        var entered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+        }));
+
+        await entered.Task.WaitAsync(DeadlockBudget);
+
+        await Task.Run(() =>
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                device.Send(new TaggedBinaryMessage($"m{i:00}"));
+            }
+        });
+
+        Assert.Equal(5, DeferredBacklogCount(device));
+
+        release.SetResult();
+        await operation.WaitAsync(DeadlockBudget);
+
+        await WaitForWriteAsync(transport, "m04");
+
+        Assert.Equal(new[] { "m00", "m01", "m02", "m03", "m04" }, TaggedWrites(transport));
+        Assert.Equal(0, device.DroppedDeferredSendCount);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task Send_HammeredThroughoutALongOperation_LeavesTheBacklogBounded()
+    {
+        // The reported failure: an SD card download is allowed thirty minutes, and a UI or agent
+        // polling at 10 Hz throughout it parked ~18,000 closures with nothing to stop it. The
+        // backlog now sits at the cap no matter how long the hammering goes on.
+        using var transport = new RecordingTransport();
+        using var device = new CappedDevice("Hammered Device", transport, cap: 4);
+        device.Connect();
+
+        var entered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+        }));
+
+        await entered.Task.WaitAsync(DeadlockBudget);
+
+        await Task.Run(() =>
+        {
+            for (var i = 0; i < 2000; i++)
+            {
+                device.Send(new TaggedBinaryMessage($"m{i:0000}"));
+
+                // Sampled as it grows, not just at the end: a backlog that ballooned and was
+                // trimmed once at the finish would pass an end-state-only assertion.
+                Assert.True(
+                    DeferredBacklogCount(device) <= 4,
+                    $"The backlog grew to {DeferredBacklogCount(device)} after {i + 1} sends.");
+            }
+        });
+
+        Assert.Equal(4, DeferredBacklogCount(device));
+        Assert.Equal(1996, device.DroppedDeferredSendCount);
+
+        release.SetResult();
+        await operation.WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task Send_PastTheDefaultCap_UsesDefaultMaxDeferredSends()
+    {
+        // The production constant, not a test seam: proves the shipped device is the bounded one.
+        using var transport = new RecordingTransport();
+        using var device = new DaqifiDevice("Default Cap Device", transport);
+        device.Connect();
+
+        var entered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+        }));
+
+        await entered.Task.WaitAsync(DeadlockBudget);
+
+        const int overflowBy = 6;
+        await Task.Run(() =>
+        {
+            for (var i = 0; i < DaqifiDevice.DefaultMaxDeferredSends + overflowBy; i++)
+            {
+                device.Send(new TaggedBinaryMessage($"m{i:0000}"));
+            }
+        });
+
+        Assert.Equal(DaqifiDevice.DefaultMaxDeferredSends, DeferredBacklogCount(device));
+        Assert.Equal(overflowBy, device.DroppedDeferredSendCount);
+
+        release.SetResult();
+        await operation.WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public void Send_OnAnIdleDevice_NeverDropsAnything()
+    {
+        using var transport = new RecordingTransport();
+        using var device = new CappedDevice("Idle Device", transport, cap: 1);
+        device.Connect();
+
+        Assert.Equal(0, device.DroppedDeferredSendCount);
+
+        for (var i = 0; i < 20; i++)
+        {
+            device.Send(new TaggedBinaryMessage($"m{i:00}"));
+        }
+
+        // Nothing owns the device, so nothing was parked and nothing could be dropped — even with
+        // a cap of one.
+        Assert.Equal(0, device.DroppedDeferredSendCount);
+        Assert.Equal(20, TaggedWrites(transport).Count);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task Send_OverflowingTwoOperations_AccumulatesTheCountAndWarnsOncePerBacklog()
+    {
+        var logger = new CapturingLogger();
+        using var transport = new RecordingTransport();
+        using var device = new CappedDevice("Twice Overflowed Device", transport, cap: 2, logger: logger);
+        device.Connect();
+
+        for (var round = 0; round < 2; round++)
+        {
+            var entered = new TaskCompletionSource();
+            var release = new TaskCompletionSource();
+
+            var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
+            {
+                entered.SetResult();
+                await release.Task;
+            }));
+
+            await entered.Task.WaitAsync(DeadlockBudget);
+
+            await Task.Run(() =>
+            {
+                for (var i = 0; i < 5; i++)
+                {
+                    device.Send(new TaggedBinaryMessage($"r{round}i{i}"));
+                }
+            });
+
+            release.SetResult();
+            await operation.WaitAsync(DeadlockBudget);
+
+            // The backlog has to be observed empty before the next round, or the second round's
+            // overflow would land in the first round's backlog and be reported as one episode.
+            await WaitForBacklogDrainAsync(device);
+        }
+
+        Assert.Equal(6, device.DroppedDeferredSendCount);
+
+        // One line per overflowing backlog, not one per dropped message: three were dropped in
+        // each round, and a warning per drop is how a diagnostic becomes noise nobody reads.
+        var overflowWarnings = logger.Entries
+            .Where(e => e.Level == LogLevel.Warning
+                        && e.Message.Contains("reached its cap", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Equal(2, overflowWarnings.Count);
+        Assert.All(overflowWarnings, w => Assert.Contains("DroppedDeferredSendCount", w.Message, StringComparison.Ordinal));
+
+        device.Disconnect();
+    }
+
+    /// <summary>The live backlog length, read straight off the device's own queue.</summary>
+    private static int DeferredBacklogCount(DaqifiDevice device)
+    {
+        var backlog = (System.Collections.ICollection?)typeof(DaqifiDevice)
+            .GetField("_deferredSends", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(device);
+
+        return backlog?.Count ?? 0;
+    }
+
+    /// <summary>
+    /// Waits for the backlog to reach its resting state. The tail of a flush can be handed to a
+    /// background drain, so "the operation returned" is not yet "the backlog is gone".
+    /// </summary>
+    private static async Task WaitForBacklogDrainAsync(DaqifiDevice device)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (DeferredBacklogCount(device) == 0)
+            {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+
+        Assert.Fail("The deferred backlog never drained.");
+    }
+
+    /// <summary>The tagged payloads that reached the wire, in order.</summary>
+    private static List<string> TaggedWrites(RecordingTransport transport) =>
+        transport.Writes
+            .Where(w => w.Length > 1 && (w[0] == 'm' || w[0] == 'r'))
+            .ToList();
+
+    /// <summary>Shrinks the backlog cap so the drop path is reachable in a bounded test.</summary>
+    private sealed class CappedDevice : DaqifiDevice
+    {
+        private readonly int _cap;
+
+        public CappedDevice(string name, IStreamTransport transport, int cap, ILogger? logger = null)
+            : base(name, transport, logger)
+        {
+            _cap = cap;
+        }
+
+        internal override int MaxDeferredSends => _cap;
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly object _gate = new();
+        private readonly List<(LogLevel Level, string Message)> _entries = new();
+
+        public IReadOnlyList<(LogLevel Level, string Message)> Entries
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _entries.ToList();
+                }
+            }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (_gate)
+            {
+                _entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
     }
 
     // ── Qodo round 3: teardown must reset deferral state ────────────────────────────────────

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -770,6 +770,46 @@ namespace Daqifi.Core.Device
         private Queue<Action>? _deferredSends;
 
         /// <summary>
+        /// The most messages <see cref="Send{T}"/> will park while another flow owns the device
+        /// before it starts discarding the oldest of them.
+        /// </summary>
+        /// <remarks>
+        /// Exclusive operations can be very long — an SD card download is allowed thirty minutes and
+        /// a firmware update longer — so an uncapped backlog grows with the sender's rate for as
+        /// long as the operation runs, and then fires every one of those stale commands at the
+        /// device in a burst when it ends. The cap is far above any backlog an ordinary text query
+        /// can build (those are measured in milliseconds), so it only ever engages on the long
+        /// exclusive operations it exists for.
+        /// </remarks>
+        public const int DefaultMaxDeferredSends = 1024;
+
+        /// <summary>
+        /// The live backlog cap. A seam for tests, which need a small cap to reach the drop path in
+        /// bounded time; production always reads <see cref="DefaultMaxDeferredSends"/>. Values below
+        /// one are clamped, so an override can never make the append path throw.
+        /// </summary>
+        internal virtual int MaxDeferredSends => DefaultMaxDeferredSends;
+
+        /// <summary>Backing field for <see cref="DroppedDeferredSendCount"/>.</summary>
+        private long _droppedDeferredSendCount;
+
+        /// <summary>
+        /// Whether the current backlog has already reported an overflow, so a sender that keeps
+        /// overflowing it produces one log line rather than one per dropped message. Guarded by
+        /// <see cref="_deferralGate"/>, and cleared wherever the backlog itself is.
+        /// </summary>
+        private bool _deferralOverflowReported;
+
+        /// <summary>
+        /// Gets the cumulative number of messages passed to <see cref="Send{T}"/> that were
+        /// discarded because the backlog of messages parked during an exclusive operation was full
+        /// (drop-oldest policy, capped at <see cref="DefaultMaxDeferredSends"/>). A non-zero and
+        /// growing value means commands are being issued faster than a long-running exclusive
+        /// operation can let them out.
+        /// </summary>
+        public long DroppedDeferredSendCount => Interlocked.Read(ref _droppedDeferredSendCount);
+
+        /// <summary>
         /// Serializes writes on the producer-less path, where <see cref="Send{T}"/> writes to the
         /// stream on the caller's own thread. Two threads writing a stream concurrently is the one
         /// place SCPI bytes really can interleave mid-command; the queued path is already safe
@@ -793,7 +833,9 @@ namespace Daqifi.Core.Device
         /// While the operation runs, a <see cref="Send{T}"/> from another thread is <b>deferred</b>,
         /// not blocked: it returns immediately, as fire-and-forget always has, and the message goes
         /// out in order once this operation finishes. Text queries from other threads wait, exactly
-        /// as they already waited for each other.
+        /// as they already waited for each other. A long operation paired with a busy sender can
+        /// park more than the backlog holds, in which case the oldest parked messages are dropped —
+        /// see <see cref="Send{T}"/> and <see cref="DroppedDeferredSendCount"/>.
         /// </para>
         /// <para>
         /// Reentrant on the same logical flow, so the body is free to call anything on the device,
@@ -960,6 +1002,7 @@ namespace Daqifi.Core.Device
                         // observed, so no message can be parked into a backlog nobody will drain.
                         _deferredSends = null;
                         _operationInFlight = false;
+                        _deferralOverflowReported = false;
                         return;
                     }
 
@@ -1004,6 +1047,7 @@ namespace Daqifi.Core.Device
                     {
                         _deferredSends = null;
                         _operationInFlight = false;
+                        _deferralOverflowReported = false;
                     }
 
                     SafeLog(() => _logger.LogWarning(
@@ -1077,6 +1121,7 @@ namespace Daqifi.Core.Device
             {
                 _deferredSends = null;
                 _operationInFlight = false;
+                _deferralOverflowReported = false;
             }
         }
 
@@ -1106,8 +1151,18 @@ namespace Daqifi.Core.Device
         /// and parking them would leave the operation waiting for itself.
         /// </para>
         /// <para>
-        /// Only ever appends: this holds the gate for a queue insert and nothing else, which is what
-        /// lets <see cref="Send{T}"/> promise it will not block.
+        /// The backlog is capped at <see cref="MaxDeferredSends"/> and overflows by discarding its
+        /// <b>oldest</b> entries. Drop-oldest is the right way round for what actually gets parked:
+        /// these are level-setting commands — set this pin, set that duty cycle — where the newest
+        /// instruction is the one the caller currently wants and an older one it has already
+        /// superseded is worth less than the memory it costs. Every discarded message counts into
+        /// <see cref="DroppedDeferredSendCount"/>.
+        /// </para>
+        /// <para>
+        /// Never blocks: this holds the gate for a queue insert (plus, at the cap, one dequeue) and
+        /// nothing else, which is what lets <see cref="Send{T}"/> promise it will not block. The
+        /// overflow log deliberately happens after the gate is released, so a slow logger cannot
+        /// turn a fire-and-forget send into a wait.
         /// </para>
         /// </remarks>
         private bool TryDeferSend<T>(IOutboundMessage<T> message)
@@ -1117,6 +1172,12 @@ namespace Daqifi.Core.Device
                 return false;
             }
 
+            // Read once, outside the gate: the seam is a property, and reading it again for the log
+            // below could report a different number than the one that was actually enforced.
+            // Clamped so an override can never drive Dequeue past empty.
+            var cap = Math.Max(1, MaxDeferredSends);
+
+            bool reportOverflow;
             lock (_deferralGate)
             {
                 if (!_operationInFlight && _deferredSends == null)
@@ -1124,9 +1185,42 @@ namespace Daqifi.Core.Device
                     return false;
                 }
 
-                (_deferredSends ??= new Queue<Action>()).Enqueue(() => SendNow(message));
-                return true;
+                var backlog = _deferredSends ??= new Queue<Action>();
+
+                // A loop rather than a single test, so a cap that shrank still converges on the
+                // first append after it did.
+                var dropped = 0;
+                while (backlog.Count >= cap)
+                {
+                    backlog.Dequeue();
+                    dropped++;
+                }
+
+                if (dropped > 0)
+                {
+                    Interlocked.Add(ref _droppedDeferredSendCount, dropped);
+                }
+
+                // One line per overflowing backlog, not per dropped message: the sender that
+                // overflows a backlog usually goes on overflowing it thousands of times.
+                reportOverflow = dropped > 0 && !_deferralOverflowReported;
+                if (reportOverflow)
+                {
+                    _deferralOverflowReported = true;
+                }
+
+                backlog.Enqueue(() => SendNow(message));
             }
+
+            if (reportOverflow)
+            {
+                SafeLog(() => _logger.LogWarning(
+                    "The backlog of messages deferred while an exclusive operation runs reached its "
+                    + "cap of {Cap}; the oldest are being dropped. See DroppedDeferredSendCount.",
+                    cap));
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -1783,6 +1877,15 @@ namespace Daqifi.Core.Device
         /// has — but the message can reach the device later than it used to. That is the point: a
         /// command written while a text query owns the stream gets its reply mixed into that
         /// query's answer.
+        /// </para>
+        /// <para>
+        /// That held-back backlog is capped at <see cref="DefaultMaxDeferredSends"/> messages, and
+        /// overflows by discarding the <b>oldest</b> of them — so sending continuously through a
+        /// long exclusive operation (an SD card download may run for thirty minutes) costs bounded
+        /// memory and replays a bounded burst afterwards, keeping the most recent commands rather
+        /// than the most stale. Discards are counted by <see cref="DroppedDeferredSendCount"/>.
+        /// Nothing is dropped while the device is idle, and nothing is dropped for a backlog under
+        /// the cap.
         /// </para>
         /// </remarks>
         /// <typeparam name="T">The type of the message data payload.</typeparam>


### PR DESCRIPTION
## What was wrong

`Send()` never blocks — when another flow owns the device it parks the message and returns, and the message goes out in order once that flow finishes. The queue it parked into had no limit.

That is fine for a text query, which owns the device for milliseconds. It is not fine for the operations that own it for a long time: an SD card download is allowed **thirty minutes**, and a firmware update longer. A UI or agent sending DIO/PWM/status commands at even 10 Hz throughout a download parked about **18,000** closures — a couple of megabytes, plus every message object they held alive — and then, the moment the download ended, replayed **all of them** at the device in one burst. So the memory growth came with a second surprise: thousands of commands the caller had long since superseded, all arriving at once at a device that had moved on.

## How it was fixed

The backlog is capped at `DaqifiDevice.DefaultMaxDeferredSends` (1024) and overflows by discarding its **oldest** entries. Drop-oldest is the right way round for what actually gets parked — these are level-setting commands ("set this pin", "set that duty cycle"), where the newest instruction is the one the caller currently wants and the superseded one is worth less than the memory it costs. Discards are counted by a new `DroppedDeferredSendCount` property, mirroring the existing `DroppedLiveSampleCount`, and the first overflow of each backlog logs one warning so this is not something you have to already know about to notice.

Things you may want to push back on:

- **1024 is a judgement call.** It is far above any backlog an ordinary text query can build, so the cap only ever engages on the long exclusive operations it exists for — but it still means a burst of up to 1024 replayed commands at the end of a download, just no longer 18,000. Coalescing per-command ("only the latest write to this pin survives") would fix the burst too, and is deliberately **not** done here: it needs a notion of message identity the outbound layer doesn't have.
- **The cap is a constant, not an option.** There is no `DeviceConnectionOptions` knob for it. `internal virtual MaxDeferredSends` exists purely as a test seam.
- **Drops are silent apart from the counter and one log line.** They do not raise `SendFailed`. Raising a public event from inside the deferral gate would put consumer code under a lock that `Send()` promises not to block on, and moving it outside makes ordering murky; the counter is the pattern the library already uses for the identical drop-oldest decision on live samples.
- **`DefaultMaxDeferredSends` and `DroppedDeferredSendCount` are new public members.** Additive only — no interface changed, no existing signature touched.

## Verification

- 6 new tests in `DaqifiDeviceOperationSerializationTests`: drop-oldest keeps the newest N in order; a backlog under the cap drops nothing (the guard on the existing ordering guarantees, which are unchanged); 2000 sends hammered through a held operation leave the backlog bounded, sampled as it grows rather than only at the end; the shipped default cap really is the one enforced; an idle device drops nothing even with a cap of one; and the counter accumulates across operations while the warning stays at one per overflowing backlog. Four of the six were re-run against the un-fixed code first — **all four failed**, the two guards passed — so they pin the bug rather than the fix.
- Full suite green on **net9.0** (2908 Core + 43 Mcp) and **net10.0** (2908), 0 failures, 0 warnings.
- Bench, fw 3.7.2 on `/dev/cu.usbmodem1101`: four connect → status → 3 s @ 500 Hz stream → disconnect cycles, exit 0, 1188–1189 samples (this unit's known ~79% clock ratio), `sn` and firmware unchanged, clean `Disconnected`. Non-destructive; serial only.

closes #492

Not merging — for review.