### PR TITLE
fix(sdcard): an SD download now owns the device, so a concurrent command can't corrupt the file

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceRawCaptureLockTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceRawCaptureLockTests.cs
@@ -295,6 +295,62 @@ public class DaqifiDeviceRawCaptureLockTests
         device.Disconnect();
     }
 
+    // ── Nested consumer swaps ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RawCapture_NestedInsideAnotherRawCapture_IsRejected()
+    {
+        // The lock deliberately lets a flow that already owns it run nested — which is exactly what
+        // makes a nested swap silent. The inner capture's finally would restart the protobuf
+        // consumer while the outer one still had the stream, putting a second reader on it.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Nested-swap Device", transport);
+        device.Connect();
+
+        Exception? inner = null;
+
+        await device.RunRawCaptureAsync(async (_, ct) =>
+        {
+            inner = await Record.ExceptionAsync(
+                () => device.RunRawCaptureAsync((_, _) => Task.CompletedTask, ct));
+        }).WaitAsync(DeadlockBudget);
+
+        var rejected = Assert.IsType<InvalidOperationException>(inner);
+        Assert.Contains("not re-entrant", rejected.Message, StringComparison.Ordinal);
+
+        // The guard is per-flow state, so it must be cleared: a later capture still works.
+        await device.RunRawCaptureAsync((_, _) => Task.CompletedTask).WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task TextExchange_FromInsideARawCapture_IsRejected()
+    {
+        // Same corruption from the other direction, and the one a caller is likelier to write:
+        // "while I have the stream, let me just ask the device something."
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Nested-exchange Device", transport);
+        device.Connect();
+
+        Exception? inner = null;
+
+        await device.RunRawCaptureAsync(async (_, ct) =>
+        {
+            inner = await Record.ExceptionAsync(
+                () => device.RunTextExchangeAsync(() => device.Send(ScpiMessageProducer.GetDeviceInfo), ct));
+        }).WaitAsync(DeadlockBudget);
+
+        var rejected = Assert.IsType<InvalidOperationException>(inner);
+        Assert.Contains("not re-entrant", rejected.Message, StringComparison.Ordinal);
+
+        // And the outer capture left the device usable.
+        await device.RunTextExchangeAsync(() => device.Send(ScpiMessageProducer.GetDeviceInfo))
+            .WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
     // ── Lock hygiene ────────────────────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceRawCaptureLockTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceRawCaptureLockTests.cs
@@ -1,0 +1,597 @@
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using System.Text;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Coverage for #493 — the raw-capture path (what an SD download runs on) must take the device's
+/// operation lock, not just the SD download gate.
+/// </summary>
+/// <remarks>
+/// Before the fix a capture suspended the protobuf consumer and took the transport stream while
+/// excluding nothing: a text query from another thread acquired the exchange lock uncontended and
+/// started a second reader on that same stream, and a plain <see cref="DaqifiDevice.Send{T}"/> was
+/// not deferred at all, so its bytes went out mid-transfer and the reply landed inside the captured
+/// file. These tests pin both halves — mutual exclusion against text exchanges, and deferral of
+/// other flows' sends — plus the lock hygiene that comes with holding a lock: nested re-entry,
+/// release on every exit path, and validation performed after the wait rather than before it.
+/// </remarks>
+public class DaqifiDeviceRawCaptureLockTests
+{
+    private static readonly TimeSpan DeadlockBudget = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Long enough that a send which was NOT deferred would have reached the wire — the queued
+    /// producer path writes on its own thread, so "nothing yet" has to be given time to be wrong.
+    /// </summary>
+    private static readonly TimeSpan WireSettleWait = TimeSpan.FromMilliseconds(250);
+
+    // ── Mutual exclusion against text exchanges ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task TextExchange_StartedDuringARawCapture_WaitsForTheCaptureToFinish()
+    {
+        // The corruption this closes: the text exchange's own consumer swap would put a SECOND
+        // reader on the stream the capture is draining.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Capturing Device", transport);
+        device.Connect();
+
+        var captureEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCapture = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var captureLeft = 0;
+        var exchangeSawCaptureStillRunning = false;
+
+        var capture = Task.Run(() => device.RunRawCaptureAsync(async (_, ct) =>
+        {
+            captureEntered.SetResult();
+            await releaseCapture.Task.WaitAsync(ct);
+            Volatile.Write(ref captureLeft, 1);
+        }));
+
+        await captureEntered.Task.WaitAsync(DeadlockBudget);
+
+        var exchange = Task.Run(() => device.RunTextExchangeAsync(() =>
+        {
+            // Reached only once the capture is done; if the lock were not taken this would run
+            // while the capture still owned the stream.
+            if (Volatile.Read(ref captureLeft) == 0)
+            {
+                exchangeSawCaptureStillRunning = true;
+            }
+
+            device.Send(ScpiMessageProducer.GetDeviceInfo);
+        }));
+
+        // The exchange must be parked on the lock, not running: give it far longer than it needs
+        // to get to its setup action.
+        await Task.Delay(WireSettleWait);
+        Assert.False(exchange.IsCompleted, "The text exchange ran while a raw capture held the device.");
+
+        releaseCapture.SetResult();
+        await capture.WaitAsync(DeadlockBudget);
+        await exchange.WaitAsync(DeadlockBudget);
+
+        Assert.False(
+            exchangeSawCaptureStillRunning,
+            "The text exchange's setup action ran before the raw capture had finished.");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task RawCapture_StartedDuringAnExclusiveOperation_WaitsForIt()
+    {
+        // The mirror direction: whoever holds the device first keeps it.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Waiting Device", transport);
+        device.Connect();
+
+        var operationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var operationLeft = 0;
+        var captureSawOperationStillRunning = false;
+
+        var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
+        {
+            operationEntered.SetResult();
+            await releaseOperation.Task;
+            Volatile.Write(ref operationLeft, 1);
+        }));
+
+        await operationEntered.Task.WaitAsync(DeadlockBudget);
+
+        var capture = Task.Run(() => device.RunRawCaptureAsync((_, _) =>
+        {
+            if (Volatile.Read(ref operationLeft) == 0)
+            {
+                captureSawOperationStillRunning = true;
+            }
+
+            return Task.CompletedTask;
+        }));
+
+        await Task.Delay(WireSettleWait);
+        Assert.False(capture.IsCompleted, "A raw capture started while an exclusive operation owned the device.");
+
+        releaseOperation.SetResult();
+        await operation.WaitAsync(DeadlockBudget);
+        await capture.WaitAsync(DeadlockBudget);
+
+        Assert.False(
+            captureSawOperationStillRunning,
+            "The raw capture ran before the exclusive operation had finished.");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task RawCapture_FromInsideAnExclusiveOperation_RunsNestedWithoutDeadlocking()
+    {
+        // The SD operations reach the capture from flows that may already own the lock (#407), so
+        // re-entry has to run nested rather than wait on a semaphore this flow is holding.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Nesting Device", transport);
+        device.Connect();
+
+        var reached = false;
+
+        await device.RunExclusiveAsync(ct => device.RunRawCaptureAsync((_, _) =>
+        {
+            reached = true;
+            return Task.CompletedTask;
+        }, ct)).WaitAsync(DeadlockBudget);
+
+        Assert.True(reached);
+
+        // The nested capture must not have released the outer flow's lock on its way out.
+        await device.RunExclusiveAsync(_ => Task.CompletedTask).WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
+    // ── Send deferral ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Send_DuringARawCapture_IsDeferredAndReplayedAfterwards()
+    {
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Deferring Device", transport);
+        device.Connect();
+
+        var captureEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCapture = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var capture = Task.Run(() => device.RunRawCaptureAsync(async (_, ct) =>
+        {
+            captureEntered.SetResult();
+            await releaseCapture.Task.WaitAsync(ct);
+        }));
+
+        await captureEntered.Task.WaitAsync(DeadlockBudget);
+
+        await Task.Run(() => device.Send(ScpiMessageProducer.SetDioPortState(4, 1)));
+
+        await Task.Delay(WireSettleWait);
+        Assert.DoesNotContain(transport.Writes, w => w.Text.Contains("DIO:PORt:STATe", StringComparison.Ordinal));
+
+        releaseCapture.SetResult();
+        await capture.WaitAsync(DeadlockBudget);
+
+        await WaitForWriteAsync(transport, "DIO:PORt:STATe");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task Send_DuringARawCapture_StillReturnsImmediately()
+    {
+        // Deferred, not blocked: Send is fire-and-forget and must stay that way even when the
+        // device is owned by a 30-minute download.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Non-blocking Device", transport);
+        device.Connect();
+
+        var captureEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCapture = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var capture = Task.Run(() => device.RunRawCaptureAsync(async (_, ct) =>
+        {
+            captureEntered.SetResult();
+            await releaseCapture.Task.WaitAsync(ct);
+        }));
+
+        await captureEntered.Task.WaitAsync(DeadlockBudget);
+
+        var send = Task.Run(() => device.Send(ScpiMessageProducer.GetDeviceInfo));
+        var returned = await Task.WhenAny(send, Task.Delay(TimeSpan.FromSeconds(2))) == send;
+
+        releaseCapture.SetResult();
+        await capture.WaitAsync(DeadlockBudget);
+        await send.WaitAsync(DeadlockBudget);
+
+        Assert.True(returned, "Send blocked while a raw capture owned the device.");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task RawCapture_UnderASendHammer_ReadsThePayloadWithNothingInterleaved()
+    {
+        // The end-to-end shape of the bug: a caller polling status or firing commands while a
+        // download runs. Every one of those sends used to hit the wire mid-transfer, so the
+        // device's replies landed inside the file's bytes.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Hammered Device", transport);
+        device.Connect();
+
+        var payload = new byte[4096];
+        new Random(493).NextBytes(payload);
+        transport.CaptureStream.Payload = payload;
+
+        var captureEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopHammer = 0;
+        var received = new MemoryStream();
+
+        var capture = Task.Run(() => device.RunRawCaptureAsync(async (stream, ct) =>
+        {
+            transport.CaptureStream.CaptureWindowOpen = true;
+            try
+            {
+                captureEntered.SetResult();
+
+                var buffer = new byte[256];
+                while (received.Length < payload.Length)
+                {
+                    var read = stream.Read(buffer, 0, buffer.Length);
+                    if (read > 0)
+                    {
+                        received.Write(buffer, 0, read);
+                    }
+
+                    // Widen the window so the hammer has every chance to interleave.
+                    await Task.Delay(1, ct);
+                }
+            }
+            finally
+            {
+                transport.CaptureStream.CaptureWindowOpen = false;
+            }
+        }));
+
+        await captureEntered.Task.WaitAsync(DeadlockBudget);
+
+        var hammer = Task.Run(() =>
+        {
+            var sent = 0;
+            while (Volatile.Read(ref stopHammer) == 0)
+            {
+                device.Send(new TaggedBinaryMessage($"HAMMER-{sent++}"));
+                Thread.Sleep(1);
+            }
+
+            return sent;
+        });
+
+        await capture.WaitAsync(DeadlockBudget);
+        Volatile.Write(ref stopHammer, 1);
+        var hammered = await hammer.WaitAsync(DeadlockBudget);
+
+        Assert.True(hammered > 0, "The hammer never sent anything, so this proves nothing.");
+        Assert.Equal(payload, received.ToArray());
+
+        var duringCapture = transport.Writes.Where(w => w.DuringCapture).ToList();
+        Assert.True(
+            duringCapture.Count == 0,
+            $"{duringCapture.Count} write(s) reached the wire during the capture: "
+            + string.Join(" | ", duringCapture.Take(5).Select(w => w.Text)));
+
+        // And they were parked, not dropped.
+        await WaitForWriteAsync(transport, "HAMMER-0");
+
+        device.Disconnect();
+    }
+
+    // ── Lock hygiene ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RawCapture_ReleasesTheLockWhenTheActionThrows()
+    {
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Throwing Device", transport);
+        device.Connect();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => device.RunRawCaptureAsync((_, _) => throw new InvalidOperationException("boom")));
+
+        // A leaked lock would hang here instead of completing.
+        await device.RunExclusiveAsync(_ => Task.CompletedTask).WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task RawCapture_ReleasesTheLockAfterAValidationFailure()
+    {
+        // Not connected: the failure now happens with the lock held, so the release has to run on
+        // that path too. Two calls, then an unrelated operation — any of them would hang on a leak.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Unconnected Device", transport);
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => device.RunRawCaptureAsync((_, _) => Task.CompletedTask));
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => device.RunRawCaptureAsync((_, _) => Task.CompletedTask));
+
+        device.Connect();
+        await device.RunExclusiveAsync(_ => Task.CompletedTask).WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task RawCapture_WhenTheDeviceDisconnectsWhileItWaits_FailsInsteadOfTakingADeadStream()
+    {
+        // The reason validation moved inside the lock: everything checked before the wait was
+        // checked against a session that can be gone by the time the lock arrives.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Torn-down Device", transport);
+        device.Connect();
+
+        var operationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
+        {
+            operationEntered.SetResult();
+            await releaseOperation.Task;
+        }));
+
+        await operationEntered.Task.WaitAsync(DeadlockBudget);
+
+        // Started from the test's own flow, deliberately: a Task.Run from INSIDE the exclusive
+        // block would inherit that flow's ownership of the lock and run nested instead of queueing.
+        var captureStarted = false;
+        var capture = Task.Run(() => device.RunRawCaptureAsync((_, _) =>
+        {
+            captureStarted = true;
+            return Task.CompletedTask;
+        }));
+
+        // Let it queue on the lock, then pull the session out from under it. The cancelled token
+        // shortens teardown's courtesy wait for a lock the operation is still holding.
+        await Task.Delay(WireSettleWait);
+        using var shortWait = new CancellationTokenSource();
+        await shortWait.CancelAsync();
+        await device.DisconnectAsync(shortWait.Token).WaitAsync(DeadlockBudget);
+
+        releaseOperation.SetResult();
+        await operation.WaitAsync(DeadlockBudget);
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(() => capture.WaitAsync(DeadlockBudget));
+        Assert.False(captureStarted, "The raw capture took a stream from a session that had already been torn down.");
+    }
+
+    [Fact]
+    public async Task RawCapture_WhenCancelledWhileWaitingForTheLock_DoesNotRun()
+    {
+        // Captures can be long, so a caller that cannot wait needs the token to work while queued.
+        using var transport = new CaptureTransport();
+        using var device = new RawCaptureDevice("Cancelling Device", transport);
+        device.Connect();
+
+        var operationEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var operation = Task.Run(() => device.RunExclusiveAsync(async _ =>
+        {
+            operationEntered.SetResult();
+            await releaseOperation.Task;
+        }));
+
+        await operationEntered.Task.WaitAsync(DeadlockBudget);
+
+        using var cts = new CancellationTokenSource();
+        var started = false;
+        var capture = Task.Run(() => device.RunRawCaptureAsync((_, _) =>
+        {
+            started = true;
+            return Task.CompletedTask;
+        }, cts.Token));
+
+        await Task.Delay(WireSettleWait);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => capture.WaitAsync(DeadlockBudget));
+        Assert.False(started);
+
+        releaseOperation.SetResult();
+        await operation.WaitAsync(DeadlockBudget);
+
+        device.Disconnect();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────────────────
+
+    private static async Task WaitForWriteAsync(CaptureTransport transport, string fragment)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (transport.Writes.Any(w => w.Text.Contains(fragment, StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.Fail($"'{fragment}' never reached the wire.");
+    }
+
+    /// <summary>Exposes the protected raw-capture and text-exchange entry points.</summary>
+    private sealed class RawCaptureDevice : DaqifiDevice
+    {
+        public RawCaptureDevice(string name, IStreamTransport transport)
+            : base(name, transport)
+        {
+        }
+
+        public Task RunRawCaptureAsync(
+            Func<Stream, CancellationToken, Task> rawAction,
+            CancellationToken cancellationToken = default) =>
+            ExecuteRawCaptureAsync(rawAction, cancellationToken);
+
+        public Task<IReadOnlyList<string>> RunTextExchangeAsync(
+            Action setupAction,
+            CancellationToken cancellationToken = default) =>
+            ExecuteTextCommandAsync(
+                setupAction,
+                responseTimeoutMs: 300,
+                completionTimeoutMs: 100,
+                cancellationToken: cancellationToken);
+    }
+
+    /// <summary>A message that writes straight to the stream, so a send is observable the instant it happens.</summary>
+    private sealed class TaggedBinaryMessage : IOutboundMessage<byte[]>
+    {
+        public TaggedBinaryMessage(string tag) => Data = Encoding.UTF8.GetBytes(tag);
+
+        public byte[] Data { get; set; }
+
+        public byte[] GetBytes() => Data;
+    }
+
+    private sealed record RecordedWrite(string Text, bool DuringCapture);
+
+    private sealed class CaptureTransport : IStreamTransport
+    {
+        private bool _isConnected;
+        private bool _disposed;
+
+        public CaptureStream CaptureStream { get; } = new();
+
+        public IReadOnlyList<RecordedWrite> Writes => CaptureStream.Writes;
+
+        public Stream Stream => _disposed
+            ? throw new ObjectDisposedException(nameof(CaptureTransport))
+            : CaptureStream;
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "Capture: Connected" : "Capture: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(CaptureTransport));
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().Wait();
+
+        public void Disconnect() => DisconnectAsync().Wait();
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _isConnected = false;
+            _disposed = true;
+        }
+    }
+
+    /// <summary>
+    /// Records every write together with whether the raw capture had the stream at that moment,
+    /// and serves a scripted payload to the capture itself.
+    /// </summary>
+    private sealed class CaptureStream : Stream
+    {
+        private readonly List<RecordedWrite> _writes = new();
+        private readonly object _gate = new();
+        private int _payloadOffset;
+        private volatile bool _captureWindowOpen;
+
+        /// <summary>Set by the raw action around the window in which it owns the stream.</summary>
+        public bool CaptureWindowOpen
+        {
+            get => _captureWindowOpen;
+            set => _captureWindowOpen = value;
+        }
+
+        /// <summary>Bytes served to the capture, a chunk at a time. Null means "nothing to read".</summary>
+        public byte[]? Payload { get; set; }
+
+        public IReadOnlyList<RecordedWrite> Writes
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _writes.ToList();
+                }
+            }
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var payload = Payload;
+
+            // Only the capture is served: outside its window this is the device's own consumer
+            // polling, and handing it the file would make the test's premise false.
+            if (payload == null || !_captureWindowOpen || _payloadOffset >= payload.Length)
+            {
+                // Nothing to read; back off so the consumer's reader loop doesn't spin.
+                Thread.Sleep(5);
+                return 0;
+            }
+
+            var take = Math.Min(Math.Min(count, 64), payload.Length - _payloadOffset);
+            Array.Copy(payload, _payloadOffset, buffer, offset, take);
+            _payloadOffset += take;
+            return take;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var duringCapture = _captureWindowOpen;
+            lock (_gate)
+            {
+                _writes.Add(new RecordedWrite(Encoding.UTF8.GetString(buffer, offset, count), duringCapture));
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1926,17 +1926,25 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
-        /// Temporarily pauses the protobuf message consumer to allow raw byte access to the
-        /// underlying transport stream. The consumer is restored when the returned action completes
-        /// or is disposed.
+        /// Takes exclusive use of the device and hands the transport stream to <paramref name="rawAction"/>
+        /// for raw byte access, with the protobuf consumer paused for the duration. Everything is
+        /// restored when the action completes, however it completes.
         /// </summary>
+        /// <remarks>
+        /// Runs under the same operation lock as <see cref="RunExclusiveAsync{TResult}"/> and the
+        /// text exchange, so a text query from another thread waits for the capture and a
+        /// <see cref="Send{T}"/> from another thread is deferred and replayed afterwards (#493).
+        /// Reentrant on the flow that already holds the lock. Captures can be long — an SD
+        /// download's budget is 30 minutes — so pass a cancellation token if the caller cannot wait
+        /// that long for the lock.
+        /// </remarks>
         /// <param name="rawAction">
         /// An async function that receives the transport stream and performs raw I/O.
         /// The protobuf consumer will not read from the stream while this action is executing.
         /// </param>
         /// <param name="cancellationToken">A cancellation token to observe.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected, disconnecting or disposed.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the device has no transport-based connection.</exception>
         protected virtual Task ExecuteRawCaptureAsync(
             Func<Stream, CancellationToken, Task> rawAction,

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -445,7 +445,8 @@ namespace Daqifi.Core.Device
         private readonly SemaphoreSlim _textExchangeLock = new(1, 1);
 
         // Async-context flag that tracks whether the current logical flow
-        // is inside the consumer swap of ExecuteTextCommandAsync. AsyncLocal flows across await
+        // is inside a consumer swap — ExecuteTextCommandAsync's or ExecuteRawCaptureAsync's; both
+        // stop the protobuf consumer and take the stream. AsyncLocal flows across await
         // resumptions on different threads, so a setupAction that re-enters
         // ExecuteTextCommandAsync after a ConfigureAwait(false) hop is still
         // detected and surfaced as InvalidOperationException — instead of

--- a/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
+++ b/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
@@ -109,8 +109,9 @@ namespace Daqifi.Core.Device.Internal
         void ExitOperationLockOwnership();
 
         /// <summary>
-        /// Whether the current logical flow is already inside a consumer swap. Set by the engine
-        /// around the exchange so a <c>setupAction</c> that re-enters is caught rather than wedging.
+        /// Whether the current logical flow is already inside a consumer swap — a text exchange or
+        /// a raw capture. Set by the engine around both, so a callback that re-enters either one is
+        /// caught rather than restarting the consumer underneath the swap that is still running.
         /// </summary>
         /// <remarks>
         /// <b>The setter must not be made async</b> — see the remarks on

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -46,18 +46,36 @@ namespace Daqifi.Core.Device.Internal
         }
 
         /// <summary>
-        /// Temporarily pauses the protobuf message consumer to allow raw byte access to the
-        /// underlying transport stream. The consumer is restored when the returned action completes
-        /// or is disposed.
+        /// Takes exclusive use of the device and hands the transport stream to the caller for raw
+        /// byte access, with the protobuf consumer paused for the duration. Everything is restored
+        /// when the action completes, however it completes.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Runs under the device's operation lock, on the same protocol
+        /// <see cref="ExecuteAsync"/> uses — including nested re-entry for a flow that already holds
+        /// it. Until #493 this was the one path that took the stream without excluding anything: a
+        /// status poll from another thread would acquire the exchange lock uncontended and put a
+        /// second reader on the same stream mid-capture, and a plain <see cref="DaqifiDevice.Send{T}"/>
+        /// was not even deferred, so its reply landed inside the captured bytes. The capture window
+        /// is therefore also what makes other flows' sends defer; they are replayed on the way out.
+        /// </para>
+        /// <para>
+        /// Captures can be long — an SD download's budget is 30 minutes — so a competing text
+        /// exchange now waits that long rather than corrupting the transfer. Callers who cannot
+        /// wait should pass a cancellation token: it is observed while queueing for the lock.
+        /// </para>
+        /// </remarks>
         /// <param name="rawAction">
         /// An async function that receives the transport stream and performs raw I/O.
         /// The protobuf consumer will not read from the stream while this action is executing.
         /// </param>
         /// <param name="cancellationToken">A cancellation token to observe.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected, disconnecting or disposed.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the device has no transport-based connection.</exception>
+        /// <exception cref="TransportNotConnectedException">Thrown when the transport dropped while this capture waited for the lock.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when cancelled, including while waiting for the lock.</exception>
         internal async Task ExecuteRawCaptureAsync(
             Func<Stream, CancellationToken, Task> rawAction,
             CancellationToken cancellationToken = default)
@@ -67,25 +85,104 @@ namespace Daqifi.Core.Device.Internal
                 throw new DeviceNotConnectedException();
             }
 
-            var transport = _host.Transport;
-            if (transport == null)
-            {
-                throw new InvalidOperationException("ExecuteRawCaptureAsync requires a transport-based connection.");
-            }
-
             cancellationToken.ThrowIfCancellationRequested();
+
+            // A flow that already owns the lock — an exclusive block, or the SD operations' own
+            // prepare/restore exchanges (#407) — runs nested rather than waiting on a semaphore it
+            // is itself holding, and leaves the release to the owner. Same rule as ExecuteAsync.
+            var ownsLock = !_host.HoldsOperationLock;
+            if (ownsLock)
+            {
+                try
+                {
+                    await _host.WaitForOperationLockAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    // Dispose() raced ahead of us and disposed the semaphore. Surface the same clean
+                    // failure as the post-acquisition shutdown check below, with the original kept
+                    // as InnerException so the race stays diagnosable.
+                    throw new DeviceNotConnectedException(
+                        "ExecuteRawCaptureAsync cannot run because the device is disposed.",
+                        ex,
+                        isShuttingDown: true);
+                }
+
+                // Claimed in this frame, not behind an await: an AsyncLocal write flows forward to
+                // this frame's callees but never back to its caller, and the callees — the raw
+                // action and every Send() it makes — are exactly who must see it. See the remarks
+                // on ITextExchangeHost. This is also what starts deferring other flows' sends.
+                _host.EnterOperationLockOwnership();
+            }
 
             try
             {
-                // Stop the protobuf consumer so it doesn't compete for stream bytes
-                SuspendInboundConsumer();
+                // All validation runs INSIDE the lock. Everything checked before the wait was
+                // checked against a session that may have been torn down while this flow queued
+                // behind another operation — the same TOCTOU window #186 closed for the text
+                // exchange, and a wider one here because captures are long.
+                if (_host.IsShuttingDown)
+                {
+                    throw new DeviceNotConnectedException(
+                        "ExecuteRawCaptureAsync cannot run while the device is disposing or disconnecting.",
+                        isShuttingDown: true);
+                }
 
-                // Hand the stream to the caller for raw I/O
-                await rawAction(transport.Stream, cancellationToken).ConfigureAwait(false);
+                if (!_host.IsConnected)
+                {
+                    throw new DeviceNotConnectedException();
+                }
+
+                var transport = _host.Transport;
+                if (transport == null)
+                {
+                    throw new InvalidOperationException("ExecuteRawCaptureAsync requires a transport-based connection.");
+                }
+
+                // Device-level IsConnected is status-based and can still report Connected when the
+                // underlying transport has dropped. Fail typed here rather than dereferencing
+                // Stream below and surfacing the framework's raw "BaseStream is only available when
+                // the port is open." (issue #238, the same check ExecuteAsync makes).
+                if (!transport.IsConnected)
+                {
+                    throw new TransportNotConnectedException(
+                        "Device transport is no longer connected.");
+                }
+
+                // Let anything queued before this capture opened reach the wire while the protobuf
+                // consumer is still the one reading (issue #342). Deferral only parks sends that
+                // arrive from here on; a command queued microseconds earlier would otherwise be
+                // written mid-capture and its reply read as captured content.
+                //
+                // Deliberately OUTSIDE the swap's try/finally below, for the same reason as in
+                // ExecuteAsync: this is the one step that can throw (a cancelled token) before the
+                // consumer has been stopped, and that finally restarts the consumer — which on a
+                // consumer that was never stopped means subscribing the inbound handler a second
+                // time and dispatching every frame twice.
+                await _host.DrainOutboundQueueAsync(cancellationToken).ConfigureAwait(false);
+
+                try
+                {
+                    // Stop the protobuf consumer so it doesn't compete for stream bytes
+                    SuspendInboundConsumer();
+
+                    // Hand the stream to the caller for raw I/O
+                    await rawAction(transport.Stream, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    RestartMessageConsumerAfterSwap();
+                }
             }
             finally
             {
-                RestartMessageConsumerAfterSwap();
+                // Only the flow that took the lock releases it; a nested capture leaves that to the
+                // block that owns it. The release replays the sends parked while the capture ran,
+                // before the semaphore is handed on, so they are queued ahead of whatever runs next.
+                if (ownsLock)
+                {
+                    _host.ExitOperationLockOwnership();
+                }
             }
         }
 
@@ -499,10 +596,10 @@ namespace Daqifi.Core.Device.Internal
         /// </para>
         /// <para>
         /// Never throws: it runs from <c>finally</c> blocks, where an exception would mask the real
-        /// failure already unwinding. The consumer is also snapshotted once up front — the
-        /// text-exchange path holds the operation lock (which <see cref="DaqifiDevice.Disconnect"/>
-        /// waits on), but the raw-capture path does not, so a concurrent teardown could otherwise
-        /// null the field between reads.
+        /// failure already unwinding. The consumer is also snapshotted once up front: both swap
+        /// paths hold the operation lock (which <see cref="DaqifiDevice.Disconnect"/> waits on), but
+        /// that wait is bounded and teardown proceeds anyway once it expires, so a concurrent
+        /// teardown could still null the field between reads.
         /// </para>
         /// </remarks>
         private void RestartMessageConsumerAfterSwap()

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -94,8 +94,9 @@ namespace Daqifi.Core.Device.Internal
             if (_host.IsInsideTextExchange)
             {
                 throw new InvalidOperationException(
-                    "ExecuteRawCaptureAsync is not re-entrant on the same device and cannot run "
-                    + "inside a text exchange; both swap the device's message consumer.");
+                    "ExecuteRawCaptureAsync is not re-entrant: this flow is already inside a "
+                    + "consumer swap — another raw capture, or a text exchange — and both take "
+                    + "the device's message consumer and its stream.");
             }
 
             // A flow that already owns the lock — an exclusive block, or the SD operations' own

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -87,6 +87,17 @@ namespace Daqifi.Core.Device.Internal
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            // A capture is a consumer swap, so it obeys the same nesting rule an exchange does: one
+            // swap at a time per flow. The lock does not cover this — a nested call runs nested by
+            // design — and without the guard the inner swap's finally would restart the protobuf
+            // consumer while the outer capture still owns the stream, putting a second reader on it.
+            if (_host.IsInsideTextExchange)
+            {
+                throw new InvalidOperationException(
+                    "ExecuteRawCaptureAsync is not re-entrant on the same device and cannot run "
+                    + "inside a text exchange; both swap the device's message consumer.");
+            }
+
             // A flow that already owns the lock — an exclusive block, or the SD operations' own
             // prepare/restore exchanges (#407) — runs nested rather than waiting on a semaphore it
             // is itself holding, and leaves the release to the owner. Same rule as ExecuteAsync.
@@ -114,6 +125,11 @@ namespace Daqifi.Core.Device.Internal
                 // on ITextExchangeHost. This is also what starts deferring other flows' sends.
                 _host.EnterOperationLockOwnership();
             }
+
+            // Claims the swap for this flow, so anything the raw action calls that would swap the
+            // consumer again is caught by the guard above (or by ExecuteAsync's) rather than
+            // restarting the consumer underneath this capture.
+            _host.IsInsideTextExchange = true;
 
             try
             {
@@ -176,6 +192,8 @@ namespace Daqifi.Core.Device.Internal
             }
             finally
             {
+                _host.IsInsideTextExchange = false;
+
                 // Only the flow that took the lock releases it; a nested capture leaves that to the
                 // block that owns it. The release replays the sends parked while the capture ran,
                 // before the semaphore is handed on, so they are queued ahead of whatever runs next.
@@ -217,11 +235,13 @@ namespace Daqifi.Core.Device.Internal
             // AsyncLocal flows across await thread hops so this catches
             // re-entry even when the inner call resumes on a different
             // thread than the outer call.
+            // The flag covers a raw capture's swap too, so this also catches an
+            // exchange opened from inside one — same corruption, same answer.
             if (_host.IsInsideTextExchange)
             {
                 throw new InvalidOperationException(
                     "ExecuteTextCommandAsync is not re-entrant on the same device; "
-                    + "do not call it from inside a setupAction callback.");
+                    + "do not call it from inside a setupAction callback or a raw capture.");
             }
 
             // The exchange runs under the device's operation lock. A flow that already owns it —

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -846,6 +846,13 @@ namespace Daqifi.Core.Device.SdCard
         /// </exception>
         /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is canceled.</exception>
         /// <remarks>
+        /// The transfer holds the device's operation lock for its whole duration (#493), so while it
+        /// runs a text query from another thread waits and a <see cref="DaqifiDevice.Send{T}"/> from
+        /// another thread is deferred and replayed afterwards. That is what keeps a status poll from
+        /// putting a second reader on the stream, and a stray command's reply out of the file's
+        /// bytes. The cost is that an unrelated query on another thread can now wait for the whole
+        /// download rather than corrupting it; pass it a cancellation token if it cannot.
+        /// <para>
         /// On a timeout — or a cancellation the parked transfer cannot itself observe — the
         /// in-flight transfer is <b>abandoned</b> rather than awaited: it may be blocked in native
         /// serial I/O that no token can interrupt, and waiting for it is the hang this method
@@ -856,6 +863,14 @@ namespace Daqifi.Core.Device.SdCard
         /// not be reused for anything else; and the device is left mid-<c>SD:GET</c> with the
         /// protobuf consumer stopped, so reconnecting (or power-cycling, if its SD subsystem is
         /// genuinely wedged) is the reliable way to resume normal operation.
+        /// </para>
+        /// <para>
+        /// An abandoned transfer also still holds the operation lock. Its token is cancelled on the
+        /// way out, so the usual case — a read that returns late — unwinds at its next token check
+        /// and releases it. A read that never returns keeps the lock, and keeps the transport stream
+        /// with it: a text query blocked on that lock is blocked on a stream nothing could safely
+        /// have used anyway, and the reconnect this case already calls for is what clears it.
+        /// </para>
         /// <para>
         /// The LAN interface is deliberately <b>not</b> restored in that case: the abandoned
         /// transfer still owns the transport, and putting the restore commands onto a link it is


### PR DESCRIPTION
## What was wrong

If anything else touched the device while an SD card download was running, the downloaded file could come back silently corrupted. A UI status poll, an MCP `get_device_status`, an SD listing, or even a single fire-and-forget `device.Send(...)` from another thread was enough: the download had the transport stream to itself only by convention, not by any lock. A text query would open its own reader on the same stream and start eating the file's bytes; a bare `Send()` would put SCPI onto the wire mid-transfer and the device's reply would land *inside* the `.bin`. Nothing failed loudly — you got a truncated or garbled file, or the end-of-file marker was eaten and the download sat there until its 30-minute deadline expired. The other thread's own response was garbage too.

The download did hold a gate, but that gate only serialized downloads against each other.

## How it was fixed

The raw-capture path the download runs on now takes the same device operation lock every other operation already takes. While a download is in flight, a text query from another thread waits for it, and a `Send()` from another thread is deferred and replayed afterwards — exactly what already happens around `RunExclusiveAsync`. Re-entry is nested, so the SD prepare/restore exchanges that already run under that lock don't deadlock against it. A capture also now counts as a consumer swap for the existing re-entrancy guard, so a second swap started from inside one is rejected instead of restarting the message consumer under a capture that still owns the stream.

Things you may want to push back on:

- **A download can now make an unrelated query wait up to 30 minutes.** That is the deliberate trade: the alternative is the corruption above. Callers who cannot wait should pass a cancellation token — it is observed while queueing for the lock.
- **An abandoned transfer (the timeout path) holds the lock.** It is cancelled on the way out, so the usual case unwinds and releases it. A read that never returns keeps the lock *and* the stream — at which point a blocked query was blocked on a stream nothing could have used anyway, and the reconnect that case already calls for clears it. Documented on `DownloadSdCardFileAsync`.
- **Validation moved to after the lock acquisition**, so a session torn down while a capture queued is caught rather than handing out a dead stream. This adds `TransportNotConnectedException` (an `InvalidOperationException`) to the path, mirroring #238's fix for the text exchange.
- **An outbound drain was added at the start of the capture.** The lock alone only parks sends that arrive *after* the capture opens; a command queued microseconds earlier would still have been written into it. This is the same barrier `ExecuteAsync` takes for #342, and costs at most 250 ms per download.
- **Merge order vs #505.** The deferred-send backlog is unbounded on `main` today (#492, fixed in #505). This PR does not create that, but it does widen the window in which it can fill — so #505 landing first is the tidier order.

## Verification

12 new tests in `DaqifiDeviceRawCaptureLockTests`, covering all three of the issue's success criteria plus lock hygiene (nested re-entry, release on throw / on validation failure, cancellation while queued, teardown during the wait) and the two nested-swap rejections. Confirmed they catch the bugs rather than just passing: with the lock change reverted, **6 of 10 failed**; with the swap guard reverted, **2 of 2 failed** — and in both cases the tests that are guards correctly still passed.

Full suite green on **net9.0** (2914 Core + 43 Mcp) and **net10.0** (2914), 0 failures, 0 warnings.

Bench (non-destructive), fw 3.7.2 on `/dev/cu.usbmodem1101`, re-run after the review fix: connect → `--show-status` → 3 s @ 500 Hz → disconnect cycles returning 1177–1189 samples (this unit's known clock ratio), plus SD `--sd-list` (45 files) and `--sd-storage` — the SD prepare/finalize exchange path this change sits next to. `sn` and firmware unchanged, clean `Disconnected`. No `SD:GET`, no delete/format, no reboot, no firmware, serial only.

closes #493

Not merging — for review.