### PR TITLE
fix(streaming): a live await foreach now ends when the device does, instead of hanging forever

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -851,6 +851,22 @@ increments; the decode thread is never blocked. Cancelling the token ends the en
 (surfaced as `OperationCanceledException`) and unsubscribes, but does **not** stop the device stream —
 call `StopStreaming()` for that. This is additive: `SampleReceived` and `MessageReceived` are unaffected.
 
+**An enumeration is bound to the connected session it starts in.** Samples only ever arrive on one, so
+the loop ends as soon as the device stops being connected, after yielding whatever was already
+buffered:
+
+| What happened | What the `await foreach` does |
+| --- | --- |
+| `Disconnect()` / `DisconnectAsync()` / `Dispose()` | Ends normally |
+| Unplug, WiFi loss, a reconnect that gave up | Throws `DeviceNotConnectedException` |
+| Started while the device is not connected | Throws `DeviceNotConnectedException` on the first `MoveNextAsync` |
+| Token cancelled | Throws `OperationCanceledException`, as before |
+
+A drop is deliberately not silent: an acquisition cut short by a pulled cable must not look identical
+to one that finished. Automatic reconnection (`ReconnectOptions`) does **not** resume an enumeration —
+the drop ends it, and a consumer that wants live samples from the restored session starts a new
+`await foreach` once `Status` reads `Connected` again.
+
 #### Raw protobuf frames
 
 ```csharp

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTerminationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTerminationTests.cs
@@ -211,6 +211,43 @@ namespace Daqifi.Core.Tests.Device
             await e.DisposeAsync();
         }
 
+        [Fact]
+        public void AThrowingStatusHook_DoesNotAbortTheTransition()
+        {
+            // The hooks this fix added sit on the drop path, where issue #494 established that an
+            // escaping exception skips the reconnect start and unwinds into the transport before it
+            // has released the port. That rule cannot be weaker for the library's own code than it
+            // is for a consumer's handler.
+            using var transport = new DroppableTransport();
+            using var device = new ThrowingHookDevice("Badly Wired Device", transport);
+
+            var seen = new List<ConnectionStatus>();
+            var errors = new List<DeviceErrorEventArgs>();
+            device.StatusChanged += (_, e) => seen.Add(e.Status);
+            device.ErrorOccurred += (_, e) => errors.Add(e);
+
+            var escaped = Record.Exception(() => device.Connect());
+
+            Assert.Null(escaped);
+            Assert.Equal(ConnectionStatus.Connected, device.Status);
+            Assert.Contains(ConnectionStatus.Connected, seen);
+            Assert.Contains(errors, e => e.Source == DeviceErrorSource.StatusNotification);
+        }
+
+        [Fact]
+        public void AThrowingReleaseHook_DoesNotFailDispose()
+        {
+            using var transport = new DroppableTransport();
+            var device = new ThrowingHookDevice("Badly Wired Device", transport);
+            device.Connect();
+
+            var escaped = Record.Exception(() => device.Dispose());
+
+            // A Dispose that throws hides the handles it did release behind an exception nobody can
+            // act on, so the library's own cleanup failure is reported instead.
+            Assert.Null(escaped);
+        }
+
         #region Helpers
 
         private static LiveStreamDevice CreateStreaming(IStreamTransport transport)
@@ -256,6 +293,23 @@ namespace Daqifi.Core.Tests.Device
 
             // The transport here exists to report a drop, not to carry traffic.
             public override void Send<T>(IOutboundMessage<T> message) { }
+        }
+
+        /// <summary>
+        /// A device whose internal lifecycle hooks throw — the shape of a defect inside Core, which
+        /// still must not be able to break a status transition or a dispose.
+        /// </summary>
+        private sealed class ThrowingHookDevice : DaqifiStreamingDevice
+        {
+            public ThrowingHookDevice(string name, IStreamTransport transport) : base(name, transport) { }
+
+            public override void Send<T>(IOutboundMessage<T> message) { }
+
+            internal override void OnConnectionStatusChanged(ConnectionStatus status) =>
+                throw new InvalidOperationException("a badly wired internal status hook");
+
+            internal override void ReleaseDerivedResources() =>
+                throw new InvalidOperationException("a badly wired internal release hook");
         }
 
         /// <summary>

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTerminationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTerminationTests.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    /// <summary>
+    /// Issue #496: <see cref="DaqifiStreamingDevice.StreamSamplesAsync"/> never ended when the device
+    /// went away. The buffer behind it was completed only by the enumerator's own exit path, so a
+    /// consumer sitting in the documented <c>await foreach</c> idiom when the cable was pulled got no
+    /// samples, no exception and no loop exit — it waited forever on a device the rest of the library
+    /// had already reported as <see cref="ConnectionStatus.Lost"/>, still subscribed to every channel.
+    /// </summary>
+    /// <remarks>
+    /// These drive the whole path a real drop takes — transport watchdog, device status transition,
+    /// enumeration — through a transport that can report a drop on command. The collaborator's own
+    /// bookkeeping (which channels stay subscribed, what happens with several enumerations at once,
+    /// the dispose that transitions nowhere) is pinned directly in <c>LiveSampleStreamTests</c>.
+    /// </remarks>
+    public class DaqifiStreamingDeviceLiveStreamTerminationTests
+    {
+        /// <summary>
+        /// Upper bound on every await here. A regression in this fix is precisely "the await never
+        /// returns", so an unbounded wait would park the whole test run rather than fail it.
+        /// </summary>
+        private static readonly TimeSpan MoveNextTimeout = TimeSpan.FromSeconds(5);
+
+        [Fact]
+        public async Task AnUnplug_FaultsTheEnumeration_WithDeviceNotConnected()
+        {
+            using var transport = new DroppableTransport();
+            using var device = CreateStreaming(transport);
+
+            await using var e = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync(); // runs the body: registers and subscribes synchronously
+
+            transport.SimulateDrop();
+
+            // The whole point of the issue: this used to be an unbounded wait.
+            var thrown = await Assert.ThrowsAsync<DeviceNotConnectedException>(
+                () => moveNext.AsTask().WaitAsync(MoveNextTimeout));
+
+            // A drop is not a shutdown the caller asked for, and the flag is how a consumer decides
+            // whether to offer a reconnect.
+            Assert.False(thrown.IsShuttingDown);
+            Assert.Equal(ConnectionStatus.Lost, device.Status);
+        }
+
+        [Fact]
+        public async Task AnUnplug_YieldsWhatWasAlreadyBuffered_BeforeItFaults()
+        {
+            using var transport = new DroppableTransport();
+            using var device = CreateStreaming(transport);
+
+            await using var e = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync();
+            device.InvokeStreamMessage(AnalogFrame(1000, 1.5f));
+            device.InvokeStreamMessage(AnalogFrame(1010, 2.5f));
+
+            Assert.True(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+            Assert.Equal(1.5, e.Current.Sample.Value);
+
+            transport.SimulateDrop();
+
+            // Samples decoded before the drop are real measurements; reporting the drop must not
+            // throw them away.
+            Assert.True(await e.MoveNextAsync().AsTask().WaitAsync(MoveNextTimeout));
+            Assert.Equal(2.5, e.Current.Sample.Value);
+
+            await Assert.ThrowsAsync<DeviceNotConnectedException>(
+                () => e.MoveNextAsync().AsTask().WaitAsync(MoveNextTimeout));
+        }
+
+        [Fact]
+        public async Task ADisconnect_EndsTheEnumeration_WithoutThrowing()
+        {
+            using var transport = new DroppableTransport();
+            using var device = CreateStreaming(transport);
+
+            await using var e = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync();
+
+            device.Disconnect();
+
+            // A teardown the caller asked for is the ordinary end of a session, not a failure —
+            // making it throw would mean every clean shutdown ended in an exception.
+            Assert.False(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+        }
+
+        [Fact]
+        public async Task AnAsyncDisconnect_EndsTheEnumeration_WithoutThrowing()
+        {
+            using var transport = new DroppableTransport();
+            using var device = CreateStreaming(transport);
+
+            await using var e = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync();
+
+            await device.DisconnectAsync();
+
+            Assert.False(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+        }
+
+        [Fact]
+        public async Task ADispose_EndsTheEnumeration_WithoutThrowing()
+        {
+            using var transport = new DroppableTransport();
+            var device = CreateStreaming(transport);
+
+            var e = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync();
+
+            // `await using var device` cannot rescue a parked loop — DisposeAsync only runs once the
+            // loop exits — so the loop has to end when something else disposes the device.
+            await device.DisposeAsync();
+
+            Assert.False(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+            await e.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task StartingOnADeviceThatIsNotConnected_ThrowsRatherThanWaiting()
+        {
+            using var transport = new DroppableTransport();
+            using var device = new LiveStreamDevice("Never Connected", transport);
+
+            var thrown = await Assert.ThrowsAsync<DeviceNotConnectedException>(
+                async () =>
+                {
+                    await foreach (var _ in device.StreamSamplesAsync(CancellationToken.None))
+                    {
+                    }
+                });
+
+            Assert.False(thrown.IsShuttingDown);
+        }
+
+        [Fact]
+        public async Task StartingOnADisposedDevice_ThrowsWithIsShuttingDown()
+        {
+            using var transport = new DroppableTransport();
+            var device = CreateStreaming(transport);
+            var enumerable = device.StreamSamplesAsync(CancellationToken.None);
+
+            device.Dispose();
+
+            var thrown = await Assert.ThrowsAsync<DeviceNotConnectedException>(
+                async () =>
+                {
+                    await foreach (var _ in enumerable)
+                    {
+                    }
+                });
+
+            Assert.True(thrown.IsShuttingDown);
+        }
+
+        [Fact]
+        public async Task AfterADrop_ANewEnumerationOnTheRestoredSessionWorks()
+        {
+            using var transport = new DroppableTransport();
+            using var device = CreateStreaming(transport);
+
+            await using (var dropped = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator())
+            {
+                var moveNext = dropped.MoveNextAsync();
+                transport.SimulateDrop();
+                await Assert.ThrowsAsync<DeviceNotConnectedException>(
+                    () => moveNext.AsTask().WaitAsync(MoveNextTimeout));
+            }
+
+            // The documented way back after a drop — including one an automatic reconnect repaired:
+            // the old enumeration is over, and the restored session gets a new one. Nothing about
+            // the drop leaves the device unable to serve it.
+            device.Connect();
+            device.PopulateChannelsFromStatus(StatusFrame(analogCount: 1));
+            AnalogChannel(device, 0).IsEnabled = true;
+            device.StartStreaming();
+
+            await using var resumed = device.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var next = resumed.MoveNextAsync();
+            device.InvokeStreamMessage(AnalogFrame(2000, 3.5f));
+
+            Assert.True(await next.AsTask().WaitAsync(MoveNextTimeout));
+            Assert.Equal(3.5, resumed.Current.Sample.Value);
+        }
+
+        [Fact]
+        public async Task ADropDoesNotDisturbACancellingConsumer()
+        {
+            // Cancellation still wins its own race: it is the consumer's own exit, and it must keep
+            // surfacing as OperationCanceledException rather than as the drop's typed exception.
+            using var transport = new DroppableTransport();
+            using var device = CreateStreaming(transport);
+
+            using var cts = new CancellationTokenSource();
+            var e = device.StreamSamplesAsync(cts.Token).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => moveNext.AsTask().WaitAsync(MoveNextTimeout));
+            await e.DisposeAsync();
+        }
+
+        #region Helpers
+
+        private static LiveStreamDevice CreateStreaming(IStreamTransport transport)
+        {
+            var device = new LiveStreamDevice("TestDevice", transport);
+            device.Connect();
+            device.PopulateChannelsFromStatus(StatusFrame(analogCount: 1));
+            AnalogChannel(device, 0).IsEnabled = true;
+            device.StartStreaming();
+            return device;
+        }
+
+        private static DaqifiOutMessage StatusFrame(int analogCount)
+        {
+            var status = new DaqifiOutMessage
+            {
+                AnalogInPortNum = (uint)analogCount,
+                DigitalPortNum = 0,
+                AnalogInRes = 65535,
+            };
+            for (var i = 0; i < analogCount; i++)
+            {
+                status.AnalogInPortRange.Add(1.0f);
+            }
+            return status;
+        }
+
+        private static IAnalogChannel AnalogChannel(DaqifiStreamingDevice device, int number) =>
+            (IAnalogChannel)device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == number);
+
+        private static DaqifiOutMessage AnalogFrame(uint timestamp, float value)
+        {
+            var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+            frame.AnalogInDataFloat.Add(value);
+            return frame;
+        }
+
+        private sealed class LiveStreamDevice : DaqifiStreamingDevice
+        {
+            public LiveStreamDevice(string name, IStreamTransport transport) : base(name, transport) { }
+
+            public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+
+            // The transport here exists to report a drop, not to carry traffic.
+            public override void Send<T>(IOutboundMessage<T> message) { }
+        }
+
+        /// <summary>
+        /// A transport over an in-memory stream that can report an unexpected drop on command, which
+        /// is all these tests need from it. Mirrors the one in
+        /// <c>DeviceStatusChangedIsolationTests</c>; kept local so neither test file's fake can be
+        /// bent to suit the other.
+        /// </summary>
+        private sealed class DroppableTransport : IStreamTransport
+        {
+            private readonly MemoryStream _stream = new();
+            private bool _isConnected;
+            private bool _disposed;
+
+            public Stream Stream => _disposed
+                ? throw new ObjectDisposedException(nameof(DroppableTransport))
+                : _stream;
+
+            public bool IsConnected => _isConnected && !_disposed;
+
+            public string ConnectionInfo => IsConnected ? "Droppable: Connected" : "Droppable: Disconnected";
+
+            public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+            public Task ConnectAsync() => ConnectAsync(null);
+
+            public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+            {
+                _isConnected = true;
+                StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+                return Task.CompletedTask;
+            }
+
+            public Task DisconnectAsync()
+            {
+                _isConnected = false;
+                StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+                return Task.CompletedTask;
+            }
+
+            public void Connect() => ConnectAsync().GetAwaiter().GetResult();
+
+            public void Disconnect() => DisconnectAsync().GetAwaiter().GetResult();
+
+            /// <summary>Reports an unexpected drop, the way a watchdog would.</summary>
+            public void SimulateDrop()
+            {
+                _isConnected = false;
+                StatusChanged?.Invoke(this, new TransportStatusEventArgs(
+                    false, ConnectionInfo, new TransportNotConnectedException("the device went away")));
+            }
+
+            public void Dispose()
+            {
+                _isConnected = false;
+                _disposed = true;
+                _stream.Dispose();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -197,6 +197,203 @@ public class LiveSampleStreamTests
         }
     }
 
+    // -----------------------------------------------------------------------------------------
+    // Issue #496: an enumeration is bound to the connected session it started in. What the device
+    // observes end to end is pinned by DaqifiStreamingDeviceLiveStreamTerminationTests; these add
+    // what only a direct test can see — the subscription bookkeeping on the new exit paths, several
+    // enumerations at once, and the release that no status transition accompanies.
+    // -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Enumeration_EndedByADrop_UnsubscribesFromEveryChannel()
+    {
+        var host = new FakeHost(new FakeChannel(0), new FakeChannel(1));
+        var stream = new LiveSampleStream(host);
+
+        await using var e = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        var moveNext = e.MoveNextAsync();
+
+        stream.OnConnectionStatusChanged(ConnectionStatus.Lost);
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => moveNext.AsTask().WaitAsync(MoveNextTimeout));
+
+        // The issue's second criterion: the handlers went with the enumeration. A drop that ended
+        // the loop but left it subscribed would still root the device for the rest of its life.
+        Assert.All(host.Channels, c => Assert.Equal(0, c.SubscriberCount));
+    }
+
+    [Fact]
+    public async Task Enumeration_EndedByADeliberateDisconnect_CompletesWithoutThrowing()
+    {
+        var host = new FakeHost(new FakeChannel(0));
+        var stream = new LiveSampleStream(host);
+
+        await using var e = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        var moveNext = e.MoveNextAsync();
+
+        stream.OnConnectionStatusChanged(ConnectionStatus.Disconnected);
+
+        Assert.False(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+        Assert.Equal(0, host.Channels[0].SubscriberCount);
+    }
+
+    [Fact]
+    public async Task Enumeration_EndedByADrop_YieldsWhatWasBufferedFirst()
+    {
+        var host = new FakeHost(new FakeChannel(0));
+        var stream = new LiveSampleStream(host);
+
+        await using var e = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        var moveNext = e.MoveNextAsync();
+        host.Channels[0].RaiseSample(1.0);
+        host.Channels[0].RaiseSample(2.0);
+
+        Assert.True(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+        Assert.Equal(1.0, e.Current.Sample.Value);
+
+        stream.OnConnectionStatusChanged(ConnectionStatus.Lost);
+
+        Assert.True(await e.MoveNextAsync().AsTask().WaitAsync(MoveNextTimeout));
+        Assert.Equal(2.0, e.Current.Sample.Value);
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => e.MoveNextAsync().AsTask().WaitAsync(MoveNextTimeout));
+    }
+
+    [Fact]
+    public async Task Enumeration_ADropFollowedByTheTeardownItCauses_StillReportsTheDrop()
+    {
+        var host = new FakeHost(new FakeChannel(0));
+        var stream = new LiveSampleStream(host);
+
+        await using var e = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        var moveNext = e.MoveNextAsync();
+
+        // The real sequence after an unplug: Lost, then whatever teardown follows it — the reconnect
+        // loop's Retrying, or the Disconnect a consumer issues from its status handler. None of them
+        // may downgrade the drop to an ordinary end of session.
+        stream.OnConnectionStatusChanged(ConnectionStatus.Lost);
+        stream.OnConnectionStatusChanged(ConnectionStatus.Retrying);
+        stream.OnConnectionStatusChanged(ConnectionStatus.Disconnected);
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => moveNext.AsTask().WaitAsync(MoveNextTimeout));
+    }
+
+    [Fact]
+    public async Task Enumeration_EndedByRelease_CompletesEvenWithNoStatusTransition()
+    {
+        var host = new FakeHost(new FakeChannel(0));
+        var stream = new LiveSampleStream(host);
+
+        await using var e = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        var moveNext = e.MoveNextAsync();
+
+        // Disposing a device that is already disconnected moves it nowhere, so the status hook never
+        // fires. This is the path that keeps such a dispose from leaving the loop parked.
+        stream.OnDeviceReleased();
+
+        Assert.False(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+        Assert.Equal(0, host.Channels[0].SubscriberCount);
+    }
+
+    [Fact]
+    public async Task Enumeration_StartedAfterRelease_ThrowsWithIsShuttingDown()
+    {
+        var host = new FakeHost(new FakeChannel(0));
+        var stream = new LiveSampleStream(host);
+        stream.OnDeviceReleased();
+
+        var thrown = await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => ConsumeAsync().WaitAsync(MoveNextTimeout));
+
+        // Latched, not momentary: a disposed device can never produce another sample, so this has to
+        // keep failing rather than park.
+        Assert.True(thrown.IsShuttingDown);
+        Assert.Equal(0, host.SnapshotCalls);
+
+        async Task ConsumeAsync()
+        {
+            await foreach (var _ in stream.StreamSamplesAsync(CancellationToken.None)) { }
+        }
+    }
+
+    [Fact]
+    public async Task Enumeration_StartedWhileDisconnected_ThrowsBeforeSubscribingToAnything()
+    {
+        var host = new FakeHost(new FakeChannel(0)) { IsConnected = false };
+        var stream = new LiveSampleStream(host);
+
+        var thrown = await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => ConsumeAsync().WaitAsync(MoveNextTimeout));
+
+        Assert.False(thrown.IsShuttingDown);
+        Assert.Equal(0, host.SnapshotCalls);
+        Assert.Equal(0, host.Channels[0].SubscriberCount);
+
+        async Task ConsumeAsync()
+        {
+            await foreach (var _ in stream.StreamSamplesAsync(CancellationToken.None)) { }
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentEnumerations_AllEndOnTheSameDrop()
+    {
+        var host = new FakeHost(new FakeChannel(0));
+        var stream = new LiveSampleStream(host);
+
+        await using var first = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        await using var second = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        var firstMove = first.MoveNextAsync();
+        var secondMove = second.MoveNextAsync();
+
+        stream.OnConnectionStatusChanged(ConnectionStatus.Lost);
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => firstMove.AsTask().WaitAsync(MoveNextTimeout));
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => secondMove.AsTask().WaitAsync(MoveNextTimeout));
+        Assert.Equal(0, host.Channels[0].SubscriberCount);
+    }
+
+    [Fact]
+    public async Task ADropAfterTheEnumerationHasEnded_IsANoOp()
+    {
+        var host = new FakeHost(new FakeChannel(0));
+        var stream = new LiveSampleStream(host);
+
+        var e = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        var moveNext = e.MoveNextAsync();
+        host.Channels[0].RaiseSample(1.0);
+        Assert.True(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+        await e.DisposeAsync();
+
+        // A finished enumeration deregisters itself, so the device's own teardown — which always
+        // follows eventually — has nothing left to touch.
+        stream.OnConnectionStatusChanged(ConnectionStatus.Lost);
+        stream.OnDeviceReleased();
+        Assert.Equal(0, host.Channels[0].SubscriberCount);
+    }
+
+    [Fact]
+    public async Task StayingConnected_DoesNotEndAnEnumeration()
+    {
+        var host = new FakeHost(new FakeChannel(0));
+        var stream = new LiveSampleStream(host);
+
+        await using var e = stream.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+        var moveNext = e.MoveNextAsync();
+
+        // The transition a reconnect ends on. Only leaving Connected ends an enumeration; arriving
+        // at it must leave a healthy one alone.
+        stream.OnConnectionStatusChanged(ConnectionStatus.Connected);
+        host.Channels[0].RaiseSample(4.0);
+
+        Assert.True(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+        Assert.Equal(4.0, e.Current.Sample.Value);
+    }
+
     #region Helpers
 
     /// <summary>
@@ -274,10 +471,17 @@ public class LiveSampleStreamTests
             return _channels.ToArray();
         }
 
+        /// <summary>
+        /// In the collaborator's remit since issue #496: an enumeration is only meaningful on a
+        /// connected device, so the start-up guard reads this. Settable so both sides of that guard
+        /// can be exercised. Reading state is still a world away from the members below, which
+        /// <em>do</em> something to the device.
+        /// </summary>
+        public bool IsConnected { get; set; } = true;
+
         // Outside this block's remit — reaching for any of these is a regression, not a refinement.
         // In particular the live path must never send a command or take the channels lock: it is an
         // adapter over events the decoder already raises, and it runs on the decode thread.
-        public bool IsConnected => throw new NotSupportedException();
         public bool IsUsbConnection => throw new NotSupportedException();
         public bool IsStreaming { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
         public int StreamingFrequency => throw new NotSupportedException();

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -475,7 +475,7 @@ namespace Daqifi.Core.Device
             {
                 if (_status == value) return;
                 _status = value;
-                OnConnectionStatusChanged(_status);
+                RaiseConnectionStatusChanged(_status);
                 RaiseStatusChanged(_status);
             }
         }
@@ -494,14 +494,38 @@ namespace Daqifi.Core.Device
         /// </para>
         /// <para>
         /// Runs before <see cref="StatusChanged"/> so that a consumer's handler already sees the
-        /// library's own reaction as done. An override must not throw: an exception here would
-        /// escape the transition itself, which is the failure issue #494 removed from the consumer
-        /// side.
+        /// library's own reaction as done, and is isolated by <see cref="RaiseConnectionStatusChanged"/>
+        /// exactly as a consumer's handler is. An override still has no business throwing, but a
+        /// transition is never allowed to fail — that is the whole of issue #494, and the rule cannot
+        /// be weaker for the library's own code than it is for a consumer's.
         /// </para>
         /// </remarks>
         /// <param name="status">The status the device has just moved to.</param>
         internal virtual void OnConnectionStatusChanged(ConnectionStatus status)
         {
+        }
+
+        /// <summary>
+        /// Calls <see cref="OnConnectionStatusChanged"/>, isolating a throwing override from the
+        /// transition it is reacting to.
+        /// </summary>
+        /// <remarks>
+        /// The same guarantee, for the same reason, as <see cref="RaiseStatusChanged"/> one line
+        /// further on: this runs on the drop path, where an escaping exception used to skip the
+        /// reconnect start and unwind into the transport before it had released the port handle
+        /// (issue #494). A failure here is reported on <see cref="ErrorOccurred"/> and the transition
+        /// completes regardless.
+        /// </remarks>
+        private void RaiseConnectionStatusChanged(ConnectionStatus status)
+        {
+            try
+            {
+                OnConnectionStatusChanged(status);
+            }
+            catch (Exception ex)
+            {
+                RaiseDeviceError(DeviceErrorSource.StatusNotification, ex);
+            }
         }
 
         /// <summary>
@@ -3327,6 +3351,14 @@ namespace Daqifi.Core.Device
             {
                 ReleaseDerivedResources();
             }
+            catch (Exception ex)
+            {
+                // Disposal must not fail on account of the library's own cleanup — the handles
+                // released below are what a caller is actually relying on this for, and a throwing
+                // Dispose would hide them behind an exception nobody can act on. Reported rather
+                // than swallowed.
+                RaiseDeviceError(DeviceErrorSource.Unknown, ex);
+            }
             finally
             {
                 _messageConsumer?.Dispose();
@@ -3345,9 +3377,9 @@ namespace Daqifi.Core.Device
         /// The companion to <see cref="OnConnectionStatusChanged"/>, and internal for the same
         /// reason. It covers the one teardown a status transition cannot: disposing a device that
         /// was never connected, or was already disconnected, moves it nowhere, so nothing would tell
-        /// a live-sample enumeration parked on it that the device is gone (issue #496). Wrapped in a
-        /// <c>try</c> so that an override which throws still cannot leak the transport handle this
-        /// method exists to release.
+        /// a live-sample enumeration parked on it that the device is gone (issue #496). An override
+        /// that throws is caught and reported on <see cref="ErrorOccurred"/>: the handles this method
+        /// exists to release are freed regardless, and <see cref="Dispose()"/> does not fail.
         /// </remarks>
         internal virtual void ReleaseDerivedResources()
         {

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -475,8 +475,33 @@ namespace Daqifi.Core.Device
             {
                 if (_status == value) return;
                 _status = value;
+                OnConnectionStatusChanged(_status);
                 RaiseStatusChanged(_status);
             }
+        }
+
+        /// <summary>
+        /// Tells a derived device inside this library that the connection status has changed, before
+        /// consumers are notified on <see cref="StatusChanged"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Internal rather than protected: this is wiring between this class and the collaborators
+        /// the library ships, not an extension point. It exists because some of those collaborators
+        /// hold work that only makes sense on a live session — the live-sample enumerations behind
+        /// <see cref="DaqifiStreamingDevice.StreamSamplesAsync"/>, which used to park forever once
+        /// the device went away (issue #496).
+        /// </para>
+        /// <para>
+        /// Runs before <see cref="StatusChanged"/> so that a consumer's handler already sees the
+        /// library's own reaction as done. An override must not throw: an exception here would
+        /// escape the transition itself, which is the failure issue #494 removed from the consumer
+        /// side.
+        /// </para>
+        /// </remarks>
+        /// <param name="status">The status the device has just moved to.</param>
+        internal virtual void OnConnectionStatusChanged(ConnectionStatus status)
+        {
         }
 
         /// <summary>
@@ -3298,11 +3323,34 @@ namespace Daqifi.Core.Device
         /// </remarks>
         private void ReleaseResources()
         {
-            _messageConsumer?.Dispose();
-            _messageProducer?.Dispose();
-            _transport?.Dispose();
-            _textExchangeLock.Dispose();
-            _disposed = true;
+            try
+            {
+                ReleaseDerivedResources();
+            }
+            finally
+            {
+                _messageConsumer?.Dispose();
+                _messageProducer?.Dispose();
+                _transport?.Dispose();
+                _textExchangeLock.Dispose();
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Releases what a derived device inside this library owns, ahead of the handles this class
+        /// owns.
+        /// </summary>
+        /// <remarks>
+        /// The companion to <see cref="OnConnectionStatusChanged"/>, and internal for the same
+        /// reason. It covers the one teardown a status transition cannot: disposing a device that
+        /// was never connected, or was already disconnected, moves it nowhere, so nothing would tell
+        /// a live-sample enumeration parked on it that the device is gone (issue #496). Wrapped in a
+        /// <c>try</c> so that an override which throws still cannot leak the transport handle this
+        /// method exists to release.
+        /// </remarks>
+        internal virtual void ReleaseDerivedResources()
+        {
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -572,6 +572,36 @@ namespace Daqifi.Core.Device
         /// device's stream — call <see cref="StopStreaming"/> for that.
         /// </para>
         /// <para>
+        /// <b>An enumeration is bound to the connected session it starts in</b> (issue #496), because
+        /// samples only ever arrive on one. It ends as soon as the device stops being connected, after
+        /// yielding whatever was already buffered:
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>
+        /// A teardown that was asked for — <see cref="DaqifiDevice.Disconnect"/>,
+        /// <see cref="DaqifiDevice.DisconnectAsync"/>, or <see cref="DaqifiDevice.Dispose()"/> — ends
+        /// the <c>await foreach</c> normally.
+        /// </description></item>
+        /// <item><description>
+        /// A drop the caller did not ask for — an unplug, a WiFi loss, a reconnect that gives up —
+        /// throws <see cref="DeviceNotConnectedException"/>. A cut-short acquisition must not be
+        /// indistinguishable from a complete one.
+        /// </description></item>
+        /// <item><description>
+        /// Starting an enumeration on a device that is not connected throws
+        /// <see cref="DeviceNotConnectedException"/> on the first <c>MoveNextAsync</c>, rather than
+        /// waiting for samples that cannot come.
+        /// </description></item>
+        /// </list>
+        /// <para>
+        /// Automatic reconnection (<see cref="DaqifiDevice.ReconnectOptions"/>) does <b>not</b> resume
+        /// an enumeration: the drop ends it, and a caller that wants live samples from the restored
+        /// session starts a new one once <see cref="DaqifiDevice.Status"/> reads
+        /// <see cref="ConnectionStatus.Connected"/> again. Ending is what makes the outcome the same
+        /// whether or not reconnect is enabled, and the restored session may not even be built from
+        /// the same channel objects this enumeration subscribed to.
+        /// </para>
+        /// <para>
         /// This returns <see cref="LiveSampleStream"/>'s async iterator directly rather than wrapping
         /// it in one of its own, which is what keeps the two deferred behaviors a caller can observe
         /// exactly as they were: <c>WithCancellation</c> still reaches the iterator's own
@@ -585,10 +615,38 @@ namespace Daqifi.Core.Device
         /// </param>
         /// <returns>An async stream of <see cref="LiveSample"/> (channel + decoded sample).</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bufferCapacity"/> is less than 1.</exception>
+        /// <exception cref="DeviceNotConnectedException">
+        /// The device is not connected when enumeration starts, or the connection was lost while it
+        /// was running. Both are raised from <c>MoveNextAsync</c>, after any buffered samples.
+        /// </exception>
         public IAsyncEnumerable<LiveSample> StreamSamplesAsync(
             CancellationToken cancellationToken = default,
             int? bufferCapacity = null)
             => _liveSampleStream.StreamSamplesAsync(cancellationToken, bufferCapacity);
+
+        /// <summary>
+        /// Ends the live-sample enumerations when the device stops being connected (issue #496).
+        /// </summary>
+        /// <remarks>
+        /// The only device state that has to react to a transition before consumers do. Everything
+        /// else the streaming device owns is either driven by inbound frames — which stop on their
+        /// own — or torn down by the disconnect itself.
+        /// </remarks>
+        internal override void OnConnectionStatusChanged(ConnectionStatus status)
+        {
+            base.OnConnectionStatusChanged(status);
+
+            // Null only if a transition could somehow beat InitializeStreamingDevice, which no
+            // constructor path allows; cheap enough to not depend on that staying true.
+            _liveSampleStream?.OnConnectionStatusChanged(status);
+        }
+
+        /// <inheritdoc />
+        internal override void ReleaseDerivedResources()
+        {
+            base.ReleaseDerivedResources();
+            _liveSampleStream?.OnDeviceReleased();
+        }
 
         /// <summary>
         /// Handles a streaming data frame by handing it to <see cref="StreamFrameDecoder"/>, which

--- a/src/Daqifi.Core/Device/DeviceErrorSource.cs
+++ b/src/Daqifi.Core/Device/DeviceErrorSource.cs
@@ -52,7 +52,9 @@ public enum DeviceErrorSource
     /// <remarks>
     /// The transition itself already happened and is not rolled back; this reports only that one
     /// consumer callback failed. A cross-thread UI exception is the common cause, since the event
-    /// is raised on whichever background thread observed the change.
+    /// is raised on whichever background thread observed the change. The library's own reaction to a
+    /// transition is isolated the same way and reported here too, so a defect inside Core cannot
+    /// break a transition either.
     /// </remarks>
     StatusNotification = 4,
 }

--- a/src/Daqifi.Core/Device/Internal/LiveSampleStream.cs
+++ b/src/Daqifi.Core/Device/Internal/LiveSampleStream.cs
@@ -28,10 +28,39 @@ namespace Daqifi.Core.Device.Internal
     /// enumeration observes the same channel collection — under the same lock — that the rest of
     /// the device does.
     /// </para>
+    /// <para>
+    /// Every enumeration is bound to the connected session it started in (issue #496). Samples only
+    /// ever arrive while the device is connected, so an enumeration that outlived its session had
+    /// nothing left to wait for and waited anyway — forever, with no exception and no loop exit.
+    /// <see cref="OnConnectionStatusChanged"/> and <see cref="OnDeviceReleased"/> are the two ends
+    /// the device calls to close that out; see <see cref="StreamSamplesAsync"/> for the contract
+    /// they implement.
+    /// </para>
     /// </remarks>
     internal sealed class LiveSampleStream
     {
         private readonly IDeviceOperationHost _host;
+
+        /// <summary>
+        /// Guards <see cref="_enumerations"/> and <see cref="_deviceReleased"/>. Held only for
+        /// bookkeeping: an enumeration is always ended <em>outside</em> it, because completing a
+        /// buffer can schedule the consumer's continuation, and the consumer's exit path takes this
+        /// same lock to deregister itself.
+        /// </summary>
+        private readonly object _enumerationsLock = new object();
+
+        /// <summary>
+        /// The enumerations currently parked on this device, in start order. A live consumer is
+        /// normally alone here; the list exists because nothing stops a caller from running several.
+        /// </summary>
+        private readonly List<Enumeration> _enumerations = new List<Enumeration>();
+
+        /// <summary>
+        /// Set once the device has released its resources. Latched rather than momentary: a disposed
+        /// device can never produce another sample, so an enumeration started afterwards must fail
+        /// rather than park.
+        /// </summary>
+        private bool _deviceReleased;
 
         /// <summary>
         /// Cumulative drop count across every enumeration this collaborator has served. Lives here
@@ -46,6 +75,42 @@ namespace Daqifi.Core.Device.Internal
 
         /// <inheritdoc cref="DaqifiStreamingDevice.DroppedLiveSampleCount"/>
         internal long DroppedSampleCount => Interlocked.Read(ref _droppedSampleCount);
+
+        /// <summary>
+        /// Ends every enumeration in flight when the device stops being connected.
+        /// </summary>
+        /// <remarks>
+        /// Called by the device on every status transition, before consumers are notified. A
+        /// transition to anything other than <see cref="ConnectionStatus.Connected"/> means no
+        /// further samples can arrive on this session, so the enumerations are drained and closed:
+        /// gracefully when the teardown was asked for (<see cref="ConnectionStatus.Disconnected"/>),
+        /// and as a failure otherwise — an unplug reports <see cref="ConnectionStatus.Lost"/>, and a
+        /// consumer that had its acquisition cut short must not mistake it for the end of the data.
+        /// </remarks>
+        /// <param name="status">The status the device has just moved to.</param>
+        internal void OnConnectionStatusChanged(ConnectionStatus status)
+        {
+            if (status == ConnectionStatus.Connected)
+            {
+                return;
+            }
+
+            EndEnumerations(
+                status == ConnectionStatus.Disconnected ? EndReason.Deliberate : EndReason.Dropped,
+                release: false);
+        }
+
+        /// <summary>
+        /// Ends every enumeration in flight, permanently, when the device releases its resources.
+        /// </summary>
+        /// <remarks>
+        /// Disposal reaches here through <see cref="DaqifiDevice.Dispose()"/>'s disconnect in the
+        /// normal case, which has already ended the enumerations by the time this runs. This is what
+        /// covers the case that disconnect cannot: a device that was never connected — or was
+        /// already disconnected — transitions nowhere on the way to being disposed, and an
+        /// enumeration parked on it would otherwise never be told.
+        /// </remarks>
+        internal void OnDeviceReleased() => EndEnumerations(EndReason.Deliberate, release: true);
 
         /// <inheritdoc cref="DaqifiStreamingDevice.StreamSamplesAsync"/>
         internal async IAsyncEnumerable<LiveSample> StreamSamplesAsync(
@@ -65,20 +130,51 @@ namespace Daqifi.Core.Device.Internal
                     FullMode = BoundedChannelFullMode.DropOldest,
                     SingleReader = true,
                     SingleWriter = false,
+
+                    // Explicit because ending an enumeration now happens on whichever thread
+                    // observed the drop — a transport watchdog, mid-teardown. Completing the buffer
+                    // must hand the consumer's continuation to the thread pool rather than run the
+                    // body of somebody's `await foreach` on that thread. This is the default; it is
+                    // spelled out so it cannot be flipped without reading this comment.
+                    AllowSynchronousContinuations = false,
                 },
                 _ => Interlocked.Increment(ref _droppedSampleCount));
+
+            var enumeration = new Enumeration(buffer.Writer);
+
+            // Registered before anything is subscribed, so a teardown landing anywhere after this
+            // point finds the enumeration and ends it. The connectivity guard shares the lock with
+            // the teardown path, which is what makes "released, then registered" impossible.
+            lock (_enumerationsLock)
+            {
+                if (_deviceReleased)
+                {
+                    throw new DeviceNotConnectedException(
+                        "The device has been disposed; live samples can no longer be enumerated.",
+                        isShuttingDown: true);
+                }
+
+                if (!_host.IsConnected)
+                {
+                    throw new DeviceNotConnectedException(
+                        "Device is not connected; live samples can only be enumerated on a connected device.");
+                }
+
+                _enumerations.Add(enumeration);
+            }
 
             void OnSample(object? sender, SampleReceivedEventArgs e) =>
                 buffer.Writer.TryWrite(new LiveSample(e.Channel, e.Sample));
 
-            var channels = _host.SnapshotChannels();
-            foreach (var channel in channels)
-            {
-                channel.SampleReceived += OnSample;
-            }
-
+            IReadOnlyList<IChannel> channels = Array.Empty<IChannel>();
             try
             {
+                channels = _host.SnapshotChannels();
+                foreach (var channel in channels)
+                {
+                    channel.SampleReceived += OnSample;
+                }
+
                 await foreach (var sample in buffer.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
                 {
                     yield return sample;
@@ -91,6 +187,92 @@ namespace Daqifi.Core.Device.Internal
                     channel.SampleReceived -= OnSample;
                 }
                 buffer.Writer.TryComplete();
+
+                lock (_enumerationsLock)
+                {
+                    _enumerations.Remove(enumeration);
+                }
+            }
+
+            // Reached only when the buffer completed and drained — a caller that breaks out of the
+            // loop disposes the enumerator instead and never gets here. Everything already buffered
+            // has been yielded by now, so the drop is reported after the last good sample rather
+            // than in place of it.
+            if (enumeration.Reason == EndReason.Dropped)
+            {
+                throw new DeviceNotConnectedException(
+                    "The device connection was lost while live samples were being enumerated.");
+            }
+        }
+
+        /// <summary>
+        /// Ends the enumerations currently registered, optionally latching the device as released.
+        /// </summary>
+        private void EndEnumerations(EndReason reason, bool release)
+        {
+            Enumeration[] ending;
+            lock (_enumerationsLock)
+            {
+                if (release)
+                {
+                    _deviceReleased = true;
+                }
+
+                if (_enumerations.Count == 0)
+                {
+                    return;
+                }
+
+                ending = _enumerations.ToArray();
+            }
+
+            // Outside the lock on purpose: completing a buffer releases the consumer, whose exit
+            // path deregisters itself under this same lock.
+            foreach (var enumeration in ending)
+            {
+                enumeration.End(reason);
+            }
+        }
+
+        /// <summary>
+        /// Why an enumeration stopped, which is what decides whether the consumer's
+        /// <c>await foreach</c> ends or throws.
+        /// </summary>
+        private enum EndReason
+        {
+            /// <summary>Still running, or ended by the consumer itself (cancellation, or a break).</summary>
+            None = 0,
+
+            /// <summary>The session was torn down on request — a disconnect, or a dispose.</summary>
+            Deliberate,
+
+            /// <summary>The connection went away underneath the enumeration.</summary>
+            Dropped,
+        }
+
+        /// <summary>
+        /// One in-flight enumeration, as the teardown paths see it: something to complete, plus the
+        /// reason the consumer needs once it drains.
+        /// </summary>
+        private sealed class Enumeration
+        {
+            private readonly ChannelWriter<LiveSample> _writer;
+            private int _reason;
+
+            internal Enumeration(ChannelWriter<LiveSample> writer)
+            {
+                _writer = writer;
+            }
+
+            internal EndReason Reason => (EndReason)Volatile.Read(ref _reason);
+
+            internal void End(EndReason reason)
+            {
+                // First reason wins. A drop is always followed by more transitions — the reconnect
+                // loop's teardown, or the disconnect a consumer issues when it sees `Lost` — and
+                // none of them may downgrade the unplug the consumer still has to be told about.
+                Interlocked.CompareExchange(ref _reason, (int)reason, (int)EndReason.None);
+                _writer.TryComplete();
             }
         }
     }


### PR DESCRIPTION
## What was wrong

If you consumed live samples the documented way —

```csharp
await foreach (var s in device.StreamSamplesAsync()) { ... }
```

— and the USB cable was pulled, the loop just stopped. No samples, no exception, no exit: it waited forever on a device the rest of the library had already reported as `Lost`. Every channel subscription stayed attached, so the dead enumeration also kept the device alive. `await using var device` was no help, because `DisposeAsync` only runs *after* the loop exits, and the loop was never going to exit. This was the one consumer surface that could not observe a drop the library detects everywhere else.

## How it was fixed

An enumeration is now tied to the connected session it started in, which is the only session samples can arrive on, and it ends as soon as the device stops being connected — after yielding whatever was already buffered. A teardown you asked for (`Disconnect`, `DisconnectAsync`, `Dispose`) ends the `await foreach` normally; a drop nobody asked for throws `DeviceNotConnectedException`; and starting one on a device that is not connected throws straight away instead of parking.

Two things worth pushing back on:

- **A drop throws rather than ending quietly.** A silent end would mean an acquisition cut short by a pulled cable looks exactly like one that finished — a bad failure mode for measurement data — so the unexpected case is loud and the deliberate one is not. `IsShuttingDown` on the exception distinguishes a dispose from a drop.
- **Automatic reconnect does not resume an enumeration.** The drop ends it and the caller starts a new one once `Status` reads `Connected` again. Resuming was the alternative, but it would make behaviour depend on whether reconnect happened to be enabled, and the restored session need not even be built from the same channel objects the enumeration subscribed to — which is how you get a loop that silently never yields again.

The signals reach the stream through two new **internal** `virtual` hooks on `DaqifiDevice` (a status transition, and the resource release that covers disposing a device which transitions nowhere). Nothing widens the public API.

## Verification

- 19 new tests: 9 driving the whole path a real drop takes through a droppable transport, 10 on the collaborator for the subscription bookkeeping, concurrent enumerations, and the release that no status transition accompanies. Verified they catch the bug: against `origin/main` the first one fails and the run then **wedges** — a parked async iterator's `DisposeAsync` never returns, which is the reported failure mode exactly.
- Full suite green on **net9.0** (2940 Core + 43 Mcp) and **net10.0** (2940), 0 failures, 0 warnings.
- **Bench, fw 3.7.2 on `/dev/cu.usbmodem1101`** (non-destructive; serial only): 1190 live samples pulled through `StreamSamplesAsync` at 500 Hz, then `DisconnectAsync` while the loop was parked — the loop ended 516 ms later with no exception. Enumerating the disconnected device then threw `DeviceNotConnectedException(IsShuttingDown=false)`, and the disposed device `IsShuttingDown=true`. Device healthy at exit: `sn=9090539562006014104`, fw unchanged, clean `Disconnected`. No reboot, format, delete, `SD:GET`, firmware or LAN writes. The unplug path itself is covered by the scripted-transport tests rather than by physically pulling the cable.

closes #496

Not merging — for review.