### PR TITLE
perf(discovery): Windows discovery no longer slows down with every COM port on the machine

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/UsbPortDescriptorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/UsbPortDescriptorTests.cs
@@ -151,4 +151,57 @@ public class UsbPortDescriptorTests
         Assert.Equal(1240, result["/dev/cu.usbmodem1011"].VendorId);
         Assert.Equal(1240, result["/dev/cu.usbmodem1013"].VendorId);
     }
+
+    [Fact]
+    public void PnpDeviceIdParser_ParseVidPid_UsbSerialDeviceId_ReturnsDescriptor()
+    {
+        var descriptor = PnpDeviceIdParser.ParseVidPid(@"USB\VID_04D8&PID_F794\5&1A2B3C4D&0&2");
+
+        Assert.NotNull(descriptor);
+        Assert.Equal(0x04D8, descriptor.VendorId);
+        Assert.Equal(0xF794, descriptor.ProductId);
+    }
+
+    [Fact]
+    public void PnpDeviceIdParser_ParseVidPid_LowercaseKeys_StillParses()
+    {
+        // Some drivers report "Vid_" / "Pid_".
+        var descriptor = PnpDeviceIdParser.ParseVidPid(@"usb\vid_04d8&pid_f794\5&1a2b3c4d&0&2");
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), descriptor);
+    }
+
+    [Fact]
+    public void PnpDeviceIdParser_ParseVidPid_NonUsbDeviceId_ReturnsNull()
+    {
+        // A motherboard serial port and a Bluetooth SPP port both live under PNPClass='Ports'
+        // but carry no VID/PID, and must stay unclassified rather than be misread.
+        Assert.Null(PnpDeviceIdParser.ParseVidPid(@"ACPI\PNP0501\1"));
+        Assert.Null(PnpDeviceIdParser.ParseVidPid(@"BTHENUM\{00001101-0000-1000-8000-00805F9B34FB}_LOCALMFG&0000\7&2"));
+    }
+
+    [Fact]
+    public void PnpDeviceIdParser_ParseVidPid_NullOrEmpty_ReturnsNull()
+    {
+        Assert.Null(PnpDeviceIdParser.ParseVidPid(null));
+        Assert.Null(PnpDeviceIdParser.ParseVidPid(""));
+    }
+
+    [Fact]
+    public void PnpDeviceIdParser_SelectUsbDescriptor_SkipsIdsWithoutVidPid()
+    {
+        // A port claimed by both a non-USB entity and a USB one is still classified — the same
+        // "keep looking" behavior the per-port WMI query had when it walked its result set.
+        var descriptor = PnpDeviceIdParser.SelectUsbDescriptor(
+            [@"ACPI\PNP0501\1", @"USB\VID_04D8&PID_F794\5&1A2B3C4D&0&2"]);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), descriptor);
+    }
+
+    [Fact]
+    public void PnpDeviceIdParser_SelectUsbDescriptor_NoIdsOrNoneUsb_ReturnsNull()
+    {
+        Assert.Null(PnpDeviceIdParser.SelectUsbDescriptor([]));
+        Assert.Null(PnpDeviceIdParser.SelectUsbDescriptor([@"ACPI\PNP0501\1"]));
+    }
 }

--- a/src/Daqifi.Core.Tests/Device/Discovery/WindowsPnpPortMapTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WindowsPnpPortMapTests.cs
@@ -149,6 +149,22 @@ public class WindowsPnpPortMapTests
         Assert.Equal(0, Volatile.Read(ref calls));
     }
 
+    /// <summary>
+    /// A lookup hands out part of a map several threads are reading, so it must hand out something
+    /// none of them can change: a caller that cast it back to a mutable list would be editing every
+    /// other caller's view of that port.
+    /// </summary>
+    [Fact]
+    public void WhatALookupReturns_CannotBeMutatedByItsCaller()
+    {
+        var map = new WindowsPnpPortMap(() => [Usb("COM3")]);
+
+        var deviceIds = map.GetDeviceIds("COM3");
+
+        Assert.Throws<NotSupportedException>(() => ((IList<string>)deviceIds).Add("injected"));
+        Assert.Single(map.GetDeviceIds("COM3"));
+    }
+
     // ---- caching ---------------------------------------------------------
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Device/Discovery/WindowsPnpPortMapTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WindowsPnpPortMapTests.cs
@@ -1,0 +1,376 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+/// <summary>
+/// Issue #487: both Windows discovery providers ran their own <c>Win32_PnPEntity</c> query per COM
+/// port, per discovery pass. These cover the shared map that answers all of those questions with
+/// one query, and the caption parsing that replaces the per-port <c>LIKE '%(COMn)%'</c> predicate.
+/// The map takes its rows from an injected query, so the parsing and caching are exercised on any
+/// platform without WMI.
+/// </summary>
+public class WindowsPnpPortMapTests
+{
+    private static PnpPortEntity Usb(string port, string vidPid = "VID_04D8&PID_F794") =>
+        new($@"USB\{vidPid}\SERIAL{port}", $"USB Serial Device ({port})");
+
+    // ---- caption parsing -------------------------------------------------
+
+    [Fact]
+    public void BuildMap_NoEntities_IsEmpty()
+    {
+        Assert.Empty(WindowsPnpPortMap.BuildMap([]));
+    }
+
+    [Fact]
+    public void BuildMap_TypicalUsbSerialCaption_MapsThePortToItsDeviceId()
+    {
+        var map = WindowsPnpPortMap.BuildMap([Usb("COM9")]);
+
+        Assert.Equal([@"USB\VID_04D8&PID_F794\SERIALCOM9"], map["COM9"]);
+    }
+
+    [Fact]
+    public void BuildMap_ManyPorts_MapsEachOfThem()
+    {
+        var map = WindowsPnpPortMap.BuildMap(
+        [
+            Usb("COM3"),
+            new PnpPortEntity(@"ACPI\PNP0501\1", "Communications Port (COM1)"),
+            new PnpPortEntity(@"BTHENUM\{0000}\7&2", "Standard Serial over Bluetooth link (COM7)")
+        ]);
+
+        Assert.Equal(3, map.Count);
+        Assert.Equal([@"ACPI\PNP0501\1"], map["COM1"]);
+        Assert.Equal([@"BTHENUM\{0000}\7&2"], map["COM7"]);
+    }
+
+    [Fact]
+    public void BuildMap_CaptionNamingNoPort_IsSkipped()
+    {
+        // PNPClass='Ports' also covers printer ports and the like, whose captions carry no
+        // "(COMn)" token at all.
+        var map = WindowsPnpPortMap.BuildMap([new PnpPortEntity(@"ACPI\PNP0400\4", "Printer Port (LPT1)")]);
+
+        Assert.Empty(map);
+    }
+
+    [Fact]
+    public void BuildMap_EntityMissingItsDeviceIdOrCaption_IsSkipped()
+    {
+        var map = WindowsPnpPortMap.BuildMap(
+        [
+            new PnpPortEntity(null, "USB Serial Device (COM4)"),
+            new PnpPortEntity(@"USB\VID_04D8&PID_F794\X", null),
+            new PnpPortEntity("", "USB Serial Device (COM5)"),
+            new PnpPortEntity(@"USB\VID_04D8&PID_F794\Y", "")
+        ]);
+
+        Assert.Empty(map);
+    }
+
+    /// <summary>
+    /// The predicate this replaces matched a caption <em>substring</em>, so more than one entity
+    /// could answer for one port. Both are kept, in enumeration order, because the two callers
+    /// pick different entries out of that set.
+    /// </summary>
+    [Fact]
+    public void BuildMap_TwoEntitiesClaimingOnePort_KeepsBothInEnumerationOrder()
+    {
+        var map = WindowsPnpPortMap.BuildMap(
+        [
+            new PnpPortEntity(@"ACPI\PNP0501\1", "Legacy bridge (COM9)"),
+            Usb("COM9")
+        ]);
+
+        Assert.Equal([@"ACPI\PNP0501\1", @"USB\VID_04D8&PID_F794\SERIALCOM9"], map["COM9"]);
+    }
+
+    [Fact]
+    public void BuildMap_OneCaptionNamingThePortTwice_ListsThatEntityOnce()
+    {
+        var map = WindowsPnpPortMap.BuildMap(
+            [new PnpPortEntity(@"USB\VID_04D8&PID_F794\Z", "Dual bridge (COM9) mirror of (COM9)")]);
+
+        Assert.Equal([@"USB\VID_04D8&PID_F794\Z"], map["COM9"]);
+    }
+
+    [Fact]
+    public void BuildMap_OneCaptionNamingTwoPorts_MapsBoth()
+    {
+        var map = WindowsPnpPortMap.BuildMap(
+            [new PnpPortEntity(@"USB\VID_04D8&PID_F794\Z", "Dual bridge (COM9) and (COM10)")]);
+
+        Assert.Equal([@"USB\VID_04D8&PID_F794\Z"], map["COM9"]);
+        Assert.Equal([@"USB\VID_04D8&PID_F794\Z"], map["COM10"]);
+    }
+
+    /// <summary>
+    /// The parentheses are load-bearing: <c>LIKE '%(COM9)%'</c> never matched the entity captioned
+    /// "(COM90)", and neither may the token parsing that replaces it.
+    /// </summary>
+    [Fact]
+    public void BuildMap_APortWhoseNumberIsAPrefixOfAnother_IsNotConfusedWithIt()
+    {
+        var map = WindowsPnpPortMap.BuildMap([Usb("COM90")]);
+
+        Assert.False(map.ContainsKey("COM9"));
+        Assert.Single(map["COM90"]);
+    }
+
+    [Fact]
+    public void GetDeviceIds_MatchesThePortNameCaseInsensitively()
+    {
+        var map = new WindowsPnpPortMap(() => [Usb("COM9")]);
+
+        Assert.Single(map.GetDeviceIds("com9"));
+    }
+
+    [Fact]
+    public void GetDeviceIds_ForAPortNoEntityClaims_IsEmpty()
+    {
+        var map = new WindowsPnpPortMap(() => [Usb("COM9")]);
+
+        Assert.Empty(map.GetDeviceIds("COM4"));
+    }
+
+    [Fact]
+    public void GetDeviceIds_ForAnEmptyPortName_IsEmptyWithoutQuerying()
+    {
+        var calls = 0;
+        var map = new WindowsPnpPortMap(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return [Usb("COM9")];
+        });
+
+        Assert.Empty(map.GetDeviceIds(""));
+        Assert.Empty(map.GetDeviceIds("   "));
+        Assert.Equal(0, Volatile.Read(ref calls));
+    }
+
+    // ---- caching ---------------------------------------------------------
+
+    /// <summary>
+    /// The point of the change, and the issue's first success criterion: a pass classifying every
+    /// COM port on the machine costs one query, not one per port.
+    /// </summary>
+    [Fact]
+    public void ClassifyingEveryPortInAPass_QueriesOnce()
+    {
+        var ports = Enumerable.Range(1, 12).Select(n => $"COM{n}").ToArray();
+        var calls = 0;
+        var map = new WindowsPnpPortMap(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return ports.Select(p => Usb(p)).ToArray();
+        });
+
+        foreach (var port in ports)
+        {
+            Assert.Single(map.GetDeviceIds(port));
+        }
+
+        Assert.Equal(1, Volatile.Read(ref calls));
+        Assert.Equal(1L, map.QueryCount);
+    }
+
+    /// <summary>
+    /// The issue's second success criterion: two passes inside the window issue no further queries.
+    /// </summary>
+    [Fact]
+    public void ASecondPassInsideTheWindow_QueriesNoFurther()
+    {
+        var calls = 0;
+        var map = new WindowsPnpPortMap(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return [Usb("COM3"), Usb("COM7")];
+        });
+
+        for (var pass = 0; pass < 2; pass++)
+        {
+            map.GetDeviceIds("COM3");
+            map.GetDeviceIds("COM7");
+        }
+
+        Assert.Equal(1, Volatile.Read(ref calls));
+    }
+
+    [Fact]
+    public void ALookupAfterTheWindow_QueriesAgain()
+    {
+        var calls = 0;
+        var map = new WindowsPnpPortMap(
+            () =>
+            {
+                Interlocked.Increment(ref calls);
+                return [Usb("COM3")];
+            },
+            cacheDurationMs: 1);
+
+        Assert.Single(map.GetDeviceIds("COM3"));
+        Thread.Sleep(20);
+        Assert.Single(map.GetDeviceIds("COM3"));
+
+        Assert.Equal(2, Volatile.Read(ref calls));
+    }
+
+    [Fact]
+    public void WithCachingDisabled_EveryLookupQueries()
+    {
+        var calls = 0;
+        var map = new WindowsPnpPortMap(
+            () =>
+            {
+                Interlocked.Increment(ref calls);
+                return [Usb("COM3")];
+            },
+            cacheDurationMs: 0);
+
+        map.GetDeviceIds("COM3");
+        map.GetDeviceIds("COM3");
+        map.GetDeviceIds("COM3");
+
+        Assert.Equal(3, Volatile.Read(ref calls));
+    }
+
+    /// <summary>
+    /// Ports are classified from several threads at once, which is the case the shared map exists
+    /// for: they cost one query between them, not one each.
+    /// </summary>
+    [Fact]
+    public void ConcurrentLookups_QueryOnce()
+    {
+        var calls = 0;
+        var map = new WindowsPnpPortMap(() =>
+        {
+            Interlocked.Increment(ref calls);
+
+            // Wide enough that every other caller is definitely inside GetDeviceIds before this
+            // returns.
+            Thread.Sleep(30);
+            return [Usb("COM3")];
+        });
+
+        const int callers = 8;
+        using var everyoneReady = new Barrier(callers);
+        var found = new int[callers];
+
+        // Dedicated threads, not the thread pool: the barrier requires all of them to be running at
+        // once, which a pool that is ramping up cannot promise.
+        var threads = new Thread[callers];
+        for (var i = 0; i < callers; i++)
+        {
+            var index = i;
+            threads[i] = new Thread(() =>
+            {
+                everyoneReady.SignalAndWait();
+                found[index] = map.GetDeviceIds("COM3").Count;
+            })
+            {
+                IsBackground = true
+            };
+            threads[i].Start();
+        }
+
+        foreach (var thread in threads)
+        {
+            Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "A concurrent lookup never returned.");
+        }
+
+        Assert.Equal(1, Volatile.Read(ref calls));
+        Assert.All(found, count => Assert.Equal(1, count));
+    }
+
+    // ---- the two staleness rules ----------------------------------------
+
+    /// <summary>
+    /// The descriptor provider's rule: a miss is left alone. Re-querying for it would put a WMI
+    /// query back on the per-port path on any machine with a COM port that has no
+    /// <c>PNPClass='Ports'</c> entity, which is the cost this class removes.
+    /// </summary>
+    [Fact]
+    public void AMissInsideTheWindow_DoesNotQueryAgain()
+    {
+        var calls = 0;
+        var map = new WindowsPnpPortMap(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return [Usb("COM3")];
+        });
+
+        map.GetDeviceIds("COM3");
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.Empty(map.GetDeviceIds("COM8"));
+        }
+
+        Assert.Equal(1, Volatile.Read(ref calls));
+    }
+
+    /// <summary>
+    /// The location provider's rule: for it a miss is a real answer — no location key at all for a
+    /// port that has just probed as a DAQiFi device — so a port that appeared since the map was
+    /// built must still resolve.
+    /// </summary>
+    [Fact]
+    public void AMissWithRefreshOnMiss_RebuildsAndSeesTheNewPort()
+    {
+        var calls = 0;
+        PnpPortEntity[] present = [Usb("COM3")];
+        var map = new WindowsPnpPortMap(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return present;
+        });
+
+        Assert.Single(map.GetDeviceIds("COM3"));
+        Assert.Empty(map.GetDeviceIds("COM8", refreshOnMiss: true));
+
+        // COM8 is plugged in well inside the cache window.
+        present = [Usb("COM3"), Usb("COM8")];
+
+        Assert.Single(map.GetDeviceIds("COM8", refreshOnMiss: true));
+        Assert.Equal(3, Volatile.Read(ref calls));
+    }
+
+    [Fact]
+    public void AHitWithRefreshOnMiss_DoesNotQueryAgain()
+    {
+        var calls = 0;
+        var map = new WindowsPnpPortMap(() =>
+        {
+            Interlocked.Increment(ref calls);
+            return [Usb("COM3")];
+        });
+
+        map.GetDeviceIds("COM3", refreshOnMiss: true);
+        map.GetDeviceIds("COM3", refreshOnMiss: true);
+
+        Assert.Equal(1, Volatile.Read(ref calls));
+    }
+
+    // ---- failure ---------------------------------------------------------
+
+    /// <summary>
+    /// A failed rebuild must not install an empty map: that would read as "every port just
+    /// disappeared" for the rest of the window, turning one WMI hiccup into a pass that classifies
+    /// nothing. The failure is reported to the caller, which already treats it as "unknown".
+    /// </summary>
+    [Fact]
+    public void AFailedRebuild_LeavesTheLastGoodMapInPlace()
+    {
+        var fail = false;
+        var map = new WindowsPnpPortMap(() =>
+            fail ? throw new InvalidOperationException("WMI unavailable") : [Usb("COM3")]);
+
+        Assert.Single(map.GetDeviceIds("COM3"));
+
+        fail = true;
+        Assert.Throws<InvalidOperationException>(() => map.GetDeviceIds("COM8", refreshOnMiss: true));
+
+        // Still answering from the map built before the failure.
+        Assert.Single(map.GetDeviceIds("COM3"));
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/PnpDeviceIdParser.cs
+++ b/src/Daqifi.Core/Device/Discovery/PnpDeviceIdParser.cs
@@ -1,0 +1,62 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Reads the USB vendor/product identification embedded in a Windows PnP device instance ID. Kept
+/// separate from <see cref="WindowsUsbPortDescriptorProvider"/> (which is Windows-only because it
+/// calls into <see cref="System.Management"/>) so this pure string-manipulation logic can be unit
+/// tested on any platform without WMI/hardware access.
+/// </summary>
+internal static class PnpDeviceIdParser
+{
+    // Win32_PnPEntity DeviceID for USB-attached COM ports follows the form
+    // USB\VID_XXXX&PID_XXXX&...\<serial>. Each XXXX is 4 hex chars. We match
+    // case-insensitively because some drivers report "Vid_" / "Pid_".
+    private static readonly Regex VidPidRegex = new(
+        @"VID_(?<vid>[0-9A-F]{4}).*PID_(?<pid>[0-9A-F]{4})",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Returns the USB descriptor encoded in <paramref name="deviceId"/>, or null if it carries no
+    /// VID/PID pair — which is the normal answer for a COM port that is not USB-attached (a
+    /// motherboard serial port's ID starts <c>ACPI\</c>, a Bluetooth SPP port's <c>BTHENUM\</c>).
+    /// </summary>
+    internal static UsbPortDescriptor? ParseVidPid(string? deviceId)
+    {
+        if (string.IsNullOrEmpty(deviceId))
+        {
+            return null;
+        }
+
+        var match = VidPidRegex.Match(deviceId);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var vid = int.Parse(match.Groups["vid"].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        var pid = int.Parse(match.Groups["pid"].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        return new UsbPortDescriptor(vid, pid);
+    }
+
+    /// <summary>
+    /// Returns the descriptor of the first ID in <paramref name="deviceIds"/> that carries a
+    /// VID/PID pair, or null if none does. Skipping over IDs without one is what lets a port
+    /// claimed by both a USB entity and a non-USB one still be classified.
+    /// </summary>
+    internal static UsbPortDescriptor? SelectUsbDescriptor(IReadOnlyList<string> deviceIds)
+    {
+        for (var i = 0; i < deviceIds.Count; i++)
+        {
+            var descriptor = ParseVidPid(deviceIds[i]);
+            if (descriptor != null)
+            {
+                return descriptor;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/WindowsPnpPortMap.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsPnpPortMap.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
@@ -70,11 +71,11 @@ internal sealed class WindowsPnpPortMap
         @"\((COM\d+)\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    private static readonly IReadOnlyList<string> NoDeviceIds = [];
+    private static readonly ReadOnlyCollection<string> NoDeviceIds = ReadOnlyCollection<string>.Empty;
 
     private readonly Func<IEnumerable<PnpPortEntity>> _query;
     private readonly object _gate = new();
-    private Dictionary<string, List<string>> _map = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, ReadOnlyCollection<string>> _map = new(StringComparer.OrdinalIgnoreCase);
     private long _builtAtMs;
     private bool _hasMap;
     private long _queryCount;
@@ -149,7 +150,7 @@ internal sealed class WindowsPnpPortMap
     /// <summary>
     /// Rebuilds and publishes the map. Must be called holding <see cref="_gate"/>.
     /// </summary>
-    private Dictionary<string, List<string>> Rebuild()
+    private Dictionary<string, ReadOnlyCollection<string>> Rebuild()
     {
         // Published only after the query returns: a throwing query must leave the previous map and
         // its timestamp untouched rather than install an empty one, which would read as "every
@@ -167,17 +168,24 @@ internal sealed class WindowsPnpPortMap
     /// the caption parsing is unit testable on any platform without WMI access.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A port maps to a list rather than a single ID because the predicate this replaces matched a
     /// caption substring, not a whole caption: two entities can both mention "(COM9)", and the two
     /// callers pick different entries out of that set — the descriptor provider takes the first one
     /// carrying a VID/PID, the location provider the first one full stop.
+    /// </para>
+    /// <para>
+    /// Those lists are wrapped before they are published, so what a lookup hands out cannot be
+    /// mutated: a published map is shared by concurrent lookups, and a caller that cast one of its
+    /// lists back to the mutable type would be corrupting every other caller's view of it.
+    /// </para>
     /// </remarks>
-    internal static Dictionary<string, List<string>> BuildMap(IEnumerable<PnpPortEntity> entities)
+    internal static Dictionary<string, ReadOnlyCollection<string>> BuildMap(IEnumerable<PnpPortEntity> entities)
     {
         var map = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         if (entities == null)
         {
-            return map;
+            return Freeze(map);
         }
 
         foreach (var entity in entities)
@@ -206,7 +214,20 @@ internal sealed class WindowsPnpPortMap
             }
         }
 
-        return map;
+        return Freeze(map);
+    }
+
+    private static Dictionary<string, ReadOnlyCollection<string>> Freeze(Dictionary<string, List<string>> map)
+    {
+        var frozen = new Dictionary<string, ReadOnlyCollection<string>>(map.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var (portName, deviceIds) in map)
+        {
+            // AsReadOnly wraps the list rather than copying it, and the only reference to the list
+            // itself goes out of scope with this method — nothing can reach it to mutate it.
+            frozen[portName] = deviceIds.AsReadOnly();
+        }
+
+        return frozen;
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/Discovery/WindowsPnpPortMap.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsPnpPortMap.cs
@@ -1,0 +1,252 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
+
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// One row of the <c>Win32_PnPEntity</c> projection the port map is built from.
+/// </summary>
+/// <param name="DeviceId">The entity's PnP device instance ID, e.g. <c>USB\VID_04D8&amp;PID_F794\...</c>.</param>
+/// <param name="Caption">The entity's display name, e.g. <c>USB Serial Device (COM9)</c>.</param>
+internal readonly record struct PnpPortEntity(string? DeviceId, string? Caption);
+
+/// <summary>
+/// A short-lived, shared map from COM port name to the PnP device instance IDs of the
+/// <c>PNPClass = 'Ports'</c> entities that claim it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both Windows discovery providers used to answer "which PnP entity is COM9?" with their own
+/// WMI query, one per port, per discovery pass — a <c>Win32_PnPEntity</c> search with a
+/// <c>LIKE</c> predicate, which costs on the order of 100-500 ms warm. A machine with a dozen
+/// COM ports (Bluetooth SPP pairs, vendor virtual ports) therefore spent seconds of strictly
+/// sequential blocking work before opening a single port, and continuous discovery repeated
+/// that every second (issue #487). One query per pass answers all of those questions at once,
+/// which is what the macOS provider already does with <c>ioreg</c>.
+/// </para>
+/// <para>
+/// A map may be reused for <see cref="CacheDurationMs"/>, so an entry can be that stale. The
+/// exposure is deliberately bounded to less than one discovery pass, and it is the safe
+/// direction for both callers: a stale <em>miss</em> makes
+/// <see cref="WindowsUsbPortDescriptorProvider"/> return no classification, and an unclassified
+/// port is probed rather than skipped. The caller for whom a miss is a real answer — the
+/// location provider, which runs only for the handful of ports that probed as DAQiFi devices —
+/// asks with <c>refreshOnMiss</c> so a port that appeared since the map was built still
+/// resolves.
+/// </para>
+/// <para>
+/// A stale <em>hit</em> is the residual risk: a port re-assigned to different hardware inside
+/// the window keeps its old VID/PID for the rest of that window, so a device plugged into a
+/// just-vacated COM number can be skipped for one pass and is found on the next. That is the
+/// same trade the macOS provider has always made.
+/// </para>
+/// </remarks>
+internal sealed class WindowsPnpPortMap
+{
+    /// <summary>
+    /// Default lifetime of a map. Slightly longer than the continuous-discovery interval
+    /// (<see cref="ContinuousDiscoveryOptions"/> defaults to one second) so a single pass is
+    /// covered by one query, matching <see cref="MacOsUsbPortDescriptorProvider"/>'s window.
+    /// </summary>
+    internal const int DefaultCacheDurationMs = 2000;
+
+    /// <summary>
+    /// The instance the production providers read. Tests construct their own with a fake query
+    /// rather than mutating this one, so nothing here is process-wide mutable state.
+    /// </summary>
+    // QueryPortEntities is annotated [SupportedOSPlatform("windows")] because it touches
+    // System.Management; taking the method group here is not calling it, and it re-checks the
+    // platform at runtime before it touches WMI, so the analyzer warning is suppressed.
+#pragma warning disable CA1416
+    internal static WindowsPnpPortMap Shared { get; } = new(QueryPortEntities);
+#pragma warning restore CA1416
+
+    // The COM port number a PnP entity claims appears parenthesized in its caption, e.g.
+    // "USB Serial Device (COM9)". Matching the parentheses is what keeps "(COM9)" from also
+    // matching the entity captioned "(COM90)" — the same distinction the LIKE '%(COM9)%'
+    // predicate this replaces relied on.
+    private static readonly Regex CaptionPortRegex = new(
+        @"\((COM\d+)\)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly IReadOnlyList<string> NoDeviceIds = [];
+
+    private readonly Func<IEnumerable<PnpPortEntity>> _query;
+    private readonly object _gate = new();
+    private Dictionary<string, List<string>> _map = new(StringComparer.OrdinalIgnoreCase);
+    private long _builtAtMs;
+    private bool _hasMap;
+    private long _queryCount;
+
+    /// <summary>
+    /// Initializes a new port map.
+    /// </summary>
+    /// <param name="query">The underlying entity enumeration to cache.</param>
+    /// <param name="cacheDurationMs">
+    /// How long a built map may be reused, in milliseconds. Zero or less disables caching.
+    /// </param>
+    internal WindowsPnpPortMap(Func<IEnumerable<PnpPortEntity>> query, int cacheDurationMs = DefaultCacheDurationMs)
+    {
+        _query = query ?? throw new ArgumentNullException(nameof(query));
+        CacheDurationMs = cacheDurationMs;
+    }
+
+    /// <summary>
+    /// How long a built map may be reused, in milliseconds.
+    /// </summary>
+    internal int CacheDurationMs { get; }
+
+    /// <summary>
+    /// How many times the underlying enumeration has run to completion. The point of this class
+    /// is that it grows with elapsed time rather than with the number of ports asking.
+    /// </summary>
+    internal long QueryCount => Interlocked.Read(ref _queryCount);
+
+    /// <summary>
+    /// Returns the device instance IDs of the entities whose caption claims
+    /// <paramref name="portName"/>, in enumeration order, or an empty list if none does.
+    /// </summary>
+    /// <param name="portName">A COM port name such as <c>COM9</c>; compared case-insensitively.</param>
+    /// <param name="refreshOnMiss">
+    /// When true, a port missing from a reusable map forces a rebuild before answering, so a
+    /// port that appeared since the map was built is still found. Callers that treat a miss as
+    /// "no classification, probe it anyway" should leave this false — refreshing for them would
+    /// reinstate a per-port query on any machine with a COM port that has no
+    /// <c>PNPClass = 'Ports'</c> entity at all.
+    /// </param>
+    internal IReadOnlyList<string> GetDeviceIds(string portName, bool refreshOnMiss = false)
+    {
+        if (string.IsNullOrWhiteSpace(portName))
+        {
+            return NoDeviceIds;
+        }
+
+        // The query runs under the gate rather than outside it. Concurrent callers are exactly the
+        // case this exists for — a discovery pass classifying every port — and letting them all
+        // through would have each run its own query, which is the cost being removed. A blocked
+        // caller re-checks freshness on the way in, so only the first one queries.
+        lock (_gate)
+        {
+            var live = _hasMap && Environment.TickCount64 - _builtAtMs < CacheDurationMs;
+            if (live)
+            {
+                if (_map.TryGetValue(portName, out var cached))
+                {
+                    return cached;
+                }
+
+                if (!refreshOnMiss)
+                {
+                    return NoDeviceIds;
+                }
+            }
+
+            return Rebuild().TryGetValue(portName, out var fresh) ? fresh : NoDeviceIds;
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds and publishes the map. Must be called holding <see cref="_gate"/>.
+    /// </summary>
+    private Dictionary<string, List<string>> Rebuild()
+    {
+        // Published only after the query returns: a throwing query must leave the previous map and
+        // its timestamp untouched rather than install an empty one, which would read as "every
+        // port just disappeared" for the rest of the window.
+        var rebuilt = BuildMap(_query());
+        Interlocked.Increment(ref _queryCount);
+        _map = rebuilt;
+        _builtAtMs = Environment.TickCount64;
+        _hasMap = true;
+        return rebuilt;
+    }
+
+    /// <summary>
+    /// Groups <paramref name="entities"/> by the COM port names their captions claim. Pure, so
+    /// the caption parsing is unit testable on any platform without WMI access.
+    /// </summary>
+    /// <remarks>
+    /// A port maps to a list rather than a single ID because the predicate this replaces matched a
+    /// caption substring, not a whole caption: two entities can both mention "(COM9)", and the two
+    /// callers pick different entries out of that set — the descriptor provider takes the first one
+    /// carrying a VID/PID, the location provider the first one full stop.
+    /// </remarks>
+    internal static Dictionary<string, List<string>> BuildMap(IEnumerable<PnpPortEntity> entities)
+    {
+        var map = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        if (entities == null)
+        {
+            return map;
+        }
+
+        foreach (var entity in entities)
+        {
+            if (string.IsNullOrEmpty(entity.DeviceId) || string.IsNullOrEmpty(entity.Caption))
+            {
+                continue;
+            }
+
+            foreach (Match match in CaptionPortRegex.Matches(entity.Caption))
+            {
+                var portName = match.Groups[1].Value;
+                if (map.TryGetValue(portName, out var existing))
+                {
+                    // Guards a caption that names the same port twice ("… (COM9) bridge (COM9)"),
+                    // which would otherwise list one entity under it twice.
+                    if (!existing.Contains(entity.DeviceId, StringComparer.OrdinalIgnoreCase))
+                    {
+                        existing.Add(entity.DeviceId);
+                    }
+                }
+                else
+                {
+                    map[portName] = [entity.DeviceId];
+                }
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Projects every serial-port PnP entity in one WMI query. Errors are reported as "no
+    /// entities" rather than thrown, which makes every port unclassified for the current window —
+    /// the same fallback the per-port query had, and the direction that costs a probe rather than
+    /// a missed device.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static IEnumerable<PnpPortEntity> QueryPortEntities()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return [];
+        }
+
+        try
+        {
+            // Restricting to PNPClass='Ports' skips the rest of the device tree and shrinks WMI's
+            // enumeration cost; the same restriction the per-port queries used. No caller value is
+            // interpolated into this query at all, which is what retires the COM-name validation
+            // the per-port callers needed. The result collection owns native handles and must be
+            // disposed, so the rows are materialized here rather than streamed to the caller.
+            var entities = new List<PnpPortEntity>();
+            using var searcher = new System.Management.ManagementObjectSearcher(
+                "SELECT DeviceID, Caption FROM Win32_PnPEntity WHERE PNPClass = 'Ports'");
+            using var results = searcher.Get();
+            foreach (var entity in results)
+            {
+                using (entity)
+                {
+                    entities.Add(new PnpPortEntity(entity["DeviceID"] as string, entity["Caption"] as string));
+                }
+            }
+
+            return entities;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/WindowsUsbLocationProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsUsbLocationProvider.cs
@@ -56,11 +56,16 @@ internal sealed class WindowsUsbLocationProvider : IUsbLocationProvider
 
     private static string? QueryLocationByCaption(string portName)
     {
-        // Match COM-port entities by Caption suffix, e.g. "USB Serial Device (COM9)",
-        // same query shape as WindowsUsbPortDescriptorProvider.
-        using var searcher = new System.Management.ManagementObjectSearcher(
-            $"SELECT DeviceID FROM Win32_PnPEntity WHERE PNPClass = 'Ports' AND Caption LIKE '%({portName})%'");
-        var deviceId = FindDeviceId(searcher)?.ToUpperInvariant();
+        // Resolved from the shared port map, the same one WindowsUsbPortDescriptorProvider reads,
+        // rather than by re-running the per-port entity query it already ran this pass.
+        // refreshOnMiss because a miss is a real answer here: unlike the descriptor provider — for
+        // which "unknown" simply means "probe it" — an unresolved port yields no location key at
+        // all, and this runs for a port that has just been probed as a DAQiFi device, i.e. exactly
+        // the freshly-appeared port a map built moments earlier could be missing.
+        var deviceId = WindowsPnpPortMap.Shared
+            .GetDeviceIds(portName, refreshOnMiss: true)
+            .FirstOrDefault()?
+            .ToUpperInvariant();
         return deviceId != null ? QueryLocationByDeviceId(deviceId) : null;
     }
 
@@ -100,20 +105,6 @@ internal sealed class WindowsUsbLocationProvider : IUsbLocationProvider
         }
 
         return (null, null);
-    }
-
-    private static string? FindDeviceId(System.Management.ManagementObjectSearcher searcher)
-    {
-        using var results = searcher.Get();
-        foreach (var entity in results)
-        {
-            using (entity)
-            {
-                return entity["DeviceID"] as string;
-            }
-        }
-
-        return null;
     }
 
     private static (string? Location, string? ParentId) GetDeviceProperties(System.Management.ManagementObject entity)

--- a/src/Daqifi.Core/Device/Discovery/WindowsUsbPortDescriptorProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsUsbPortDescriptorProvider.cs
@@ -1,31 +1,16 @@
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Text.RegularExpressions;
 
 namespace Daqifi.Core.Device.Discovery;
 
 /// <summary>
-/// Resolves USB VID/PID for serial ports via WMI <c>Win32_PnPEntity</c>.
-/// Uses <see cref="System.Management"/>; returns null on non-Windows
-/// platforms so callers can fall back to a probe-everything strategy.
+/// Resolves USB VID/PID for serial ports from the shared <see cref="WindowsPnpPortMap"/>, which is
+/// built from a single WMI <c>Win32_PnPEntity</c> query per discovery pass. Returns null on
+/// non-Windows platforms so callers can fall back to a probe-everything strategy.
 /// </summary>
 [SupportedOSPlatform("windows")]
 internal sealed class WindowsUsbPortDescriptorProvider : IUsbPortDescriptorProvider
 {
-    // Win32_PnPEntity DeviceID for USB-attached COM ports follows the form
-    // USB\VID_XXXX&PID_XXXX&...\<serial>. Each XXXX is 4 hex chars. We
-    // match case-insensitively because some drivers report "Vid_" / "Pid_".
-    private static readonly Regex VidPidRegex = new(
-        @"VID_(?<vid>[0-9A-F]{4}).*PID_(?<pid>[0-9A-F]{4})",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-    // SerialPort.GetPortNames() returns "COM<n>" on Windows, but defend
-    // against malformed input reaching the WMI query string by validating
-    // the shape and rejecting anything that could close out the WQL literal.
-    private static readonly Regex PortNameRegex = new(
-        @"^COM\d+$",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
     public UsbPortDescriptor? GetDescriptor(string portName)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -35,7 +20,10 @@ internal sealed class WindowsUsbPortDescriptorProvider : IUsbPortDescriptorProvi
 
         try
         {
-            return QueryWmi(portName);
+            // A port the map doesn't list is left unclassified rather than refreshed: the caller
+            // probes anything it can't classify, so a miss costs one probe, while refreshing for
+            // every miss would put a WMI query back on the per-port path this exists to remove.
+            return PnpDeviceIdParser.SelectUsbDescriptor(WindowsPnpPortMap.Shared.GetDeviceIds(portName));
         }
         catch
         {
@@ -44,50 +32,5 @@ internal sealed class WindowsUsbPortDescriptorProvider : IUsbPortDescriptorProvi
             // is correct for any port we can't classify.
             return null;
         }
-    }
-
-    private static UsbPortDescriptor? QueryWmi(string portName)
-    {
-        // Bail explicitly on null/whitespace rather than relying on the
-        // outer try/catch to swallow an NRE from the regex match.
-        if (string.IsNullOrWhiteSpace(portName))
-            return null;
-
-        // Reject anything that doesn't match COM<n> shape — the WQL string is
-        // built by interpolation, so a stray quote would corrupt the query.
-        if (!PortNameRegex.IsMatch(portName))
-            return null;
-
-        // Match COM-port entities by Caption suffix, e.g. "USB Serial Device (COM9)".
-        // Restricting to PNPClass='Ports' skips the rest of the device tree
-        // and shrinks WMI's enumeration cost; the result collection itself
-        // owns native handles and must be disposed.
-        using var searcher = new System.Management.ManagementObjectSearcher(
-            $"SELECT DeviceID FROM Win32_PnPEntity WHERE PNPClass = 'Ports' AND Caption LIKE '%({portName})%'");
-        using var results = searcher.Get();
-        foreach (var entity in results)
-        {
-            using (entity)
-            {
-                var deviceId = entity["DeviceID"] as string;
-                if (string.IsNullOrEmpty(deviceId))
-                    continue;
-
-                var match = VidPidRegex.Match(deviceId);
-                if (!match.Success)
-                    continue;
-
-                var vid = int.Parse(
-                    match.Groups["vid"].Value,
-                    System.Globalization.NumberStyles.HexNumber,
-                    System.Globalization.CultureInfo.InvariantCulture);
-                var pid = int.Parse(
-                    match.Groups["pid"].Value,
-                    System.Globalization.NumberStyles.HexNumber,
-                    System.Globalization.CultureInfo.InvariantCulture);
-                return new UsbPortDescriptor(vid, pid);
-            }
-        }
-        return null;
     }
 }


### PR DESCRIPTION
## What was wrong

On Windows, discovering a DAQiFi over USB got slower with every unrelated COM port on the machine. Before opening a single port, Core asked Windows "which device is COM3? which is COM4? …" one port at a time, and each of those questions is a WMI query costing roughly 100-500 ms. A normal laptop has eight to twelve COM ports (Bluetooth pairs, vendor virtual ports), so the filtering step alone burned one to five seconds of blocking work — and continuous discovery repeated the whole thing every second, so it never caught up. macOS and Linux were never affected; they already ask once and reuse the answer.

## How it was fixed

Ask once. A single query now lists every serial port on the machine with the device it belongs to, and both Windows providers read that one map instead of running their own per-port query. The map is reused for two seconds, the same window the macOS provider has always used, so one discovery pass costs one query no matter how many COM ports are present.

**The thing worth pushing back on** is that a two-second-old map can be wrong about a port that appeared since it was built. The two callers need different things there, so they get different rules. For the port *filter*, an unknown port simply gets probed the old-fashioned way, so a stale miss costs one probe and can never hide a device — it takes the cached answer. For *location keys*, a miss is a real answer (no key at all) and it is asked precisely about a port that just showed up, so it forces a fresh map before answering no. The residual risk both share is a stale *hit*: a device plugged into a COM number that another device just vacated keeps the old identity until the map expires, so it is found on the next pass rather than this one. That is the same trade the macOS provider makes today.

## Verification

- 27 new tests. The WMI call is behind an injected query, so the caption parsing, the caching, and both staleness rules are exercised on any platform. Seven mutations confirm the tests catch the regressions: removing the cache fails 6, ignoring `refreshOnMiss` fails 2, refreshing on every miss fails 1, publishing the map before the query returns fails 1, checking only the first device id fails 1, case-sensitive port keys fail 1, and overwriting instead of appending fails 1. Full suite green on **net9.0** (3070 Core + 86 Mcp) and **net10.0** (3070), 0 warnings.
- **Honest limitation: the WMI path itself is not exercised anywhere.** This repo has no Windows machine and CI runs `ubuntu-latest` only — the same caveat `docs/DEVICE_INTERFACES.md` already records for `WindowsUsbLocationProvider`. What is verified by inspection is that the new query is the old one minus its per-port `AND Caption LIKE '%(COMn)%'` clause, and that matching `(COMn)` including the parentheses reproduces that clause exactly (notably, `(COM9)` still does not match `(COM90)`).
- **Bench, non-destructive, Nq1 fw 3.7.2 on `/dev/cu.usbmodem1101`** — a no-regression check only, since macOS never constructs these providers: serial discovery found `sn=9090539562006014104` fw 3.7.2, 3 s @ 500 Hz on channels 0-2 gave 1186 samples (this unit's known ~79 % clock ratio), SD storage query 7.80 GB, clean disconnect. No reboot, format, delete, `SD:GET`, firmware or LAN writes.

closes #487

**Not merging — this is for your review.**
