### PR TITLE
perf(mcp): discover_devices no longer waits out one transport before starting the other

### DIFF
--- a/src/Daqifi.Mcp.Tests/DiscoveryFanOutTests.cs
+++ b/src/Daqifi.Mcp.Tests/DiscoveryFanOutTests.cs
@@ -1,0 +1,289 @@
+using System.Net;
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Mcp.Tests;
+
+/// <summary>
+/// Covers <c>discover_devices</c>' transport fan-out (#488): the enabled transports run
+/// concurrently, so a pass costs the slower transport's window rather than the sum of both.
+/// </summary>
+public class DiscoveryFanOutTests
+{
+    /// <summary>
+    /// How long a rendezvous waits before concluding the other transport is never going to start.
+    /// Only reached when the fan-out has regressed to sequential, where the first finder blocks
+    /// forever waiting for a second that cannot start until it returns.
+    /// </summary>
+    private const int RendezvousTimeoutMs = 10_000;
+
+    // ------------------------------------------------------------------ concurrency
+
+    [Fact]
+    public async Task DiscoverAcrossTransports_RunsTheTransportsConcurrently()
+    {
+        // Deliberately not a wall-clock assertion. Each finder blocks until the other has entered
+        // its own discovery, so "both got in at once" is proven by the pass completing at all:
+        // run sequentially, the first finder waits out RendezvousTimeoutMs on a partner that has
+        // not been started yet, and the assertions below fail.
+        var rendezvous = new Rendezvous(participants: 2);
+        var wifi = new ListDeviceFinder(new[] { Info("A", ConnectionType.WiFi) }, rendezvous: rendezvous);
+        var serial = new ListDeviceFinder(new[] { Info("B", ConnectionType.Serial) }, rendezvous: rendezvous);
+
+        var result = await DaqifiAgent.DiscoverAcrossTransportsAsync(
+            new IDeviceFinder[] { wifi, serial }, TimeSpan.FromSeconds(1));
+
+        Assert.True(wifi.MetPartner, "WiFi discovery ran without serial discovery ever starting alongside it.");
+        Assert.True(serial.MetPartner, "Serial discovery ran without WiFi discovery ever starting alongside it.");
+        Assert.Equal(2, result.Count);
+    }
+
+    // ------------------------------------------------------------------ result set
+
+    [Fact]
+    public async Task DiscoverAcrossTransports_ReportsWiFiBeforeSerial()
+    {
+        // The order callers have always seen. CreateTransportFinders builds the list in the same
+        // order for the same reason.
+        var wifi = new ListDeviceFinder(new[] { Info("A", ConnectionType.WiFi) });
+        var serial = new ListDeviceFinder(new[] { Info("B", ConnectionType.Serial) });
+
+        var result = await DaqifiAgent.DiscoverAcrossTransportsAsync(
+            new IDeviceFinder[] { wifi, serial }, TimeSpan.FromSeconds(1));
+
+        Assert.Equal(new[] { "A", "B" }, result.Select(d => d.SerialNumber));
+    }
+
+    [Fact]
+    public async Task DiscoverAcrossTransports_SameUnitOnBothTransports_StaysTwoEntries()
+    {
+        // Two genuine ways to connect to one device, so an agent must still see both. The identity
+        // used for deduplication is transport-prefixed, which is what keeps them apart.
+        var wifi = new ListDeviceFinder(new[] { Info("SHARED", ConnectionType.WiFi) });
+        var serial = new ListDeviceFinder(new[] { Info("SHARED", ConnectionType.Serial) });
+
+        var result = await DaqifiAgent.DiscoverAcrossTransportsAsync(
+            new IDeviceFinder[] { wifi, serial }, TimeSpan.FromSeconds(1));
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task DiscoverAcrossTransports_OneTransportReportingADeviceTwice_CollapsesToOne()
+    {
+        var serial = new ListDeviceFinder(new[]
+        {
+            Info("DUP", ConnectionType.Serial, name: "first"),
+            Info("DUP", ConnectionType.Serial, name: "second"),
+        });
+
+        var result = await DaqifiAgent.DiscoverAcrossTransportsAsync(
+            new IDeviceFinder[] { serial }, TimeSpan.FromSeconds(1));
+
+        var device = Assert.Single(result);
+        Assert.Equal("first", device.Name);
+    }
+
+    [Fact]
+    public async Task DiscoverAcrossTransports_OneTransportFails_TheOtherStillReports()
+    {
+        // The reason this matters for discover_devices: a WiFi probe on a host with no usable
+        // network used to throw straight out of the tool call and lose the USB device found
+        // alongside it.
+        var wifi = new ListDeviceFinder(
+            Array.Empty<IDeviceInfo>(),
+            throwOnDiscover: new InvalidOperationException("no network"));
+        var serial = new ListDeviceFinder(new[] { Info("USB", ConnectionType.Serial) });
+
+        var result = await DaqifiAgent.DiscoverAcrossTransportsAsync(
+            new IDeviceFinder[] { wifi, serial }, TimeSpan.FromSeconds(1));
+
+        var device = Assert.Single(result);
+        Assert.Equal("USB", device.SerialNumber);
+    }
+
+    // ------------------------------------------------------------------ ownership
+
+    [Fact]
+    public async Task DiscoverAcrossTransports_DisposesTheFindersItWasGiven()
+    {
+        var wifi = new ListDeviceFinder(new[] { Info("A", ConnectionType.WiFi) });
+        var serial = new ListDeviceFinder(new[] { Info("B", ConnectionType.Serial) });
+
+        await DaqifiAgent.DiscoverAcrossTransportsAsync(
+            new IDeviceFinder[] { wifi, serial }, TimeSpan.FromSeconds(1));
+
+        Assert.True(wifi.Disposed);
+        Assert.True(serial.Disposed);
+    }
+
+    [Fact]
+    public async Task DiscoverAcrossTransports_NoTransportsEnabled_ReturnsEmptyRatherThanThrowing()
+    {
+        // AllTransportsDeviceFinder requires at least one finder; "both transports off" is a
+        // legitimate call and must not surface that as an ArgumentException.
+        var result = await DaqifiAgent.DiscoverAcrossTransportsAsync(
+            Array.Empty<IDeviceFinder>(), TimeSpan.FromSeconds(1));
+
+        Assert.Empty(result);
+    }
+
+    // ------------------------------------------------------------------ wiring
+
+    [Fact]
+    public void CreateTransportFinders_BothEnabled_IsWiFiThenSerial()
+    {
+        var finders = DaqifiAgent.CreateTransportFinders(wifi: true, serial: true);
+
+        Assert.Collection(
+            finders,
+            f => Assert.IsType<WiFiDeviceFinder>(f),
+            f => Assert.IsType<SerialDeviceFinder>(f));
+
+        DisposeAll(finders);
+    }
+
+    [Theory]
+    [InlineData(true, false, typeof(WiFiDeviceFinder))]
+    [InlineData(false, true, typeof(SerialDeviceFinder))]
+    public void CreateTransportFinders_OneEnabled_BuildsOnlyThatTransport(bool wifi, bool serial, Type expected)
+    {
+        var finders = DaqifiAgent.CreateTransportFinders(wifi, serial);
+
+        Assert.IsType(expected, Assert.Single(finders));
+
+        DisposeAll(finders);
+    }
+
+    [Fact]
+    public void CreateTransportFinders_NeitherEnabled_IsEmpty()
+    {
+        Assert.Empty(DaqifiAgent.CreateTransportFinders(wifi: false, serial: false));
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_NeitherTransportEnabled_ReturnsEmptyWithoutTouchingHardware()
+    {
+        var agent = new DaqifiAgent(new ServerOptions());
+
+        var result = await agent.DiscoverAsync(
+            timeoutMs: 1000, wifi: false, serial: false, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static void DisposeAll(IEnumerable<IDeviceFinder> finders)
+    {
+        foreach (var finder in finders)
+        {
+            (finder as IDisposable)?.Dispose();
+        }
+    }
+
+    private static IDeviceInfo Info(string serialNumber, ConnectionType connectionType, string name = "Fake") =>
+        new FakeDeviceInfo
+        {
+            Name = name,
+            SerialNumber = serialNumber,
+            ConnectionType = connectionType,
+            PortName = connectionType == ConnectionType.Serial ? "/dev/fake" : null,
+            IPAddress = connectionType == ConnectionType.WiFi ? IPAddress.Loopback : null,
+        };
+
+    /// <summary>
+    /// A meeting point for a fixed number of participants: each one announces its arrival and then
+    /// waits for the rest. Used to assert that two discoveries were genuinely in flight at the same
+    /// moment, which sequential execution can never satisfy.
+    /// </summary>
+    private sealed class Rendezvous
+    {
+        private readonly TaskCompletionSource _allArrived =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly int _participants;
+        private int _arrived;
+
+        public Rendezvous(int participants) => _participants = participants;
+
+        /// <summary>
+        /// Announces this participant and waits for the others, giving up after
+        /// <see cref="RendezvousTimeoutMs"/> so a regression fails the assertion instead of
+        /// hanging the whole test run.
+        /// </summary>
+        /// <returns>True when every participant arrived; false if the wait timed out.</returns>
+        public async Task<bool> ArriveAndWaitAsync()
+        {
+            if (Interlocked.Increment(ref _arrived) == _participants)
+            {
+                _allArrived.TrySetResult();
+            }
+
+            var completed = await Task.WhenAny(_allArrived.Task, Task.Delay(RendezvousTimeoutMs))
+                .ConfigureAwait(false);
+            return completed == _allArrived.Task;
+        }
+    }
+
+    private sealed class ListDeviceFinder : IDeviceFinder, IDisposable
+    {
+        private readonly IReadOnlyList<IDeviceInfo> _devices;
+        private readonly Exception? _throw;
+        private readonly Rendezvous? _rendezvous;
+
+        public ListDeviceFinder(
+            IEnumerable<IDeviceInfo> devices,
+            Exception? throwOnDiscover = null,
+            Rendezvous? rendezvous = null)
+        {
+            _devices = devices.ToList();
+            _throw = throwOnDiscover;
+            _rendezvous = rendezvous;
+        }
+
+        public bool Disposed { get; private set; }
+
+        /// <summary>Whether every other participant was already inside its own discovery.</summary>
+        public bool MetPartner { get; private set; }
+
+#pragma warning disable CS0067 // interface events unused by this fake
+        public event EventHandler<DeviceDiscoveredEventArgs>? DeviceDiscovered;
+        public event EventHandler? DiscoveryCompleted;
+#pragma warning restore CS0067
+
+        public async Task<IEnumerable<IDeviceInfo>> DiscoverAsync(CancellationToken cancellationToken = default)
+        {
+            if (_rendezvous != null)
+            {
+                MetPartner = await _rendezvous.ArriveAndWaitAsync().ConfigureAwait(false);
+            }
+
+            if (_throw != null)
+            {
+                throw _throw;
+            }
+
+            return _devices;
+        }
+
+        public Task<IEnumerable<IDeviceInfo>> DiscoverAsync(TimeSpan timeout) =>
+            DiscoverAsync(CancellationToken.None);
+
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class FakeDeviceInfo : IDeviceInfo
+    {
+        public string Name { get; set; } = "Fake";
+        public string SerialNumber { get; set; } = "SN";
+        public string FirmwareVersion { get; set; } = "3.7.2";
+        public IPAddress? IPAddress { get; set; }
+        public string? MacAddress { get; set; }
+        public int? Port { get; set; }
+        public IPAddress? LocalInterfaceAddress { get; set; }
+        public DeviceType Type { get; set; } = DeviceType.Nyquist1;
+        public bool IsPowerOn { get; set; } = true;
+        public ConnectionType ConnectionType { get; set; } = ConnectionType.Unknown;
+        public string? PortName { get; set; }
+        public string? DevicePath { get; set; }
+    }
+}

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -97,23 +97,19 @@ public sealed class DaqifiAgent
 
     // ---------------------------------------------------------------- discovery
 
+    /// <remarks>
+    /// The enabled transports run concurrently, so the call costs the slower transport's window
+    /// rather than the sum of both (#488). That matters because <see cref="WiFiDeviceFinder"/>
+    /// listens for its whole budget by design, so running it before serial used to add its full
+    /// timeout to every pass — on the first tool call of every session.
+    /// </remarks>
     public async Task<IReadOnlyList<DiscoveredDevice>> DiscoverAsync(
         int timeoutMs, bool wifi, bool serial, CancellationToken cancellationToken)
     {
         var timeout = ClampDiscoveryTimeout(timeoutMs);
-        var infos = new List<IDeviceInfo>();
 
-        if (wifi)
-        {
-            using var finder = new WiFiDeviceFinder();
-            infos.AddRange(await finder.DiscoverAsync(timeout).ConfigureAwait(false));
-        }
-
-        if (serial)
-        {
-            using var finder = new SerialDeviceFinder();
-            infos.AddRange(await finder.DiscoverAsync(timeout).ConfigureAwait(false));
-        }
+        var infos = await DiscoverAcrossTransportsAsync(
+            CreateTransportFinders(wifi, serial), timeout).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -125,6 +121,67 @@ public sealed class DaqifiAgent
             result.Add(DiscoveredDevice.From(id, info));
         }
         return result;
+    }
+
+    /// <summary>
+    /// The transport finders a discovery pass runs over, in the order their results are reported.
+    /// WiFi comes first so that a device reachable both ways keeps the ordering callers have always
+    /// seen. Internal for testing.
+    /// </summary>
+    internal static IReadOnlyList<IDeviceFinder> CreateTransportFinders(bool wifi, bool serial)
+    {
+        var finders = new List<IDeviceFinder>(2);
+        if (wifi)
+        {
+            finders.Add(new WiFiDeviceFinder());
+        }
+
+        if (serial)
+        {
+            finders.Add(new SerialDeviceFinder());
+        }
+
+        return finders;
+    }
+
+    /// <summary>
+    /// Runs the supplied transport finders concurrently and returns one deduplicated device set.
+    /// Owns the finders: they are disposed before this returns, so the caller passes them in and
+    /// forgets them. Internal for testing.
+    /// </summary>
+    /// <remarks>
+    /// The fan-out itself is <see cref="AllTransportsDeviceFinder"/> rather than a local
+    /// <c>Task.WhenAll</c> — Core already had the primitive, and with it come two behaviours this
+    /// path did not have: intra-transport duplicates collapse (the same unit reported twice by one
+    /// finder is one entry, while the same unit reached over two transports stays two, because the
+    /// identity is transport-prefixed), and one transport failing no longer sinks the pass. A WiFi
+    /// probe on a host with no usable network used to throw straight out of <c>discover_devices</c>
+    /// and lose the USB device that was found alongside it.
+    /// </remarks>
+    internal static async Task<IReadOnlyList<IDeviceInfo>> DiscoverAcrossTransportsAsync(
+        IReadOnlyList<IDeviceFinder> finders, TimeSpan timeout)
+    {
+        // Both transports disabled is a legitimate no-op call, but AllTransportsDeviceFinder
+        // requires at least one finder — answer it here rather than let the aggregator throw.
+        if (finders.Count == 0)
+        {
+            return Array.Empty<IDeviceInfo>();
+        }
+
+        try
+        {
+            using var allTransports = new AllTransportsDeviceFinder(finders);
+            return (await allTransports.DiscoverAsync(timeout).ConfigureAwait(false)).ToList();
+        }
+        finally
+        {
+            // AllTransportsDeviceFinder only disposes finders it created itself, so the ones
+            // constructed above are ours to release — including when the pass throws.
+            foreach (var finder in finders)
+            {
+                (finder as IDisposable)?.Dispose();
+            }
+        }
     }
 
     // ------------------------------------------------------------- connection


### PR DESCRIPTION
## What was wrong

`discover_devices` is the first tool call of nearly every MCP session, and it took roughly three seconds at its default two-second budget. The reason is that it ran the two transports one after the other: WiFi discovery listens for its entire budget by design (it is waiting for broadcast replies, so there is nothing to return early for), and only once that finished did the serial probe start. An agent therefore paid the WiFi window *plus* the serial handshake on every discovery, including the mid-conversation re-discoveries agents tend to do.

A second, quieter problem: if WiFi discovery threw — a host with no usable network, most commonly — the exception came straight out of the tool call and the USB device that had been sitting there the whole time was never reported.

## How it was fixed

The enabled transports now run concurrently, so a pass costs the slower transport's window instead of the sum of both. The fan-out is Core's existing `AllTransportsDeviceFinder` rather than a local `Task.WhenAll` — the primitive was already there, and adopting it also fixes the failure case above (a transport that throws is skipped, not fatal) and collapses duplicates reported twice by a single transport.

The one thing worth pushing back on is that this changes two observable behaviours, both deliberately: a failing transport no longer fails the whole call, and a device a single transport reports twice now appears once. A device reachable over *both* USB and WiFi still appears as two entries, because the deduplication identity is transport-prefixed — that is two genuine ways to connect, and the bench run below confirms both still come back.

## Verification

Bench, non-destructive, fw 3.7.2 on `/dev/cu.usbmodem1101` (the unit is also on WiFi at 192.168.1.30, so this exercised the cross-transport path for real):

| | sequential (before) | concurrent (after) |
|---|---|---|
| round 1 | 3086 ms | 2017 ms |
| round 2 | 2833 ms | 2003 ms |
| round 3 | 2825 ms | 2002 ms |

Same two devices found either way. The after-figure is the WiFi window itself, which is the point — the serial probe is now free. Transport flags re-checked end to end on hardware: both `2024 ms`, WiFi-only `2003 ms`, serial-only `843 ms`, neither `0 ms` and empty rather than throwing.

12 new tests in `DiscoveryFanOutTests`. Concurrency is asserted with a rendezvous rather than a wall clock — each fake finder blocks until the other has entered its own discovery, so sequential execution cannot satisfy it. Three of the twelve were proven regression catchers by temporarily restoring the sequential loop: the concurrency test, the deduplication test and the one-transport-fails test all failed against it.

Full suite green on **net9.0** (2921 Core + 55 Mcp) and **net10.0** (2921 Core; `Daqifi.Mcp.Tests` targets net9.0 only), 0 failures, 0 warnings.

closes #488

Not merging — opened for your review.