### PR TITLE
fix(transport): the sync Connect() helpers no longer freeze a UI thread

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,15 @@ All code changes go through a pull request:
 3. Open a PR against `main` describing the change and linking any related issue.
 4. CI must pass and the PR needs review before merge.
 
+### Awaits in `Daqifi.Core` must be `ConfigureAwait(false)`
+
+`Daqifi.Core` ships synchronous facades (`DaqifiDevice.Connect()`,
+`DaqifiDeviceFactory.ConnectTcp`/`ConnectSerial`, `IStreamTransport.Connect`/`Disconnect`)
+that block on their own async work. An `await` that resumes on the caller's
+`SynchronizationContext` therefore deadlocks a WPF/WinForms app calling from the UI
+thread. CA2007 is enabled for the library project (see `src/Daqifi.Core/.editorconfig`)
+and warnings are errors, so a naked `await` fails the build. Test projects are exempt.
+
 ## Security: how we do and don't accept code
 
 **We only ever accept code changes as pull requests against this repository.** A PR gives

--- a/src/Daqifi.Core.Tests/Communication/Transport/SynchronizationContextDeadlockTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SynchronizationContextDeadlockTests.cs
@@ -1,0 +1,300 @@
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Daqifi.Core.Tests.Communication.Transport;
+
+/// <summary>
+/// Pins the fix for issue #495: the library's synchronous facades block on their own async
+/// work (<c>ConnectAsync().GetAwaiter().GetResult()</c>), so every await underneath them must
+/// resume on the thread pool rather than on the caller's <see cref="SynchronizationContext"/>.
+/// A WPF/WinForms app that calls <see cref="DaqifiDeviceFactory.ConnectTcp(IPAddress,int,DeviceConnectionOptions?)"/>
+/// on the UI thread otherwise freezes permanently: the continuation is posted back to a context
+/// that is already blocked inside <c>GetResult()</c>, with no timeout and no exception.
+///
+/// Each test runs the blocking call on a dedicated thread that has a UI-like, single-threaded
+/// context installed and never pumps it. If a naked <c>await</c> survives anywhere on the path,
+/// the thread never returns and the test fails on the join timeout instead of hanging the run.
+/// </summary>
+public class SynchronizationContextDeadlockTests
+{
+    private static readonly TimeSpan JoinTimeout = TimeSpan.FromSeconds(10);
+
+    #region Harness
+
+    /// <summary>
+    /// A stand-in for a UI dispatcher: continuations posted to it are queued and only run when
+    /// the owning thread pumps. The owning thread here is blocked inside a synchronous facade
+    /// and never pumps, which is exactly the condition that deadlocks a WPF app.
+    /// </summary>
+    private sealed class BlockedSynchronizationContext : SynchronizationContext
+    {
+        private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _queue = new();
+
+        public override void Post(SendOrPostCallback d, object? state) => _queue.Add((d, state));
+
+        public override void Send(SendOrPostCallback d, object? state) =>
+            throw new NotSupportedException(
+                "Nothing on the connect path may call Send: a synchronous dispatch from a thread " +
+                "that is already blocked deadlocks just as surely as a posted continuation.");
+
+        public override SynchronizationContext CreateCopy() => this;
+
+        /// <summary>
+        /// Runs the queued continuations from another thread so a failed (i.e. genuinely
+        /// deadlocked) run does not leak a permanently blocked thread into the rest of the suite.
+        /// Only cleanup — the assertion has already been decided by the time this runs.
+        /// </summary>
+        public void DrainUntil(Thread blocked)
+        {
+            var elapsed = Stopwatch.StartNew();
+            while (blocked.IsAlive && elapsed.Elapsed < TimeSpan.FromSeconds(10))
+            {
+                if (!_queue.TryTake(out var work, millisecondsTimeout: 50))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    work.Callback(work.State);
+                }
+                catch
+                {
+                    // Cleanup path: an exception here cannot change a verdict already reached.
+                }
+            }
+        }
+    }
+
+    private sealed record BlockingRun(bool Completed, Exception? Error);
+
+    /// <summary>
+    /// Runs <paramref name="body"/> on a fresh thread under a never-pumped single-threaded
+    /// context and reports whether it returned within <paramref name="timeout"/>.
+    /// </summary>
+    private static BlockingRun RunBlocking(Action body, TimeSpan? timeout = null)
+    {
+        var context = new BlockedSynchronizationContext();
+        Exception? error = null;
+
+        var thread = new Thread(() =>
+        {
+            var previous = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(context);
+            try
+            {
+                body();
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(previous);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = nameof(BlockedSynchronizationContext)
+        };
+
+        thread.Start();
+        var completed = thread.Join(timeout ?? JoinTimeout);
+        if (!completed)
+        {
+            context.DrainUntil(thread);
+        }
+
+        return new BlockingRun(completed, error);
+    }
+
+    private static async Task NakedDelayAsync() => await Task.Delay(20);
+
+    private static async Task ConfiguredDelayAsync() => await Task.Delay(20).ConfigureAwait(false);
+
+    #endregion
+
+    #region Harness self-checks
+
+    /// <summary>
+    /// Without this test the others could pass vacuously — a harness that never reproduces the
+    /// deadlock proves nothing about the fix. A naked await under the blocked context must hang.
+    /// </summary>
+    [Fact]
+    public void Harness_NakedAwaitBlockedOnTheContext_Deadlocks()
+    {
+        var run = RunBlocking(() => NakedDelayAsync().GetAwaiter().GetResult(), TimeSpan.FromSeconds(2));
+
+        Assert.False(
+            run.Completed,
+            "The harness failed to reproduce the #495 deadlock, so the other tests in this class prove nothing.");
+    }
+
+    [Fact]
+    public void Harness_ConfiguredAwaitBlockedOnTheContext_Completes()
+    {
+        var run = RunBlocking(() => ConfiguredDelayAsync().GetAwaiter().GetResult());
+
+        Assert.True(run.Completed, "ConfigureAwait(false) should resume on the thread pool, not the blocked context.");
+        Assert.Null(run.Error);
+    }
+
+    #endregion
+
+    #region Transports
+
+    [Fact]
+    public void TcpStreamTransport_ConnectAndDisconnect_UnderBlockedContext_Complete()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        // No explicit accept: the OS completes the handshake into the listen backlog, which is
+        // all the dial needs, and it keeps a blocking Task.Result out of the test body.
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        try
+        {
+            using var transport = new TcpStreamTransport(IPAddress.Loopback, port);
+
+            var run = RunBlocking(() =>
+            {
+                transport.Connect();
+                transport.Disconnect();
+            });
+
+            Assert.True(run.Completed, "TcpStreamTransport.Connect()/Disconnect() deadlocked under a UI-like context.");
+            Assert.Null(run.Error);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    /// <summary>
+    /// The serial case named in #495: the first <c>Open()</c> after a re-plug fails, retry engages,
+    /// and the connect path parks on <c>await Task.Delay(backoff)</c>. That delay's continuation is
+    /// what a blocked UI thread would never run.
+    /// </summary>
+    [Fact]
+    public void SerialStreamTransport_ConnectWithRetry_UnderBlockedContext_ThrowsInsteadOfHanging()
+    {
+        using var transport = new SerialStreamTransport("COM999");
+        var retry = new ConnectionRetryOptions
+        {
+            Enabled = true,
+            MaxAttempts = 2,
+            InitialDelay = TimeSpan.FromMilliseconds(50),
+            MaxDelay = TimeSpan.FromMilliseconds(50),
+            BackoffMultiplier = 1.0,
+            ConnectionTimeout = TimeSpan.FromSeconds(1)
+        };
+
+        var run = RunBlocking(() => transport.ConnectAsync(retry).GetAwaiter().GetResult());
+
+        Assert.True(run.Completed, "SerialStreamTransport connect-with-retry deadlocked under a UI-like context.");
+        Assert.NotNull(run.Error);
+        Assert.False(transport.IsConnected);
+    }
+
+    [Fact]
+    public void UdpTransport_OpenAndClose_UnderBlockedContext_Complete()
+    {
+        using var transport = new UdpTransport();
+
+        var run = RunBlocking(() =>
+        {
+            transport.Open();
+            transport.Close();
+        });
+
+        Assert.True(run.Completed, "UdpTransport.Open()/Close() deadlocked under a UI-like context.");
+        Assert.Null(run.Error);
+        Assert.False(transport.IsOpen);
+    }
+
+    #endregion
+
+    #region Retry scaffolding
+
+    /// <summary>
+    /// <see cref="ConnectRetryExecutor"/> is the one place both transports share, and the backoff
+    /// delay it awaits is the single await most likely to strand a blocked caller.
+    /// </summary>
+    [Fact]
+    public void ConnectRetryExecutor_BackoffDelay_UnderBlockedContext_ResumesAndRetries()
+    {
+        var attempts = 0;
+        var retry = new ConnectionRetryOptions
+        {
+            Enabled = true,
+            MaxAttempts = 2,
+            InitialDelay = TimeSpan.FromMilliseconds(50),
+            MaxDelay = TimeSpan.FromMilliseconds(50),
+            BackoffMultiplier = 1.0,
+            ConnectionTimeout = TimeSpan.FromSeconds(1)
+        };
+
+        var run = RunBlocking(() =>
+            ConnectRetryExecutor.ExecuteAsync(
+                retry,
+                connectAttempt: (_, _) =>
+                {
+                    // First attempt fails the way a just-re-plugged port does, forcing the
+                    // executor through its backoff delay before the second attempt.
+                    attempts++;
+                    return attempts == 1
+                        ? Task.FromException(new IOException("port busy"))
+                        : Task.CompletedTask;
+                },
+                onAttemptFailed: () => { },
+                onStatusChanged: (_, _) => { }).GetAwaiter().GetResult());
+
+        Assert.True(run.Completed, "ConnectRetryExecutor deadlocked on its backoff delay under a UI-like context.");
+        Assert.Null(run.Error);
+        Assert.Equal(2, attempts);
+    }
+
+    #endregion
+
+    #region Factory facades
+
+    /// <summary>
+    /// The entry point the issue names: a WPF app calling the sync factory helper on its UI thread.
+    /// Device initialization is switched off because a bare loopback listener answers no SCPI —
+    /// the deadlock being pinned is in the connect path, which runs either way.
+    /// </summary>
+    [Fact]
+    public void DaqifiDeviceFactory_ConnectTcp_UnderBlockedContext_Completes()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        DaqifiStreamingDevice? device = null;
+
+        try
+        {
+            var run = RunBlocking(() =>
+                device = DaqifiDeviceFactory.ConnectTcp(
+                    IPAddress.Loopback,
+                    port,
+                    new DeviceConnectionOptions { InitializeDevice = false }));
+
+            Assert.True(run.Completed, "DaqifiDeviceFactory.ConnectTcp deadlocked under a UI-like context.");
+            Assert.Null(run.Error);
+            Assert.NotNull(device);
+        }
+        finally
+        {
+            device?.Dispose();
+            listener.Stop();
+        }
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core/.editorconfig
+++ b/src/Daqifi.Core/.editorconfig
@@ -1,0 +1,15 @@
+# Analyzer configuration for the Daqifi.Core library only.
+#
+# Daqifi.Core ships synchronous facades that block on their own async work
+# (DaqifiDevice.Connect(), DaqifiDeviceFactory.ConnectTcp/ConnectSerial,
+# IStreamTransport.Connect/Disconnect, ...). Under a single-threaded
+# SynchronizationContext — a WPF/WinForms UI thread — a naked `await` posts its
+# continuation back to that context, which is already blocked inside
+# GetAwaiter().GetResult(), and the application deadlocks with no timeout and no
+# exception (issue #495).
+#
+# CA2007 makes that a build error rather than a code-review habit. Library code
+# has no business resuming on the caller's context, so the rule applies to every
+# await in this project, not just the connect path.
+[*.cs]
+dotnet_diagnostic.CA2007.severity = warning

--- a/src/Daqifi.Core/Communication/Transport/ConnectRetryExecutor.cs
+++ b/src/Daqifi.Core/Communication/Transport/ConnectRetryExecutor.cs
@@ -66,11 +66,11 @@ internal static class ConnectRetryExecutor
                     var delay = options.CalculateDelay(attempt);
                     if (delay > TimeSpan.Zero)
                     {
-                        await Task.Delay(delay, cancellationToken);
+                        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                     }
                 }
 
-                await connectAttempt(options, cancellationToken);
+                await connectAttempt(options, cancellationToken).ConfigureAwait(false);
                 onStatusChanged(true, null);
                 return; // Success!
             }

--- a/src/Daqifi.Core/Communication/Transport/IStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/IStreamTransport.cs
@@ -30,13 +30,15 @@ public interface IStreamTransport : IDisposable
     /// Occurs when the connection status changes.
     /// </summary>
     /// <remarks>
-    /// Handlers run synchronously on whatever thread raised the change, and that is never
-    /// guaranteed to be the thread that asked for the connection. A drop is reported from the
-    /// watchdog or reader thread that detected it, and the connect path deliberately resumes off
-    /// the caller's <see cref="SynchronizationContext"/> so the synchronous
-    /// <see cref="Connect"/>/<see cref="Disconnect"/> facades cannot deadlock a UI thread
-    /// (issue #495) — so a successful connect is reported from a thread-pool thread too. A UI
-    /// consumer must marshal to its own dispatcher before touching controls.
+    /// Handlers run synchronously on whatever thread raised the change, and no particular thread
+    /// is guaranteed. A drop is raised from the watchdog or reader thread that detected it. A
+    /// connect is raised from a thread-pool thread when the dial actually suspends, or inline on
+    /// the calling thread when it does not — the connect path deliberately resumes off the
+    /// caller's <see cref="SynchronizationContext"/> so the synchronous <see cref="Connect"/> and
+    /// <see cref="Disconnect"/> facades cannot deadlock a UI thread (issue #495), but
+    /// <c>ConfigureAwait(false)</c> only declines the context, it does not force a thread hop.
+    /// Treat the thread as arbitrary: a UI consumer must marshal to its own dispatcher before
+    /// touching controls.
     /// </remarks>
     event EventHandler<TransportStatusEventArgs>? StatusChanged;
 

--- a/src/Daqifi.Core/Communication/Transport/IStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/IStreamTransport.cs
@@ -29,6 +29,15 @@ public interface IStreamTransport : IDisposable
     /// <summary>
     /// Occurs when the connection status changes.
     /// </summary>
+    /// <remarks>
+    /// Handlers run synchronously on whatever thread raised the change, and that is never
+    /// guaranteed to be the thread that asked for the connection. A drop is reported from the
+    /// watchdog or reader thread that detected it, and the connect path deliberately resumes off
+    /// the caller's <see cref="SynchronizationContext"/> so the synchronous
+    /// <see cref="Connect"/>/<see cref="Disconnect"/> facades cannot deadlock a UI thread
+    /// (issue #495) — so a successful connect is reported from a thread-pool thread too. A UI
+    /// consumer must marshal to its own dispatcher before touching controls.
+    /// </remarks>
     event EventHandler<TransportStatusEventArgs>? StatusChanged;
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Transport/IUdpTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/IUdpTransport.cs
@@ -21,6 +21,13 @@ public interface IUdpTransport : IDisposable
     /// <summary>
     /// Occurs when the transport status changes.
     /// </summary>
+    /// <remarks>
+    /// Handlers run synchronously on whatever thread raised the change, which is not guaranteed
+    /// to be the caller's — the library resumes its awaits off the caller's
+    /// <see cref="SynchronizationContext"/> so its synchronous facades cannot deadlock a UI
+    /// thread (issue #495). A UI consumer must marshal to its own dispatcher before touching
+    /// controls.
+    /// </remarks>
     event EventHandler<TransportStatusEventArgs>? StatusChanged;
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Transport/IUdpTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/IUdpTransport.cs
@@ -22,10 +22,11 @@ public interface IUdpTransport : IDisposable
     /// Occurs when the transport status changes.
     /// </summary>
     /// <remarks>
-    /// Handlers run synchronously on whatever thread raised the change, which is not guaranteed
-    /// to be the caller's — the library resumes its awaits off the caller's
-    /// <see cref="SynchronizationContext"/> so its synchronous facades cannot deadlock a UI
-    /// thread (issue #495). A UI consumer must marshal to its own dispatcher before touching
+    /// Handlers run synchronously on whatever thread raised the change, and no particular thread
+    /// is guaranteed — it may be the caller's or a thread-pool thread. The library resumes its
+    /// awaits off the caller's <see cref="SynchronizationContext"/> so its synchronous facades
+    /// cannot deadlock a UI thread (issue #495), but that only declines the context, it does not
+    /// force a thread hop. A UI consumer must marshal to its own dispatcher before touching
     /// controls.
     /// </remarks>
     event EventHandler<TransportStatusEventArgs>? StatusChanged;

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -232,7 +232,7 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     /// </exception>
     public async Task ConnectAsync()
     {
-        await ConnectAsync(null);
+        await ConnectAsync(null).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -246,13 +246,13 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     /// </exception>
     public async Task ConnectAsync(ConnectionRetryOptions? retryOptions)
     {
-        await ConnectAsync(retryOptions, CancellationToken.None);
+        await ConnectAsync(retryOptions, CancellationToken.None).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task ConnectAsync(CancellationToken cancellationToken)
     {
-        await ConnectAsync(null, cancellationToken);
+        await ConnectAsync(null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -346,7 +346,7 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
                 _serialPort = null;
             },
             onStatusChanged: OnStatusChanged,
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         StartDropDetection();
     }
@@ -394,7 +394,7 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
             OnStatusChanged(false, null);
         }
 
-        await Task.CompletedTask;
+        await Task.CompletedTask.ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/TcpStreamTransport.cs
@@ -199,7 +199,7 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
     /// </exception>
     public async Task ConnectAsync()
     {
-        await ConnectAsync(null);
+        await ConnectAsync(null).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -213,13 +213,13 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
     /// </exception>
     public async Task ConnectAsync(ConnectionRetryOptions? retryOptions)
     {
-        await ConnectAsync(retryOptions, CancellationToken.None);
+        await ConnectAsync(retryOptions, CancellationToken.None).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task ConnectAsync(CancellationToken cancellationToken)
     {
-        await ConnectAsync(null, cancellationToken);
+        await ConnectAsync(null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -262,7 +262,7 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
 
                 try
                 {
-                    await connectTask.WaitAsync(cts.Token);
+                    await connectTask.WaitAsync(cts.Token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException oce)
                     when (cts.IsCancellationRequested && !attemptToken.IsCancellationRequested)
@@ -295,7 +295,7 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
                 _networkStream = null;
             },
             onStatusChanged: OnStatusChanged,
-            cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         _watchdog.Arm();
     }
@@ -358,7 +358,7 @@ public class TcpStreamTransport : IStreamTransport, ITransportHealthSink
             OnStatusChanged(false, null);
         }
 
-        await Task.CompletedTask;
+        await Task.CompletedTask.ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Communication/Transport/UdpTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/UdpTransport.cs
@@ -99,7 +99,7 @@ public class UdpTransport : IUdpTransport
             _udpClient.Client.SendTimeout = 5000;
 
             OnStatusChanged(true, null);
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -135,7 +135,7 @@ public class UdpTransport : IUdpTransport
             OnStatusChanged(false, null);
         }
 
-        await Task.CompletedTask;
+        await Task.CompletedTask.ConfigureAwait(false);
     }
 
     /// <summary>
@@ -152,7 +152,7 @@ public class UdpTransport : IUdpTransport
             throw new InvalidOperationException("UDP transport is not open.");
 
         var broadcastEndPoint = new IPEndPoint(IPAddress.Broadcast, port);
-        await _udpClient!.SendAsync(data, data.Length, broadcastEndPoint);
+        await _udpClient!.SendAsync(data, data.Length, broadcastEndPoint).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -168,7 +168,7 @@ public class UdpTransport : IUdpTransport
         if (!IsOpen)
             throw new InvalidOperationException("UDP transport is not open.");
 
-        await _udpClient!.SendAsync(data, data.Length, endPoint);
+        await _udpClient!.SendAsync(data, data.Length, endPoint).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -184,7 +184,7 @@ public class UdpTransport : IUdpTransport
         if (!IsOpen)
             throw new InvalidOperationException("UDP transport is not open.");
 
-        await _udpClient!.SendAsync(data, data.Length, endPoint);
+        await _udpClient!.SendAsync(data, data.Length, endPoint).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -211,7 +211,7 @@ public class UdpTransport : IUdpTransport
 
                 try
                 {
-                    result = await _udpClient!.ReceiveAsync(cts.Token);
+                    result = await _udpClient!.ReceiveAsync(cts.Token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -221,7 +221,7 @@ public class UdpTransport : IUdpTransport
             }
             else
             {
-                result = await _udpClient!.ReceiveAsync(cancellationToken);
+                result = await _udpClient!.ReceiveAsync(cancellationToken).ConfigureAwait(false);
             }
 
             return (result.Buffer, result.RemoteEndPoint);

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -244,7 +244,7 @@ public class SerialDeviceFinder : DeviceFinderBase
         ThrowIfDisposed();
 
         // Prevent concurrent discovery operations
-        await DiscoverySemaphore.WaitAsync(cancellationToken);
+        await DiscoverySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             var discoveredDevices = new List<IDeviceInfo>();
@@ -582,7 +582,7 @@ public class SerialDeviceFinder : DeviceFinderBase
             port.DtrEnable = true;
 
             // Wait for device to wake up (devices need time after DTR is enabled)
-            await Task.Delay(DeviceWakeUpDelayMs, cancellationToken);
+            await Task.Delay(DeviceWakeUpDelayMs, cancellationToken).ConfigureAwait(false);
 
             // Set up message producer and consumer
             var stream = port.BaseStream;
@@ -640,7 +640,7 @@ public class SerialDeviceFinder : DeviceFinderBase
                 {
                     await Task.WhenAny(
                         messageReceived.Task,
-                        Task.Delay(remainingTime, cancellationToken));
+                        Task.Delay(remainingTime, cancellationToken)).ConfigureAwait(false);
                 }
             }
 
@@ -710,7 +710,7 @@ public class SerialDeviceFinder : DeviceFinderBase
                 if (port is { IsOpen: true })
                 {
                     port.DtrEnable = false;
-                    await Task.Delay(50); // Give DTR time to be processed
+                    await Task.Delay(50).ConfigureAwait(false); // Give DTR time to be processed
                     port.Close();
                 }
 

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -85,7 +85,7 @@ public class WiFiDeviceFinder : DeviceFinderBase
     /// <returns>A task containing the collection of discovered devices.</returns>
     public override async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
     {
-        return await DiscoverAsync(Timeout.InfiniteTimeSpan, cancellationToken);
+        return await DiscoverAsync(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -217,7 +217,7 @@ public class WiFiDeviceFinder : DeviceFinderBase
         ThrowIfDisposed();
 
         // Prevent concurrent discovery operations
-        await DiscoverySemaphore.WaitAsync(cancellationToken);
+        await DiscoverySemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             var discoveredDevices = new List<IDeviceInfo>();
@@ -268,7 +268,7 @@ public class WiFiDeviceFinder : DeviceFinderBase
                             // it). Devices that reply to source-port still reach us either way.
                             udp.Client.Bind(new IPEndPoint(interfaceInfo.LocalAddress, 0));
                         }
-                        await udp.SendAsync(_queryCommandBytes, _queryCommandBytes.Length, interfaceInfo.BroadcastEndpoint);
+                        await udp.SendAsync(_queryCommandBytes, _queryCommandBytes.Length, interfaceInfo.BroadcastEndpoint).ConfigureAwait(false);
                         perNicClients.Add((udp, interfaceInfo.LocalAddress));
                         added = true;
                     }
@@ -296,7 +296,7 @@ public class WiFiDeviceFinder : DeviceFinderBase
                     .Select(c => ReceiveLoopAsync(c.Client, c.LocalAddress, discoveredDevices, cts.Token))
                     .ToArray();
 
-                await Task.WhenAll(receiveTasks);
+                await Task.WhenAll(receiveTasks).ConfigureAwait(false);
             }
             finally
             {
@@ -326,7 +326,7 @@ public class WiFiDeviceFinder : DeviceFinderBase
             UdpReceiveResult result;
             try
             {
-                result = await udp.ReceiveAsync(cancellationToken);
+                result = await udp.ReceiveAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/Daqifi.Core/Device/IDevice.cs
+++ b/src/Daqifi.Core/Device/IDevice.cs
@@ -42,6 +42,15 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Occurs when the device status changes.
         /// </summary>
+        /// <remarks>
+        /// Handlers run synchronously on whatever thread raised the change, and that is never
+        /// guaranteed to be the thread that asked for the connection: a drop is reported from the
+        /// watchdog or reader thread that detected it, a reconnect from the reconnect supervisor,
+        /// and — because the library resumes its awaits off the caller's
+        /// <see cref="SynchronizationContext"/> so the synchronous <see cref="Connect"/> facade
+        /// cannot deadlock a UI thread (issue #495) — a successful connect from a thread-pool
+        /// thread. A UI consumer must marshal to its own dispatcher before touching controls.
+        /// </remarks>
         event EventHandler<DeviceStatusEventArgs> StatusChanged;
 
         /// <summary>

--- a/src/Daqifi.Core/Device/IDevice.cs
+++ b/src/Daqifi.Core/Device/IDevice.cs
@@ -43,13 +43,14 @@ namespace Daqifi.Core.Device
         /// Occurs when the device status changes.
         /// </summary>
         /// <remarks>
-        /// Handlers run synchronously on whatever thread raised the change, and that is never
-        /// guaranteed to be the thread that asked for the connection: a drop is reported from the
-        /// watchdog or reader thread that detected it, a reconnect from the reconnect supervisor,
-        /// and — because the library resumes its awaits off the caller's
-        /// <see cref="SynchronizationContext"/> so the synchronous <see cref="Connect"/> facade
-        /// cannot deadlock a UI thread (issue #495) — a successful connect from a thread-pool
-        /// thread. A UI consumer must marshal to its own dispatcher before touching controls.
+        /// Handlers run synchronously on whatever thread raised the change, and no particular
+        /// thread is guaranteed: a drop is raised from the watchdog or reader thread that detected
+        /// it, a reconnect from the reconnect supervisor, and a connect either from a thread-pool
+        /// thread or inline on the calling thread depending on whether the dial suspended. The
+        /// library resumes its awaits off the caller's <see cref="SynchronizationContext"/> so the
+        /// synchronous <see cref="Connect"/> facade cannot deadlock a UI thread (issue #495), but
+        /// that only declines the context — it is not a promise of a thread hop. Treat the thread
+        /// as arbitrary: a UI consumer must marshal to its own dispatcher before touching controls.
         /// </remarks>
         event EventHandler<DeviceStatusEventArgs> StatusChanged;
 

--- a/src/Daqifi.Core/Device/Network/NetworkConfigurationOperations.cs
+++ b/src/Daqifi.Core/Device/Network/NetworkConfigurationOperations.cs
@@ -149,7 +149,7 @@ namespace Daqifi.Core.Device.Network
             // while the device is sitting on a different network.
             try
             {
-                await Task.Delay(WIFI_MODULE_RESTART_DELAY_MS, cancellationToken);
+                await Task.Delay(WIFI_MODULE_RESTART_DELAY_MS, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -126,7 +126,7 @@ public sealed class SdCardCsvFileParser
     {
         ArgumentNullException.ThrowIfNull(filePath);
 
-        await using var fileStream = new FileStream(
+        var fileStream = new FileStream(
             filePath,
             FileMode.Open,
             FileAccess.Read,
@@ -134,7 +134,10 @@ public sealed class SdCardCsvFileParser
             bufferSize: options?.BufferSize ?? 64 * 1024,
             useAsync: true);
 
-        return await ParseAsync(fileStream, Path.GetFileName(filePath), options, ct);
+        await using (fileStream.ConfigureAwait(false))
+        {
+            return await ParseAsync(fileStream, Path.GetFileName(filePath), options, ct).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -137,7 +137,7 @@ public sealed class SdCardFileParser
             throw new ArgumentOutOfRangeException(nameof(options), "BufferSize must be greater than zero.");
         }
 
-        await using var stream = new FileStream(
+        var stream = new FileStream(
             filePath,
             FileMode.Open,
             FileAccess.Read,
@@ -145,7 +145,10 @@ public sealed class SdCardFileParser
             options.BufferSize,
             useAsync: true);
 
-        return await ParseAsync(stream, Path.GetFileName(filePath), options, ct).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            return await ParseAsync(stream, Path.GetFileName(filePath), options, ct).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
@@ -34,7 +34,7 @@ public static class SdCardFileParserFactory
         ArgumentNullException.ThrowIfNull(filePath);
 
         var format = DetectFormat(filePath);
-        await using var stream = new FileStream(
+        var stream = new FileStream(
             filePath,
             FileMode.Open,
             FileAccess.Read,
@@ -42,7 +42,10 @@ public static class SdCardFileParserFactory
             bufferSize: options?.BufferSize ?? 64 * 1024,
             useAsync: true);
 
-        return await ParseWithFormatAsync(stream, Path.GetFileName(filePath), format, options, ct);
+        await using (stream.ConfigureAwait(false))
+        {
+            return await ParseWithFormatAsync(stream, Path.GetFileName(filePath), format, options, ct).ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -63,7 +66,7 @@ public static class SdCardFileParserFactory
         ArgumentNullException.ThrowIfNull(fileName);
 
         var format = DetectFormat(fileName);
-        return await ParseWithFormatAsync(fileStream, fileName, format, options, ct);
+        return await ParseWithFormatAsync(fileStream, fileName, format, options, ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -101,7 +101,7 @@ public sealed class SdCardJsonFileParser
     {
         ArgumentNullException.ThrowIfNull(filePath);
 
-        await using var fileStream = new FileStream(
+        var fileStream = new FileStream(
             filePath,
             FileMode.Open,
             FileAccess.Read,
@@ -109,7 +109,10 @@ public sealed class SdCardJsonFileParser
             bufferSize: options?.BufferSize ?? 64 * 1024,
             useAsync: true);
 
-        return await ParseAsync(fileStream, Path.GetFileName(filePath), options, ct);
+        await using (fileStream.ConfigureAwait(false))
+        {
+            return await ParseAsync(fileStream, Path.GetFileName(filePath), options, ct).ConfigureAwait(false);
+        }
     }
 
 #pragma warning disable CS1998 // Async iterator: yield return requires async; method has no real awaits.

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -270,7 +270,7 @@ namespace Daqifi.Core.Device.SdCard
                     completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
                     cancellationToken: cancellationToken,
                     prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                    finalizeAsync: RestoreLanInterfaceAsync);
+                    finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
 
                 isComplete = TrySplitAtSdListTerminator(lines, out listing);
 
@@ -448,7 +448,7 @@ namespace Daqifi.Core.Device.SdCard
                 responseTimeoutMs: 3000,
                 cancellationToken: cancellationToken,
                 prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                finalizeAsync: RestoreLanInterfaceAsync);
+                finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
 
             // Only retry transient SCPI errors. A "No SD Card Detected" line
             // is non-transient — retrying just delays the typed exception and
@@ -466,7 +466,7 @@ namespace Daqifi.Core.Device.SdCard
                         responseTimeoutMs: 3000,
                         cancellationToken: cancellationToken,
                         prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                        finalizeAsync: RestoreLanInterfaceAsync);
+                        finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
 
                     if (!ScpiResponseClassifier.ContainsScpiError(lines) || ContainsNoSdCardMarker(lines))
                     {
@@ -627,25 +627,25 @@ namespace Daqifi.Core.Device.SdCard
             // SD card and LAN share the SPI bus on the hardware, so LAN must be
             // disabled before the SD card can be used.
             _host.Send(ScpiMessageProducer.DisableNetworkLan);
-            await Task.Delay(100, cancellationToken);
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
 
             _host.Send(ScpiMessageProducer.EnableStorageSd);
-            await Task.Delay(100, cancellationToken);
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
 
             // Route the data stream to the SD card interface.
             _host.Send(ScpiMessageProducer.SetStreamInterface(StreamInterface.SdCard));
-            await Task.Delay(100, cancellationToken);
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
 
             _host.Send(ScpiMessageProducer.SetSdLoggingFileName(logFileName));
-            await Task.Delay(100, cancellationToken);
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
 
             _host.Send(formatCommand);
-            await Task.Delay(100, cancellationToken);
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
 
             if (!string.IsNullOrWhiteSpace(channelMask))
             {
                 _host.Send(ScpiMessageProducer.EnableAdcChannels(channelMask));
-                await Task.Delay(100, cancellationToken);
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
             }
 
             _host.Send(ScpiMessageProducer.StartStreaming(_host.StreamingFrequency));
@@ -753,7 +753,7 @@ namespace Daqifi.Core.Device.SdCard
                 responseTimeoutMs: 3000,
                 cancellationToken: cancellationToken,
                 prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                finalizeAsync: RestoreLanInterfaceAsync);
+                finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
 
             if (ScpiResponseClassifier.ContainsScpiError(lines))
             {
@@ -772,7 +772,7 @@ namespace Daqifi.Core.Device.SdCard
                         responseTimeoutMs: 3000,
                         cancellationToken: cancellationToken,
                         prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                        finalizeAsync: RestoreLanInterfaceAsync);
+                        finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
 
                     if (!ScpiResponseClassifier.ContainsScpiError(lines))
                     {
@@ -1069,7 +1069,7 @@ namespace Daqifi.Core.Device.SdCard
             var tempPath = Path.Combine(Path.GetTempPath(), $"daqifi_{Guid.NewGuid():N}{ext}");
             try
             {
-                await using var fileStream = new FileStream(
+                var fileStream = new FileStream(
                     tempPath,
                     FileMode.Create,
                     FileAccess.Write,
@@ -1077,10 +1077,13 @@ namespace Daqifi.Core.Device.SdCard
                     bufferSize: 65536,
                     useAsync: true);
 
-                var result = await DownloadSdCardFileAsync(fileName, fileStream, progress, cancellationToken)
-                    .ConfigureAwait(false);
+                await using (fileStream.ConfigureAwait(false))
+                {
+                    var result = await DownloadSdCardFileAsync(fileName, fileStream, progress, cancellationToken)
+                        .ConfigureAwait(false);
 
-                return result with { FilePath = tempPath };
+                    return result with { FilePath = tempPath };
+                }
             }
             catch
             {

--- a/src/Daqifi.Core/Firmware/GitHubFirmwareDownloadService.cs
+++ b/src/Daqifi.Core/Firmware/GitHubFirmwareDownloadService.cs
@@ -64,7 +64,7 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
         bool includePreRelease = false,
         CancellationToken cancellationToken = default)
     {
-        var releases = await GetFirmwareReleasesAsync(cancellationToken);
+        var releases = await GetFirmwareReleasesAsync(cancellationToken).ConfigureAwait(false);
         return FindLatestRelease(releases, includePreRelease, ".hex");
     }
 
@@ -75,7 +75,7 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
         CancellationToken cancellationToken = default)
     {
         var hasCurrent = FirmwareVersion.TryParse(deviceVersionString, out var deviceVersion);
-        var latest = await GetLatestReleaseAsync(includePreRelease, cancellationToken);
+        var latest = await GetLatestReleaseAsync(includePreRelease, cancellationToken).ConfigureAwait(false);
 
         if (latest == null)
         {
@@ -104,12 +104,12 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
         IProgress<int>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        var release = await GetLatestReleaseAsync(includePreRelease, cancellationToken);
+        var release = await GetLatestReleaseAsync(includePreRelease, cancellationToken).ConfigureAwait(false);
         if (release?.DownloadUrl == null || release.AssetFileName == null) return null;
 
         return await DownloadFileAsync(
             release.DownloadUrl, destinationDirectory, release.AssetFileName,
-            release.AssetSize, progress, cancellationToken);
+            release.AssetSize, progress, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -119,7 +119,7 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
         IProgress<int>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        var releases = await GetFirmwareReleasesAsync(cancellationToken);
+        var releases = await GetFirmwareReleasesAsync(cancellationToken).ConfigureAwait(false);
 
         FirmwareReleaseInfo? release = null;
         foreach (var element in releases)
@@ -138,14 +138,14 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
 
         return await DownloadFileAsync(
             release.DownloadUrl, destinationDirectory, release.AssetFileName,
-            release.AssetSize, progress, cancellationToken);
+            release.AssetSize, progress, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task<FirmwareReleaseInfo?> GetLatestWifiReleaseAsync(
         CancellationToken cancellationToken = default)
     {
-        var releases = await GetWifiReleasesAsync(cancellationToken);
+        var releases = await GetWifiReleasesAsync(cancellationToken).ConfigureAwait(false);
         return FindLatestRelease(releases, includePreRelease: false, assetExtension: null);
     }
 
@@ -155,7 +155,7 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
         IProgress<int>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        var releases = await GetWifiReleasesAsync(cancellationToken);
+        var releases = await GetWifiReleasesAsync(cancellationToken).ConfigureAwait(false);
         var release = FindLatestRelease(releases, includePreRelease: false, assetExtension: null);
         if (release?.ZipballUrl == null) return null;
 
@@ -168,23 +168,27 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
         var zipFilePath = Path.Combine(destinationDirectory, zipFileName);
 
         // Download the zipball
-        using var response = await _httpClient.GetAsync(zipballUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        using var response = await _httpClient.GetAsync(zipballUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         var totalBytes = response.Content.Headers.ContentLength ?? -1;
-        await using (var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken))
-        await using (var fileStream = new FileStream(zipFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+        var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (contentStream.ConfigureAwait(false))
         {
-            var buffer = new byte[DOWNLOAD_BUFFER_SIZE];
-            long bytesRead = 0;
-            int read;
-            while ((read = await contentStream.ReadAsync(buffer, cancellationToken)) > 0)
+            var fileStream = new FileStream(zipFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await using (fileStream.ConfigureAwait(false))
             {
-                await fileStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
-                bytesRead += read;
-                if (totalBytes > 0)
+                var buffer = new byte[DOWNLOAD_BUFFER_SIZE];
+                long bytesRead = 0;
+                int read;
+                while ((read = await contentStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
                 {
-                    progress?.Report((int)((double)bytesRead / totalBytes * 80));
+                    await fileStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                    bytesRead += read;
+                    if (totalBytes > 0)
+                    {
+                        progress?.Report((int)((double)bytesRead / totalBytes * 80));
+                    }
                 }
             }
         }
@@ -233,7 +237,7 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
             return _cachedReleases;
         }
 
-        var elements = await FetchReleasesFromApiAsync(_firmwareRepoApiUrl, cancellationToken);
+        var elements = await FetchReleasesFromApiAsync(_firmwareRepoApiUrl, cancellationToken).ConfigureAwait(false);
         _cachedReleases = elements;
         _cacheTimestamp = DateTime.UtcNow;
         return elements;
@@ -246,7 +250,7 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
             return _cachedWifiReleases;
         }
 
-        var elements = await FetchReleasesFromApiAsync(_wifiRepoApiUrl, cancellationToken);
+        var elements = await FetchReleasesFromApiAsync(_wifiRepoApiUrl, cancellationToken).ConfigureAwait(false);
         _cachedWifiReleases = elements;
         _wifiCacheTimestamp = DateTime.UtcNow;
         return elements;
@@ -254,7 +258,7 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
 
     private async Task<List<JsonElement>> FetchReleasesFromApiAsync(string apiUrl, CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.GetAsync(apiUrl, cancellationToken);
+        using var response = await _httpClient.GetAsync(apiUrl, cancellationToken).ConfigureAwait(false);
 
         if ((int)response.StatusCode == 403 && response.Headers.Contains("X-RateLimit-Reset"))
         {
@@ -269,7 +273,7 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
 
         response.EnsureSuccessStatusCode();
 
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         using var doc = JsonDocument.Parse(json);
 
         var elements = new List<JsonElement>();
@@ -388,24 +392,29 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
         Directory.CreateDirectory(destinationDirectory);
         var filePath = Path.Combine(destinationDirectory, safeName);
 
-        using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         var totalBytes = response.Content.Headers.ContentLength ?? expectedSize ?? -1;
 
-        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-        await using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
-
-        var buffer = new byte[DOWNLOAD_BUFFER_SIZE];
+        var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         long bytesRead = 0;
-        int read;
-        while ((read = await contentStream.ReadAsync(buffer, cancellationToken)) > 0)
+        await using (contentStream.ConfigureAwait(false))
         {
-            await fileStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
-            bytesRead += read;
-            if (totalBytes > 0)
+            var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await using (fileStream.ConfigureAwait(false))
             {
-                progress?.Report((int)((double)bytesRead / totalBytes * 100));
+                var buffer = new byte[DOWNLOAD_BUFFER_SIZE];
+                int read;
+                while ((read = await contentStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                    bytesRead += read;
+                    if (totalBytes > 0)
+                    {
+                        progress?.Report((int)((double)bytesRead / totalBytes * 100));
+                    }
+                }
             }
         }
 

--- a/src/Daqifi.Core/Logging/Export/CsvExporter.cs
+++ b/src/Daqifi.Core/Logging/Export/CsvExporter.cs
@@ -87,28 +87,28 @@ public class CsvExporter
 
         var channelKeys = channels.Select(c => c.Key).ToList();
 
-        await WriteHeaderAsync(writer, channelKeys, options);
+        await WriteHeaderAsync(writer, channelKeys, options).ConfigureAwait(false);
 
         var totalSamples = progress != null
-            ? await source.GetSampleCountAsync(cancellationToken)
+            ? await source.GetSampleCountAsync(cancellationToken).ConfigureAwait(false)
             : 0;
 
         if (options.AverageWindow.HasValue)
-            await ExportAveragedAsync(source, writer, options, channelKeys, totalSamples, progress, cancellationToken);
+            await ExportAveragedAsync(source, writer, options, channelKeys, totalSamples, progress, cancellationToken).ConfigureAwait(false);
         else
-            await ExportAllSamplesAsync(source, writer, options, channelKeys, totalSamples, progress, cancellationToken);
+            await ExportAllSamplesAsync(source, writer, options, channelKeys, totalSamples, progress, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task WriteHeaderAsync(TextWriter writer, List<string> channelKeys, CsvExportOptions options)
     {
         var timeHeader = options.UseRelativeTime ? "Relative Time (s)" : "Time";
-        await writer.WriteAsync(EscapeCsvField(timeHeader, options.Delimiter));
+        await writer.WriteAsync(EscapeCsvField(timeHeader, options.Delimiter)).ConfigureAwait(false);
         foreach (var key in channelKeys)
         {
-            await writer.WriteAsync(options.Delimiter);
-            await writer.WriteAsync(EscapeCsvField(key, options.Delimiter));
+            await writer.WriteAsync(options.Delimiter).ConfigureAwait(false);
+            await writer.WriteAsync(EscapeCsvField(key, options.Delimiter)).ConfigureAwait(false);
         }
-        await writer.WriteLineAsync();
+        await writer.WriteLineAsync().ConfigureAwait(false);
     }
 
     private static async Task ExportAllSamplesAsync(
@@ -126,13 +126,13 @@ public class CsvExporter
         var bucket = new List<SampleRow>();
         var processed = 0;
 
-        await foreach (var sample in source.StreamSamples(cancellationToken))
+        await foreach (var sample in source.StreamSamples(cancellationToken).ConfigureAwait(false))
         {
             firstTicks ??= sample.TimestampTicks;
 
             if (currentTick.HasValue && sample.TimestampTicks != currentTick.Value)
             {
-                await WriteTimestampRowAsync(writer, sb, bucket, channelKeys, firstTicks.Value, options);
+                await WriteTimestampRowAsync(writer, sb, bucket, channelKeys, firstTicks.Value, options).ConfigureAwait(false);
                 processed += bucket.Count;
                 ReportProgress(progress, processed, totalSamples);
                 bucket.Clear();
@@ -143,7 +143,7 @@ public class CsvExporter
         }
 
         if (bucket.Count > 0)
-            await WriteTimestampRowAsync(writer, sb, bucket, channelKeys, firstTicks!.Value, options);
+            await WriteTimestampRowAsync(writer, sb, bucket, channelKeys, firstTicks!.Value, options).ConfigureAwait(false);
 
         progress?.Report(100);
     }
@@ -179,7 +179,7 @@ public class CsvExporter
         }
 
         sb.AppendLine();
-        await writer.WriteAsync(sb.ToString());
+        await writer.WriteAsync(sb.ToString()).ConfigureAwait(false);
     }
 
     private static async Task ExportAveragedAsync(
@@ -200,7 +200,7 @@ public class CsvExporter
         var windowCount = 0;
         var processed = 0;
 
-        await foreach (var sample in source.StreamSamples(cancellationToken))
+        await foreach (var sample in source.StreamSamples(cancellationToken).ConfigureAwait(false))
         {
             firstTicks ??= sample.TimestampTicks;
             lastTick = sample.TimestampTicks;
@@ -216,7 +216,7 @@ public class CsvExporter
 
             if (windowCount >= window)
             {
-                await WriteAveragedRowAsync(writer, sb, channelKeys, totals, counts, lastTick, firstTicks.Value, options);
+                await WriteAveragedRowAsync(writer, sb, channelKeys, totals, counts, lastTick, firstTicks.Value, options).ConfigureAwait(false);
 
                 foreach (var key in channelKeys)
                 {
@@ -231,7 +231,7 @@ public class CsvExporter
 
         // Flush any trailing samples that didn't fill a complete window.
         if (windowCount > 0 && firstTicks.HasValue)
-            await WriteAveragedRowAsync(writer, sb, channelKeys, totals, counts, lastTick, firstTicks.Value, options);
+            await WriteAveragedRowAsync(writer, sb, channelKeys, totals, counts, lastTick, firstTicks.Value, options).ConfigureAwait(false);
 
         progress?.Report(100);
     }
@@ -261,7 +261,7 @@ public class CsvExporter
         }
 
         sb.AppendLine();
-        await writer.WriteAsync(sb.ToString());
+        await writer.WriteAsync(sb.ToString()).ConfigureAwait(false);
     }
 
     /// <summary>


### PR DESCRIPTION
## What was wrong

A desktop app that called DAQiFi Core's synchronous connect helpers from its UI thread froze
solid. `DaqifiDeviceFactory.ConnectTcp(...)`, `DaqifiDeviceFactory.ConnectSerial(...)` and
`device.Connect()` never returned, never timed out and never threw — the app was simply gone,
with no error to report and nothing in a log to explain it. Serial did the same thing the
moment a retry engaged (a first `Open()` that fails after a re-plug), which is exactly the
situation a user is in when they unplug and re-plug a device.

The cause is the classic sync-over-async deadlock. These helpers block the calling thread on
their own async work, and none of the awaits underneath them opted out of the caller's
`SynchronizationContext`. So the continuation was posted back to the UI thread, which was
already blocked waiting for that very continuation. The WPF desktop migration is the first
consumer that would hit this.

## How it was fixed

Every `await` in `Daqifi.Core` now uses `ConfigureAwait(false)`, so the library resumes on the
thread pool rather than on the caller's context — and CA2007 is switched on for the library
project (`src/Daqifi.Core/.editorconfig`), where warnings are already errors, so a naked
`await` can no longer be reintroduced without failing the build. Test projects are exempt.

Two things a reviewer may want to push back on:

- **The sweep is library-wide, not just the connect path.** Enumerating "which awaits are
  reachable from a blocking facade" is a judgment call that goes stale on the next refactor,
  and it is the wrong rule for a library anyway — even on a fully async path, resuming on the
  UI context means the UI thread does the protobuf decoding and CSV export. Making the compiler
  enforce the rule everywhere is what closes the second success criterion on #495.
- **Eleven `await using` sites had to be restructured** (SD-card parsers, firmware download,
  the SD download temp file). `await using var x = expr.ConfigureAwait(false)` changes `x`'s
  type to `ConfiguredAsyncDisposable`, so the variable is now declared first and the disposal
  scope wraps the body. Disposal order and the "dispose before the enclosing `catch` runs"
  behaviour are unchanged; only the nesting moved.

Review also surfaced that the status events had no written threading contract — and that this
change is what makes it matter, since a successful connect used to land on the UI thread when
awaited from one. `IStreamTransport.StatusChanged`, `IUdpTransport.StatusChanged` and
`IDevice.StatusChanged` now say plainly that no particular thread is guaranteed and that a UI
consumer must marshal. Documentation only — marshalling notifications back to a captured
context is the exact coupling that caused this bug.

Not in scope: the wider `.editorconfig` and style enforcement tracked by #484 — this adds only
the one rule the bug needs, and #484 can extend the same file.

## Verification

- 7 new tests in `SynchronizationContextDeadlockTests` run each blocking facade on a thread
  with a UI-like single-threaded context installed that never pumps, and fail on a join timeout
  instead of hanging the suite. Two of them are harness self-checks, including one that asserts
  a naked `await` **does** still deadlock — without it the rest could pass vacuously.
- **The tests were confirmed to catch the bug**: with `src/Daqifi.Core` reverted to `main`,
  4 of the 5 real tests fail with the reported symptom (TCP connect/disconnect, serial
  connect-with-retry, the retry executor's backoff delay, and `ConnectTcp`). The UDP one passes
  either way — its awaits complete synchronously — so it is a guard, not a regression catcher.
- Full suite green on **net9.0** (2928 Core + 43 Mcp) and **net10.0** (2928), 0 failures,
  0 warnings.
- Bench, non-destructive, fw 3.7.2 on `/dev/cu.usbmodem1101`: connect → `--show-status` →
  3 s @ 500 Hz → disconnect (**1188 samples**, this unit's known ~79% clock ratio),
  `--discover-serial` (found Nq1, `sn=9090539562006014104`), `--sd-list` (45 files) and
  `--sd-storage` — the last two cover the SD text-exchange path this change touches. No
  `SD:GET`, no delete/format, no reboot, no firmware, no LAN writes; serial only.

closes #495

Not merging — opened for your review.
