### PR TITLE
perf(device): an idle connected device no longer burns CPU every second

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerIdleWakeupTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerIdleWakeupTests.cs
@@ -114,6 +114,34 @@ public class MessageProducerIdleWakeupTests
     }
 
     /// <summary>
+    /// The counter spans the instance, not a run: a restarted producer keeps counting from where it
+    /// was. Pinned because the alternative — zeroing it in <c>Start()</c> — races a previous
+    /// background thread that a timed-out join left alive and still incrementing.
+    /// </summary>
+    [Fact]
+    public void WakeCount_IsCumulativeAcrossRestarts()
+    {
+        using var stream = new MemoryStream();
+        using var producer = new MessageProducer<string>(stream);
+
+        producer.Start();
+        producer.Send(new ScpiMessage("TEST:BEFORE"));
+        WaitUntilIdle(producer);
+        Assert.True(producer.StopSafely(2000));
+
+        var wakesBeforeTheRestart = producer.WakeCount;
+        Assert.True(wakesBeforeTheRestart >= 1);
+
+        producer.Start();
+        producer.Send(new ScpiMessage("TEST:AFTER"));
+        WaitUntilIdle(producer);
+        Assert.True(producer.StopSafely(2000));
+
+        Assert.True(producer.WakeCount > wakesBeforeTheRestart,
+            $"Expected the count to carry over and grow; it went {wakesBeforeTheRestart} -> {producer.WakeCount}.");
+    }
+
+    /// <summary>
     /// The failure mode the removed timeout would have masked. A signal lost in the window between
     /// the drain's last look at the queue and the loop parking again strands whatever was enqueued
     /// there — and with an unbounded wait, strands it until the <em>next</em> send rather than for

--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerIdleWakeupTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerIdleWakeupTests.cs
@@ -1,0 +1,246 @@
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
+using System.Diagnostics;
+using System.Text;
+
+namespace Daqifi.Core.Tests.Communication.Producers;
+
+/// <summary>
+/// Issue #491, item 1: the background loop used to wake ten times a second for the life of every
+/// connected device, whether or not there was anything to send. These pin both halves of the fix —
+/// that an idle producer costs nothing, and that removing the poll did not cost a wakeup that the
+/// timeout had been covering for.
+/// </summary>
+public class MessageProducerIdleWakeupTests
+{
+    /// <summary>
+    /// Long enough that the old 100 ms poll would have produced several wakeups, short enough not
+    /// to slow the suite down noticeably.
+    /// </summary>
+    private const int IdleObservationMs = 400;
+
+    [Fact]
+    public void AnIdleProducer_NeverWakes()
+    {
+        using var stream = new MemoryStream();
+        using var producer = new MessageProducer<string>(stream);
+
+        producer.Start();
+        Thread.Sleep(IdleObservationMs);
+
+        // The old loop would sit at roughly IdleObservationMs / 100 here.
+        Assert.Equal(0L, producer.WakeCount);
+    }
+
+    [Fact]
+    public void AfterDrainingAMessage_TheProducerGoesBackToNotWaking()
+    {
+        using var stream = new MemoryStream();
+        using var producer = new MessageProducer<string>(stream);
+
+        producer.Start();
+        producer.Send(new ScpiMessage("TEST:ONE"));
+        WaitUntilIdle(producer);
+
+        var wakesAfterTheSend = producer.WakeCount;
+        Assert.InRange(wakesAfterTheSend, 1L, 2L);
+
+        Thread.Sleep(IdleObservationMs);
+
+        Assert.Equal(wakesAfterTheSend, producer.WakeCount);
+    }
+
+    [Fact]
+    public void EachSend_WakesTheLoop()
+    {
+        using var stream = new MemoryStream();
+        using var producer = new MessageProducer<string>(stream);
+
+        producer.Start();
+
+        for (var i = 0; i < 5; i++)
+        {
+            producer.Send(new ScpiMessage($"TEST:{i}"));
+            WaitUntilIdle(producer);
+        }
+
+        Assert.True(producer.StopSafely(2000));
+        Assert.True(producer.WakeCount >= 5,
+            $"Expected at least one wakeup per send, saw {producer.WakeCount}.");
+    }
+
+    /// <summary>
+    /// The lost-wakeup case the 100 ms timeout was papering over: a message enqueued from inside the
+    /// write of the message before it, i.e. after the drain loop has already looked at the queue.
+    /// With the wait now unbounded, a signal dropped here would strand the message forever rather
+    /// than delaying it by a tenth of a second.
+    /// </summary>
+    [Fact]
+    public void AMessageEnqueuedFromInsideTheWrite_IsStillSent()
+    {
+        var followUpSent = new ManualResetEventSlim(false);
+        MessageProducer<string>? producer = null;
+        var enqueuedFollowUp = false;
+
+        using var stream = new CallbackStream(payload =>
+        {
+            if (!enqueuedFollowUp)
+            {
+                enqueuedFollowUp = true;
+                producer!.Send(new ScpiMessage("TEST:FOLLOWUP"));
+                return;
+            }
+
+            if (payload.Contains("FOLLOWUP", StringComparison.Ordinal))
+            {
+                followUpSent.Set();
+            }
+        });
+
+        producer = new MessageProducer<string>(stream);
+        try
+        {
+            producer.Start();
+            producer.Send(new ScpiMessage("TEST:FIRST"));
+
+            Assert.True(followUpSent.Wait(TimeSpan.FromSeconds(5)),
+                "The message enqueued during the first write was never written.");
+        }
+        finally
+        {
+            producer.Dispose();
+            followUpSent.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The failure mode the removed timeout would have masked. A signal lost in the window between
+    /// the drain's last look at the queue and the loop parking again strands whatever was enqueued
+    /// there — and with an unbounded wait, strands it until the <em>next</em> send rather than for
+    /// 100 ms. Each iteration therefore confirms its own message reached the stream before sending
+    /// the next, so a single stranded message fails the test instead of being swept up later.
+    /// </summary>
+    [Fact]
+    public void SendsThatLandAtEveryPointInTheLoopCycle_AreNeverStranded()
+    {
+        var written = 0;
+
+        // Declared first so it is disposed last: the producer's background thread signals it, and
+        // that thread only stops when the producer below is disposed.
+        using var delivered = new AutoResetEvent(false);
+        using var stream = new CallbackStream(_ =>
+        {
+            Interlocked.Increment(ref written);
+            delivered.Set();
+        });
+        using var producer = new MessageProducer<string>(stream);
+
+        producer.Start();
+
+        const int sends = 200;
+        for (var i = 0; i < sends; i++)
+        {
+            // Vary where the enqueue lands relative to the drain/park cycle. A plain tight loop
+            // always arrives while the loop is still draining, which is the easy case.
+            if (i % 3 == 0)
+            {
+                Thread.Sleep(1);
+            }
+            else if (i % 3 == 1)
+            {
+                Thread.SpinWait(200);
+            }
+
+            producer.Send(new ScpiMessage($"TEST:{i}"));
+
+            Assert.True(delivered.WaitOne(TimeSpan.FromSeconds(2)),
+                $"Message {i} was never written; a wakeup was lost.");
+        }
+
+        Assert.Equal(sends, Volatile.Read(ref written));
+    }
+
+    /// <summary>
+    /// Both stops set the event before joining, so a loop parked in an unbounded wait still exits
+    /// promptly. Bounded well under the 1 s join so a regression shows up as a failure rather than
+    /// as a slow suite.
+    /// </summary>
+    [Fact]
+    public void Stop_FromAParkedLoop_ReturnsPromptly()
+    {
+        using var stream = new MemoryStream();
+        using var producer = new MessageProducer<string>(stream);
+
+        producer.Start();
+        Thread.Sleep(50);
+
+        var sw = Stopwatch.StartNew();
+        producer.Stop();
+        sw.Stop();
+
+        Assert.False(producer.IsRunning);
+        Assert.True(sw.ElapsedMilliseconds < 500,
+            $"Stop() took {sw.ElapsedMilliseconds} ms from a parked loop.");
+    }
+
+    [Fact]
+    public void StopSafely_FromAParkedLoop_ReturnsPromptly()
+    {
+        using var stream = new MemoryStream();
+        using var producer = new MessageProducer<string>(stream);
+
+        producer.Start();
+        Thread.Sleep(50);
+
+        var sw = Stopwatch.StartNew();
+        var stopped = producer.StopSafely(1000);
+        sw.Stop();
+
+        Assert.True(stopped);
+        Assert.False(producer.IsRunning);
+        Assert.True(sw.ElapsedMilliseconds < 500,
+            $"StopSafely() took {sw.ElapsedMilliseconds} ms from a parked loop.");
+    }
+
+    private static void WaitUntilIdle(MessageProducer<string> producer)
+    {
+        var deadline = Stopwatch.StartNew();
+        while (!producer.IsIdle && deadline.ElapsedMilliseconds < 5000)
+        {
+            Thread.Sleep(5);
+        }
+
+        Assert.True(producer.IsIdle, "The producer never drained its queue.");
+    }
+
+    /// <summary>
+    /// A stream that hands each written payload to a callback, so a test can act at the exact
+    /// moment the producer is mid-write.
+    /// </summary>
+    private sealed class CallbackStream(Action<string> onWrite) : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => 0;
+
+        public override long Position
+        {
+            get => 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            onWrite(Encoding.ASCII.GetString(buffer, offset, count));
+    }
+}

--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialPortNameSnapshotTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialPortNameSnapshotTests.cs
@@ -1,0 +1,311 @@
+using Daqifi.Core.Communication.Transport;
+
+namespace Daqifi.Core.Tests.Communication.Transport;
+
+/// <summary>
+/// Issue #491, item 2: the presence probe ran a full <c>SerialPort.GetPortNames()</c> per connected
+/// device per second. These cover the shared snapshot that makes the enumeration a function of
+/// elapsed time instead of of device count, and the ordering change in
+/// <see cref="SerialStreamTransport.IsPortEnumerated(string, SerialPortNameSnapshot)"/> that keeps
+/// it from running at all on Unix while the device node is there.
+/// </summary>
+public class SerialPortNameSnapshotTests
+{
+    [Fact]
+    public void RepeatedLookupsWithinTheCacheWindow_EnumerateOnce()
+    {
+        var calls = 0;
+        var snapshot = new SerialPortNameSnapshot(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return ["COM3", "COM7"];
+        });
+
+        for (var i = 0; i < 25; i++)
+        {
+            Assert.True(snapshot.Contains("COM3"));
+        }
+
+        Assert.Equal(1, Volatile.Read(ref calls));
+        Assert.Equal(1L, snapshot.EnumerationCount);
+    }
+
+    [Fact]
+    public void ALookupAfterTheCacheWindow_EnumeratesAgain()
+    {
+        var calls = 0;
+        var snapshot = new SerialPortNameSnapshot(
+            () =>
+            {
+                Interlocked.Increment(ref calls);
+                return ["COM3"];
+            },
+            cacheDurationMs: 1);
+
+        Assert.True(snapshot.Contains("COM3"));
+        Thread.Sleep(20);
+        Assert.True(snapshot.Contains("COM3"));
+
+        Assert.Equal(2, Volatile.Read(ref calls));
+    }
+
+    [Fact]
+    public void WithCachingDisabled_EveryLookupEnumerates()
+    {
+        var calls = 0;
+        var snapshot = new SerialPortNameSnapshot(
+            () =>
+            {
+                Interlocked.Increment(ref calls);
+                return ["COM3"];
+            },
+            cacheDurationMs: 0);
+
+        snapshot.Contains("COM3");
+        snapshot.Contains("COM3");
+        snapshot.Contains("COM3");
+
+        Assert.Equal(3, Volatile.Read(ref calls));
+    }
+
+    /// <summary>
+    /// The point of the change: N transports polling on the same tick cost one enumeration, not N.
+    /// </summary>
+    [Fact]
+    public void ConcurrentLookupsOnTheSameTick_EnumerateOnce()
+    {
+        var calls = 0;
+        var snapshot = new SerialPortNameSnapshot(() =>
+        {
+            Interlocked.Increment(ref calls);
+
+            // Wide enough that every other caller is definitely inside Contains before this returns.
+            Thread.Sleep(30);
+            return ["COM3"];
+        });
+
+        const int callers = 8;
+        using var everyoneReady = new Barrier(callers);
+        var results = new bool[callers];
+
+        // Dedicated threads, not the thread pool: the barrier requires all of them to be running at
+        // once, which a pool that is ramping up cannot promise.
+        var threads = new Thread[callers];
+        for (var i = 0; i < callers; i++)
+        {
+            var index = i;
+            threads[i] = new Thread(() =>
+            {
+                everyoneReady.SignalAndWait();
+                results[index] = snapshot.Contains("COM3");
+            })
+            {
+                IsBackground = true
+            };
+            threads[i].Start();
+        }
+
+        foreach (var thread in threads)
+        {
+            Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "A concurrent lookup never returned.");
+        }
+
+        Assert.All(results, Assert.True);
+        Assert.Equal(1, Volatile.Read(ref calls));
+    }
+
+    /// <summary>
+    /// The hazard a plain time-based cache would introduce: a port that appeared after the last
+    /// snapshot must not read as absent. A transport arms its presence check by asking this the
+    /// moment it opens the port, so a stale "no" there would silently disable drop detection for
+    /// the life of that connection — and a stale "no" during polling would tear down a healthy one.
+    /// </summary>
+    [Fact]
+    public void APortThatAppearedAfterTheCachedSnapshot_IsStillFound()
+    {
+        var ports = new List<string> { "COM3" };
+        var snapshot = new SerialPortNameSnapshot(() => ports.ToArray(), cacheDurationMs: 60_000);
+
+        Assert.True(snapshot.Contains("COM3"));
+
+        ports.Add("COM9");
+
+        // Well inside the cache window, and the cached snapshot does not list COM9.
+        Assert.True(snapshot.Contains("COM9"));
+        Assert.Equal(2L, snapshot.EnumerationCount);
+    }
+
+    /// <summary>
+    /// Only a miss forces the extra enumeration; once the fresh snapshot has the port, the window
+    /// starts again from there.
+    /// </summary>
+    [Fact]
+    public void AMissThatRefreshes_LeavesTheNewSnapshotCached()
+    {
+        var ports = new List<string> { "COM3" };
+        var snapshot = new SerialPortNameSnapshot(() => ports.ToArray(), cacheDurationMs: 60_000);
+
+        Assert.True(snapshot.Contains("COM3"));
+        ports.Add("COM9");
+        Assert.True(snapshot.Contains("COM9"));
+
+        Assert.True(snapshot.Contains("COM9"));
+        Assert.True(snapshot.Contains("COM3"));
+        Assert.Equal(2L, snapshot.EnumerationCount);
+    }
+
+    /// <summary>
+    /// A refresh forced by a cached miss can itself fail. That is "not observed", not "absent", so
+    /// it must reach the caller rather than being answered from the stale snapshot.
+    /// </summary>
+    [Fact]
+    public void AFailedRefreshAfterACachedMiss_Propagates()
+    {
+        var shouldThrow = false;
+        var snapshot = new SerialPortNameSnapshot(
+            () => shouldThrow ? throw new IOException("enumeration failed") : ["COM3"],
+            cacheDurationMs: 60_000);
+
+        Assert.True(snapshot.Contains("COM3"));
+
+        shouldThrow = true;
+        Assert.Throws<IOException>(() => snapshot.Contains("COM9"));
+    }
+
+    [Fact]
+    public void PortNameComparison_IsCaseInsensitive()
+    {
+        var snapshot = new SerialPortNameSnapshot(() => ["COM3"]);
+
+        Assert.True(snapshot.Contains("com3"));
+        Assert.False(snapshot.Contains("COM4"));
+    }
+
+    [Fact]
+    public void AnEnumerationThatReturnsNull_IsTreatedAsNoPorts()
+    {
+        var snapshot = new SerialPortNameSnapshot(() => null!);
+
+        Assert.False(snapshot.Contains("COM3"));
+    }
+
+    /// <summary>
+    /// A failed enumeration must stay a failure. Reporting "not found" for it would let two
+    /// transient failures look like two consecutive presence misses and close a healthy connection.
+    /// </summary>
+    [Fact]
+    public void AnEnumerationThatThrows_Propagates()
+    {
+        var snapshot = new SerialPortNameSnapshot(() => throw new UnauthorizedAccessException("nope"));
+
+        Assert.Throws<UnauthorizedAccessException>(() => snapshot.Contains("COM3"));
+    }
+
+    /// <summary>
+    /// A failure must not be cached — neither as an empty snapshot (which would read as every port
+    /// disappearing at once) nor as a fresh timestamp over the last good one. The next lookup, even
+    /// well inside the cache window, has to try the enumeration again.
+    /// </summary>
+    [Fact]
+    public void AFailedEnumeration_IsNotCached()
+    {
+        var shouldThrow = true;
+        var snapshot = new SerialPortNameSnapshot(
+            () => shouldThrow ? throw new IOException("enumeration failed") : ["COM3"],
+            cacheDurationMs: 60_000);
+
+        Assert.Throws<IOException>(() => snapshot.Contains("COM3"));
+
+        shouldThrow = false;
+        Assert.True(snapshot.Contains("COM3"));
+        Assert.Equal(1L, snapshot.EnumerationCount);
+    }
+
+    [Fact]
+    public void Constructor_WithNullEnumerator_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SerialPortNameSnapshot(null!));
+    }
+
+    [Fact]
+    public void IsPortEnumerated_ForAPresentDeviceNode_DoesNotEnumerateAtAll()
+    {
+        // A Windows port name is not a path, so the cheap check does not apply there.
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var calls = 0;
+        var snapshot = new SerialPortNameSnapshot(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return [];
+        });
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            Assert.StartsWith("/", path);
+            Assert.True(SerialStreamTransport.IsPortEnumerated(path, snapshot));
+            Assert.Equal(0, Volatile.Read(ref calls));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsPortEnumerated_ForAnAbsentDeviceNode_FallsBackToTheEnumeration()
+    {
+        var snapshot = new SerialPortNameSnapshot(() => ["/dev/daqifi-491-listed-but-absent"]);
+
+        Assert.True(SerialStreamTransport.IsPortEnumerated("/dev/daqifi-491-listed-but-absent", snapshot));
+        Assert.False(SerialStreamTransport.IsPortEnumerated("/dev/daqifi-491-not-listed", snapshot));
+    }
+
+    /// <summary>
+    /// The device node already answered "absent" before the enumeration was reached, so a failure
+    /// there adds nothing and the probe reports absence rather than propagating — the behaviour the
+    /// old ordering reached through its <c>catch</c>.
+    /// </summary>
+    [Fact]
+    public void IsPortEnumerated_ForAnAbsentDeviceNode_SwallowsAFailedEnumeration()
+    {
+        var snapshot = new SerialPortNameSnapshot(() => throw new UnauthorizedAccessException("nope"));
+
+        Assert.False(SerialStreamTransport.IsPortEnumerated("/dev/daqifi-491-does-not-exist", snapshot));
+    }
+
+    /// <summary>
+    /// A Windows-style name has no second source, so a failed enumeration is "not observed" and
+    /// must reach the caller instead of being reported as a missing port.
+    /// </summary>
+    [Fact]
+    public void IsPortEnumerated_ForAWindowsStyleName_PropagatesAFailedEnumeration()
+    {
+        var snapshot = new SerialPortNameSnapshot(() => throw new UnauthorizedAccessException("nope"));
+
+        Assert.Throws<UnauthorizedAccessException>(
+            () => SerialStreamTransport.IsPortEnumerated("COM9", snapshot));
+    }
+
+    [Fact]
+    public void IsPortEnumerated_ForManyPortsOnTheSameSnapshot_EnumeratesOnce()
+    {
+        var calls = 0;
+        var snapshot = new SerialPortNameSnapshot(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return ["COM3", "COM4", "COM5", "COM6"];
+        });
+
+        foreach (var port in new[] { "COM3", "COM4", "COM5", "COM6" })
+        {
+            Assert.True(SerialStreamTransport.IsPortEnumerated(port, snapshot));
+        }
+
+        Assert.Equal(1, Volatile.Read(ref calls));
+    }
+}

--- a/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
@@ -79,10 +79,17 @@ public class MessageProducer<T> : IMessageProducer<T>
     public bool IsRunning => _isRunning;
 
     /// <summary>
-    /// Number of times the background loop has woken from its wait since <see cref="Start"/>.
+    /// Number of times the background loop has woken from its wait over the life of this instance.
     /// A producer with nothing to send must never wake at all, so this stays at its value for as
     /// long as the queue is empty and no stop has been requested.
     /// </summary>
+    /// <remarks>
+    /// Monotonic, and deliberately not reset by <see cref="Start"/>: a stop whose
+    /// <see cref="Thread.Join(int)"/> timed out leaves the previous background thread alive and
+    /// still able to increment this, so a per-run counter would be a counter with a race in it. The
+    /// property it exists to express — that an idle producer does not accumulate wakeups — is a
+    /// statement about the value not changing, which a cumulative count states just as well.
+    /// </remarks>
     internal long WakeCount => Interlocked.Read(ref _wakeCount);
 
     /// <inheritdoc />

--- a/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
@@ -35,6 +35,12 @@ public class MessageProducer<T> : IMessageProducer<T>
     private Thread? _producerThread;
 
     /// <summary>
+    /// Number of times the background loop has returned from its wait. Exposed for tests: an idle
+    /// producer must not accumulate wakeups (issue #491).
+    /// </summary>
+    private long _wakeCount;
+
+    /// <summary>
     /// Initializes a new instance of the MessageProducer class.
     /// </summary>
     /// <param name="stream">The stream to write messages to.</param>
@@ -71,6 +77,13 @@ public class MessageProducer<T> : IMessageProducer<T>
     /// Gets a value indicating whether the producer is currently running.
     /// </summary>
     public bool IsRunning => _isRunning;
+
+    /// <summary>
+    /// Number of times the background loop has woken from its wait since <see cref="Start"/>.
+    /// A producer with nothing to send must never wake at all, so this stays at its value for as
+    /// long as the queue is empty and no stop has been requested.
+    /// </summary>
+    internal long WakeCount => Interlocked.Read(ref _wakeCount);
 
     /// <inheritdoc />
     public event EventHandler<MessageSendFailedEventArgs<T>>? SendFailed;
@@ -184,8 +197,24 @@ public class MessageProducer<T> : IMessageProducer<T>
             {
                 try
                 {
-                    // Wait for a message to be enqueued or timeout after 100ms
-                    _messageAvailable.Wait(100);
+                    // Park until something actually happens. There is no timeout: a connected but
+                    // silent device used to cost 10 wakeups a second here, forever, per device
+                    // (issue #491), and the timeout was never load-bearing.
+                    //
+                    // Every state change that this loop must observe sets the event, and
+                    // ManualResetEventSlim is sticky, so none of them can be missed:
+                    //   - Send() enqueues and then sets, so a set that is observed always has its
+                    //     message already visible to the TryDequeue below;
+                    //   - Stop() and StopSafely() clear _isRunning and then set, and the while
+                    //     condition above is re-read after this iteration, so a set consumed by the
+                    //     Reset() below still exits the loop on the next pass;
+                    //   - a set that arrives after Reset() but before the drain is picked up by the
+                    //     drain itself, and one that arrives after the drain leaves the event set,
+                    //     so the next wait returns immediately.
+                    // The Reset() stays *before* the drain for that last reason: resetting after it
+                    // would discard a set whose message the drain had already passed.
+                    _messageAvailable.Wait();
+                    Interlocked.Increment(ref _wakeCount);
                     _messageAvailable.Reset();
 
                     // Claimed around the whole batch rather than around each write, so there is

--- a/src/Daqifi.Core/Communication/Transport/SerialPortNameSnapshot.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialPortNameSnapshot.cs
@@ -1,0 +1,140 @@
+using System.IO.Ports;
+
+namespace Daqifi.Core.Communication.Transport;
+
+/// <summary>
+/// A short-lived, shared cache of <see cref="SerialPort.GetPortNames"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every connected <see cref="SerialStreamTransport"/> re-checks that its port is still enumerated
+/// once a second. The enumeration is a whole-system scan that allocates a <see cref="string"/> per
+/// port plus the array, and on Windows it is a registry read — so a ten-device fleet ran ten full
+/// scans a second to answer ten questions that one scan already answers (issue #491). Sharing one
+/// snapshot makes that cost a function of elapsed time instead of of how many devices are connected.
+/// </para>
+/// <para>
+/// <b>Staleness runs one way only: a "yes" may be up to <see cref="CacheDurationMs"/> old, a "no"
+/// is always taken now.</b> Reusing a positive is what makes the cache worth having, and the cost
+/// is bounded — a port removed just after a snapshot keeps reading as present until that snapshot
+/// expires, moving worst-case unplug detection from roughly three seconds to roughly four. Reusing
+/// a <em>negative</em> would be the dangerous direction and is therefore never done: it would report
+/// a port plugged in since the snapshot as absent, which is the difference between a transport
+/// arming its presence check at connect time and silently not arming it, and between a healthy
+/// connection surviving and being torn down. A cached snapshot that does not list the port is
+/// treated as no answer at all, and a fresh enumeration decides.
+/// </para>
+/// <para>
+/// A failed enumeration is never cached and never turned into an answer — it propagates, so the
+/// caller can still tell "not observed" from "observed absent".
+/// </para>
+/// </remarks>
+internal sealed class SerialPortNameSnapshot
+{
+    /// <summary>
+    /// Default lifetime of a snapshot. Matches the presence-poll cadence
+    /// (<see cref="TransportConnectionWatchdog.DefaultPresencePollInterval"/>), so a process makes
+    /// at most about one enumeration per second no matter how many transports are polling.
+    /// </summary>
+    internal const int DefaultCacheDurationMs = 1000;
+
+    /// <summary>
+    /// The instance the production presence probe reads. Tests construct their own rather than
+    /// mutating this one, so nothing here is process-wide mutable state.
+    /// </summary>
+    internal static SerialPortNameSnapshot Shared { get; } = new(SerialPort.GetPortNames);
+
+    private readonly Func<string[]> _enumerate;
+    private readonly object _gate = new();
+    private string[] _names = [];
+    private long _takenAtMs;
+    private bool _hasSnapshot;
+    private long _enumerationCount;
+
+    /// <summary>
+    /// Initializes a new snapshot cache.
+    /// </summary>
+    /// <param name="enumerate">The underlying enumeration to cache.</param>
+    /// <param name="cacheDurationMs">
+    /// How long a snapshot may be reused, in milliseconds. Zero or less disables caching, which is
+    /// what a caller wanting the uncached behaviour should pass.
+    /// </param>
+    internal SerialPortNameSnapshot(Func<string[]> enumerate, int cacheDurationMs = DefaultCacheDurationMs)
+    {
+        _enumerate = enumerate ?? throw new ArgumentNullException(nameof(enumerate));
+        CacheDurationMs = cacheDurationMs;
+    }
+
+    /// <summary>
+    /// How long a snapshot may be reused, in milliseconds.
+    /// </summary>
+    internal int CacheDurationMs { get; }
+
+    /// <summary>
+    /// How many times the underlying enumeration has actually run. The point of this class is that
+    /// it grows with elapsed time rather than with the number of transports asking.
+    /// </summary>
+    internal long EnumerationCount => Interlocked.Read(ref _enumerationCount);
+
+    /// <summary>
+    /// Reports whether <paramref name="portName"/> appears in the current snapshot, taking a fresh
+    /// one first if none is live.
+    /// </summary>
+    /// <param name="portName">The port name to look for; compared case-insensitively.</param>
+    /// <exception cref="Exception">
+    /// Propagates whatever the underlying enumeration raised when a fresh snapshot was needed and
+    /// could not be taken.
+    /// </exception>
+    internal bool Contains(string portName)
+    {
+        // The enumeration runs under the gate rather than outside it. Concurrent callers are exactly
+        // the case this exists for — several watchdog timers firing on the same tick — and letting
+        // them all through would have each take its own snapshot, which is the cost being removed.
+        // A blocked caller re-checks freshness on the way in, so only the first one enumerates.
+        lock (_gate)
+        {
+            var live = _hasSnapshot && Environment.TickCount64 - _takenAtMs < CacheDurationMs;
+            if (live)
+            {
+                if (ContainsName(_names, portName))
+                {
+                    return true;
+                }
+
+                // A cached snapshot that does not list the port is no answer: it predates anything
+                // plugged in since. Fall through and let a fresh enumeration decide.
+            }
+
+            return ContainsName(Enumerate(), portName);
+        }
+    }
+
+    /// <summary>
+    /// Takes and publishes a fresh snapshot. Must be called holding <see cref="_gate"/>.
+    /// </summary>
+    private string[] Enumerate()
+    {
+        // Published only after the call returns: a throwing enumeration must leave the previous
+        // snapshot and its timestamp untouched rather than install an empty one, which would read
+        // as "every port just disappeared".
+        var names = _enumerate() ?? [];
+        _names = names;
+        _takenAtMs = Environment.TickCount64;
+        _hasSnapshot = true;
+        Interlocked.Increment(ref _enumerationCount);
+        return names;
+    }
+
+    private static bool ContainsName(string[] names, string portName)
+    {
+        foreach (var name in names)
+        {
+            if (string.Equals(name, portName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -18,12 +18,13 @@ namespace Daqifi.Core.Communication.Transport;
 /// <list type="bullet">
 /// <item><description>
 /// <b>Port-presence polling</b> at <see cref="DefaultLivenessCheckInterval"/> (1 s), requiring two
-/// consecutive misses. This bounds detection of an unplug at <b>roughly three seconds</b> even on
-/// a completely idle connection. Presence is <see cref="SerialPort.GetPortNames"/> containing the
-/// port, falling back to the device node still existing on Unix — no WMI, so it behaves
-/// identically on Windows, macOS, and Linux. It is armed only if the port is visible to that probe
-/// at connect time, so a platform or port-name spelling the probe cannot see disables the check
-/// rather than reporting a false drop.
+/// consecutive misses. This bounds detection of an unplug at <b>roughly three to four seconds</b>
+/// even on a completely idle connection (the extra second is the shared enumeration snapshot's
+/// lifetime — see <see cref="SerialPortNameSnapshot"/>). Presence is the device node still existing
+/// on Unix, where a port name is a path, falling back to <see cref="SerialPort.GetPortNames"/>
+/// listing the port — no WMI, so it behaves identically on Windows, macOS, and Linux. It is armed
+/// only if the port is visible to that probe at connect time, so a platform or port-name spelling
+/// the probe cannot see disables the check rather than reporting a false drop.
 /// </description></item>
 /// <item><description>
 /// <b>I/O fault escalation</b> via <see cref="ITransportHealthSink"/>: the reader/writer loops
@@ -573,36 +574,50 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     /// look like two consecutive misses and close a healthy connection. A failed enumeration is
     /// therefore only swallowed when the filesystem check can still answer for this port name.
     /// </para>
+    /// <para>
+    /// The two sources are OR-ed, so the order they run in cannot change the answer — and the
+    /// filesystem check goes first because it is by far the cheaper one. On Unix, where the port
+    /// name <em>is</em> a device node path, that single stat answers the overwhelmingly common case
+    /// (the port is still there) outright, and the system-wide enumeration never runs at all. When
+    /// it does run it comes from <see cref="SerialPortNameSnapshot"/>, one snapshot shared by every
+    /// polling transport in the process (issue #491).
+    /// </para>
     /// </remarks>
     /// <exception cref="Exception">
     /// Propagates whatever the underlying probe raised when no source could answer.
     /// </exception>
-    internal static bool IsPortEnumerated(string portName)
+    internal static bool IsPortEnumerated(string portName) =>
+        IsPortEnumerated(portName, SerialPortNameSnapshot.Shared);
+
+    /// <inheritdoc cref="IsPortEnumerated(string)"/>
+    /// <param name="portName">The port name to probe.</param>
+    /// <param name="snapshot">
+    /// The enumeration cache to consult. Tests pass their own so the ordering can be asserted
+    /// without touching the process-wide instance.
+    /// </param>
+    internal static bool IsPortEnumerated(string portName, SerialPortNameSnapshot snapshot)
     {
         var isDeviceNodePath = portName.StartsWith('/');
 
+        if (isDeviceNodePath && File.Exists(portName))
+        {
+            return true;
+        }
+
         try
         {
-            foreach (var name in SerialPort.GetPortNames())
-            {
-                if (string.Equals(name, portName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
+            return snapshot.Contains(portName);
         }
         catch (Exception) when (isDeviceNodePath)
         {
             // Enumeration can fail transiently (a /dev scan racing a device change). A Unix port
             // name is also a filesystem path, so an independent answer is still available — the
             // failure is only swallowed because that second source can actually answer. When it
-            // cannot (a Windows-style name), the exception propagates as "no observation".
-            return File.Exists(portName);
+            // cannot (a Windows-style name), the exception propagates as "no observation". Here
+            // that second source has already spoken: the device node check above ran first and did
+            // not find it.
+            return false;
         }
-
-        // The enumeration answered and did not list this port. On Unix it may simply not enumerate
-        // the spelling the caller opened, so the device node is the tie-breaker.
-        return isDeviceNodePath && File.Exists(portName);
     }
 
     /// <summary>


### PR DESCRIPTION
## What was wrong

A DAQiFi device that is connected but doing absolutely nothing was not free. Every connected device woke a background thread ten times a second forever, and every second it also ran a whole-system scan of the machine's serial ports just to confirm its own port was still there. On a long-running consumer — the desktop app or the MCP server, which hold devices open for hours — that is continuous background CPU and garbage for no work, and it got worse with every extra device connected.

Measured on the bench with one device connected and completely idle, that came to **~250 ms of CPU and 68 KiB of garbage per 30 seconds, per device**.

## How it was fixed

Two independent changes, neither of which alters what the library does:

- **The producer's wait no longer has a timeout.** It was polling on a 100 ms timeout, but that timeout was never load-bearing: everything the loop needs to notice (a queued message, a stop request) already sets the event before the loop looks, and the event is sticky, so nothing can be missed. An idle producer now wakes exactly zero times.
- **The port-presence probe asks the cheap question first.** It was calling `SerialPort.GetPortNames()` and only falling back to "does the device node still exist". Those two are OR-ed, so the order cannot change the answer — and on macOS/Linux, where a port name *is* a path, the filesystem check answers outright and the system-wide enumeration never runs. When it does run (Windows), it comes from one snapshot shared by every polling transport instead of one scan per device.

**The one thing worth pushing back on** is the snapshot's staleness. A cached "this port is present" can be up to a second old, so worst-case unplug detection moves from roughly three seconds to roughly four. A cached "this port is absent" is deliberately *never* reused — that direction is the dangerous one (it would report a port plugged in since the snapshot as missing, which would stop a transport from arming its presence check at all), so a cached miss always forces a fresh enumeration before answering.

Item 3 of the issue — the reader thread created per SCPI exchange — is **not** in this PR, so #491 stays open. It is not an idle cost (it only happens when you send a command), and removing it means reworking `StreamMessageConsumer`'s thread lifecycle, including the stale-reader guard that stops two readers ever landing on one stream. That deserves its own change.

## Verification

- 20 new tests. Both fixes are proven regression catchers by mutation: restoring the 100 ms poll fails 2, restoring the enumeration-first ordering fails 1, and serving cached negatives fails 3. Full suite green on **net9.0** (3067 Core + 86 Mcp) and **net10.0** (3067), 0 warnings.
- **Bench, non-destructive, Nq1 fw 3.7.2 on `/dev/cu.usbmodem1101`.** Harness alternating against an `origin/main` baseline worktree, 30 s idle with the transport connected and a producer running, 3 runs each: **230/255/257 ms CPU → 93/79/86 ms** (7.7-8.6 → 2.6-4.0 ms per second) and **68.5 KiB allocated → 0**, connection still healthy at the end of every run. One `GetPortNames()` costs 0.11 ms on this machine, so the enumeration alone was ~0.11 ms per device per second. Health checks after: serial discovery finds `sn=9090539562006014104`, 3 s @ 500 Hz on channels 0-2 → 1187 samples (this unit's known ~79 % clock ratio), SD storage query 7.80 GB, clean disconnect. No reboot, format, delete, `SD:GET`, firmware or LAN writes.
- The shared snapshot itself is not exercised on macOS (the device-node check answers first), so that half is covered by unit tests rather than by the bench.

Addresses items 1 and 2 of #491.

**Not merging — this is for your review.**