### PR TITLE
test(device): a raw-capture test was failing on CI for a reason that had nothing to do with the PR under review

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceRawCaptureLockTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceRawCaptureLockTests.cs
@@ -29,6 +29,15 @@ public class DaqifiDeviceRawCaptureLockTests
     /// </summary>
     private static readonly TimeSpan WireSettleWait = TimeSpan.FromMilliseconds(250);
 
+    /// <summary>
+    /// How many messages the send hammer fires. Derived from the deferral cap rather than picked,
+    /// because the relationship is what matters: the backlog overflows by discarding its
+    /// <b>oldest</b> entry, so a hammer allowed to park more than the cap evicts <c>HAMMER-0</c> —
+    /// the one message the test then waits for (#516). An eighth of the cap keeps every send
+    /// parked while still spanning several <c>MaxDeferredSendsPerFlush</c> replay batches.
+    /// </summary>
+    private const int HammerSendBudget = DaqifiDevice.DefaultMaxDeferredSends / 8;
+
     // ── Mutual exclusion against text exchanges ─────────────────────────────────────────────
 
     [Fact]
@@ -233,7 +242,7 @@ public class DaqifiDeviceRawCaptureLockTests
         transport.CaptureStream.Payload = payload;
 
         var captureEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var stopHammer = 0;
+        var hammerFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var received = new MemoryStream();
 
         var capture = Task.Run(() => device.RunRawCaptureAsync(async (stream, ct) =>
@@ -243,8 +252,11 @@ public class DaqifiDeviceRawCaptureLockTests
             {
                 captureEntered.SetResult();
 
+                // Holding the stream until the hammer is done is what makes the assertions below
+                // about the hammer's sends true by construction rather than by timing: every one
+                // of them is issued while the capture owns the device, however slow the machine.
                 var buffer = new byte[256];
-                while (received.Length < payload.Length)
+                while (received.Length < payload.Length || !hammerFinished.Task.IsCompleted)
                 {
                     var read = stream.Read(buffer, 0, buffer.Length);
                     if (read > 0)
@@ -266,21 +278,37 @@ public class DaqifiDeviceRawCaptureLockTests
 
         var hammer = Task.Run(() =>
         {
-            var sent = 0;
-            while (Volatile.Read(ref stopHammer) == 0)
+            var sentIntoTheOpenWindow = 0;
+            try
             {
-                device.Send(new TaggedBinaryMessage($"HAMMER-{sent++}"));
-                Thread.Sleep(1);
+                for (var sent = 0; sent < HammerSendBudget; sent++)
+                {
+                    if (transport.CaptureStream.CaptureWindowOpen)
+                    {
+                        sentIntoTheOpenWindow++;
+                    }
+
+                    device.Send(new TaggedBinaryMessage($"HAMMER-{sent}"));
+                    Thread.Sleep(1);
+                }
+            }
+            finally
+            {
+                // Always signalled, so a hammer that throws surfaces as its own failure instead of
+                // hanging the capture that is waiting on it.
+                hammerFinished.SetResult();
             }
 
-            return sent;
+            return sentIntoTheOpenWindow;
         });
 
         await capture.WaitAsync(DeadlockBudget);
-        Volatile.Write(ref stopHammer, 1);
-        var hammered = await hammer.WaitAsync(DeadlockBudget);
+        var hammeredIntoTheOpenWindow = await hammer.WaitAsync(DeadlockBudget);
 
-        Assert.True(hammered > 0, "The hammer never sent anything, so this proves nothing.");
+        Assert.True(
+            hammeredIntoTheOpenWindow == HammerSendBudget,
+            $"Only {hammeredIntoTheOpenWindow} of the hammer's {HammerSendBudget} sends were made "
+            + "while the capture owned the device, so the assertions below prove less than they claim.");
         Assert.Equal(payload, received.ToArray());
 
         var duringCapture = transport.Writes.Where(w => w.DuringCapture).ToList();
@@ -289,7 +317,10 @@ public class DaqifiDeviceRawCaptureLockTests
             $"{duringCapture.Count} write(s) reached the wire during the capture: "
             + string.Join(" | ", duringCapture.Take(5).Select(w => w.Text)));
 
-        // And they were parked, not dropped.
+        // And they were parked, not dropped. The budget keeps the backlog under its cap, so an
+        // eviction here means the two have drifted apart — worth saying so directly, because the
+        // symptom is otherwise the unrelated-looking "HAMMER-0 never reached the wire" (#516).
+        Assert.Equal(0, device.DroppedDeferredSendCount);
         await WaitForWriteAsync(transport, "HAMMER-0");
 
         device.Disconnect();


### PR DESCRIPTION
**What was wrong.** One of the raw-capture tests (`RawCapture_UnderASendHammer_...`) would go red on GitHub Actions on pull requests that had not touched any of the code it covers — it failed twice in a row on #515, a branch that only changes Windows discovery. The test fires a stream of `Send()` calls at a device while a raw capture holds it, then checks that the very first of those messages (`HAMMER-0`) was parked and replayed rather than thrown away. But `Send()`'s hold-back backlog is capped, and when it overflows it discards its **oldest** entry — so `HAMMER-0` is by definition the first casualty. The hammer ran for as long as the capture window stayed open, so on a fast machine it parked a couple of hundred messages and passed, and on a loaded CI runner it parked thousands, evicted the message the test was waiting for, and failed. Nothing was wrong with the library; the test was asserting something the design does not promise.

**How it was fixed.** The hammer now sends a fixed number of messages instead of running until told to stop, and that number is derived from the backlog cap (`DefaultMaxDeferredSends / 8`) rather than picked by hand, so the two cannot drift apart silently. To keep the test as strong as it was, the capture now holds the stream until the hammer has finished, which makes "every one of those sends happened while the capture owned the device" true by construction rather than by hoping the window outlasts the sender. A `DroppedDeferredSendCount == 0` assertion sits next to the original wait, so if anyone does raise the budget past the cap the failure says "112 messages were dropped" instead of the misleading "HAMMER-0 never reached the wire". No production code changed.

The one thing worth pushing back on: the capture task now waits on the hammer, which is a dependency the old version did not have. It is signalled from a `finally`, so a hammer that throws surfaces as its own failure rather than hanging the capture.

**Verified.** Simulating a loaded runner by serving the capture payload one byte at a time (a ~10 s window) reproduces the CI failure on the old test with the exact same message, and the new test passes 3/3 under those same conditions. Two more mutations confirm the assertions are real catchers: shrinking the backlog cap to 16 trips the new dropped-count assertion, and disabling send deferral entirely still fails the test — now catching all 128 sends instead of a timing-dependent subset. Full suite green on net9.0 (3045 Core + 86 Mcp) and net10.0 (3045), 0 warnings. Bench health check on the Nq1 (fw 3.7.2, `/dev/cu.usbmodem1101`), non-destructive: discovery, 3 s @ 500 Hz on channels 0-2 → 1186 samples (this unit's usual ratio), SD storage 7.80 GB, clean disconnect — unchanged, as expected for a test-only change.

closes #516

*Not merging — opened for your review.*