### PR TITLE
perf(streaming): stop rebuilding the channel map and copying the buffer on every frame

### DIFF
--- a/src/Daqifi.Core.Tests/Channel/ChannelEnablementNotificationTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/ChannelEnablementNotificationTests.cs
@@ -1,0 +1,82 @@
+using Daqifi.Core.Channel;
+
+namespace Daqifi.Core.Tests.Channel;
+
+/// <summary>
+/// Tests for <see cref="IChannelEnablementNotifier"/>, the hook that lets a device notice a caller
+/// writing <see cref="IChannel.IsEnabled"/> straight onto a channel (issue #490).
+/// </summary>
+public class ChannelEnablementNotificationTests
+{
+    public static TheoryData<IChannel> Channels() => new()
+    {
+        new AnalogChannel(0),
+        new DigitalChannel(0),
+    };
+
+    [Theory]
+    [MemberData(nameof(Channels))]
+    public void ChangingIsEnabled_Notifies(IChannel channel)
+    {
+        var notifications = 0;
+        ((IChannelEnablementNotifier)channel).EnablementChanged += () => notifications++;
+
+        channel.IsEnabled = true;
+
+        Assert.Equal(1, notifications);
+    }
+
+    /// <summary>
+    /// A write that does not change the value is not a change. Status messages re-assert the same
+    /// enabled mask constantly, and treating each one as a change would throw away the caches this
+    /// notification exists to keep valid.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Channels))]
+    public void WritingTheSameValue_DoesNotNotify(IChannel channel)
+    {
+        channel.IsEnabled = true;
+
+        var notifications = 0;
+        ((IChannelEnablementNotifier)channel).EnablementChanged += () => notifications++;
+
+        channel.IsEnabled = true;
+        channel.IsEnabled = true;
+
+        Assert.Equal(0, notifications);
+    }
+
+    /// <summary>
+    /// The notification is raised outside the channel's own lock. A handler that reads the channel
+    /// back — which is the obvious thing for a handler to do — would otherwise re-enter that lock
+    /// from the thread already holding it; that happens to be legal for a <c>Monitor</c>, but it
+    /// makes the contract depend on the lock being reentrant. Asserting the value is readable and
+    /// already updated pins both halves.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Channels))]
+    public void TheHandlerCanReadTheChannelBack_AndSeesTheNewValue(IChannel channel)
+    {
+        bool? observed = null;
+        ((IChannelEnablementNotifier)channel).EnablementChanged += () => observed = channel.IsEnabled;
+
+        channel.IsEnabled = true;
+
+        Assert.True(observed);
+    }
+
+    [Theory]
+    [MemberData(nameof(Channels))]
+    public void UnsubscribingStopsNotifications(IChannel channel)
+    {
+        var notifications = 0;
+        void Handler() => notifications++;
+
+        ((IChannelEnablementNotifier)channel).EnablementChanged += Handler;
+        channel.IsEnabled = true;
+        ((IChannelEnablementNotifier)channel).EnablementChanged -= Handler;
+        channel.IsEnabled = false;
+
+        Assert.Equal(1, notifications);
+    }
+}

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBufferCopyTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBufferCopyTests.cs
@@ -153,6 +153,43 @@ public class StreamMessageConsumerBufferCopyTests
         Assert.Equal(new uint[] { 4242 }, messages);
     }
 
+    /// <summary>
+    /// The two events are independent deliveries. Core's own subscribers ride
+    /// <c>MessageParsed</c>, so one of them throwing must not withhold the message from an external
+    /// <c>MessageReceived</c> subscriber that had nothing to do with the failure — and the failure
+    /// must still be reported.
+    /// </summary>
+    [Fact]
+    public void AThrowingMessageParsedSubscriber_DoesNotWithholdMessageReceived()
+    {
+        using var stream = new MemoryStream(Frame(7).Concat(Frame(8)).ToArray());
+        using var consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, new ProtobufMessageParser());
+
+        var errors = new List<Exception>();
+        var delivered = new List<uint>();
+        var done = new ManualResetEventSlim(false);
+
+        consumer.MessageParsed += _ => throw new InvalidOperationException("bad internal handler");
+        consumer.ErrorOccurred += (_, e) => errors.Add(e.Error);
+        consumer.MessageReceived += (_, args) =>
+        {
+            delivered.Add(args.Message.Data.MsgTimeStamp);
+            if (delivered.Count == 2)
+            {
+                done.Set();
+            }
+        };
+
+        consumer.Start();
+        var fired = done.Wait(TimeSpan.FromSeconds(2));
+        consumer.Stop();
+
+        Assert.True(fired, "both messages should still have reached MessageReceived");
+        Assert.Equal(new uint[] { 7, 8 }, delivered);
+        Assert.Equal(2, errors.Count);
+        Assert.All(errors, error => Assert.IsType<InvalidOperationException>(error));
+    }
+
     private static byte[] Frame(uint timestamp)
     {
         var message = new DaqifiOutMessage { MsgTimeStamp = timestamp };

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBufferCopyTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerBufferCopyTests.cs
@@ -1,0 +1,256 @@
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Messages;
+using Google.Protobuf;
+
+namespace Daqifi.Core.Tests.Communication.Consumers;
+
+/// <summary>
+/// Tests for what <see cref="StreamMessageConsumer{T}"/> copies on every read (issue #490).
+/// </summary>
+/// <remarks>
+/// Two copies used to happen per read regardless of what anyone needed: the accumulation buffer was
+/// filled a byte at a time from the read buffer, and then the whole accumulation buffer was copied
+/// out again purely so the parser could be handed an array. On a device streaming at kilohertz
+/// rates that is the wire throughput duplicated as garbage, for the life of the connection. What is
+/// asserted here is the observable consequence — the parser is handed a view rather than a copy,
+/// and the raw-buffer snapshot is taken only for a subscriber that asked for it — plus the framing
+/// behaviour that must survive the change.
+/// </remarks>
+public class StreamMessageConsumerBufferCopyTests
+{
+    /// <summary>
+    /// The parser now sees the span entry point. That is the whole mechanism by which the per-read
+    /// copy disappears, so it is asserted directly rather than inferred.
+    /// </summary>
+    [Fact]
+    public void TheParserIsCalledThroughItsSpanEntryPoint()
+    {
+        var parser = new EntryPointRecordingParser();
+        using var stream = new MemoryStream(Frame(1));
+        using var consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, parser);
+
+        var received = new ManualResetEventSlim(false);
+        consumer.MessageParsed += _ => received.Set();
+
+        consumer.Start();
+        var fired = received.Wait(TimeSpan.FromSeconds(2));
+        consumer.Stop();
+
+        Assert.True(fired, "the consumer should have parsed the frame");
+        Assert.True(parser.SpanCalls > 0);
+        Assert.Equal(0, parser.ArrayCalls);
+    }
+
+    /// <summary>
+    /// The raw-buffer snapshot exists for <c>MessageReceived</c> subscribers. With none attached
+    /// there is nobody to hand it to, so it is not taken — this is the allocation that used to
+    /// happen on every read of every stream whether or not anything wanted it.
+    /// </summary>
+    [Fact]
+    public void WithNoMessageReceivedSubscriber_NoBufferSnapshotIsTaken()
+    {
+        using var stream = new MemoryStream(Frame(1));
+        using var consumer = new RawDataRecordingConsumer(stream);
+
+        var received = new ManualResetEventSlim(false);
+        consumer.MessageParsed += _ => received.Set();
+
+        consumer.Start();
+        var fired = received.Wait(TimeSpan.FromSeconds(2));
+        consumer.Stop();
+
+        Assert.True(fired);
+        Assert.NotNull(consumer.LastRawData);
+        Assert.Empty(consumer.LastRawData!);
+    }
+
+    /// <summary>
+    /// And with a subscriber attached it keeps its documented meaning: everything that was buffered
+    /// when the batch was parsed, handed over before the consumed bytes are drained.
+    /// </summary>
+    [Fact]
+    public void WithAMessageReceivedSubscriber_TheSnapshotIsStillTheWholeBufferedRead()
+    {
+        var frame = Frame(1);
+        using var stream = new MemoryStream(frame);
+        using var consumer = new RawDataRecordingConsumer(stream);
+
+        var received = new ManualResetEventSlim(false);
+        byte[]? rawFromArgs = null;
+        consumer.MessageReceived += (_, args) =>
+        {
+            rawFromArgs = args.RawData;
+            received.Set();
+        };
+
+        consumer.Start();
+        var fired = received.Wait(TimeSpan.FromSeconds(2));
+        consumer.Stop();
+
+        Assert.True(fired);
+        Assert.Equal(frame, rawFromArgs);
+        Assert.Equal(frame, consumer.LastRawData);
+    }
+
+    /// <summary>
+    /// Both events describe the same messages, in the same order. <see cref="StreamMessageConsumer{T}.MessageParsed"/>
+    /// is only a cheaper view of <c>MessageReceived</c>, not a different feed.
+    /// </summary>
+    [Fact]
+    public void BothEventsSeeTheSameMessagesInTheSameOrder()
+    {
+        var payload = Frame(1).Concat(Frame(2)).Concat(Frame(3)).ToArray();
+        using var stream = new MemoryStream(payload);
+        using var consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, new ProtobufMessageParser());
+
+        var parsed = new List<uint>();
+        var receivedList = new List<uint>();
+        var done = new ManualResetEventSlim(false);
+
+        consumer.MessageParsed += message => parsed.Add(message.Data.MsgTimeStamp);
+        consumer.MessageReceived += (_, args) =>
+        {
+            receivedList.Add(args.Message.Data.MsgTimeStamp);
+            if (receivedList.Count == 3)
+            {
+                done.Set();
+            }
+        };
+
+        consumer.Start();
+        var fired = done.Wait(TimeSpan.FromSeconds(2));
+        consumer.Stop();
+
+        Assert.True(fired);
+        Assert.Equal(new uint[] { 1, 2, 3 }, parsed);
+        Assert.Equal(new uint[] { 1, 2, 3 }, receivedList);
+    }
+
+    /// <summary>
+    /// The bulk append has to accumulate across reads exactly as the byte-at-a-time loop did: a
+    /// frame split over two reads must still be reassembled and parsed once.
+    /// </summary>
+    [Fact]
+    public void AFrameSplitAcrossReads_IsStillReassembled()
+    {
+        var frame = Frame(4242);
+        using var stream = new ChunkedStream(frame.Take(3).ToArray(), frame.Skip(3).ToArray());
+        using var consumer = new StreamMessageConsumer<DaqifiOutMessage>(stream, new ProtobufMessageParser());
+
+        var messages = new List<uint>();
+        var received = new ManualResetEventSlim(false);
+        consumer.MessageParsed += message =>
+        {
+            messages.Add(message.Data.MsgTimeStamp);
+            received.Set();
+        };
+
+        consumer.Start();
+        var fired = received.Wait(TimeSpan.FromSeconds(2));
+        consumer.Stop();
+
+        Assert.True(fired);
+        Assert.Equal(new uint[] { 4242 }, messages);
+    }
+
+    private static byte[] Frame(uint timestamp)
+    {
+        var message = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+        using var buffer = new MemoryStream();
+        message.WriteDelimitedTo(buffer);
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Records which of the parser's two entry points the consumer used.
+    /// </summary>
+    private sealed class EntryPointRecordingParser : IMessageParser<DaqifiOutMessage>
+    {
+        private readonly ProtobufMessageParser _inner = new();
+
+        public int ArrayCalls { get; private set; }
+
+        public int SpanCalls { get; private set; }
+
+        public IEnumerable<IInboundMessage<DaqifiOutMessage>> ParseMessages(byte[] data, out int consumedBytes)
+        {
+            ArrayCalls++;
+            return _inner.ParseMessages(data, out consumedBytes);
+        }
+
+        public IEnumerable<IInboundMessage<DaqifiOutMessage>> ParseMessages(
+            ReadOnlySpan<byte> data,
+            out int consumedBytes)
+        {
+            SpanCalls++;
+            return _inner.ParseMessages(data, out consumedBytes);
+        }
+    }
+
+    /// <summary>
+    /// Captures the raw-data argument the consumer passes down to <c>OnMessageReceived</c>, which
+    /// is the only place the snapshot decision is observable.
+    /// </summary>
+    private sealed class RawDataRecordingConsumer : StreamMessageConsumer<DaqifiOutMessage>
+    {
+        public RawDataRecordingConsumer(Stream stream)
+            : base(stream, new ProtobufMessageParser())
+        {
+        }
+
+        public byte[]? LastRawData { get; private set; }
+
+        protected override void OnMessageReceived(IInboundMessage<DaqifiOutMessage> message, byte[] rawData)
+        {
+            LastRawData = rawData;
+            base.OnMessageReceived(message, rawData);
+        }
+    }
+
+    /// <summary>
+    /// Hands out its content one chunk per read, so a frame can be forced to arrive split.
+    /// </summary>
+    private sealed class ChunkedStream : Stream
+    {
+        private readonly Queue<byte[]> _chunks;
+
+        public ChunkedStream(params byte[][] chunks)
+        {
+            _chunks = new Queue<byte[]>(chunks);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_chunks.Count == 0)
+            {
+                // Behaves like an idle serial port: no data right now, not end of stream.
+                Thread.Sleep(5);
+                return 0;
+            }
+
+            var chunk = _chunks.Dequeue();
+            var length = Math.Min(chunk.Length, count);
+            Array.Copy(chunk, 0, buffer, offset, length);
+            return length;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/ChannelStateVersionTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelStateVersionTests.cs
@@ -77,6 +77,54 @@ public class ChannelStateVersionTests
     }
 
     /// <summary>
+    /// A status that describes the same channels the device already has is not a change. The
+    /// populator reuses those instances, so nothing derived from them can have gone stale — moving
+    /// the version anyway would throw away a live stream's cache on every status poll.
+    /// </summary>
+    [Fact]
+    public void RepopulatingWithTheSameChannels_DoesNotMoveTheVersion()
+    {
+        var device = CreateDevice(analogCount: 2, digitalCount: 2);
+        var before = device.ChannelStateVersion;
+
+        device.PopulateChannelsFromStatus(Status(analogCount: 2, digitalCount: 2));
+        device.PopulateChannelsFromStatus(Status(analogCount: 2, digitalCount: 2));
+
+        Assert.Equal(before, device.ChannelStateVersion);
+    }
+
+    /// <summary>
+    /// …but a status that changes the enabled mask on those same instances still moves it, through
+    /// the channels' own notifications rather than through the membership check.
+    /// </summary>
+    [Fact]
+    public void RepopulatingWithADifferentEnabledMask_StillMovesTheVersion()
+    {
+        var device = CreateDevice(analogCount: 2);
+        var before = device.ChannelStateVersion;
+
+        var status = Status(analogCount: 2);
+        status.AnalogInPortEnabled = Google.Protobuf.ByteString.CopyFrom(0b0000_0011);
+        device.PopulateChannelsFromStatus(status);
+
+        Assert.NotEqual(before, device.ChannelStateVersion);
+    }
+
+    /// <summary>
+    /// A channel count change replaces the membership, which no per-channel notification covers.
+    /// </summary>
+    [Fact]
+    public void RepopulatingWithADifferentChannelCount_MovesTheVersion()
+    {
+        var device = CreateDevice(analogCount: 2);
+        var before = device.ChannelStateVersion;
+
+        device.PopulateChannelsFromStatus(Status(analogCount: 3));
+
+        Assert.NotEqual(before, device.ChannelStateVersion);
+    }
+
+    /// <summary>
     /// A channel the device no longer owns must not keep bumping the version — that is a
     /// subscription leak, and it would make every write to a long-discarded channel invalidate a
     /// live stream's cache.

--- a/src/Daqifi.Core.Tests/Device/ChannelStateVersionTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelStateVersionTests.cs
@@ -1,0 +1,232 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using System.Linq;
+using System.Net;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Tests for <see cref="DaqifiDevice.ChannelStateVersion"/> and the end-to-end consequence it
+/// exists for: the streaming decoder caches which analog channels are active, and that cache has to
+/// follow every way the answer can change (issue #490).
+/// </summary>
+/// <remarks>
+/// The decoder's own view of this is covered directly in <c>StreamFrameDecoderTests</c> against a
+/// fake host. These run it through a real <see cref="DaqifiStreamingDevice"/>, because the wiring
+/// between a channel being written to and the version moving is the part a fake cannot vouch for.
+/// </remarks>
+public class ChannelStateVersionTests
+{
+    #region The version itself
+
+    [Fact]
+    public void PopulatingChannelsFromAStatus_MovesTheVersion()
+    {
+        var device = new VersionProbeDevice("TestDevice");
+        var before = device.ChannelStateVersion;
+
+        device.PopulateChannelsFromStatus(Status(analogCount: 2));
+
+        Assert.NotEqual(before, device.ChannelStateVersion);
+    }
+
+    [Fact]
+    public void WritingIsEnabledOnAChannelTheDeviceOwns_MovesTheVersion()
+    {
+        var device = CreateDevice(analogCount: 2);
+        var before = device.ChannelStateVersion;
+
+        device.Channels.First(c => c.ChannelNumber == 0).IsEnabled = true;
+
+        Assert.NotEqual(before, device.ChannelStateVersion);
+    }
+
+    /// <summary>
+    /// A write that changes nothing is not a change. Without this the version would move on every
+    /// status message that re-asserts the same enabled mask, throwing away the cache the version
+    /// exists to protect.
+    /// </summary>
+    [Fact]
+    public void WritingTheSameEnabledValue_DoesNotMoveTheVersion()
+    {
+        var device = CreateDevice(analogCount: 2);
+        var channel = device.Channels.First(c => c.ChannelNumber == 0);
+        channel.IsEnabled = true;
+        var before = device.ChannelStateVersion;
+
+        channel.IsEnabled = true;
+
+        Assert.Equal(before, device.ChannelStateVersion);
+    }
+
+    /// <summary>
+    /// Digital channels are part of the snapshot the decoder caches, so their enablement has to
+    /// move the version as well.
+    /// </summary>
+    [Fact]
+    public void WritingIsEnabledOnADigitalChannel_MovesTheVersion()
+    {
+        var device = CreateDevice(analogCount: 1, digitalCount: 2);
+        var before = device.ChannelStateVersion;
+
+        device.Channels.First(c => c.Type == ChannelType.Digital).IsEnabled = true;
+
+        Assert.NotEqual(before, device.ChannelStateVersion);
+    }
+
+    /// <summary>
+    /// A channel the device no longer owns must not keep bumping the version — that is a
+    /// subscription leak, and it would make every write to a long-discarded channel invalidate a
+    /// live stream's cache.
+    /// </summary>
+    [Fact]
+    public void AChannelDroppedByRepopulation_NoLongerMovesTheVersion()
+    {
+        var device = CreateDevice(analogCount: 2);
+        var dropped = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 1);
+
+        // Repopulate with a single analog channel, so channel 1 is no longer the device's.
+        device.PopulateChannelsFromStatus(Status(analogCount: 1));
+        Assert.DoesNotContain(dropped, device.Channels);
+
+        var before = device.ChannelStateVersion;
+        dropped.IsEnabled = !dropped.IsEnabled;
+
+        Assert.Equal(before, device.ChannelStateVersion);
+    }
+
+    /// <summary>
+    /// The mirror image: an instance the populator <em>reused</em> across a repopulation is still
+    /// the device's channel, and detaching-then-reattaching it must leave it subscribed exactly
+    /// once — not zero times (silent staleness) and not twice.
+    /// </summary>
+    [Fact]
+    public void AChannelReusedByRepopulation_StillMovesTheVersion_Once()
+    {
+        var device = CreateDevice(analogCount: 2);
+        device.PopulateChannelsFromStatus(Status(analogCount: 2));
+
+        var reused = device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+        var before = device.ChannelStateVersion;
+
+        reused.IsEnabled = !reused.IsEnabled;
+
+        Assert.Equal(before + 1, device.ChannelStateVersion);
+    }
+
+    #endregion
+
+    #region End-to-end through the decode path
+
+    /// <summary>
+    /// The behaviour success criterion of #490: a channel enabled mid-stream takes effect on the
+    /// next frame. Runs through the public API a consumer actually uses.
+    /// </summary>
+    [Fact]
+    public void EnablingAChannelMidStream_TakesEffectOnTheNextFrame()
+    {
+        var device = CreateDevice(analogCount: 2);
+        var ai0 = Analog(device, 0);
+        var ai1 = Analog(device, 1);
+        ai1.IsEnabled = true;
+
+        device.StartStreaming();
+        device.InvokeStreamMessage(Frame(1000, 5.0f));
+        Assert.Equal(5.0, ai1.ActiveSample!.Value, 3);
+        Assert.Null(ai0.ActiveSample);
+
+        ai0.IsEnabled = true;
+        device.InvokeStreamMessage(Frame(2000, 1.0f, 2.0f));
+
+        Assert.Equal(1.0, ai0.ActiveSample!.Value, 3);
+        Assert.Equal(2.0, ai1.ActiveSample!.Value, 3);
+    }
+
+    /// <summary>
+    /// A status message arriving mid-stream repopulates channels, and the frames after it must be
+    /// decoded against the new set.
+    /// </summary>
+    [Fact]
+    public void RepopulatingChannelsMidStream_TakesEffectOnTheNextFrame()
+    {
+        var device = CreateDevice(analogCount: 1);
+        Analog(device, 0).IsEnabled = true;
+
+        device.StartStreaming();
+        device.InvokeStreamMessage(Frame(1000, 1.0f));
+        Assert.Equal(1.0, Analog(device, 0).ActiveSample!.Value, 3);
+
+        // Two analog channels now, both enabled by the device-reported mask.
+        var status = Status(analogCount: 2);
+        status.AnalogInPortEnabled = Google.Protobuf.ByteString.CopyFrom(0b0000_0011);
+        device.PopulateChannelsFromStatus(status);
+
+        device.InvokeStreamMessage(Frame(2000, 3.0f, 4.0f));
+
+        Assert.Equal(3.0, Analog(device, 0).ActiveSample!.Value, 3);
+        Assert.Equal(4.0, Analog(device, 1).ActiveSample!.Value, 3);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static VersionProbeDevice CreateDevice(int analogCount, int digitalCount = 0)
+    {
+        var device = new VersionProbeDevice("TestDevice");
+        device.Connect();
+        device.PopulateChannelsFromStatus(Status(analogCount, digitalCount));
+        return device;
+    }
+
+    private static DaqifiOutMessage Status(int analogCount, int digitalCount = 0)
+    {
+        var status = new DaqifiOutMessage
+        {
+            AnalogInPortNum = (uint)analogCount,
+            DigitalPortNum = (uint)digitalCount,
+            AnalogInRes = 65535,
+        };
+
+        for (var i = 0; i < analogCount; i++)
+        {
+            status.AnalogInPortRange.Add(1.0f);
+        }
+
+        return status;
+    }
+
+    private static IAnalogChannel Analog(DaqifiStreamingDevice device, int number) =>
+        (IAnalogChannel)device.Channels.First(c => c.Type == ChannelType.Analog && c.ChannelNumber == number);
+
+    private static DaqifiOutMessage Frame(uint timestamp, params float[] values)
+    {
+        var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+        foreach (var value in values)
+        {
+            frame.AnalogInDataFloat.Add(value);
+        }
+        return frame;
+    }
+
+    /// <summary>
+    /// A streaming device that swallows outbound SCPI (so streaming can be started without a
+    /// transport) and lets a frame be injected straight into the stream handler.
+    /// </summary>
+    private sealed class VersionProbeDevice : DaqifiStreamingDevice
+    {
+        public VersionProbeDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)
+        {
+        }
+
+        public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+
+        public override void Send<T>(IOutboundMessage<T> message)
+        {
+        }
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -606,6 +606,7 @@ public class DeviceAdministrationOperationsTests
         public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
         public IReadOnlyList<IChannel> SnapshotChannels() => throw new NotSupportedException();
+        public long ChannelStateVersion => throw new NotSupportedException();
         public void WithChannelsLock(Action action) => throw new NotSupportedException();
         /// <summary>
         /// Runs the setup action so its sends land in <see cref="Calls"/> in order, then answers with

--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -472,6 +472,14 @@ public class LiveSampleStreamTests
         }
 
         /// <summary>
+        /// Bumped by <see cref="Add"/> so a caller caching a derivation of the channel set sees the
+        /// change. <see cref="LiveSampleStream"/> does not cache, but the host contract says this
+        /// moves whenever the channels do, and a fake that lied about it would let a future caller
+        /// that <em>does</em> cache pass here and fail on a real device.
+        /// </summary>
+        public long ChannelStateVersion => _channels.Count;
+
+        /// <summary>
         /// In the collaborator's remit since issue #496: an enumeration is only meaningful on a
         /// connected device, so the start-up guard reads this. Settable so both sides of that guard
         /// can be exercised. Reading state is still a world away from the members below, which

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -344,6 +344,160 @@ public class StreamFrameDecoderTests
 
     #endregion
 
+    #region Channel caching (#490)
+
+    /// <summary>
+    /// The point of the cache: a stream that nobody reconfigures asks the device for its channels
+    /// once, not once per frame. Every snapshot is an array copy taken under the device's channels
+    /// lock, so at kilohertz rates this was both garbage and lock traffic against the configuration
+    /// path.
+    /// </summary>
+    [Fact]
+    public void SteadyStateFrames_AskTheDeviceForChannelsOnlyOnce()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        host.AddAnalog(0, enabled: true);
+        host.AddAnalog(1, enabled: true);
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        var afterBeginSession = host.SnapshotChannelsCallCount;
+
+        for (uint ts = 1000; ts <= 100_000; ts += 1000)
+        {
+            decoder.ProcessFrame(FullAnalogFrame(ts, 1.0f, 2.0f));
+        }
+
+        Assert.Equal(1, host.SnapshotChannelsCallCount - afterBeginSession);
+    }
+
+    /// <summary>
+    /// The cache is only sound if it is rebuilt when the device says the channel state moved —
+    /// once, not on every subsequent frame.
+    /// </summary>
+    [Fact]
+    public void AChannelStateChange_RebuildsTheCacheExactlyOnce()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(AnalogFrame(1000, 1.0f));
+        var baseline = host.SnapshotChannelsCallCount;
+
+        ai0.IsEnabled = false;
+
+        for (uint ts = 2000; ts <= 10_000; ts += 1000)
+        {
+            decoder.ProcessFrame(AnalogFrame(ts, 1.0f));
+        }
+
+        Assert.Equal(1, host.SnapshotChannelsCallCount - baseline);
+    }
+
+    /// <summary>
+    /// Enabling a channel by writing <c>IsEnabled</c> straight onto it — which
+    /// <see cref="IChannel"/> permits and which no device API sees — must reach the decoder. This
+    /// is the failure the cache invalidation exists for: without it the frame's values keep being
+    /// mapped onto the previously active channels, so AI1's reading is silently filed under AI0.
+    /// </summary>
+    [Fact]
+    public void EnablingAChannelDirectly_TakesEffectOnTheNextFrame()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: false);
+        var ai1 = host.AddAnalog(1, enabled: true);
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(AnalogFrame(1000, 5.0f));
+        Assert.Equal(5.0, ai1.ActiveSample!.Value, 3);
+        Assert.Null(ai0.ActiveSample);
+
+        ai0.IsEnabled = true;
+        decoder.ProcessFrame(FullAnalogFrame(2000, 1.0f, 2.0f));
+
+        Assert.Equal(1.0, ai0.ActiveSample!.Value, 3);
+        Assert.Equal(2.0, ai1.ActiveSample!.Value, 3);
+    }
+
+    /// <summary>
+    /// The same in the other direction: a channel disabled mid-stream must stop consuming a
+    /// position in the frame, or every channel after it is read one slot out.
+    /// </summary>
+    [Fact]
+    public void DisablingAChannelDirectly_TakesEffectOnTheNextFrame()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        var ai1 = host.AddAnalog(1, enabled: true);
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(FullAnalogFrame(1000, 1.0f, 2.0f));
+        Assert.Equal(1.0, ai0.ActiveSample!.Value, 3);
+        Assert.Equal(2.0, ai1.ActiveSample!.Value, 3);
+
+        ai0.IsEnabled = false;
+        decoder.ProcessFrame(AnalogFrame(2000, 7.0f));
+
+        // AI1 is now the only active analog channel, so the frame's single value is its reading.
+        Assert.Equal(7.0, ai1.ActiveSample!.Value, 3);
+        Assert.Equal(1.0, ai0.ActiveSample!.Value, 3); // unchanged from the first frame
+    }
+
+    /// <summary>
+    /// The device streams analog values ordered by channel number, not by the order the channels
+    /// were enabled in — so the cached array has to stay sorted, not merely filtered.
+    /// </summary>
+    [Fact]
+    public void CachedChannels_StayInAscendingChannelOrder_WhateverOrderTheyWereEnabledIn()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai2 = host.AddAnalog(2, enabled: true);
+        var ai0 = host.AddAnalog(0, enabled: true);
+        var ai1 = host.AddAnalog(1, enabled: true);
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(FullAnalogFrame(1000, 10.0f, 11.0f, 12.0f));
+
+        Assert.Equal(10.0, ai0.ActiveSample!.Value, 3);
+        Assert.Equal(11.0, ai1.ActiveSample!.Value, 3);
+        Assert.Equal(12.0, ai2.ActiveSample!.Value, 3);
+    }
+
+    /// <summary>
+    /// The warmup-frame guard (#351) counts enabled analog channels to decide whether a leading
+    /// frame is short. It now reads that count from the cache, so it has to see enablement changes
+    /// too — a guard working from a stale count would either suppress good frames or let malformed
+    /// ones through.
+    /// </summary>
+    [Fact]
+    public void TheWarmupGuard_SeesEnablementChangesThroughTheCache()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        var ai1 = host.AddAnalog(1, enabled: false);
+        var decoder = new StreamFrameDecoder(host);
+
+        // One enabled analog channel at session start: a one-value frame is full, not short.
+        decoder.BeginSession(TicksPerSecond, 100);
+        decoder.ProcessFrame(AnalogFrame(1000, 1.0f));
+        Assert.DoesNotContain("discard", host.Calls);
+
+        // Re-arm the guard with two channels enabled; now a one-value frame *is* short.
+        ai1.IsEnabled = true;
+        decoder.BeginSession(TicksPerSecond, 100);
+        decoder.ProcessFrame(AnalogFrame(2000, 9.0f));
+
+        Assert.Contains("discard", host.Calls);
+        Assert.Equal(1.0, ai0.ActiveSample!.Value, 3); // the short frame's value was withheld
+    }
+
+    #endregion
+
     #region Helpers
 
     private static ThrowSwitch AttachThrowingSubscriber(IChannel channel)
@@ -384,6 +538,7 @@ public class StreamFrameDecoderTests
     private sealed class FakeHost : IDeviceOperationHost
     {
         private readonly List<IChannel> _channels = new();
+        private long _channelStateVersion;
 
         public List<string> Calls { get; } = new();
 
@@ -398,18 +553,44 @@ public class StreamFrameDecoderTests
         public AnalogChannel AddAnalog(int number, bool enabled)
         {
             var channel = new AnalogChannel(number) { IsEnabled = enabled };
-            _channels.Add(channel);
+            Track(channel);
             return channel;
         }
 
         public IChannel AddDigital(int number, bool enabled)
         {
             var channel = new DigitalChannel(number) { IsEnabled = enabled, Direction = ChannelDirection.Input };
-            _channels.Add(channel);
+            Track(channel);
             return channel;
         }
 
-        public IReadOnlyList<IChannel> SnapshotChannels() => _channels.ToArray();
+        /// <summary>
+        /// Adds a channel and wires up change tracking exactly as <c>DaqifiDevice</c> does, so the
+        /// decoder's cache invalidation is exercised against the real contract: membership changes
+        /// bump the version, and so does a direct write to <see cref="IChannel.IsEnabled"/>.
+        /// </summary>
+        private void Track(IChannel channel)
+        {
+            _channels.Add(channel);
+            ((IChannelEnablementNotifier)channel).EnablementChanged += BumpChannelStateVersion;
+            BumpChannelStateVersion();
+        }
+
+        private void BumpChannelStateVersion() => Interlocked.Increment(ref _channelStateVersion);
+
+        /// <summary>
+        /// How many times the decoder has asked for a channel snapshot. Counted rather than
+        /// appended to <see cref="Calls"/> so the existing call-order assertions are unaffected.
+        /// </summary>
+        public int SnapshotChannelsCallCount { get; private set; }
+
+        public IReadOnlyList<IChannel> SnapshotChannels()
+        {
+            SnapshotChannelsCallCount++;
+            return _channels.ToArray();
+        }
+
+        public long ChannelStateVersion => Interlocked.Read(ref _channelStateVersion);
 
         public void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e)
         {

--- a/src/Daqifi.Core.Tests/Device/Protocol/ProtobufProtocolHandlerTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Protocol/ProtobufProtocolHandlerTests.cs
@@ -219,4 +219,69 @@ public class ProtobufProtocolHandlerTests
         // Assert
         Assert.Equal(ProtobufMessageType.Error, result);
     }
+
+    /// <summary>
+    /// The typed entry point exists so a caller that already holds a <see cref="DaqifiOutMessage"/>
+    /// does not have to wrap it just to be routed — an allocation per frame on a streaming device
+    /// (issue #490). It must route identically to <see cref="ProtobufProtocolHandler.HandleAsync"/>,
+    /// which is now built on it.
+    /// </summary>
+    [Theory]
+    [InlineData(ProtobufMessageType.Status)]
+    [InlineData(ProtobufMessageType.Stream)]
+    [InlineData(ProtobufMessageType.Error)]
+    [InlineData(ProtobufMessageType.Unknown)]
+    public async Task Handle_RoutesTheSameWayHandleAsyncDoes(ProtobufMessageType messageType)
+    {
+        var viaHandle = new List<string>();
+        var viaHandleAsync = new List<string>();
+
+        var handleHandler = HandlerRecording(viaHandle);
+        var handleAsyncHandler = HandlerRecording(viaHandleAsync);
+
+        var message = MessageOfType(messageType);
+
+        handleHandler.Handle(message);
+        await handleAsyncHandler.HandleAsync(new GenericInboundMessage<object>(message));
+
+        Assert.Equal(viaHandleAsync, viaHandle);
+        Assert.Equal(
+            messageType == ProtobufMessageType.Unknown ? 0 : 1,
+            viaHandle.Count);
+    }
+
+    [Fact]
+    public void Handle_RejectsANullMessage()
+    {
+        var handler = new ProtobufProtocolHandler();
+
+        Assert.Throws<ArgumentNullException>(() => handler.Handle(null!));
+    }
+
+    private static ProtobufProtocolHandler HandlerRecording(List<string> routed) =>
+        new(
+            statusMessageHandler: _ => routed.Add("status"),
+            streamMessageHandler: _ => routed.Add("stream"),
+            sdCardMessageHandler: _ => routed.Add("sdcard"),
+            errorMessageHandler: _ => routed.Add("error"));
+
+    private static DaqifiOutMessage MessageOfType(ProtobufMessageType messageType)
+    {
+        switch (messageType)
+        {
+            case ProtobufMessageType.Status:
+                return new DaqifiOutMessage { AnalogInPortNum = 16 };
+
+            case ProtobufMessageType.Stream:
+                var stream = new DaqifiOutMessage { MsgTimeStamp = 1000 };
+                stream.AnalogInDataFloat.Add(1.0f);
+                return stream;
+
+            case ProtobufMessageType.Error:
+                return new DaqifiOutMessage { DeviceStatus = 1 };
+
+            default:
+                return new DaqifiOutMessage();
+        }
+    }
 }

--- a/src/Daqifi.Core.Tests/Device/UndifferentiatedMessageRaiseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/UndifferentiatedMessageRaiseTests.cs
@@ -1,0 +1,114 @@
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using System.Collections.Generic;
+using System.Net;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Tests for when <see cref="DaqifiDevice.MessageReceived"/> is raised (issue #490).
+/// </summary>
+/// <remarks>
+/// Every inbound frame used to be wrapped in an <see cref="IInboundMessage{T}"/> so it could be
+/// offered to this event, whether or not anything was listening — an allocation per frame, which on
+/// a streaming device is one per sample period. The wrapper is now built only when there is a
+/// subscriber; what these pin is that nothing else about the frame's journey changed.
+/// </remarks>
+public class UndifferentiatedMessageRaiseTests
+{
+    [Fact]
+    public void WithNoSubscriber_TheUndifferentiatedEventIsNotRaised()
+    {
+        var device = new RaiseProbeDevice("TestDevice");
+
+        device.InvokeStatusMessage(StatusFrame());
+        device.InvokeStreamMessage(StreamFrame());
+
+        Assert.Equal(0, device.UndifferentiatedRaises);
+    }
+
+    [Fact]
+    public void WithASubscriber_BothStatusAndStreamFramesAreRaised()
+    {
+        var device = new RaiseProbeDevice("TestDevice");
+        var received = new List<object?>();
+        device.MessageReceived += (_, e) => received.Add(e.Message.Data);
+
+        device.InvokeStatusMessage(StatusFrame());
+        device.InvokeStreamMessage(StreamFrame());
+
+        Assert.Equal(2, received.Count);
+        Assert.All(received, data => Assert.IsType<DaqifiOutMessage>(data));
+        Assert.Equal(2, device.UndifferentiatedRaises);
+    }
+
+    /// <summary>
+    /// The classified events are the ones Core's own consumers and the decode path ride on, so they
+    /// have to stay unconditional — the subscriber check applies only to the undifferentiated event
+    /// whose payload had to be allocated.
+    /// </summary>
+    [Fact]
+    public void TheClassifiedEventsStillFireWithNoUndifferentiatedSubscriber()
+    {
+        var device = new RaiseProbeDevice("TestDevice");
+
+        var statusFrames = 0;
+        var streamFrames = 0;
+        device.StatusMessageReceived += _ => statusFrames++;
+        device.StreamMessageReceived += _ => streamFrames++;
+
+        device.InvokeStatusMessage(StatusFrame());
+        device.InvokeStreamMessage(StreamFrame());
+
+        Assert.Equal(1, statusFrames);
+        Assert.Equal(1, streamFrames);
+        Assert.Equal(0, device.UndifferentiatedRaises);
+    }
+
+    private static DaqifiOutMessage StatusFrame()
+    {
+        var status = new DaqifiOutMessage
+        {
+            AnalogInPortNum = 1,
+            AnalogInRes = 65535,
+        };
+        status.AnalogInPortRange.Add(1.0f);
+        return status;
+    }
+
+    private static DaqifiOutMessage StreamFrame()
+    {
+        var frame = new DaqifiOutMessage { MsgTimeStamp = 1000 };
+        frame.AnalogInDataFloat.Add(1.0f);
+        return frame;
+    }
+
+    /// <summary>
+    /// Counts how many times a frame actually made it as far as
+    /// <see cref="DaqifiDevice.OnMessageReceived"/> — the point past which the wrapper has already
+    /// been allocated.
+    /// </summary>
+    private sealed class RaiseProbeDevice : DaqifiStreamingDevice
+    {
+        public RaiseProbeDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)
+        {
+        }
+
+        public int UndifferentiatedRaises { get; private set; }
+
+        public void InvokeStatusMessage(DaqifiOutMessage message) => OnStatusMessageReceived(message);
+
+        public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+
+        protected override void OnMessageReceived(IInboundMessage<object> message)
+        {
+            UndifferentiatedRaises++;
+            base.OnMessageReceived(message);
+        }
+
+        public override void Send<T>(IOutboundMessage<T> message)
+        {
+        }
+    }
+}

--- a/src/Daqifi.Core/Channel/AnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogChannel.cs
@@ -3,7 +3,7 @@ namespace Daqifi.Core.Channel;
 /// <summary>
 /// Represents an analog input/output channel with scaling and calibration capabilities.
 /// </summary>
-public class AnalogChannel : IAnalogChannel
+public class AnalogChannel : IAnalogChannel, IChannelEnablementNotifier
 {
     /// <summary>
     /// Smallest <see cref="Resolution"/> (maximum raw count) accepted as a physically plausible ADC
@@ -36,6 +36,7 @@ public class AnalogChannel : IAnalogChannel
     private IDataSample? _activeSample;
     private string _name;
     private bool _isEnabled;
+    private Action? _enablementChanged;
     private ChannelDirection _direction;
     private double _minValue;
     private double _maxValue;
@@ -60,13 +61,39 @@ public class AnalogChannel : IAnalogChannel
         set { lock (_lock) { _name = value; } }
     }
 
+    /// <inheritdoc />
+    event Action? IChannelEnablementNotifier.EnablementChanged
+    {
+        add { lock (_lock) { _enablementChanged += value; } }
+        remove { lock (_lock) { _enablementChanged -= value; } }
+    }
+
     /// <summary>
     /// Gets or sets whether the channel is enabled.
     /// </summary>
     public bool IsEnabled
     {
         get { lock (_lock) { return _isEnabled; } }
-        set { lock (_lock) { _isEnabled = value; } }
+        set
+        {
+            Action? subscribers;
+            lock (_lock)
+            {
+                if (_isEnabled == value)
+                {
+                    return;
+                }
+
+                _isEnabled = value;
+                subscribers = _enablementChanged;
+            }
+
+            // Raised outside the lock: the owning device's handler is free to read back from this
+            // channel, and holding _lock across it would make that a self-deadlock waiting to
+            // happen. The subscriber list was captured inside, so a concurrent unsubscribe cannot
+            // tear it.
+            subscribers?.Invoke();
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Channel/DigitalChannel.cs
+++ b/src/Daqifi.Core/Channel/DigitalChannel.cs
@@ -3,12 +3,13 @@ namespace Daqifi.Core.Channel;
 /// <summary>
 /// Represents a digital input/output channel.
 /// </summary>
-public class DigitalChannel : IDigitalChannel
+public class DigitalChannel : IDigitalChannel, IChannelEnablementNotifier
 {
     private readonly object _lock = new();
     private IDataSample? _activeSample;
     private string _name;
     private bool _isEnabled;
+    private Action? _enablementChanged;
     private ChannelDirection _direction;
     private bool _outputValue;
     private bool _isPwmEnabled;
@@ -46,13 +47,36 @@ public class DigitalChannel : IDigitalChannel
         set { lock (_lock) { _name = value; } }
     }
 
+    /// <inheritdoc />
+    event Action? IChannelEnablementNotifier.EnablementChanged
+    {
+        add { lock (_lock) { _enablementChanged += value; } }
+        remove { lock (_lock) { _enablementChanged -= value; } }
+    }
+
     /// <summary>
     /// Gets or sets whether the channel is enabled.
     /// </summary>
     public bool IsEnabled
     {
         get { lock (_lock) { return _isEnabled; } }
-        set { lock (_lock) { _isEnabled = value; } }
+        set
+        {
+            Action? subscribers;
+            lock (_lock)
+            {
+                if (_isEnabled == value)
+                {
+                    return;
+                }
+
+                _isEnabled = value;
+                subscribers = _enablementChanged;
+            }
+
+            // Raised outside the lock — see AnalogChannel.IsEnabled for why.
+            subscribers?.Invoke();
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Channel/IChannelEnablementNotifier.cs
+++ b/src/Daqifi.Core/Channel/IChannelEnablementNotifier.cs
@@ -1,0 +1,30 @@
+namespace Daqifi.Core.Channel;
+
+/// <summary>
+/// Implemented by Core's channel types so the device that owns them can tell when a channel's
+/// <see cref="IChannel.IsEnabled"/> state has changed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists for one reason: the streaming decode path caches which analog channels are active,
+/// and that cache has to be invalidated by <em>every</em> way enablement can change — including a
+/// caller writing <c>channel.IsEnabled = true</c> directly, which <see cref="IChannel"/> permits and
+/// which no device API sees (issue #490). Without a notification the decoder would happily keep
+/// mapping frame values onto the previous set of channels, silently attributing readings to the
+/// wrong channel.
+/// </para>
+/// <para>
+/// Deliberately internal. It is an implementation detail of that invalidation, not a contract
+/// consumers implement: the device only ever holds channel instances built by
+/// <c>StatusChannelPopulator</c> from a device status message, and those are always Core's own
+/// <see cref="AnalogChannel"/> and <see cref="DigitalChannel"/>.
+/// </para>
+/// </remarks>
+internal interface IChannelEnablementNotifier
+{
+    /// <summary>
+    /// Raised after <see cref="IChannel.IsEnabled"/> changes to a different value, outside any lock
+    /// the channel holds, so a handler is free to read back from the channel.
+    /// </summary>
+    event Action? EnablementChanged;
+}

--- a/src/Daqifi.Core/Communication/Consumers/IMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/IMessageParser.cs
@@ -15,4 +15,28 @@ public interface IMessageParser<T>
     /// <param name="consumedBytes">The number of bytes consumed from the data during parsing.</param>
     /// <returns>A collection of parsed messages.</returns>
     IEnumerable<IInboundMessage<T>> ParseMessages(byte[] data, out int consumedBytes);
+
+    /// <summary>
+    /// Parses raw data into complete messages without requiring the caller to own an array.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This exists so a consumer that accumulates bytes in a buffer can hand the parser a view
+    /// over that buffer instead of copying it out first. <see cref="StreamMessageConsumer{T}"/>
+    /// calls it on every read, so on a device streaming at kilohertz rates the copy it avoids is
+    /// the whole wire throughput, duplicated as garbage (issue #490).
+    /// </para>
+    /// <para>
+    /// The default implementation copies the span into an array and defers to
+    /// <see cref="ParseMessages(byte[], out int)"/>, so existing parsers keep working unchanged and
+    /// are no slower than they were. Parsers on a hot path should override it; the span must not be
+    /// captured beyond the call, as the caller may reuse or resize the underlying storage
+    /// immediately afterwards.
+    /// </para>
+    /// </remarks>
+    /// <param name="data">The raw data to parse.</param>
+    /// <param name="consumedBytes">The number of bytes consumed from the data during parsing.</param>
+    /// <returns>A collection of parsed messages.</returns>
+    IEnumerable<IInboundMessage<T>> ParseMessages(ReadOnlySpan<byte> data, out int consumedBytes)
+        => ParseMessages(data.ToArray(), out consumedBytes);
 }

--- a/src/Daqifi.Core/Communication/Consumers/LineBasedMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/LineBasedMessageParser.cs
@@ -40,6 +40,21 @@ public class LineBasedMessageParser : IMessageParser<string>
     /// <param name="consumedBytes">The number of bytes consumed from the data during parsing.</param>
     /// <returns>A collection of parsed text messages.</returns>
     public IEnumerable<IInboundMessage<string>> ParseMessages(byte[] data, out int consumedBytes)
+        => ParseMessages(new ReadOnlySpan<byte>(data), out consumedBytes);
+
+    /// <summary>
+    /// Parses raw data into line-based text messages directly from the caller's buffer.
+    /// </summary>
+    /// <remarks>
+    /// Overriding the span entry point keeps <see cref="StreamMessageConsumer{T}"/> from copying
+    /// its accumulation buffer out on every read (issue #490), and decodes each line straight from
+    /// the buffer rather than through a per-line intermediate array. Nothing here retains
+    /// <paramref name="data"/> past the call.
+    /// </remarks>
+    /// <param name="data">The raw data to parse.</param>
+    /// <param name="consumedBytes">The number of bytes consumed from the data during parsing.</param>
+    /// <returns>A collection of parsed text messages.</returns>
+    public IEnumerable<IInboundMessage<string>> ParseMessages(ReadOnlySpan<byte> data, out int consumedBytes)
     {
         var messages = new List<IInboundMessage<string>>();
         consumedBytes = 0;
@@ -62,10 +77,7 @@ public class LineBasedMessageParser : IMessageParser<string>
             var lineLength = lineEndIndex - searchStart;
             if (lineLength > 0)
             {
-                var lineData = new byte[lineLength];
-                Array.Copy(data, searchStart, lineData, 0, lineLength);
-                
-                var messageText = _encoding.GetString(lineData);
+                var messageText = _encoding.GetString(data.Slice(searchStart, lineLength));
                 if (!string.IsNullOrWhiteSpace(messageText))
                 {
                     messages.Add(new TextInboundMessage(messageText.Trim()));
@@ -86,7 +98,7 @@ public class LineBasedMessageParser : IMessageParser<string>
     /// <param name="data">The data to search.</param>
     /// <param name="startIndex">The index to start searching from.</param>
     /// <returns>The index of the line ending, or -1 if not found.</returns>
-    private int FindLineEnding(byte[] data, int startIndex)
+    private int FindLineEnding(ReadOnlySpan<byte> data, int startIndex)
     {
         for (int i = startIndex; i <= data.Length - _lineEnding.Length; i++)
         {

--- a/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
@@ -43,6 +43,20 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
     /// <param name="consumedBytes">The number of bytes consumed from the data during parsing.</param>
     /// <returns>A collection of parsed protobuf messages.</returns>
     public IEnumerable<IInboundMessage<DaqifiOutMessage>> ParseMessages(byte[] data, out int consumedBytes)
+        => ParseMessages(new ReadOnlySpan<byte>(data), out consumedBytes);
+
+    /// <summary>
+    /// Parses raw data into protobuf messages directly from the caller's buffer.
+    /// </summary>
+    /// <remarks>
+    /// The whole method body already worked in spans — only the entry point required an array,
+    /// which forced <see cref="StreamMessageConsumer{T}"/> to copy its accumulation buffer out on
+    /// every read (issue #490). Nothing here retains <paramref name="data"/> past the call.
+    /// </remarks>
+    /// <param name="data">The raw data to parse.</param>
+    /// <param name="consumedBytes">The number of bytes consumed from the data during parsing.</param>
+    /// <returns>A collection of parsed protobuf messages.</returns>
+    public IEnumerable<IInboundMessage<DaqifiOutMessage>> ParseMessages(ReadOnlySpan<byte> data, out int consumedBytes)
     {
         var messages = new List<IInboundMessage<DaqifiOutMessage>>();
         consumedBytes = 0;
@@ -54,7 +68,7 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
 
         while (currentIndex < data.Length)
         {
-            var remainingData = new ReadOnlySpan<byte>(data, currentIndex, data.Length - currentIndex);
+            var remainingData = data.Slice(currentIndex);
 
             if (!TryReadLengthPrefix(remainingData, out var messageLength, out var prefixBytes, out var prefixIsMalformed))
             {
@@ -220,11 +234,11 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
     /// before the expensive ParseFrom, keeping the per-offset cost low even when the
     /// scan covers a large noisy buffer.
     /// </remarks>
-    private static int FindNextParseableFrameStart(byte[] data, int start)
+    private static int FindNextParseableFrameStart(ReadOnlySpan<byte> data, int start)
     {
         for (var i = start; i < data.Length; i++)
         {
-            var remaining = new ReadOnlySpan<byte>(data, i, data.Length - i);
+            var remaining = data.Slice(i);
 
             if (!TryReadLengthPrefix(remaining, out var messageLength, out var prefixBytes, out _))
             {

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -1,6 +1,7 @@
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Transport;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Daqifi.Core.Communication.Consumers;
@@ -104,7 +105,32 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// <summary>
     /// Occurs when a message is received and parsed from the device.
     /// </summary>
+    /// <remarks>
+    /// Subscribing to this event makes the consumer snapshot its accumulation buffer on every read
+    /// so that <see cref="MessageReceivedEventArgs{T}.RawData"/> can carry it. Consumers that only
+    /// need the parsed message should use <see cref="MessageParsed"/> instead, which costs nothing
+    /// per read — that is what Core's own subscribers do (issue #490).
+    /// <para>
+    /// A handler attached while a batch is already being dispatched can see an empty
+    /// <see cref="MessageReceivedEventArgs{T}.RawData"/> for the remainder of that batch, because
+    /// the decision to snapshot was taken before it subscribed. Every subsequent read carries the
+    /// snapshot as usual.
+    /// </para>
+    /// </remarks>
     public event EventHandler<MessageReceivedEventArgs<T>>? MessageReceived;
+
+    /// <summary>
+    /// Occurs when a message is received and parsed, carrying only the message itself.
+    /// </summary>
+    /// <remarks>
+    /// The raw-buffer snapshot that <see cref="MessageReceived"/> carries is a full copy of
+    /// everything buffered at the time of the read — on a device streaming at kilohertz rates that
+    /// is the entire wire throughput duplicated as garbage, and no subscriber inside Core has ever
+    /// looked at it. This event exists so those subscribers can stop paying for it; it fires for
+    /// exactly the same messages, immediately before <see cref="MessageReceived"/>, on the same
+    /// reader thread and with the same per-subscriber exception isolation.
+    /// </remarks>
+    internal event Action<IInboundMessage<T>>? MessageParsed;
 
     /// <summary>
     /// Occurs when an error occurs during message processing.
@@ -432,12 +458,11 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
 
                 // Add received data to message buffer (guarded: a caller may be reading
                 // QueuedMessageCount and ClearBuffer's drain runs on this same thread).
+                // Bulk-appended: the byte-at-a-time loop this replaced re-checked the list's
+                // capacity once per byte, on every read, for the life of the connection (#490).
                 lock (_bufferLock)
                 {
-                    for (int i = 0; i < bytesRead; i++)
-                    {
-                        _messageBuffer.Add(_buffer[i]);
-                    }
+                    _messageBuffer.AddRange(new ReadOnlySpan<byte>(_buffer, 0, bytesRead));
                 }
 
                 // Try to parse complete messages from buffer
@@ -629,8 +654,18 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
         // subscriber callback never runs while the lock is held.
         lock (_bufferLock)
         {
-            bufferData = _messageBuffer.ToArray();
-            messages = _messageParser.ParseMessages(bufferData, out var consumedBytes);
+            // Parse from a view over the accumulation buffer rather than a copy of it. The copy
+            // this replaced was the wire throughput duplicated as garbage on every single read
+            // (issue #490); it existed only because the parser entry point demanded an array.
+            var buffered = CollectionsMarshal.AsSpan(_messageBuffer);
+
+            // The snapshot MessageReceivedEventArgs<T>.RawData carries is taken only when someone
+            // is actually listening for it, and before the drain below, so it keeps its documented
+            // meaning: everything that was buffered when this batch was parsed. MessageParsed
+            // subscribers — which is all of Core — pay nothing.
+            bufferData = MessageReceived is null ? Array.Empty<byte>() : buffered.ToArray();
+
+            messages = _messageParser.ParseMessages(buffered, out var consumedBytes);
 
             // Remove consumed bytes from buffer
             if (consumedBytes > 0)
@@ -658,12 +693,19 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     }
 
     /// <summary>
-    /// Raises the MessageReceived event.
+    /// Raises the <see cref="MessageParsed"/> and <see cref="MessageReceived"/> events, in that
+    /// order.
     /// </summary>
     /// <param name="message">The received message.</param>
-    /// <param name="rawData">The raw data that was parsed.</param>
+    /// <param name="rawData">
+    /// The raw data that was parsed. Empty when <see cref="MessageReceived"/> has no subscribers:
+    /// the snapshot is only taken for that event, so nothing observable is lost, but an override
+    /// that reads it must attach a <see cref="MessageReceived"/> handler (or call
+    /// <c>base</c>) rather than assume it is always populated.
+    /// </param>
     protected virtual void OnMessageReceived(IInboundMessage<T> message, byte[] rawData)
     {
+        MessageParsed?.Invoke(message);
         MessageReceived?.Invoke(this, new MessageReceivedEventArgs<T>(message, rawData));
     }
 

--- a/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
+++ b/src/Daqifi.Core/Communication/Consumers/StreamMessageConsumer.cs
@@ -705,7 +705,22 @@ public class StreamMessageConsumer<T> : IMessageConsumer<T>
     /// </param>
     protected virtual void OnMessageReceived(IInboundMessage<T> message, byte[] rawData)
     {
-        MessageParsed?.Invoke(message);
+        try
+        {
+            MessageParsed?.Invoke(message);
+        }
+        catch (Exception ex)
+        {
+            // Isolated from the public event on purpose. MessageParsed is what Core's own
+            // subscribers ride, so without this an internal handler that threw would silently
+            // withhold the message from an external MessageReceived subscriber that had nothing to
+            // do with the failure. Reported through the same channel as any other dispatch fault.
+            SafeRaiseError(ex);
+        }
+
+        // Deliberately not wrapped: a throwing MessageReceived subscriber propagates to
+        // ProcessMessageBuffer's per-message catch exactly as it did before this event existed,
+        // which is where it has always been reported from.
         MessageReceived?.Invoke(this, new MessageReceivedEventArgs<T>(message, rawData));
     }
 

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -272,6 +272,35 @@ namespace Daqifi.Core.Device
         protected IReadOnlyList<IChannel> SnapshotChannels() => GetChannelsSnapshot();
 
         /// <summary>
+        /// A counter that changes whenever this device's set of channels, or any of their enabled
+        /// states, changes.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Lets a caller that would otherwise re-derive something from <see cref="Channels"/> on
+        /// every frame cache that derivation instead and rebuild it only when this value moves. The
+        /// streaming decoder does exactly that with the sorted set of active analog channels, which
+        /// it used to snapshot, filter and sort a thousand times a second for a set that changes
+        /// when someone configures the device (issue #490).
+        /// </para>
+        /// <para>
+        /// It is a change token, not a count: only inequality with a previously observed value is
+        /// meaningful. Read it <em>before</em> taking the snapshot you intend to cache — a change
+        /// landing in between then makes the cached value merely stale-by-one-frame rather than
+        /// stale forever.
+        /// </para>
+        /// </remarks>
+        internal long ChannelStateVersion => Interlocked.Read(ref _channelStateVersion);
+
+        /// <summary>
+        /// Bumps <see cref="ChannelStateVersion"/>. Subscribed to every channel this device owns,
+        /// so that a caller writing <c>channel.IsEnabled = true</c> directly — which
+        /// <see cref="IChannel"/> permits and no device API observes — invalidates the same caches
+        /// that <see cref="PopulateChannelsFromStatus"/> does.
+        /// </summary>
+        private void OnChannelEnablementChanged() => Interlocked.Increment(ref _channelStateVersion);
+
+        /// <summary>
         /// Runs <paramref name="action"/> under the same lock that guards structural access to
         /// <see cref="_channels"/> and the status-driven <c>IsEnabled</c> resync in
         /// <see cref="PopulateChannelsFromStatus"/>. A subclass's channel-management API (e.g.
@@ -392,6 +421,10 @@ namespace Daqifi.Core.Device
         // (Clear/Add in PopulateChannelsFromStatus) while caller threads fold over a
         // snapshot via SnapshotChannels for the device-level channel-management API.
         private readonly object _channelsLock = new();
+
+        // Backing counter for ChannelStateVersion. Interlocked because it is bumped from whichever
+        // thread changed a channel and read from the message-consumer thread.
+        private long _channelStateVersion;
 
         // Translates a status frame's channel description into channel instances. Stateless, so
         // it is built once per device and reused for every population.
@@ -1893,7 +1926,7 @@ namespace Daqifi.Core.Device
             // Unsubscribe from message consumer/producer events
             if (_messageConsumer != null)
             {
-                _messageConsumer.MessageReceived -= OnInboundMessageReceived;
+                DetachInboundMessages(_messageConsumer);
                 _messageConsumer.ErrorOccurred -= OnConsumerErrorOccurred;
             }
 
@@ -2306,11 +2339,11 @@ namespace Daqifi.Core.Device
 
         /// <inheritdoc />
         void ITextExchangeHost.AttachInboundHandler(IMessageConsumer<DaqifiOutMessage> consumer) =>
-            consumer.MessageReceived += OnInboundMessageReceived;
+            AttachInboundMessages(consumer);
 
         /// <inheritdoc />
         void ITextExchangeHost.DetachInboundHandler(IMessageConsumer<DaqifiOutMessage> consumer) =>
-            consumer.MessageReceived -= OnInboundMessageReceived;
+            DetachInboundMessages(consumer);
 
         /// <inheritdoc />
         bool ITextExchangeHost.HoldsOperationLock => HoldsOperationLock;
@@ -2602,10 +2635,34 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Raises the <see cref="MessageReceived"/> event when a message is received from the device.
         /// </summary>
+        /// <remarks>
+        /// Not called for a device frame while <see cref="MessageReceived"/> has no subscribers: the
+        /// frame would have to be wrapped in an <see cref="IInboundMessage{T}"/> to be passed here,
+        /// and on a streaming device that is an allocation per frame with nowhere to go
+        /// (issue #490). An override that must see every frame regardless should use
+        /// <see cref="StatusMessageReceived"/>/<see cref="StreamMessageReceived"/> or override
+        /// <see cref="OnStatusMessageReceived"/>/<see cref="OnStreamMessageReceived"/>, which are
+        /// unconditional.
+        /// </remarks>
         /// <param name="message">The message received from the device.</param>
         protected virtual void OnMessageReceived(IInboundMessage<object> message)
         {
             MessageReceived?.Invoke(this, new MessageReceivedEventArgs(message));
+        }
+
+        /// <summary>
+        /// Wraps <paramref name="message"/> and hands it to <see cref="OnMessageReceived"/>, but
+        /// only when <see cref="MessageReceived"/> actually has a subscriber to receive it.
+        /// </summary>
+        /// <param name="message">The device frame to re-raise.</param>
+        private void RaiseUndifferentiatedMessage(DaqifiOutMessage message)
+        {
+            if (MessageReceived is null)
+            {
+                return;
+            }
+
+            OnMessageReceived(new ProtobufMessage(message));
         }
 
         /// <summary>
@@ -3475,8 +3532,8 @@ namespace Daqifi.Core.Device
                 // process every inbound message twice; '-=' is a no-op when not subscribed.
                 if (_messageConsumer != null)
                 {
-                    _messageConsumer.MessageReceived -= OnInboundMessageReceived;
-                    _messageConsumer.MessageReceived += OnInboundMessageReceived;
+                    DetachInboundMessages(_messageConsumer);
+                    AttachInboundMessages(_messageConsumer);
                 }
 
                 // Snapshot into a local, once. Every retry attempt and the derived-class hook
@@ -3777,8 +3834,7 @@ namespace Daqifi.Core.Device
             RaiseClassifiedEvent(StatusMessageReceived, message, nameof(StatusMessageReceived));
 
             // Raise event for external consumers
-            var inboundMessage = new ProtobufMessage(message);
-            OnMessageReceived(inboundMessage);
+            RaiseUndifferentiatedMessage(message);
         }
 
         /// <summary>
@@ -3873,8 +3929,31 @@ namespace Daqifi.Core.Device
 
                 (analogCount, digitalCount) = _channelPopulator.Populate(message, _channels, updatedChannels);
 
+                // Re-point the enablement subscriptions at the channels this device is about to
+                // own. The populator reuses existing instances where it can, so most of these
+                // detach and immediately re-attach; doing it unconditionally is what keeps a
+                // dropped channel from holding a subscription and a brand-new one from missing it.
+                foreach (var channel in _channels)
+                {
+                    if (channel is IChannelEnablementNotifier notifier)
+                    {
+                        notifier.EnablementChanged -= OnChannelEnablementChanged;
+                    }
+                }
+
                 _channels.Clear();
                 _channels.AddRange(updatedChannels);
+
+                foreach (var channel in _channels)
+                {
+                    if (channel is IChannelEnablementNotifier notifier)
+                    {
+                        notifier.EnablementChanged += OnChannelEnablementChanged;
+                    }
+                }
+
+                // The membership itself changed, which no per-channel notification covers.
+                Interlocked.Increment(ref _channelStateVersion);
 
                 channelsSnapshot = _channels.ToArray();
             }
@@ -3901,8 +3980,46 @@ namespace Daqifi.Core.Device
             RaiseClassifiedEvent(StreamMessageReceived, message, nameof(StreamMessageReceived));
 
             // Raise event for external consumers
-            var inboundMessage = new ProtobufMessage(message);
-            OnMessageReceived(inboundMessage);
+            RaiseUndifferentiatedMessage(message);
+        }
+
+        /// <summary>
+        /// Subscribes this device's inbound routing to <paramref name="consumer"/>.
+        /// </summary>
+        /// <remarks>
+        /// Prefers <see cref="StreamMessageConsumer{T}.MessageParsed"/>, which carries the parsed
+        /// message and nothing else. The public <c>MessageReceived</c> event additionally carries a
+        /// snapshot of everything buffered at the time of the read, and taking that snapshot costs
+        /// a copy of the wire throughput on every read of a streaming device (issue #490) — a cost
+        /// this device has never had a use for. Any other consumer implementation falls back to the
+        /// interface event, which behaves exactly as before.
+        /// </remarks>
+        /// <param name="consumer">The consumer to subscribe to.</param>
+        private void AttachInboundMessages(IMessageConsumer<DaqifiOutMessage> consumer)
+        {
+            if (consumer is StreamMessageConsumer<DaqifiOutMessage> streamConsumer)
+            {
+                streamConsumer.MessageParsed += OnInboundMessageParsed;
+                return;
+            }
+
+            consumer.MessageReceived += OnInboundMessageReceived;
+        }
+
+        /// <summary>
+        /// Reverses <see cref="AttachInboundMessages"/>. Both events are detached rather than only
+        /// the one that would have been attached, so a consumer that somehow carries both
+        /// subscriptions cannot be left half-subscribed.
+        /// </summary>
+        /// <param name="consumer">The consumer to unsubscribe from.</param>
+        private void DetachInboundMessages(IMessageConsumer<DaqifiOutMessage> consumer)
+        {
+            if (consumer is StreamMessageConsumer<DaqifiOutMessage> streamConsumer)
+            {
+                streamConsumer.MessageParsed -= OnInboundMessageParsed;
+            }
+
+            consumer.MessageReceived -= OnInboundMessageReceived;
         }
 
         /// <summary>
@@ -3911,12 +4028,36 @@ namespace Daqifi.Core.Device
         /// <param name="sender">The message consumer that raised the event.</param>
         /// <param name="e">The message received event arguments.</param>
         private void OnInboundMessageReceived(object? sender, MessageReceivedEventArgs<DaqifiOutMessage> e)
-        {
-            // Convert to generic inbound message and route through protocol handler
-            var genericMessage = new GenericInboundMessage<object>(e.Message.Data);
+            => OnInboundMessageParsed(e.Message);
 
-            // Route through protocol handler if available
-            if (_protocolHandler != null && _protocolHandler.CanHandle(genericMessage))
+        /// <summary>
+        /// Routes a parsed inbound message through the protocol handler.
+        /// </summary>
+        /// <remarks>
+        /// The consumer is typed to <see cref="DaqifiOutMessage"/>, so the handler's type test can
+        /// never fail here — yet satisfying <see cref="IProtocolHandler.CanHandle"/> used to mean
+        /// boxing every single frame into a <c>GenericInboundMessage&lt;object&gt;</c> just to ask.
+        /// The typed entry point skips both the wrapper and the question (issue #490); a custom
+        /// <see cref="IProtocolHandler"/> still goes the long way round.
+        /// </remarks>
+        /// <param name="message">The parsed message.</param>
+        private void OnInboundMessageParsed(IInboundMessage<DaqifiOutMessage> message)
+        {
+            if (_protocolHandler is ProtobufProtocolHandler protobufHandler)
+            {
+                protobufHandler.Handle(message.Data);
+                return;
+            }
+
+            if (_protocolHandler == null)
+            {
+                return;
+            }
+
+            // Convert to generic inbound message and route through protocol handler
+            var genericMessage = new GenericInboundMessage<object>(message.Data);
+
+            if (_protocolHandler.CanHandle(genericMessage))
             {
                 // Fire and forget - we don't need to wait for the handler to complete
                 _ = _protocolHandler.HandleAsync(genericMessage);

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -301,6 +301,34 @@ namespace Daqifi.Core.Device
         private void OnChannelEnablementChanged() => Interlocked.Increment(ref _channelStateVersion);
 
         /// <summary>
+        /// Whether <paramref name="updated"/> holds a different set of channel instances, in a
+        /// different order, from <paramref name="current"/>.
+        /// </summary>
+        /// <remarks>
+        /// Instance identity, not <c>(type, number)</c> identity. Two channels can carry the same
+        /// number and type and still be different objects — the populator builds a new one whenever
+        /// it cannot reuse the old — and anything caching the old instance would keep writing
+        /// samples into a channel the device has replaced.
+        /// </remarks>
+        private static bool MembershipChanged(List<IChannel> current, List<IChannel> updated)
+        {
+            if (current.Count != updated.Count)
+            {
+                return true;
+            }
+
+            for (var i = 0; i < current.Count; i++)
+            {
+                if (!ReferenceEquals(current[i], updated[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Runs <paramref name="action"/> under the same lock that guards structural access to
         /// <see cref="_channels"/> and the status-driven <c>IsEnabled</c> resync in
         /// <see cref="PopulateChannelsFromStatus"/>. A subclass's channel-management API (e.g.
@@ -3929,31 +3957,40 @@ namespace Daqifi.Core.Device
 
                 (analogCount, digitalCount) = _channelPopulator.Populate(message, _channels, updatedChannels);
 
-                // Re-point the enablement subscriptions at the channels this device is about to
-                // own. The populator reuses existing instances where it can, so most of these
-                // detach and immediately re-attach; doing it unconditionally is what keeps a
-                // dropped channel from holding a subscription and a brand-new one from missing it.
-                foreach (var channel in _channels)
+                // Only a change of *membership* needs handling here. A status that re-asserts a
+                // different enabled mask on channels the device already had has moved the version
+                // already, through those channels' own notifications — they were still subscribed
+                // while Populate ran, which is why the comparison and the swap happen after it.
+                //
+                // Compared by reference rather than by (type, number): the populator builds a fresh
+                // instance whenever it cannot reuse one, and a cache holding the instance it
+                // replaced would go on delivering samples to a channel the device no longer has.
+                // Identical by reference and in order means the list it just built is the list the
+                // device already holds, so there is nothing to swap, re-subscribe or invalidate.
+                if (MembershipChanged(_channels, updatedChannels))
                 {
-                    if (channel is IChannelEnablementNotifier notifier)
+                    foreach (var channel in _channels)
                     {
-                        notifier.EnablementChanged -= OnChannelEnablementChanged;
+                        if (channel is IChannelEnablementNotifier notifier)
+                        {
+                            notifier.EnablementChanged -= OnChannelEnablementChanged;
+                        }
                     }
-                }
 
-                _channels.Clear();
-                _channels.AddRange(updatedChannels);
+                    _channels.Clear();
+                    _channels.AddRange(updatedChannels);
 
-                foreach (var channel in _channels)
-                {
-                    if (channel is IChannelEnablementNotifier notifier)
+                    foreach (var channel in _channels)
                     {
-                        notifier.EnablementChanged += OnChannelEnablementChanged;
+                        if (channel is IChannelEnablementNotifier notifier)
+                        {
+                            notifier.EnablementChanged += OnChannelEnablementChanged;
+                        }
                     }
-                }
 
-                // The membership itself changed, which no per-channel notification covers.
-                Interlocked.Increment(ref _channelStateVersion);
+                    // No per-channel notification covers the set itself changing.
+                    Interlocked.Increment(ref _channelStateVersion);
+                }
 
                 channelsSnapshot = _channels.ToArray();
             }

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1237,6 +1237,9 @@ namespace Daqifi.Core.Device
 
         IReadOnlyList<IChannel> IDeviceOperationHost.SnapshotChannels() => SnapshotChannels();
 
+        /// <inheritdoc />
+        long IDeviceOperationHost.ChannelStateVersion => ChannelStateVersion;
+
         void IDeviceOperationHost.WithChannelsLock(Action action) => WithChannelsLock(action);
 
 #pragma warning disable CA1068 // Matches the seam it forwards to.

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -750,9 +750,12 @@ public class SerialDeviceFinder : DeviceFinderBase
             var statusReceived =
                 new TaskCompletionSource<DaqifiOutMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            consumer.MessageReceived += (_, args) =>
+            // MessageParsed rather than MessageReceived: the probe never looks at the raw buffer,
+            // and subscribing to the event that carries it would make the consumer snapshot the
+            // buffer on every read for nothing (issue #490).
+            consumer.MessageParsed += parsed =>
             {
-                if (args.Message.Data is DaqifiOutMessage message
+                if (parsed.Data is DaqifiOutMessage message
                     && ProtobufProtocolHandler.DetectMessageType(message) == ProtobufMessageType.Status)
                 {
                     // We have what we came for, so shorten the reader's next read before releasing

--- a/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
+++ b/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
@@ -76,6 +76,9 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="DaqifiDevice.GetChannelsSnapshot"/>
         IReadOnlyList<IChannel> SnapshotChannels();
 
+        /// <inheritdoc cref="DaqifiDevice.ChannelStateVersion"/>
+        long ChannelStateVersion { get; }
+
         /// <summary>
         /// Runs <paramref name="action"/> under the device's channels lock, so a collaborator that
         /// mutates <see cref="IChannel.IsEnabled"/> and derives outbound state from it does both in

--- a/src/Daqifi.Core/Device/Internal/StreamFrameDecoder.cs
+++ b/src/Daqifi.Core/Device/Internal/StreamFrameDecoder.cs
@@ -120,6 +120,31 @@ namespace Daqifi.Core.Device.Internal
         /// </summary>
         private long _decodeFailureCount;
 
+        /// <summary>
+        /// The <see cref="IDeviceOperationHost.ChannelStateVersion"/> the two cached views below
+        /// were built from, or -1 before the first build. Any other value means they are stale.
+        /// </summary>
+        private long _cachedChannelStateVersion = -1;
+
+        /// <summary>
+        /// The channel snapshot the current frame decodes against. Refreshed only when the device
+        /// reports a different channel-state version.
+        /// </summary>
+        private IReadOnlyList<IChannel> _cachedChannels = Array.Empty<IChannel>();
+
+        /// <summary>
+        /// The enabled analog channels, ordered by channel number — the order the device streams
+        /// analog values in.
+        /// </summary>
+        /// <remarks>
+        /// Rebuilding this per frame was the single largest steady-state cost on the decode path
+        /// (issue #490): a snapshot copy taken under the device's channels lock, a fresh list, and
+        /// a comparison sort, a thousand times a second, for a set that only changes when channels
+        /// are configured. Caching it also takes the decode thread out of contention with
+        /// <c>EnableChannel</c> for that lock.
+        /// </remarks>
+        private IAnalogChannel[] _cachedActiveAnalogChannels = Array.Empty<IAnalogChannel>();
+
         internal StreamFrameDecoder(IDeviceOperationHost host)
         {
             _host = host ?? throw new ArgumentNullException(nameof(host));
@@ -163,6 +188,9 @@ namespace Daqifi.Core.Device.Internal
             // it disarmed there also avoids suppressing short analog frames that could arrive far
             // from session start if analog channels are enabled mid-stream (a scenario with no
             // observed warmup frame).
+            // Reads the device directly rather than through the decode path's cache: this runs on
+            // the caller's thread (see the class remarks), and the cache fields belong to the
+            // consumer thread. Once per session, so there is nothing to save here anyway.
             _awaitingFirstFullAnalogFrame = CountEnabledAnalogChannels(_host.SnapshotChannels()) > 0;
             _suppressedWarmupFrameCount = 0;
             Interlocked.Exchange(ref _decodeFailureCount, 0);
@@ -197,7 +225,7 @@ namespace Daqifi.Core.Device.Internal
                     StreamFrameDiscardReason.StaleLeftoverFrame,
                     message,
                     CountAnalogValues(message),
-                    CountEnabledAnalogChannels(_host.SnapshotChannels()));
+                    GetActiveAnalogChannels().Length);
                 return;
             }
 
@@ -305,7 +333,7 @@ namespace Daqifi.Core.Device.Internal
                 return false;
             }
 
-            enabledAnalogChannelCount = CountEnabledAnalogChannels(_host.SnapshotChannels());
+            enabledAnalogChannelCount = GetActiveAnalogChannels().Length;
             if (enabledAnalogChannelCount > 0
                 && analogValueCount < enabledAnalogChannelCount
                 && _suppressedWarmupFrameCount < MaxSuppressedWarmupFrames)
@@ -380,7 +408,11 @@ namespace Daqifi.Core.Device.Internal
 
             // Snapshot channels once: the consumer thread that repopulates channels is the same
             // thread that runs this decode, so the structure is stable for the duration of the call.
-            var channels = _host.SnapshotChannels();
+            // Both views are read after a single refresh so this frame's analog and digital decodes
+            // are guaranteed to be describing the same set of channels.
+            RefreshChannelCacheIfStale();
+            var channels = _cachedChannels;
+            var activeAnalog = _cachedActiveAnalogChannels;
 
             // Reconstruct a host timestamp from the device tick counter (rollover-aware) and carry
             // the raw device tick value through to each decoded sample.
@@ -400,13 +432,81 @@ namespace Daqifi.Core.Device.Internal
 
             if ((hasFloat || hasRawAnalog) && !suppressAnalog)
             {
-                DecodeAnalog(message, channels, hostTimestamp, deviceTimestamp, hasFloat);
+                DecodeAnalog(message, activeAnalog, hostTimestamp, deviceTimestamp, hasFloat);
             }
 
             if (hasDigital)
             {
                 DecodeDigital(message, channels, hostTimestamp, deviceTimestamp);
             }
+        }
+
+        /// <summary>
+        /// Brings <see cref="_cachedChannels"/> and <see cref="_cachedActiveAnalogChannels"/> up to
+        /// date if the device's channel state has moved since they were built.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The version is read <em>before</em> the snapshot, deliberately. A channel change landing
+        /// between the two reads then leaves the cache carrying newer contents under an older
+        /// version, so the next frame simply rebuilds — the cost of a redundant rebuild. Reading it
+        /// afterwards would do the opposite and stamp a pre-change snapshot with the post-change
+        /// version, which no later frame could ever detect: analog values would keep being mapped
+        /// onto the channels that were enabled before the change, silently.
+        /// </para>
+        /// <para>
+        /// Consumer-thread only, like the rest of the decode path. <see cref="BeginSession"/> runs
+        /// on the caller's thread and deliberately does not touch these fields.
+        /// </para>
+        /// </remarks>
+        private void RefreshChannelCacheIfStale()
+        {
+            var version = _host.ChannelStateVersion;
+            if (version == _cachedChannelStateVersion)
+            {
+                return;
+            }
+
+            var channels = _host.SnapshotChannels();
+
+            var activeAnalogCount = 0;
+            foreach (var channel in channels)
+            {
+                if (channel.IsEnabled && channel is IAnalogChannel)
+                {
+                    activeAnalogCount++;
+                }
+            }
+
+            var activeAnalog = activeAnalogCount == 0
+                ? Array.Empty<IAnalogChannel>()
+                : new IAnalogChannel[activeAnalogCount];
+
+            var index = 0;
+            foreach (var channel in channels)
+            {
+                if (channel.IsEnabled && channel is IAnalogChannel analog)
+                {
+                    activeAnalog[index++] = analog;
+                }
+            }
+
+            // The device streams one value per enabled analog channel, ordered by channel number,
+            // not by activation order — so re-derive that ordering here.
+            Array.Sort(activeAnalog, static (a, b) => a.ChannelNumber.CompareTo(b.ChannelNumber));
+
+            _cachedChannels = channels;
+            _cachedActiveAnalogChannels = activeAnalog;
+            _cachedChannelStateVersion = version;
+        }
+
+        /// <summary>
+        /// The enabled analog channels in device order, refreshing the cache if it is stale.
+        /// </summary>
+        private IAnalogChannel[] GetActiveAnalogChannels()
+        {
+            RefreshChannelCacheIfStale();
+            return _cachedActiveAnalogChannels;
         }
 
         /// <summary>
@@ -430,27 +530,24 @@ namespace Daqifi.Core.Device.Internal
         /// USB firmware streams pre-scaled floats (used directly); WiFi firmware streams raw ADC
         /// counts (scaled per channel via <see cref="IAnalogChannel.GetScaledValue"/>).
         /// </summary>
+        /// <param name="message">The frame being decoded.</param>
+        /// <param name="activeAnalog">
+        /// The enabled analog channels already ordered by channel number — the order the device
+        /// streams values in. Supplied by <see cref="GetActiveAnalogChannels"/> rather than derived
+        /// here, so the filter and the sort happen when channels change instead of per frame.
+        /// </param>
+        /// <param name="hostTimestamp">The reconstructed host timestamp for this frame.</param>
+        /// <param name="deviceTimestamp">The frame's raw device tick value.</param>
+        /// <param name="hasFloat">Whether the frame carries pre-scaled floats rather than raw counts.</param>
         private static void DecodeAnalog(
             DaqifiOutMessage message,
-            IReadOnlyList<IChannel> channels,
+            IAnalogChannel[] activeAnalog,
             DateTime hostTimestamp,
             uint deviceTimestamp,
             bool hasFloat)
         {
-            // The device streams one value per enabled analog channel, ordered by channel number,
-            // not by activation order — so re-derive that ordering here.
-            var activeAnalog = new List<IAnalogChannel>();
-            foreach (var channel in channels)
-            {
-                if (channel.IsEnabled && channel is IAnalogChannel analog)
-                {
-                    activeAnalog.Add(analog);
-                }
-            }
-            activeAnalog.Sort((a, b) => a.ChannelNumber.CompareTo(b.ChannelNumber));
-
             var dataCount = hasFloat ? message.AnalogInDataFloat.Count : message.AnalogInData.Count;
-            var count = Math.Min(dataCount, activeAnalog.Count);
+            var count = Math.Min(dataCount, activeAnalog.Length);
 
             for (var i = 0; i < count; i++)
             {

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -386,9 +386,12 @@ namespace Daqifi.Core.Device.Internal
                         new LineBasedMessageParser(),
                         healthSink: transport as ITransportHealthSink);
 
-                    textConsumer.MessageReceived += (_, e) =>
+                    // MessageParsed rather than MessageReceived: only the parsed line matters here,
+                    // and the raw-buffer snapshot the other event carries is a copy per read that
+                    // nothing would read (issue #490).
+                    textConsumer.MessageParsed += parsed =>
                     {
-                        collectedLines.Add(e.Message.Data);
+                        collectedLines.Add(parsed.Data);
                     };
 
                     // The protobuf consumer is stopped for the duration of this exchange, so

--- a/src/Daqifi.Core/Device/Protocol/ProtobufProtocolHandler.cs
+++ b/src/Daqifi.Core/Device/Protocol/ProtobufProtocolHandler.cs
@@ -55,24 +55,46 @@ public class ProtobufProtocolHandler : IProtocolHandler
             return Task.CompletedTask;
         }
 
-        var messageType = DetectMessageType(pbMessage);
+        Handle(pbMessage);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Classifies <paramref name="message"/> and routes it to the matching handler.
+    /// </summary>
+    /// <remarks>
+    /// The same work <see cref="HandleAsync"/> does, minus the unwrapping — routing is entirely
+    /// synchronous, so a caller that already holds a typed <see cref="DaqifiOutMessage"/> has no
+    /// reason to wrap it in an <see cref="IInboundMessage{T}"/> first. On a streaming device that
+    /// wrapper was allocated for every frame (issue #490).
+    /// </remarks>
+    /// <param name="message">The protobuf message to route.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="message"/> is <c>null</c>.</exception>
+    public void Handle(DaqifiOutMessage message)
+    {
+        if (message == null)
+        {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        var messageType = DetectMessageType(message);
 
         switch (messageType)
         {
             case ProtobufMessageType.Status:
-                _statusMessageHandler?.Invoke(pbMessage);
+                _statusMessageHandler?.Invoke(message);
                 break;
 
             case ProtobufMessageType.Stream:
-                _streamMessageHandler?.Invoke(pbMessage);
+                _streamMessageHandler?.Invoke(message);
                 break;
 
             case ProtobufMessageType.SdCard:
-                _sdCardMessageHandler?.Invoke(pbMessage);
+                _sdCardMessageHandler?.Invoke(message);
                 break;
 
             case ProtobufMessageType.Error:
-                _errorMessageHandler?.Invoke(pbMessage);
+                _errorMessageHandler?.Invoke(message);
                 break;
 
             case ProtobufMessageType.Unknown:
@@ -80,8 +102,6 @@ public class ProtobufProtocolHandler : IProtocolHandler
                 // Unknown message type - could log here if needed
                 break;
         }
-
-        return Task.CompletedTask;
     }
 
     /// <summary>


### PR DESCRIPTION
## What was wrong

A DAQiFi streaming at 1 kHz made the host do the same throwaway work a thousand times a second. For **every frame**, Core re-derived which analog channels were active — copying the whole channel list out under the device's lock, filtering it into a fresh list, and sorting that list — for a set that only changes when someone configures the device. Underneath it, the message consumer copied its entire accumulation buffer on every read, and then wrapped each frame twice more on its way to an event that, in practice, nobody had subscribed to.

None of it was visible as a bug. It showed up as an application that streams for hours quietly generating **gigabytes of garbage**, with the decode thread contending against `EnableChannel` for the same lock the whole time.

## How it was fixed

The active-channel set is worked out once and cached, and rebuilt only when the device says the channel state actually moved; the parser is handed a view over the buffer instead of a copy; and the per-frame wrappers are built only when something is listening.

**What a reviewer may want to push back on:**

- **A cache of "which channels are active" is only safe if it can never go stale, and `IChannel.IsEnabled` has a public setter.** A caller writing `channel.IsEnabled = true` straight onto a channel is legal and no device API sees it — so a version counter bumped only from the device's own configure paths would leave the decoder mapping frame values onto the previously active channels, filing AI1's reading under AI0, silently and forever. So the channel types now raise an internal notification when their enabled state actually changes, the device subscribes to every channel it owns, and that is what moves the version. Tests cover all three routes in (device API, direct write, status repopulation) and the two lifecycle edges (a dropped channel stops moving the version; a reused one still moves it exactly once).
- **The version only moves when the channel set really changes.** A status message that describes the channels the device already has reuses those instances, so the membership check compares them **by reference and order** — not by `(type, number)`, which would report "unchanged" for a set whose instances had been replaced and leave the cache writing samples into channels the device no longer has.
- **The version is read *before* the snapshot, not after.** Read afterwards, a change landing in between would stamp a pre-change snapshot with the post-change version — undetectable by any later frame. Read before, the worst case is one redundant rebuild.
- **`StreamMessageConsumer` grew a second, internal event.** `MessageReceived` carries a snapshot of everything buffered at the time of the read; taking that snapshot *is* the per-read copy. No subscriber inside Core has ever looked at it, so Core's three subscribers moved to a new internal `MessageParsed`, and the snapshot is now taken only when the public event has a subscriber. The public event's behaviour is unchanged for anyone using it, including when an internal `MessageParsed` handler throws — that is isolated, so it cannot withhold a message from an external subscriber.
- **Two documented behaviour changes for subclasses.** `DaqifiDevice.OnMessageReceived` is no longer called for a frame when `MessageReceived` has no subscribers (the frame would have to be wrapped to be passed to it, and that wrapper was the allocation); overrides that must see every frame should use the classified `OnStatusMessageReceived`/`OnStreamMessageReceived`, which stay unconditional. And `StreamMessageConsumer.OnMessageReceived`'s `rawData` argument is empty in that same no-subscriber case. Both are stated in the XML docs.
- **`IMessageParser<T>` gained a span overload as a default interface method**, so existing parsers keep compiling and behave exactly as before; `ProtobufMessageParser` and `LineBasedMessageParser` implement it for real (the protobuf parser's body already worked in spans — only its entry point demanded an array).
- **Item 1's proposed invalidation in the issue was not implementable as written** (it invalidates from `PopulateChannelsFromStatus` / `ChannelControlOperations` only, which is exactly the hole above). The notification approach is the correction.

## Verification

**Measured**, branch vs. `origin/main`, same harness, 16 analog + 16 digital channels, reproducible across runs:

| | before | after |
|---|---|---|
| decode path, bytes/frame | 2312 | **1648** |
| decode path, µs/frame | 1.79 | **1.36** |
| decode path, gen0 collections / 200k frames | 55 | **39** |
| consumer path, bytes/frame | 1385 | **1310** |

The 664 B/frame saved on decode accounts for the channel-snapshot array, the intermediate list and its growth steps, and the two per-frame wrappers — roughly seven objects per frame. At 1 kHz that is **~2.4 GB/hour of gen0 churn that no longer happens**, which is the order the issue estimated. The 75 B/frame saved on the consumer path is, as expected, almost exactly the frame size: that copy was the wire throughput, duplicated. The remaining ~1.3 KB/frame is the generated `DaqifiOutMessage` itself, which the issue puts explicitly out of scope.

**Tests** — 39 new. Proven regression catchers by reverting each half of the fix: removing the enablement notification fails **10** tests (including the direct-write mapping cases and the warm-up guard), removing the repopulation version bump fails 2, removing the unsubscribe on repopulation fails 2, making the version bump unconditional again fails 1, restoring the unconditional buffer snapshot fails 1, and neutering the `MessageParsed` isolation fails 1. Full suite green on **net9.0** (3014 Core + 95 Mcp) and **net10.0** (3014), 0 failures, 0 warnings.

**Bench (non-destructive), Nq1 fw 3.7.2 on `/dev/cu.usbmodem1101`** — example CLI built against this branch:

- `--discover-serial` found the unit (`sn=9090539562006014104`, fw 3.7.2) — this also exercises the changed subscription in `SerialDeviceFinder`.
- 3 s @ 500 Hz on channels 0,1,2 → **1186 samples, three analog values per row** (this unit's known ~79% clock ratio).
- Channel mapping re-checked across three different masks at 200 Hz: mask 1 → 1 value/row, mask 3 → 2, mask 21 (channels 0, 2, 4) → 3, with distinct values per channel. That is the cached channel map being rebuilt correctly for each session on real hardware.
- `--sd-list` (47 files) and `--sd-storage` (7.80 GB, 0.0% used) — the text-exchange path, whose line collection also moved to the new event.
- Discovery, status, streaming and SD queries only. No reboot, no format, no delete, no `SD:GET`, no firmware, no LAN writes.

closes #490

Not merging — this is for your review.
