### PR TITLE
perf(discovery): serial discovery no longer spends half its time waiting on its own reader thread

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
@@ -25,13 +25,21 @@ namespace Daqifi.Core.Tests.Device.Discovery;
 /// </remarks>
 public class SerialProbeTeardownTests
 {
-    private const int FakeReadTimeoutMs = 50;
+    /// <summary>
+    /// Stand-in for the read timeout the probe opens its port with (1s on real hardware), kept short
+    /// enough that the silent-device cases do not dominate the suite's runtime.
+    /// </summary>
+    private const int ProbeStartReadTimeoutMs = 400;
+
+    /// <summary>Mirror of the production constant the probe shortens to once a device answers.</summary>
+    private const int PostIdentifyReadTimeoutMs = 50;
+
     private const ulong TestSerialNumber = 9090539562006014104;
 
     [Fact]
     public async Task RequestDeviceStatusAsync_DeviceAnswers_ReturnsParsedStatus()
     {
-        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: true);
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: true);
 
         var status = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
 
@@ -44,7 +52,7 @@ public class SerialProbeTeardownTests
     [Fact]
     public async Task RequestDeviceStatusAsync_WhenItReturns_ReaderThreadHasExited()
     {
-        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: false);
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: false);
 
         var exchange = SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
 
@@ -72,7 +80,7 @@ public class SerialProbeTeardownTests
     [Fact]
     public async Task RequestDeviceStatusAsync_DoesNotCompleteOnTheReaderThread()
     {
-        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: false);
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: false);
 
         var exchange = SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
 
@@ -97,7 +105,7 @@ public class SerialProbeTeardownTests
     [Fact]
     public async Task RequestDeviceStatusAsync_SilentDevice_ReturnsNullAfterRetrying()
     {
-        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: false);
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: false);
 
         var status = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
 
@@ -110,7 +118,7 @@ public class SerialProbeTeardownTests
     [Fact]
     public async Task RequestDeviceStatusAsync_Cancelled_GivesUpEarlyAndStillTearsDown()
     {
-        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: false);
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: false);
         using var cts = new CancellationTokenSource();
 
         var exchange = SerialDeviceFinder.RequestDeviceStatusAsync(stream, cts.Token);
@@ -132,7 +140,7 @@ public class SerialProbeTeardownTests
     [Fact]
     public async Task RequestDeviceStatusAsync_LeavesTheStreamOpenForItsOwner()
     {
-        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: true);
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: true);
 
         await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
 
@@ -145,7 +153,7 @@ public class SerialProbeTeardownTests
     [Fact]
     public async Task RequestDeviceStatusAsync_CanBeRunTwiceOverTheSameStream()
     {
-        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: true);
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: true);
 
         var first = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
         var second = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
@@ -158,6 +166,38 @@ public class SerialProbeTeardownTests
         Assert.Equal(2, stream.ReaderThreadIds.Distinct().Count());
     }
 
+    [Fact]
+    public async Task RequestDeviceStatusAsync_AfterIdentifying_ShortensTheReadTimeoutForTeardown()
+    {
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: true);
+
+        Assert.NotNull(await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None));
+
+        // The reader can only notice the imminent stop when its current read returns, so the read it
+        // issues after handing over the status is the one teardown has to wait out.
+        Assert.Equal([PostIdentifyReadTimeoutMs], stream.ReadTimeoutHistory);
+        Assert.All(
+            stream.ReadsIssuedWithTimeout.Skip(1),
+            issued => Assert.Equal(PostIdentifyReadTimeoutMs, issued));
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_SilentDevice_LeavesTheReadTimeoutAlone()
+    {
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: false);
+
+        Assert.Null(await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None));
+
+        // A port with nothing to say keeps the timeout it started with. Shortening it for the whole
+        // probe would make an unresponsive port wake — and throw a TimeoutException — many times a
+        // second for the entire response window, which buys nothing: there is no teardown latency to
+        // save on a probe that found no device.
+        Assert.Empty(stream.ReadTimeoutHistory);
+        Assert.All(
+            stream.ReadsIssuedWithTimeout,
+            issued => Assert.Equal(ProbeStartReadTimeoutMs, issued));
+    }
+
     /// <summary>
     /// A stand-in for an open serial port: reads block for a timeout and then throw
     /// <see cref="TimeoutException"/> exactly as <c>SerialPort.BaseStream</c> does, and writes are
@@ -166,12 +206,14 @@ public class SerialProbeTeardownTests
     /// </summary>
     private sealed class ScriptedProbeStream : Stream
     {
-        private readonly int _readTimeoutMs;
         private readonly bool _autoRespond;
+        private volatile int _readTimeoutMs;
         private readonly object _gate = new();
         private readonly Queue<byte> _inbound = new();
         private readonly List<string> _written = [];
         private readonly List<int> _readerThreadIds = [];
+        private readonly List<int> _readTimeoutHistory = [];
+        private readonly List<int> _readsIssuedWithTimeout = [];
         private readonly ManualResetEventSlim _dataAvailable = new(false);
         private readonly ManualResetEventSlim _firstRead = new(false);
         private Thread? _firstReaderThread;
@@ -182,7 +224,34 @@ public class SerialProbeTeardownTests
             _autoRespond = autoRespond;
         }
 
+        /// <summary>The timeout each read was issued with, in order.</summary>
+        public IReadOnlyList<int> ReadsIssuedWithTimeout
+        {
+            get { lock (_gate) { return _readsIssuedWithTimeout.ToList(); } }
+        }
+
         public int DisposeCount { get; private set; }
+
+        /// <summary>Every value the probe assigned to <see cref="ReadTimeout"/>, in order.</summary>
+        public IReadOnlyList<int> ReadTimeoutHistory
+        {
+            get { lock (_gate) { return _readTimeoutHistory.ToList(); } }
+        }
+
+        public override bool CanTimeout => true;
+
+        public override int ReadTimeout
+        {
+            get => _readTimeoutMs;
+            set
+            {
+                _readTimeoutMs = value;
+                lock (_gate)
+                {
+                    _readTimeoutHistory.Add(value);
+                }
+            }
+        }
 
         public IReadOnlyList<string> WrittenCommands
         {
@@ -236,6 +305,7 @@ public class SerialProbeTeardownTests
             lock (_gate)
             {
                 _readerThreadIds.Add(Environment.CurrentManagedThreadId);
+                _readsIssuedWithTimeout.Add(_readTimeoutMs);
                 _firstReaderThread ??= Thread.CurrentThread;
             }
 

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
@@ -1,0 +1,307 @@
+using System.Text;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device.Discovery;
+using Google.Protobuf;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+/// <summary>
+/// Covers the serial probe's request/reply exchange and — the point of #486 — its teardown.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The probe used to complete its own continuation on the message consumer's reader thread, because
+/// the "status arrived" signal was a <see cref="TaskCompletionSource{TResult}"/> with inline
+/// continuations that is completed from inside the consumer's dispatch. Everything after the wait —
+/// including the teardown, whose first act is to join that very thread — then ran on the reader
+/// itself. The join could not possibly succeed, so it burned its whole 500ms budget and returned
+/// with the reader still running over a stream the caller was about to close.
+/// </para>
+/// <para>
+/// These tests assert that property directly rather than by wall clock: after the exchange returns,
+/// the thread that was reading the stream has exited, and the continuation did not run on it. Both
+/// fail against the inline-continuation version, and neither depends on how fast the machine is.
+/// </para>
+/// </remarks>
+public class SerialProbeTeardownTests
+{
+    private const int FakeReadTimeoutMs = 50;
+    private const ulong TestSerialNumber = 9090539562006014104;
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_DeviceAnswers_ReturnsParsedStatus()
+    {
+        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: true);
+
+        var status = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
+
+        Assert.NotNull(status);
+        Assert.Equal(TestSerialNumber, status.DeviceSn);
+        Assert.Equal("Nq1", status.DevicePn);
+        Assert.Contains(stream.WrittenCommands, c => c.Contains("SYSInfoPB"));
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_WhenItReturns_ReaderThreadHasExited()
+    {
+        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: false);
+
+        var exchange = SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
+
+        // Sampled at the moment the exchange completes, not after awaiting it: a reader that is on
+        // its way out exits within a read timeout of being asked to, so an assertion made after the
+        // await would pass either way and prove nothing.
+        bool? readerAliveAtCompletion = null;
+        var observed = exchange.ContinueWith(
+            _ => readerAliveAtCompletion = stream.FirstReaderThread!.IsAlive,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        await stream.WaitForFirstReadAsync();
+        stream.RespondWithStatus();
+        await observed;
+
+        Assert.NotNull(await exchange);
+        // The whole point: the consumer was really joined, so nothing is left reading the stream the
+        // caller is about to close under it. With the teardown running on the reader itself, that
+        // thread is necessarily still alive at completion — it is the thread completing the task.
+        Assert.False(readerAliveAtCompletion);
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_DoesNotCompleteOnTheReaderThread()
+    {
+        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: false);
+
+        var exchange = SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
+
+        // Attach before answering, so the continuation is guaranteed to run on whichever thread
+        // completes the exchange rather than inline on this one.
+        var completionThreadId = 0;
+        var observed = exchange.ContinueWith(
+            _ => completionThreadId = Environment.CurrentManagedThreadId,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        await stream.WaitForFirstReadAsync();
+        stream.RespondWithStatus();
+
+        await observed;
+        Assert.NotNull(await exchange);
+        Assert.NotEqual(0, completionThreadId);
+        Assert.DoesNotContain(completionThreadId, stream.ReaderThreadIds);
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_SilentDevice_ReturnsNullAfterRetrying()
+    {
+        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: false);
+
+        var status = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
+
+        Assert.Null(status);
+        // Two attempts, per MaxRetries — a port that answers nothing must not be probed forever.
+        Assert.Equal(2, stream.WrittenCommands.Count);
+        Assert.False(stream.FirstReaderThread!.IsAlive);
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_Cancelled_GivesUpEarlyAndStillTearsDown()
+    {
+        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: false);
+        using var cts = new CancellationTokenSource();
+
+        var exchange = SerialDeviceFinder.RequestDeviceStatusAsync(stream, cts.Token);
+        await stream.WaitForFirstReadAsync();
+        await cts.CancelAsync();
+
+        // Cancellation ends the wait but is reported as "no device on this port" rather than as an
+        // exception: the wait is a Task.WhenAny, which hands back the cancelled delay instead of
+        // throwing it. Long-standing behaviour, and callers are unaffected — ProbeSafelyAsync
+        // watches the same token itself and is what turns a cancelled sweep into an
+        // OperationCanceledException. Pinned here so a future refactor has to choose deliberately.
+        Assert.Null(await exchange);
+        // Teardown is in a finally, so giving up early must leave the stream just as quiet as the
+        // success path does.
+        Assert.False(stream.FirstReaderThread!.IsAlive);
+        Assert.True(stream.WrittenCommands.Count < 2, "cancellation should stop further retries");
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_LeavesTheStreamOpenForItsOwner()
+    {
+        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: true);
+
+        await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
+
+        // The port owner closes the port; the exchange only owns the producer and consumer it
+        // started. Disposing the stream here would close the port out from under the DTR-drop
+        // settle that follows.
+        Assert.Equal(0, stream.DisposeCount);
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_CanBeRunTwiceOverTheSameStream()
+    {
+        using var stream = new ScriptedProbeStream(FakeReadTimeoutMs, autoRespond: true);
+
+        var first = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
+        var second = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
+
+        // Only true if the first exchange left no reader behind: a second consumer over a stream
+        // that is still being read by the first would interleave reads and shred the framing.
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(TestSerialNumber, second.DeviceSn);
+        Assert.Equal(2, stream.ReaderThreadIds.Distinct().Count());
+    }
+
+    /// <summary>
+    /// A stand-in for an open serial port: reads block for a timeout and then throw
+    /// <see cref="TimeoutException"/> exactly as <c>SerialPort.BaseStream</c> does, and writes are
+    /// captured so the SCPI request can be answered with a real length-delimited protobuf status
+    /// frame. Records every thread that reads it, which is what the teardown assertions key off.
+    /// </summary>
+    private sealed class ScriptedProbeStream : Stream
+    {
+        private readonly int _readTimeoutMs;
+        private readonly bool _autoRespond;
+        private readonly object _gate = new();
+        private readonly Queue<byte> _inbound = new();
+        private readonly List<string> _written = [];
+        private readonly List<int> _readerThreadIds = [];
+        private readonly ManualResetEventSlim _dataAvailable = new(false);
+        private readonly ManualResetEventSlim _firstRead = new(false);
+        private Thread? _firstReaderThread;
+
+        public ScriptedProbeStream(int readTimeoutMs, bool autoRespond)
+        {
+            _readTimeoutMs = readTimeoutMs;
+            _autoRespond = autoRespond;
+        }
+
+        public int DisposeCount { get; private set; }
+
+        public IReadOnlyList<string> WrittenCommands
+        {
+            get { lock (_gate) { return _written.ToList(); } }
+        }
+
+        public IReadOnlyList<int> ReaderThreadIds
+        {
+            get { lock (_gate) { return _readerThreadIds.ToList(); } }
+        }
+
+        public Thread? FirstReaderThread
+        {
+            get { lock (_gate) { return _firstReaderThread; } }
+        }
+
+        public async Task WaitForFirstReadAsync()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await Task.Run(() => _firstRead.Wait(cts.Token), cts.Token);
+        }
+
+        public void RespondWithStatus()
+        {
+            var message = new DaqifiOutMessage
+            {
+                DeviceSn = TestSerialNumber,
+                DevicePn = "Nq1",
+                DeviceFwRev = "3.7.2",
+                // DetectMessageType calls a frame with a non-zero port count a status message.
+                AnalogInPortNum = 16,
+                DigitalPortNum = 16
+            };
+
+            using var buffer = new MemoryStream();
+            message.WriteDelimitedTo(buffer);
+
+            lock (_gate)
+            {
+                foreach (var b in buffer.ToArray())
+                {
+                    _inbound.Enqueue(b);
+                }
+
+                _dataAvailable.Set();
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            lock (_gate)
+            {
+                _readerThreadIds.Add(Environment.CurrentManagedThreadId);
+                _firstReaderThread ??= Thread.CurrentThread;
+            }
+
+            _firstRead.Set();
+
+            if (!_dataAvailable.Wait(_readTimeoutMs))
+            {
+                throw new TimeoutException("No data within the read timeout.");
+            }
+
+            lock (_gate)
+            {
+                var read = 0;
+                while (read < count && _inbound.Count > 0)
+                {
+                    buffer[offset + read++] = _inbound.Dequeue();
+                }
+
+                if (_inbound.Count == 0)
+                {
+                    _dataAvailable.Reset();
+                }
+
+                return read;
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var text = Encoding.ASCII.GetString(buffer, offset, count);
+            lock (_gate)
+            {
+                _written.Add(text);
+            }
+
+            if (_autoRespond && text.Contains("SYSInfoPB"))
+            {
+                RespondWithStatus();
+            }
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override void Flush() { }
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCount++;
+                _dataAvailable.Dispose();
+                _firstRead.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
@@ -164,6 +164,8 @@ public class SerialProbeTeardownTests
         Assert.NotNull(second);
         Assert.Equal(TestSerialNumber, second.DeviceSn);
         Assert.Equal(2, stream.ReaderThreadIds.Distinct().Count());
+        // Each exchange started from the timeout it found, because the previous one put it back.
+        Assert.All(stream.ReadsIssuedWithTimeout.Take(1), issued => Assert.Equal(ProbeStartReadTimeoutMs, issued));
     }
 
     [Fact]
@@ -175,10 +177,37 @@ public class SerialProbeTeardownTests
 
         // The reader can only notice the imminent stop when its current read returns, so the read it
         // issues after handing over the status is the one teardown has to wait out.
-        Assert.Equal([PostIdentifyReadTimeoutMs], stream.ReadTimeoutHistory);
+        Assert.Equal(PostIdentifyReadTimeoutMs, stream.ReadTimeoutHistory.First());
         Assert.All(
             stream.ReadsIssuedWithTimeout.Skip(1),
             issued => Assert.Equal(PostIdentifyReadTimeoutMs, issued));
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_AfterIdentifying_RestoresTheReadTimeoutItFound()
+    {
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: true);
+
+        Assert.NotNull(await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None));
+
+        // The stream belongs to the caller and stays open, so the faster teardown must not be left
+        // behind as a permanently twitchier read timeout on someone else's stream.
+        Assert.Equal(ProbeStartReadTimeoutMs, stream.ReadTimeout);
+        Assert.Equal([PostIdentifyReadTimeoutMs, ProbeStartReadTimeoutMs], stream.ReadTimeoutHistory);
+    }
+
+    [Fact]
+    public async Task RequestDeviceStatusAsync_StreamWithoutTimeoutSupport_StillCompletes()
+    {
+        using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: true)
+        {
+            RejectTimeoutAccess = true
+        };
+
+        // Shortening and restoring are both best-effort: a stream that refuses to talk about its
+        // timeouts costs a slower teardown, not a failed probe.
+        Assert.NotNull(await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None));
+        Assert.Empty(stream.ReadTimeoutHistory);
     }
 
     [Fact]
@@ -238,13 +267,21 @@ public class SerialProbeTeardownTests
             get { lock (_gate) { return _readTimeoutHistory.ToList(); } }
         }
 
-        public override bool CanTimeout => true;
+        /// <summary>When set, the stream behaves like one whose timeouts cannot be inspected or set.</summary>
+        public bool RejectTimeoutAccess { get; init; }
+
+        public override bool CanTimeout => !RejectTimeoutAccess;
 
         public override int ReadTimeout
         {
-            get => _readTimeoutMs;
+            get => RejectTimeoutAccess ? throw new InvalidOperationException("Timeouts not supported.") : _readTimeoutMs;
             set
             {
+                if (RejectTimeoutAccess)
+                {
+                    throw new InvalidOperationException("Timeouts not supported.");
+                }
+
                 _readTimeoutMs = value;
                 lock (_gate)
                 {

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
@@ -134,7 +134,11 @@ public class SerialProbeTeardownTests
         // Teardown is in a finally, so giving up early must leave the stream just as quiet as the
         // success path does.
         Assert.False(stream.FirstReaderThread!.IsAlive);
-        Assert.True(stream.WrittenCommands.Count < 2, "cancellation should stop further retries");
+        // Deliberately a bound, not an exact count. Requests go out on a RetryIntervalMs cadence and
+        // the cancellation lands wherever the scheduler puts it, so asserting that the retry did not
+        // happen is a race against a 300ms timer — it failed on CI doing exactly that. What is
+        // always true is that the probe never exceeds MaxRetries.
+        Assert.InRange(stream.WrittenCommands.Count, 1, 2);
     }
 
     [Fact]
@@ -156,6 +160,7 @@ public class SerialProbeTeardownTests
         using var stream = new ScriptedProbeStream(ProbeStartReadTimeoutMs, autoRespond: true);
 
         var first = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
+        var readsDuringFirst = stream.ReadsIssuedWithTimeout.Count;
         var second = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
 
         // Only true if the first exchange left no reader behind: a second consumer over a stream
@@ -164,8 +169,14 @@ public class SerialProbeTeardownTests
         Assert.NotNull(second);
         Assert.Equal(TestSerialNumber, second.DeviceSn);
         Assert.Equal(2, stream.ReaderThreadIds.Distinct().Count());
-        // Each exchange started from the timeout it found, because the previous one put it back.
-        Assert.All(stream.ReadsIssuedWithTimeout.Take(1), issued => Assert.Equal(ProbeStartReadTimeoutMs, issued));
+        // Each exchange started from the timeout it found, because the previous one put it back. The
+        // second exchange's opening read is the one that matters — it is the read that would have
+        // inherited the first exchange's shortened timeout — so it is indexed explicitly rather than
+        // covered by an assertion about the start of the list.
+        var reads = stream.ReadsIssuedWithTimeout;
+        Assert.True(reads.Count > readsDuringFirst, "the second exchange should have read the stream");
+        Assert.Equal(ProbeStartReadTimeoutMs, reads[0]);
+        Assert.Equal(ProbeStartReadTimeoutMs, reads[readsDuringFirst]);
     }
 
     [Fact]

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -41,36 +41,41 @@ public class SerialDeviceFinder : DeviceFinderBase
     #region Constants
 
     private const int DefaultBaudRate = 9600;
-    private const int ProbeWriteTimeoutMs = 1000;
+    private const int ProbeTimeoutMs = 1000;
 
     /// <summary>
-    /// Read timeout for the probe port, in milliseconds.
+    /// Read timeout applied to the probe stream the moment the device has identified itself, in
+    /// milliseconds.
     /// </summary>
     /// <remarks>
-    /// This is a <em>stop-latency</em> knob, not a response deadline — the probe's own
-    /// <see cref="ResponseTimeoutMs"/> loop decides how long to wait for the device. The reader
-    /// thread spends the whole probe parked in a blocking <see cref="Stream.Read(byte[], int, int)"/>,
-    /// and it can only notice a stop request when that read returns, so the teardown join at the end
-    /// of <see cref="RequestDeviceStatusAsync"/> is bounded by this value and nothing else (#486).
-    /// At the old 1s it was the single largest item in the probe's teardown; 50ms is the same
-    /// granularity the probe's own response poll already runs at (<see cref="PollIntervalMs"/>), so
-    /// the consumer is now joined within one poll interval instead of twenty.
-    /// A timed-out read is a benign loop iteration for
-    /// <see cref="StreamMessageConsumer{T}"/>, and a partially-received message survives across
-    /// iterations in its buffer, so shortening this costs only a few extra loop passes per probe —
-    /// it can neither drop bytes nor split a protobuf frame. Deliberately separate from
-    /// <see cref="ProbeWriteTimeoutMs"/>, which stays at 1s: a write has no such polling loop
-    /// behind it, and a short write timeout would fail a slow send outright.
+    /// <para>
+    /// Pure stop latency, and only for the tail of a successful probe. The consumer's reader thread
+    /// spends the probe parked in a blocking <see cref="Stream.Read(byte[], int, int)"/> and can
+    /// only notice a stop request when that read returns, so the teardown join at the end of
+    /// <see cref="RequestDeviceStatusAsync"/> is bounded by whatever timeout the in-flight read was
+    /// issued with — at <see cref="ProbeTimeoutMs"/> that was up to a second of waiting after the
+    /// device had already answered (#486).
+    /// </para>
+    /// <para>
+    /// Applied from inside the status dispatch, which runs on the reader thread between two reads:
+    /// the next read — the one teardown has to wait out — picks it up, and no read is in flight to
+    /// be disturbed. Deliberately <em>not</em> applied for the whole probe. A port that never
+    /// answers would then wake twenty times a second instead of once, and each of those wake-ups
+    /// ends in a thrown <see cref="TimeoutException"/>; bench-measured on this hardware at ~180ms of
+    /// CPU per 2s of probing against ~5-13ms at the one-second timeout. A silent port therefore
+    /// still idles exactly as it did before this change, and only a probe that has something to show
+    /// for itself pays the faster teardown.
+    /// </para>
     /// </remarks>
-    private const int ProbeReadTimeoutMs = 50;
+    private const int PostIdentifyReadTimeoutMs = 50;
 
     /// <summary>
     /// How long the probe's teardown waits for the consumer's reader thread to exit, in milliseconds.
     /// </summary>
     /// <remarks>
-    /// Only ever reached when the reader is stuck in a read that outlives
-    /// <see cref="ProbeReadTimeoutMs"/> — a healthy port joins in well under this. Left at the value
-    /// the probe has always used so a genuinely stuck stream is still bounded the same way.
+    /// A probe that identified a device joins within <see cref="PostIdentifyReadTimeoutMs"/>; one
+    /// that found nothing is still bounded by the read timeout it was running at. Left at the value
+    /// the probe has always used.
     /// </remarks>
     private const int ConsumerStopTimeoutMs = 500;
 
@@ -185,7 +190,10 @@ public class SerialDeviceFinder : DeviceFinderBase
     // settle, port close). Bench-measured on a real Nq1 (fw 3.7.2, USB, macOS): the
     // claim is held 58/57/55ms across three runs, then auto-released by the
     // abandonment continuation. It was 488/490/491ms before #486, when the consumer
-    // stop self-joined the reader thread and burned its whole 500ms budget.
+    // stop self-joined the reader thread and burned its whole 500ms budget. Both
+    // figures are for a port whose device answered before the pass was abandoned; a
+    // port that never answers unwinds at its own read timeout instead, as it always
+    // has (see PostIdentifyReadTimeoutMs).
     //
     // Within this window a fresh pass WAITS for the claim to clear instead of
     // skipping the port; past it, the port is presumed genuinely wedged and skipped
@@ -618,8 +626,8 @@ public class SerialDeviceFinder : DeviceFinderBase
             // Create and configure the serial port
             port = new SerialPort(portName, _baudRate)
             {
-                ReadTimeout = ProbeReadTimeoutMs,
-                WriteTimeout = ProbeWriteTimeoutMs
+                ReadTimeout = ProbeTimeoutMs,
+                WriteTimeout = ProbeTimeoutMs
             };
 
             // Try to open the port
@@ -743,6 +751,11 @@ public class SerialDeviceFinder : DeviceFinderBase
                 if (args.Message.Data is DaqifiOutMessage message
                     && ProtobufProtocolHandler.DetectMessageType(message) == ProtobufMessageType.Status)
                 {
+                    // We have what we came for, so shorten the reader's next read before releasing
+                    // the waiter below — see PostIdentifyReadTimeoutMs. This runs on the reader
+                    // thread, between two reads, which is the one moment the timeout can be changed
+                    // without a read already in flight under the old value.
+                    ShortenReadTimeoutForTeardown(stream);
                     statusReceived.TrySetResult(message);
                 }
             };
@@ -807,6 +820,39 @@ public class SerialDeviceFinder : DeviceFinderBase
             {
                 // Ignore cleanup errors
             }
+        }
+    }
+
+    /// <summary>
+    /// Drops the probe stream's read timeout to <see cref="PostIdentifyReadTimeoutMs"/> so the
+    /// reader notices the imminent stop promptly.
+    /// </summary>
+    /// <remarks>
+    /// Best-effort by design. A stream that does not support timeouts, or refuses this one, simply
+    /// keeps the timeout it had — the teardown is correct either way, just slower — and this runs
+    /// inside a consumer callback, where an escaping exception would be reported as a message-
+    /// handling failure and hide a perfectly good status message.
+    /// </remarks>
+    private static void ShortenReadTimeoutForTeardown(Stream stream)
+    {
+        try
+        {
+            if (!stream.CanTimeout)
+            {
+                return;
+            }
+
+            // Infinite reads as "smaller than any timeout" numerically (-1) and is the one case that
+            // most needs shortening, so it is tested for rather than compared.
+            var current = stream.ReadTimeout;
+            if (current == Timeout.Infinite || current > PostIdentifyReadTimeoutMs)
+            {
+                stream.ReadTimeout = PostIdentifyReadTimeoutMs;
+            }
+        }
+        catch
+        {
+            // Not supported on this stream — leave it as it is.
         }
     }
 

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Ports;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -23,7 +24,8 @@ namespace Daqifi.Core.Device.Discovery;
 /// Port probes are claimed process-wide so a wedged USB CDC device can block at
 /// most one thread per port (see issues #294 / #295). A pass that ends by timeout
 /// or cancellation abandons its in-flight probe and leaves the claim behind while
-/// that probe unwinds — bench-measured at ~490ms on a real Nq1.
+/// that probe unwinds — bench-measured at ~57ms on a real Nq1 (was ~490ms before
+/// the probe teardown was fixed in #486).
 /// </para>
 /// <para>
 /// A pass that starts inside that drain window waits (bounded by both the window
@@ -39,7 +41,49 @@ public class SerialDeviceFinder : DeviceFinderBase
     #region Constants
 
     private const int DefaultBaudRate = 9600;
-    private const int ProbeTimeoutMs = 1000;
+    private const int ProbeWriteTimeoutMs = 1000;
+
+    /// <summary>
+    /// Read timeout for the probe port, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// This is a <em>stop-latency</em> knob, not a response deadline — the probe's own
+    /// <see cref="ResponseTimeoutMs"/> loop decides how long to wait for the device. The reader
+    /// thread spends the whole probe parked in a blocking <see cref="Stream.Read(byte[], int, int)"/>,
+    /// and it can only notice a stop request when that read returns, so the teardown join at the end
+    /// of <see cref="RequestDeviceStatusAsync"/> is bounded by this value and nothing else (#486).
+    /// At the old 1s it was the single largest item in the probe's teardown; 50ms is the same
+    /// granularity the probe's own response poll already runs at (<see cref="PollIntervalMs"/>), so
+    /// the consumer is now joined within one poll interval instead of twenty.
+    /// A timed-out read is a benign loop iteration for
+    /// <see cref="StreamMessageConsumer{T}"/>, and a partially-received message survives across
+    /// iterations in its buffer, so shortening this costs only a few extra loop passes per probe —
+    /// it can neither drop bytes nor split a protobuf frame. Deliberately separate from
+    /// <see cref="ProbeWriteTimeoutMs"/>, which stays at 1s: a write has no such polling loop
+    /// behind it, and a short write timeout would fail a slow send outright.
+    /// </remarks>
+    private const int ProbeReadTimeoutMs = 50;
+
+    /// <summary>
+    /// How long the probe's teardown waits for the consumer's reader thread to exit, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// Only ever reached when the reader is stuck in a read that outlives
+    /// <see cref="ProbeReadTimeoutMs"/> — a healthy port joins in well under this. Left at the value
+    /// the probe has always used so a genuinely stuck stream is still bounded the same way.
+    /// </remarks>
+    private const int ConsumerStopTimeoutMs = 500;
+
+    /// <summary>
+    /// How long the probe's teardown waits for the producer's send queue to drain, in milliseconds.
+    /// </summary>
+    private const int ProducerStopTimeoutMs = 500;
+
+    /// <summary>
+    /// Pause between dropping DTR and closing the probe port, in milliseconds, so the device sees the
+    /// de-assert before the handle goes away.
+    /// </summary>
+    private const int DtrSettleMs = 50;
     // Tightened for the GetDeviceInfo-only probe (closes #157):
     //   - 200ms wake instead of 1s — USB CDC enumerates fast
     //   - 1s response timeout instead of 4s — DAQiFi devices reply within
@@ -99,7 +143,7 @@ public class SerialDeviceFinder : DeviceFinderBase
     // re-appears without a process restart at a bounded leak rate).
     //
     // A claim abandoned by a timed-out / cancelled pass is usually NOT wedged; it
-    // drains in ~490ms. Within AbandonedClaimDrainWaitMs a fresh pass waits for it
+    // drains in ~57ms. Within AbandonedClaimDrainWaitMs a fresh pass waits for it
     // rather than reporting the port absent — see ProbeSafelyAsync.
     //
     // STATIC on purpose: a wedged COM port is machine-global state, not finder
@@ -137,16 +181,19 @@ public class SerialDeviceFinder : DeviceFinderBase
     // How long AFTER abandonment a claim is still treated as "probably draining"
     // rather than "wedged". A pass that ends by timeout or caller cancellation
     // abandons its in-flight probe, but that probe is usually NOT wedged — it is
-    // unwinding TryGetDeviceInfoAsync's cleanup (consumer/producer StopSafely, DTR
-    // drop + 50ms settle, port close). Bench-measured on a real Nq1 (fw 3.7.2, USB,
-    // macOS): the claim was held 488/490/491ms across three runs, then auto-released
-    // by the abandonment continuation.
+    // unwinding the probe's cleanup (consumer/producer StopSafely, DTR drop + 50ms
+    // settle, port close). Bench-measured on a real Nq1 (fw 3.7.2, USB, macOS): the
+    // claim is held 58/57/55ms across three runs, then auto-released by the
+    // abandonment continuation. It was 488/490/491ms before #486, when the consumer
+    // stop self-joined the reader thread and burned its whole 500ms budget.
     //
     // Within this window a fresh pass WAITS for the claim to clear instead of
     // skipping the port; past it, the port is presumed genuinely wedged and skipped
-    // immediately as before. 1s is ~2x the measured drain — enough headroom for a
-    // loaded thread pool, still short enough that a truly wedged port costs at most
-    // one sub-second wait before ageing out of the window entirely.
+    // immediately as before. 1s is now ~17x the measured drain rather than ~2x —
+    // deliberately left alone, because it is a ceiling on how long a fresh pass may
+    // wait, not a cost anything pays: the wait ends the moment the claim clears, so
+    // the extra headroom is free for healthy ports and still bounds a truly wedged
+    // one at a single sub-second wait before it ages out of the window entirely.
     private const int DefaultAbandonedClaimDrainWaitMs = 1000;
 
     // Internal so tests can shrink the drain wait instead of burning ~1s per case.
@@ -565,16 +612,14 @@ public class SerialDeviceFinder : DeviceFinderBase
     private async Task<IDeviceInfo?> TryGetDeviceInfoAsync(string portName, CancellationToken cancellationToken)
     {
         SerialPort? port = null;
-        MessageProducer<string>? producer = null;
-        StreamMessageConsumer<DaqifiOutMessage>? consumer = null;
 
         try
         {
             // Create and configure the serial port
             port = new SerialPort(portName, _baudRate)
             {
-                ReadTimeout = ProbeTimeoutMs,
-                WriteTimeout = ProbeTimeoutMs
+                ReadTimeout = ProbeReadTimeoutMs,
+                WriteTimeout = ProbeWriteTimeoutMs
             };
 
             // Try to open the port
@@ -584,65 +629,8 @@ public class SerialDeviceFinder : DeviceFinderBase
             // Wait for device to wake up (devices need time after DTR is enabled)
             await Task.Delay(DeviceWakeUpDelayMs, cancellationToken);
 
-            // Set up message producer and consumer
-            var stream = port.BaseStream;
-            producer = new MessageProducer<string>(stream);
-            producer.Start();
-
-            var parser = new ProtobufMessageParser();
-            consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
-
-            // Track status message reception
-            DaqifiOutMessage? statusMessage = null;
-            var messageReceived = new TaskCompletionSource<bool>();
-
-            consumer.MessageReceived += (_, args) =>
-            {
-                if (args.Message.Data is DaqifiOutMessage message)
-                {
-                    var messageType = ProtobufProtocolHandler.DetectMessageType(message);
-                    if (messageType == ProtobufMessageType.Status)
-                    {
-                        statusMessage = message;
-                        messageReceived.TrySetResult(true);
-                    }
-                }
-            };
-
-            consumer.Start();
-
-            // Identity probe: GetDeviceInfo only. The rest of the old setup sequence
-            // (StopStreaming / TurnDeviceOn / SetProtobufStreamFormat) is connection setup, not
-            // identification — a healthy DAQiFi answers SYSTem:SYSInfoPB? regardless of stream format or
-            // power state, so the caller setting up an actual connection still owns those. Echo is left
-            // alone too: an echo-on device wraps its reply in the echoed command text plus a trailing
-            // "DAQIFI>" prompt, but ProtobufMessageParser now resyncs past that non-protobuf noise to
-            // the embedded frame (issue #268), so the probe stays GetDeviceInfo-only (closes #157)
-            // instead of toggling device echo.
-            // Send GetDeviceInfo command with retry logic
-            var timeout = DateTime.UtcNow.AddMilliseconds(ResponseTimeoutMs);
-            var lastRequestTime = DateTime.MinValue;
-            var retryCount = 0;
-
-            while (statusMessage == null && DateTime.UtcNow < timeout && !cancellationToken.IsCancellationRequested)
-            {
-                // Send request every RetryIntervalMs, up to MaxRetries times
-                if ((DateTime.UtcNow - lastRequestTime).TotalMilliseconds >= RetryIntervalMs && retryCount < MaxRetries)
-                {
-                    producer.Send(ScpiMessageProducer.GetDeviceInfo);
-                    lastRequestTime = DateTime.UtcNow;
-                    retryCount++;
-                }
-
-                // Wait a bit for response
-                var remainingTime = Math.Min(PollIntervalMs, (int)(timeout - DateTime.UtcNow).TotalMilliseconds);
-                if (remainingTime > 0)
-                {
-                    await Task.WhenAny(
-                        messageReceived.Task,
-                        Task.Delay(remainingTime, cancellationToken));
-                }
-            }
+            var statusMessage = await RequestDeviceStatusAsync(port.BaseStream, cancellationToken)
+                .ConfigureAwait(false);
 
             if (statusMessage == null)
             {
@@ -684,10 +672,125 @@ public class SerialDeviceFinder : DeviceFinderBase
         }
         finally
         {
+            // Clean up resources. The producer and consumer are already gone by here —
+            // RequestDeviceStatusAsync owns them and tears them down inside its own finally, so the
+            // reader thread has provably exited before the port below is closed under it.
+            try
+            {
+                if (port is { IsOpen: true })
+                {
+                    port.DtrEnable = false;
+                    await Task.Delay(DtrSettleMs); // Give DTR time to be processed
+                    port.Close();
+                }
+
+                port?.Dispose();
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    /// <summary>
+    /// Asks an already-open device stream to identify itself and returns its status message, or
+    /// <c>null</c> if nothing answered within <see cref="ResponseTimeoutMs"/>.
+    /// </summary>
+    /// <param name="stream">
+    /// The open device stream. Owned by the caller: this method starts and stops its own producer
+    /// and consumer over it, and both are fully torn down before it returns, but the stream itself
+    /// is left open.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// Split out of <see cref="TryGetDeviceInfoAsync"/> — which owns the port lifecycle — so the
+    /// request/reply exchange and its teardown can be exercised against a scripted stream with no
+    /// serial hardware attached (#486).
+    /// </remarks>
+    internal static async Task<DaqifiOutMessage?> RequestDeviceStatusAsync(
+        Stream stream, CancellationToken cancellationToken)
+    {
+        MessageProducer<string>? producer = null;
+        StreamMessageConsumer<DaqifiOutMessage>? consumer = null;
+
+        try
+        {
+            producer = new MessageProducer<string>(stream);
+            producer.Start();
+
+            var parser = new ProtobufMessageParser();
+            consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
+
+            // Carries the status message itself rather than signalling a separately-assigned local:
+            // the message is published on the consumer's reader thread and read back on whichever
+            // thread resumes below, and handing it through the completion source is what makes that
+            // hand-off ordered instead of a bare cross-thread field write.
+            //
+            // RunContinuationsAsynchronously is load-bearing, not a style choice (#486). This source
+            // is completed from inside the consumer's MessageReceived dispatch, i.e. ON the reader
+            // thread. With inline continuations the rest of this method — the poll-loop exit and the
+            // whole finally block below — resumed on that same reader thread, and the first thing
+            // the finally does is StopSafely, which joins it. The reader was then waiting for
+            // itself: the join could never succeed, so it burned its full timeout on every
+            // successful probe and left the consumer un-joined afterwards. Bench-measured on a real
+            // Nq1: that single self-join was ~500ms of an ~830ms serial identify.
+            var statusReceived =
+                new TaskCompletionSource<DaqifiOutMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            consumer.MessageReceived += (_, args) =>
+            {
+                if (args.Message.Data is DaqifiOutMessage message
+                    && ProtobufProtocolHandler.DetectMessageType(message) == ProtobufMessageType.Status)
+                {
+                    statusReceived.TrySetResult(message);
+                }
+            };
+
+            consumer.Start();
+
+            // Identity probe: GetDeviceInfo only. The rest of the old setup sequence
+            // (StopStreaming / TurnDeviceOn / SetProtobufStreamFormat) is connection setup, not
+            // identification — a healthy DAQiFi answers SYSTem:SYSInfoPB? regardless of stream format or
+            // power state, so the caller setting up an actual connection still owns those. Echo is left
+            // alone too: an echo-on device wraps its reply in the echoed command text plus a trailing
+            // "DAQIFI>" prompt, but ProtobufMessageParser now resyncs past that non-protobuf noise to
+            // the embedded frame (issue #268), so the probe stays GetDeviceInfo-only (closes #157)
+            // instead of toggling device echo.
+            // Send GetDeviceInfo command with retry logic
+            var timeout = DateTime.UtcNow.AddMilliseconds(ResponseTimeoutMs);
+            var lastRequestTime = DateTime.MinValue;
+            var retryCount = 0;
+
+            while (!statusReceived.Task.IsCompleted && DateTime.UtcNow < timeout
+                                                    && !cancellationToken.IsCancellationRequested)
+            {
+                // Send request every RetryIntervalMs, up to MaxRetries times
+                if ((DateTime.UtcNow - lastRequestTime).TotalMilliseconds >= RetryIntervalMs && retryCount < MaxRetries)
+                {
+                    producer.Send(ScpiMessageProducer.GetDeviceInfo);
+                    lastRequestTime = DateTime.UtcNow;
+                    retryCount++;
+                }
+
+                // Wait a bit for response
+                var remainingTime = Math.Min(PollIntervalMs, (int)(timeout - DateTime.UtcNow).TotalMilliseconds);
+                if (remainingTime > 0)
+                {
+                    await Task.WhenAny(
+                        statusReceived.Task,
+                        Task.Delay(remainingTime, cancellationToken)).ConfigureAwait(false);
+                }
+            }
+
+            return statusReceived.Task.IsCompletedSuccessfully ? statusReceived.Task.Result : null;
+        }
+        finally
+        {
             // Clean up resources
             try
             {
-                consumer?.StopSafely(500);
+                consumer?.StopSafely(ConsumerStopTimeoutMs);
                 consumer?.Dispose();
             }
             catch
@@ -697,24 +800,8 @@ public class SerialDeviceFinder : DeviceFinderBase
 
             try
             {
-                producer?.StopSafely(500);
+                producer?.StopSafely(ProducerStopTimeoutMs);
                 producer?.Dispose();
-            }
-            catch
-            {
-                // Ignore cleanup errors
-            }
-
-            try
-            {
-                if (port is { IsOpen: true })
-                {
-                    port.DtrEnable = false;
-                    await Task.Delay(50); // Give DTR time to be processed
-                    port.Close();
-                }
-
-                port?.Dispose();
             }
             catch
             {

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -721,6 +721,10 @@ public class SerialDeviceFinder : DeviceFinderBase
     {
         MessageProducer<string>? producer = null;
         StreamMessageConsumer<DaqifiOutMessage>? consumer = null;
+        // Noted before anything touches the stream so the shortened teardown timeout can be put back
+        // — the stream belongs to the caller, and a probe has no business changing how it reads
+        // afterwards.
+        var originalReadTimeout = TryGetReadTimeout(stream);
 
         try
         {
@@ -811,6 +815,11 @@ public class SerialDeviceFinder : DeviceFinderBase
                 // Ignore cleanup errors
             }
 
+            // Strictly after the consumer has been joined: the short timeout is what makes that join
+            // quick, so restoring any earlier would give the benefit back. By here the reader has
+            // exited, so this is also the only thread touching the stream.
+            RestoreReadTimeout(stream, originalReadTimeout);
+
             try
             {
                 producer?.StopSafely(ProducerStopTimeoutMs);
@@ -820,6 +829,50 @@ public class SerialDeviceFinder : DeviceFinderBase
             {
                 // Ignore cleanup errors
             }
+        }
+    }
+
+    /// <summary>
+    /// Reads a stream's current read timeout, or <c>null</c> when it does not have one.
+    /// </summary>
+    private static int? TryGetReadTimeout(Stream stream)
+    {
+        try
+        {
+            return stream.CanTimeout ? stream.ReadTimeout : null;
+        }
+        catch
+        {
+            // A stream that claims CanTimeout but refuses the getter has nothing to restore either.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Puts back the read timeout the stream had before the probe shortened it.
+    /// </summary>
+    /// <remarks>
+    /// Writes only when the value actually differs, so a probe that never shortened anything — a
+    /// port that answered nothing, most commonly — leaves the stream completely untouched rather
+    /// than rewriting it with its own value.
+    /// </remarks>
+    private static void RestoreReadTimeout(Stream stream, int? originalReadTimeout)
+    {
+        if (originalReadTimeout is not { } original)
+        {
+            return;
+        }
+
+        try
+        {
+            if (stream.CanTimeout && stream.ReadTimeout != original)
+            {
+                stream.ReadTimeout = original;
+            }
+        }
+        catch
+        {
+            // Best-effort, exactly as the shortening was.
         }
     }
 

--- a/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
+++ b/src/Daqifi.Mcp.Tests/DaqifiMcpTests.cs
@@ -66,9 +66,10 @@ public class DaqifiAgentTests
         Assert.Contains("discover_devices", ex.Message);
     }
 
-    // The serial identify handshake measures ~830 ms on real hardware (#448); a timeout below the
-    // floor returns an empty list before the device could ever answer, indistinguishable from "no
-    // device attached". These pin the clamp directly rather than through a real discovery run.
+    // A timeout below the identify handshake returns an empty list before the device could ever
+    // answer, indistinguishable from "no device attached" (#448). The handshake measured ~830 ms
+    // when the floor was set and ~320-430 ms after #486; the floor stays at 1000 ms for the reasons
+    // on MinDiscoveryTimeoutMs. These pin the clamp directly rather than through a real discovery run.
     [Theory]
     [InlineData(0)]
     [InlineData(250)]   // the old floor — must no longer be honored

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -70,21 +70,30 @@ public sealed class DaqifiAgent
     private static readonly object PwmCommandedMarker = new();
 
     /// <summary>
-    /// Floor for <see cref="DiscoverAsync"/>'s <c>timeoutMs</c> clamp. Bench-measured: the serial
-    /// identify handshake takes ~830 ms on real hardware, so this is that plus ~20% margin — a
-    /// timeout below it can never succeed and returns an empty list indistinguishable from "no
-    /// device attached" (#448). Was 250 ms, which is below the handshake time on every run.
+    /// Floor for <see cref="DiscoverAsync"/>'s <c>timeoutMs</c> clamp. A timeout below the identify
+    /// handshake can never succeed and returns an empty list indistinguishable from "no device
+    /// attached" (#448), which is why the floor exists at all; it was 250 ms, below the handshake
+    /// time on every run.
     /// </summary>
+    /// <remarks>
+    /// Originally derived from an ~830 ms bench-measured serial identify. That handshake is now
+    /// ~320-430 ms (#486), but the floor is deliberately left at 1000 ms rather than tracked down to
+    /// it: the measurement is one macOS host with one candidate port and a warm USB-descriptor
+    /// cache, while the number this floor has to cover is the slowest supported path — several
+    /// candidate ports, and a platform that still runs an uncached descriptor query per port
+    /// (#487). Lowering it on the strength of the fast case is how a caller ends up back at #448's
+    /// empty-list-means-nothing-attached, so it should follow #487 rather than lead it.
+    /// </remarks>
     internal const int MinDiscoveryTimeoutMs = 1000;
 
     /// <summary>
     /// Clamps a caller-supplied discovery timeout to <c>[<see cref="MinDiscoveryTimeoutMs"/>, 30_000]</c>
-    /// ms. The floor is derived from measurement, not a guess: the serial identify handshake takes
-    /// ~830 ms on real hardware, so anything below ~1000 ms returns empty before the device can
-    /// ever answer — indistinguishable from "nothing is attached" (#448). Serial probing can settle
-    /// and return before the full budget; <see cref="WiFiDeviceFinder"/> listens for the whole
-    /// window regardless (its receive loop runs until the timeout cancels it), so this floor mainly
-    /// rejects budgets that could never have succeeded rather than guaranteeing an early return.
+    /// ms. Anything below the floor returns empty before the device can ever answer —
+    /// indistinguishable from "nothing is attached" (#448); see <see cref="MinDiscoveryTimeoutMs"/>
+    /// for how that floor is chosen. Serial probing can settle and return before the full budget;
+    /// <see cref="WiFiDeviceFinder"/> listens for the whole window regardless (its receive loop runs
+    /// until the timeout cancels it), so this floor mainly rejects budgets that could never have
+    /// succeeded rather than guaranteeing an early return.
     /// </summary>
     internal static TimeSpan ClampDiscoveryTimeout(int timeoutMs) =>
         TimeSpan.FromMilliseconds(Math.Clamp(timeoutMs, MinDiscoveryTimeoutMs, 30_000));


### PR DESCRIPTION
## What was wrong

Finding a DAQiFi device over USB took about **830 ms**, and roughly **500 ms of that was the library waiting on itself**.

The probe asks the device "who are you?", and the reply arrives on a background reader thread. Because of how the "reply arrived" signal was set up, everything that happened *after* the reply — including the cleanup — ran **on that same reader thread**. The first thing the cleanup does is wait for the reader thread to finish. So the reader thread sat there waiting for itself. It could never succeed, so it waited out its full 500 ms timeout and then gave up, every single time a device was found.

It also meant the probe handed the port back to the caller while its reader was still running over it — the port got closed out from under a live reader.

## How it was fixed

Two things, and the second only became visible once the first was fixed.

The reply signal now resumes on a normal worker thread instead of the reader thread, so the cleanup is waiting for a *different* thread and the wait can actually complete. That alone exposed the real remaining cost: the reader only notices "please stop" when its in-progress read gives up, and the probe port's read timeout is 1 second — so the honest wait was up to a full second, worse than the 500 ms it replaced. So the moment the device answers, the probe drops that read timeout to 50 ms. It does this from inside the "status arrived" callback, which runs on the reader thread between two reads — the one moment the timeout can be changed with no read already in flight under the old value — and the next read is exactly the one the cleanup has to wait out.

The port still *opens* at the 1 second it always did. A port with nothing to say never reaches the callback, so it idles exactly as it did before.

**What a reviewer may want to push back on:**

- **The short read timeout is applied late, not for the whole probe.** Qodo's first review round flagged the obvious version of this change — a 50 ms timeout from the start — because a silent port would then wake twenty times a second and each wake-up ends in a thrown `TimeoutException`. That was measured, not waved away: ~180 ms of CPU per 2 s of probing, against ~5-13 ms at the one-second timeout, and a silent port is probed for the full response window. Applying it only after a device has identified keeps all of the teardown benefit and leaves the silent path byte-for-byte as it was. A test pins both halves.
- **The probe puts the read timeout back before returning.** The stream belongs to the caller and stays open, so leaving it permanently twitchier would be a side effect on someone else's stream — caught in review, and my own two-exchanges-over-one-stream test was already exercising the leak. The restore happens strictly after the consumer join, since the short timeout is what makes that join quick.
- **The issue suggested returning the device as soon as it identifies and finishing teardown in the background. I deliberately did not do that.** It would be faster still, but the normal thing a caller does next is *connect to the port that was just discovered* — and if the probe has not finished closing it, that open fails with a busy port. Discovery still returns only once the port is genuinely closed. Verified on the bench: opening the port the instant `DiscoverAsync` returns succeeded 10/10, in 2-4 ms.
- **The MCP discovery floor (`MinDiscoveryTimeoutMs`) stays at 1000 ms.** The issue lists lowering it as a success criterion, and the ~830 ms measurement it was derived from is now obsolete — but the new measurement is one macOS host, one candidate port, warm descriptor cache. The floor has to cover the *slowest* supported path, including platforms that still run an uncached USB descriptor query per port (#487). Lowering it on the strength of the fast case is how you land back in #448, where an empty result is indistinguishable from "nothing attached". The comment now says all of that instead of quoting a stale number.
- **The request/reply exchange moved into its own method** (`RequestDeviceStatusAsync`), leaving `TryGetDeviceInfoAsync` owning just the port lifecycle. That is what makes the bug testable at all — the exchange can now be driven by a scripted stream with no serial hardware attached.

## Verification

**Tests** — 11 new in `SerialProbeTeardownTests`. Two are regression catchers and were proven to be: with only the one-line signal change reverted, `DoesNotCompleteOnTheReaderThread` and `WhenItReturns_ReaderThreadHasExited` both fail, twice out of two runs. Neither uses a wall clock — they assert that the thread reading the stream has exited by the time the exchange completes, and that the completion did not run on it. Two more catchers cover the review-round fixes and were proven the same way: removing the timeout-shortening call fails `AfterIdentifying_ShortensTheReadTimeoutForTeardown`, and removing the restore fails both `AfterIdentifying_RestoresTheReadTimeoutItFound` and `CanBeRunTwiceOverTheSameStream`. Counterparts assert a silent port's timeout is left untouched and that a stream refusing timeout access still probes fine. The rest cover the parsed status, the silent-device retry count, cancellation, stream ownership, and running two exchanges back-to-back over one stream.

Full suite green on **net9.0** (2932 Core + 43 Mcp) and **net10.0** (2932), 0 failures, 0 warnings, on every push.

**Bench (non-destructive), Nq1 fw 3.7.2 on `/dev/cu.usbmodem1101`:**

| | before | after |
|---|---|---|
| `SerialDeviceFinder.DiscoverAsync` | 834 / 836 / 839 ms | 397 / 380 / 372 / 373 / 373 / 382 ms |
| same, warm USB-descriptor cache | — | 312-318 ms |
| abandoned-claim drain | 488 / 490 / 491 ms | 58 / 56 / 57 ms |

Both rows measured on the same host and device with the same harness; the "after" run uses 2.5 s spacing so every run pays the macOS `ioreg` descriptor refresh exactly like the baseline runs did. That refresh (~85 ms, 2 s TTL) is the whole difference between the two "after" rows and is outside the probe.

Also: back-to-back sweeps with zero delay found the device 16/16 across both pushes; discover-then-immediately-open succeeded 10/10, in 2-4 ms; example CLI `--discover-serial`, `--show-status`, and a 3 s / 500 Hz stream (1186-1187 samples, this unit's known ~79% clock ratio) and `--sd-list` (45 files) all clean, `sn=9090539562006014104`, firmware unchanged, clean `Disconnected`. No reboot, no format, no delete, no `SD:GET`, no firmware, no LAN writes; serial only.

closes #486

Not merging — this is for your review.
