### PR TITLE
feat(streaming): answer "am I actually getting the sample rate I asked for?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ More examples at [daqifi.com](https://daqifi.com).
 | **Auto-discovery** | Find any DAQiFi on WiFi or USB in seconds — no IP hunting, no config files |
 | **One-line connect** | `DaqifiDeviceFactory.ConnectTcpAsync(...)` wraps transport setup and device init; retries are opt-in via `DeviceConnectionOptions` |
 | **Real-time streaming** | Per-channel `IChannel.SampleReceived` events with decoded, scaled values — or subscribe to the raw protobuf frame directly; no polling loops to write |
+| **Acquisition health** | Attach `AcquisitionStatistics` to a stream and read back the rate you are really getting, per-channel jitter, value range, and how far behind the device's clock the host is |
 | **Digital I/O** | Set any DIO pin as input or output and drive outputs high/low; inputs stream alongside analog data |
 | **PWM outputs** | Drive PWM on capable DIO pins with per-channel duty cycle and a shared, device-wide frequency |
 | **SD card operations** | List, download, delete, format, and start/stop SD logging over USB / serial |
@@ -167,6 +168,38 @@ var devices = await wifiFinder.DiscoverAsync(cts.Token);
 
 using var customFinder = new WiFiDeviceFinder(discoveryPort: 12345);
 ```
+
+### Acquisition statistics
+
+"Am I actually getting 1 kHz?" — attach an `AcquisitionStatistics` for the duration of a stream and
+read a snapshot whenever you want the answer. It observes the same per-channel sample events
+streaming already raises, so nothing changes for consumers that do not attach one.
+
+```csharp
+using Daqifi.Core.Device;
+
+using var stats = new AcquisitionStatistics(device);
+
+device.StreamingFrequency = 1000;
+device.StartStreaming();
+await Task.Delay(TimeSpan.FromSeconds(5));
+device.StopStreaming();
+
+var snapshot = stats.Snapshot();
+foreach (var channel in snapshot.Channels)
+{
+    Console.WriteLine(
+        $"{channel.Name}: {channel.SampleCount} samples, " +
+        $"{channel.MeasuredSampleRateHz:F1} Hz measured vs {channel.DeviceClockSampleRateHz:F1} Hz by the device clock, " +
+        $"{channel.MinValue:F3}..{channel.MaxValue:F3} V, worst gap {channel.MaxSampleInterval.TotalMilliseconds:F2} ms");
+}
+```
+
+The two rates are reported side by side on purpose. Both dropping below the commanded rate means
+samples went missing; the two disagreeing means the device's own clock is not keeping real time, and
+it is `MeasuredSampleRateHz` that describes what your application actually received. `Reset()` starts
+a fresh window mid-session, and `stats.Record(sample)` feeds one by hand from `StreamSamplesAsync`
+instead of attaching.
 
 ### Digital output
 

--- a/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
@@ -226,6 +226,34 @@ namespace Daqifi.Core.Tests.Device
         }
 
         [Fact]
+        public void Record_TheSampleAfterABackwardsStep_IsNotMeasuredFromTheRewoundTimestamp()
+        {
+            // What a stale frame actually looks like: the clock rewinds, then the next frame jumps
+            // forward again to roughly where it was. Measuring that jump from the rewound value
+            // would report the whole five-second rewind as the worst gap in the acquisition.
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            foreach (var offset in new[]
+                     {
+                         TimeSpan.Zero,
+                         TimeSpan.FromMilliseconds(1),
+                         TimeSpan.FromSeconds(-5),      // stale frame
+                         TimeSpan.FromMilliseconds(2),  // the stream carrying on as if nothing happened
+                     })
+            {
+                stats.Record(channel, Sample(Epoch.Add(offset), 1.0));
+                clock.Advance(TimeSpan.FromMilliseconds(1));
+            }
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1, ai0.OutOfOrderSampleCount);
+            Assert.Equal(TimeSpan.FromMilliseconds(1), ai0.MinSampleInterval);
+            Assert.Equal(TimeSpan.FromMilliseconds(1), ai0.MaxSampleInterval);
+        }
+
+        [Fact]
         public void Record_ATimestampThatStepsFarBack_DoesNotCollapseTheDeviceClockRate()
         {
             // The damaging case: the most recently recorded sample is not the latest in time, so a

--- a/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
@@ -202,6 +202,69 @@ namespace Daqifi.Core.Tests.Device
             Assert.Equal(1000.0, ai0.MeasuredSampleRateHz, 6);
         }
 
+        [Fact]
+        public void Record_ATimestampThatMovesBackwards_IsCounted_AndKeptOutOfTheJitterBounds()
+        {
+            // TimestampProcessor reconstructs a time that moves backwards when the device sends a
+            // frame out of order, so a sample's timestamp can precede the one before it. A negative
+            // number is not a gap: it must not land in the interval bounds.
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            foreach (var offsetMs in new[] { 0.0, 1.0, 3.0, 2.0, 4.0 }) // the 4th sample steps back
+            {
+                stats.Record(channel, Sample(Epoch.AddMilliseconds(offsetMs), 1.0));
+                clock.Advance(TimeSpan.FromMilliseconds(1));
+            }
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1, ai0.OutOfOrderSampleCount);
+            Assert.Equal(TimeSpan.FromMilliseconds(1), ai0.MinSampleInterval);
+            Assert.Equal(TimeSpan.FromMilliseconds(2), ai0.MaxSampleInterval);
+            Assert.True(ai0.MinSampleInterval >= TimeSpan.Zero, "a backwards step must not be reported as a gap");
+        }
+
+        [Fact]
+        public void Record_ATimestampThatStepsFarBack_DoesNotCollapseTheDeviceClockRate()
+        {
+            // The damaging case: the most recently recorded sample is not the latest in time, so a
+            // span taken from first-and-last would be negative and the reported rate would drop to
+            // zero — a device that looked stopped because one frame arrived late.
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            stats.Record(channel, Sample(Epoch, 1.0));
+            clock.Advance(TimeSpan.FromMilliseconds(1));
+            stats.Record(channel, Sample(Epoch.AddMilliseconds(2), 1.0));
+            clock.Advance(TimeSpan.FromMilliseconds(1));
+            stats.Record(channel, Sample(Epoch.AddSeconds(-5), 1.0));
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1, ai0.OutOfOrderSampleCount);
+            Assert.Equal(Epoch.AddSeconds(-5), ai0.EarliestSampleTimestamp);
+            Assert.Equal(Epoch.AddMilliseconds(2), ai0.LatestSampleTimestamp);
+            Assert.Equal(2 / 5.002, ai0.DeviceClockSampleRateHz, 6);
+            Assert.True(ai0.MeanSampleInterval > TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void Record_MonotonicTimestamps_ReportNoOutOfOrderSamples()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            for (var i = 0; i < 10; i++)
+            {
+                stats.Record(channel, Sample(Epoch.AddMilliseconds(i), 1.0));
+                clock.Advance(TimeSpan.FromMilliseconds(1));
+            }
+
+            Assert.Equal(0, Assert.Single(stats.Snapshot().Channels).OutOfOrderSampleCount);
+        }
+
         #endregion
 
         #region Latency and window

--- a/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
@@ -1,0 +1,605 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    public class AcquisitionStatisticsTests
+    {
+        /// <summary>
+        /// The host-clock reading every test starts from. Local kind on purpose: the timestamps these
+        /// statistics measure against the host clock are local (see <c>TimestampProcessor</c>), and a
+        /// UTC-kind fixture would quietly compare two different time bases.
+        /// </summary>
+        private static readonly DateTime Epoch = new DateTime(2026, 8, 13, 9, 0, 0, DateTimeKind.Local);
+
+        #region Value statistics
+
+        [Fact]
+        public void Snapshot_WithNoSamples_IsEmptyButStillReportsWhenTheWindowStarted()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+
+            var snapshot = stats.Snapshot();
+
+            Assert.Equal(Epoch, snapshot.StartedAt);
+            Assert.Equal(0, snapshot.TotalSampleCount);
+            Assert.Empty(snapshot.Channels);
+            Assert.Equal(TimeSpan.Zero, snapshot.Duration);
+            Assert.Equal(TimeSpan.Zero, snapshot.MeanLatency);
+        }
+
+        [Fact]
+        public void Record_TracksCountAndValueExtremesAndMean()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0) { Name = "AI0" };
+
+            foreach (var value in new[] { 1.0, 3.0, 2.0 })
+            {
+                stats.Record(channel, Sample(clock.Now, value));
+                clock.Advance(TimeSpan.FromMilliseconds(1));
+            }
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(ChannelType.Analog, ai0.ChannelType);
+            Assert.Equal(0, ai0.ChannelNumber);
+            Assert.Equal("AI0", ai0.Name);
+            Assert.Equal(3, ai0.SampleCount);
+            Assert.Equal(1.0, ai0.MinValue);
+            Assert.Equal(3.0, ai0.MaxValue);
+            Assert.Equal(2.0, ai0.MeanValue, 9);
+        }
+
+        [Fact]
+        public void Record_SeedsValueExtremesFromTheFirstSample_NotFromZero()
+        {
+            // The defect this port fixes: desktop's SummaryLogger left min/max at their default 0 on
+            // the first sample, so a channel sitting at 4.5 V reported a minimum of 0 V forever.
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            stats.Record(channel, Sample(clock.Now, 4.4));
+            clock.Advance(TimeSpan.FromMilliseconds(1));
+            stats.Record(channel, Sample(clock.Now, 4.6));
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(4.4, ai0.MinValue);
+            Assert.Equal(4.6, ai0.MaxValue);
+            Assert.Equal(4.5, ai0.MeanValue, 9);
+        }
+
+        [Fact]
+        public void Record_MeanValue_DividesByTheSamplesActuallySeen()
+        {
+            // Desktop divided by a configured window size instead, so a window that never filled
+            // under-reported its mean by whatever fraction was missing.
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            stats.Record(channel, Sample(clock.Now, 10.0));
+            clock.Advance(TimeSpan.FromMilliseconds(1));
+            stats.Record(channel, Sample(clock.Now, 20.0));
+
+            Assert.Equal(15.0, Assert.Single(stats.Snapshot().Channels).MeanValue, 9);
+        }
+
+        #endregion
+
+        #region Rate and jitter
+
+        [Fact]
+        public void Record_MeasuredRateAndDeviceClockRate_AgreeWhenTheDeviceClockKeepsRealTime()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            // 1 kHz: one sample every millisecond, on both clocks.
+            for (var i = 0; i < 1000; i++)
+            {
+                stats.Record(channel, Sample(clock.Now, 1.0));
+                clock.Advance(TimeSpan.FromMilliseconds(1));
+            }
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1000.0, ai0.MeasuredSampleRateHz, 6);
+            Assert.Equal(1000.0, ai0.DeviceClockSampleRateHz, 6);
+        }
+
+        [Fact]
+        public void Record_MeasuredRate_FollowsTheHostClock_WhenTheDeviceClockRunsSlow()
+        {
+            // Reproduces what a device whose timestamps do not track real time looks like
+            // (daqifi-nyquist-firmware #716): the device stamps a millisecond per sample while the
+            // host sees 1.25 ms pass. The device-clock rate still claims 1 kHz; the measured rate is
+            // what the caller actually received, and their disagreement is the diagnosis.
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+            var deviceTime = Epoch;
+
+            for (var i = 0; i < 1000; i++)
+            {
+                stats.Record(channel, Sample(deviceTime, 1.0));
+                deviceTime = deviceTime.AddMilliseconds(1);
+                clock.Advance(TimeSpan.FromMilliseconds(1.25));
+            }
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1000.0, ai0.DeviceClockSampleRateHz, 6);
+            Assert.Equal(800.0, ai0.MeasuredSampleRateHz, 6);
+        }
+
+        [Fact]
+        public void Record_SampleIntervals_ReportTheSmallestLargestAndMeanGap()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+            var deviceTime = Epoch;
+
+            // Gaps of 1 ms, 4 ms, 1 ms — a stall in the middle, which is what a dropped block of
+            // samples looks like from the host's side.
+            foreach (var gapMs in new[] { 0.0, 1.0, 4.0, 1.0 })
+            {
+                deviceTime = deviceTime.AddMilliseconds(gapMs);
+                stats.Record(channel, Sample(deviceTime, 1.0));
+                clock.Advance(TimeSpan.FromMilliseconds(gapMs));
+            }
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(TimeSpan.FromMilliseconds(1), ai0.MinSampleInterval);
+            Assert.Equal(TimeSpan.FromMilliseconds(4), ai0.MaxSampleInterval);
+            Assert.Equal(TimeSpan.FromMilliseconds(2), ai0.MeanSampleInterval);
+        }
+
+        [Fact]
+        public void Record_ASingleSample_HasNoRateAndNoInterval()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+
+            stats.Record(new AnalogChannel(0), Sample(clock.Now, 1.0));
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1, ai0.SampleCount);
+            Assert.Equal(0.0, ai0.MeasuredSampleRateHz);
+            Assert.Equal(0.0, ai0.DeviceClockSampleRateHz);
+            Assert.Equal(TimeSpan.Zero, ai0.MinSampleInterval);
+            Assert.Equal(TimeSpan.Zero, ai0.MaxSampleInterval);
+            Assert.Equal(TimeSpan.Zero, ai0.MeanSampleInterval);
+        }
+
+        [Fact]
+        public void Record_RepeatedDeviceTimestamps_ReportZeroIntervalRatherThanDividingByZero()
+        {
+            // Firmware that stamps several samples with the same tick value at high rates
+            // (daqifi-nyquist-firmware #717): the device-clock span collapses to nothing.
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            for (var i = 0; i < 3; i++)
+            {
+                stats.Record(channel, Sample(Epoch, 1.0));
+                clock.Advance(TimeSpan.FromMilliseconds(1));
+            }
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(0.0, ai0.DeviceClockSampleRateHz);
+            Assert.Equal(TimeSpan.Zero, ai0.MaxSampleInterval);
+            Assert.Equal(1000.0, ai0.MeasuredSampleRateHz, 6);
+        }
+
+        #endregion
+
+        #region Latency and window
+
+        [Fact]
+        public void Record_Latency_MeasuresHostArrivalAgainstTheDeviceTimestamp()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+            var deviceTime = Epoch;
+
+            // Arrivals 2 ms, 6 ms and 4 ms after the timestamps they carry.
+            foreach (var latencyMs in new[] { 2.0, 6.0, 4.0 })
+            {
+                clock.Set(deviceTime.AddMilliseconds(latencyMs));
+                stats.Record(channel, Sample(deviceTime, 1.0));
+                deviceTime = deviceTime.AddMilliseconds(10);
+            }
+
+            var snapshot = stats.Snapshot();
+            Assert.Equal(TimeSpan.FromMilliseconds(2), snapshot.MinLatency);
+            Assert.Equal(TimeSpan.FromMilliseconds(6), snapshot.MaxLatency);
+            Assert.Equal(TimeSpan.FromMilliseconds(4), snapshot.MeanLatency);
+        }
+
+        [Fact]
+        public void Record_Latency_CanBeNegative_WhenTheDeviceClockOutrunsTheHost()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+
+            stats.Record(new AnalogChannel(0), Sample(Epoch.AddMilliseconds(5), 1.0));
+
+            Assert.Equal(TimeSpan.FromMilliseconds(-5), stats.Snapshot().MinLatency);
+        }
+
+        [Fact]
+        public void Snapshot_Duration_SpansTheSamples_NotTheLifetimeOfTheAggregator()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            clock.Advance(TimeSpan.FromSeconds(30)); // idle before anything streams
+            stats.Record(channel, Sample(clock.Now, 1.0));
+            clock.Advance(TimeSpan.FromSeconds(2));
+            stats.Record(channel, Sample(clock.Now, 1.0));
+
+            var snapshot = stats.Snapshot();
+            Assert.Equal(Epoch, snapshot.StartedAt);
+            Assert.Equal(TimeSpan.FromSeconds(2), snapshot.Duration);
+            Assert.Equal(Epoch.AddSeconds(30), snapshot.FirstReceivedAt);
+            Assert.Equal(Epoch.AddSeconds(32), snapshot.LastReceivedAt);
+        }
+
+        [Fact]
+        public void Reset_DiscardsTheWindow_AndStartsANewOne()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            stats.Record(channel, Sample(clock.Now, 1.0));
+            clock.Advance(TimeSpan.FromSeconds(1));
+
+            stats.Reset();
+
+            var afterReset = stats.Snapshot();
+            Assert.Equal(0, afterReset.TotalSampleCount);
+            Assert.Empty(afterReset.Channels);
+            Assert.Equal(Epoch.AddSeconds(1), afterReset.StartedAt);
+
+            stats.Record(channel, Sample(clock.Now, 7.0));
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1, ai0.SampleCount);
+            Assert.Equal(7.0, ai0.MinValue);
+        }
+
+        #endregion
+
+        #region Multiple channels
+
+        [Fact]
+        public void Record_TracksChannelsSeparately_AndReportsThemInDeviceOrder()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+
+            stats.Record(new DigitalChannel(2), Sample(clock.Now, 1.0));
+            stats.Record(new AnalogChannel(1), Sample(clock.Now, 2.0));
+            stats.Record(new DigitalChannel(0), Sample(clock.Now, 0.0));
+            stats.Record(new AnalogChannel(0), Sample(clock.Now, 3.0));
+            stats.Record(new AnalogChannel(0), Sample(clock.Now, 5.0));
+
+            var channels = stats.Snapshot().Channels;
+            Assert.Equal(
+                new[]
+                {
+                    (ChannelType.Analog, 0),
+                    (ChannelType.Analog, 1),
+                    (ChannelType.Digital, 0),
+                    (ChannelType.Digital, 2),
+                },
+                channels.Select(c => (c.ChannelType, c.ChannelNumber)));
+            Assert.Equal(2, channels[0].SampleCount);
+            Assert.Equal(4.0, channels[0].MeanValue, 9);
+            Assert.Equal(5, stats.Snapshot().TotalSampleCount);
+        }
+
+        [Fact]
+        public void Record_LiveSampleOverload_RecordsTheSameAsTheChannelOverload()
+        {
+            var clock = new TestClock(Epoch);
+            using var stats = new AcquisitionStatistics(null, clock.Read);
+            var channel = new AnalogChannel(0);
+
+            stats.Record(new LiveSample(channel, Sample(clock.Now, 2.5)));
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1, ai0.SampleCount);
+            Assert.Equal(2.5, ai0.MeanValue);
+        }
+
+        [Fact]
+        public void Record_FromSeveralThreadsAtOnce_CountsEverySample()
+        {
+            using var stats = new AcquisitionStatistics();
+            var channels = new[] { new AnalogChannel(0), new AnalogChannel(1), new AnalogChannel(2) };
+            const int perThread = 5_000;
+
+            Parallel.ForEach(channels, channel =>
+            {
+                for (var i = 0; i < perThread; i++)
+                {
+                    stats.Record(channel, Sample(Epoch.AddMilliseconds(i), i));
+                }
+            });
+
+            var snapshot = stats.Snapshot();
+            Assert.Equal(channels.Length * perThread, snapshot.TotalSampleCount);
+            Assert.All(snapshot.Channels, c => Assert.Equal(perThread, c.SampleCount));
+        }
+
+        #endregion
+
+        #region Argument validation
+
+        [Fact]
+        public void Ctor_WithNullDevice_Throws() =>
+            Assert.Throws<ArgumentNullException>(() => new AcquisitionStatistics((IStreamingDevice)null!));
+
+        [Fact]
+        public void Record_WithNullArguments_Throws()
+        {
+            using var stats = new AcquisitionStatistics();
+
+            Assert.Throws<ArgumentNullException>(() => stats.Record(null!, Sample(Epoch, 1.0)));
+            Assert.Throws<ArgumentNullException>(() => stats.Record(new AnalogChannel(0), null!));
+            Assert.Throws<ArgumentNullException>(() => stats.Record(null!));
+        }
+
+        #endregion
+
+        #region Attached to a device
+
+        [Fact]
+        public void AttachedToDevice_RecordsEveryDecodedSample()
+        {
+            var device = CreateStreaming(analogCount: 2);
+            EnableAllChannels(device);
+            device.StartStreaming();
+
+            using var stats = new AcquisitionStatistics(device);
+
+            device.InvokeStreamMessage(AnalogFrame(1_000, 1.0f, 2.0f));
+            device.InvokeStreamMessage(AnalogFrame(51_000, 3.0f, 4.0f));
+
+            var snapshot = stats.Snapshot();
+            Assert.Equal(4, snapshot.TotalSampleCount);
+            Assert.Equal(2, snapshot.Channels.Count);
+            Assert.Equal(1.0, snapshot.Channels[0].MinValue);
+            Assert.Equal(3.0, snapshot.Channels[0].MaxValue);
+            Assert.Equal(2.0, snapshot.Channels[1].MinValue);
+            Assert.Equal(4.0, snapshot.Channels[1].MaxValue);
+
+            // Frames one millisecond apart on the device's 50 MHz tick clock.
+            Assert.Equal(TimeSpan.FromMilliseconds(1), snapshot.Channels[0].MaxSampleInterval);
+        }
+
+        [Fact]
+        public void AttachedToDevice_SurvivesAChannelRepopulation_WithoutSplittingOrDoubleCountingAChannel()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            EnableAllChannels(device);
+            device.StartStreaming();
+
+            using var stats = new AcquisitionStatistics(device);
+            device.InvokeStreamMessage(AnalogFrame(1_000, 1.0f));
+
+            // A second status message re-runs population and re-raises ChannelsPopulated, which is
+            // what the aggregator resubscribes on.
+            device.PopulateChannelsFromStatus(StatusMessage(analogCount: 1));
+            EnableAllChannels(device);
+            device.InvokeStreamMessage(AnalogFrame(51_000, 2.0f));
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(2, ai0.SampleCount); // one entry, and the second sample counted exactly once
+            Assert.Equal(1.0, ai0.MinValue);
+            Assert.Equal(2.0, ai0.MaxValue);
+        }
+
+        [Fact]
+        public void Dispose_StopsRecording_ButLeavesTheSnapshotReadable()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            EnableAllChannels(device);
+            device.StartStreaming();
+
+            var stats = new AcquisitionStatistics(device);
+            device.InvokeStreamMessage(AnalogFrame(1_000, 1.0f));
+            stats.Dispose();
+            device.InvokeStreamMessage(AnalogFrame(51_000, 9.0f));
+
+            var ai0 = Assert.Single(stats.Snapshot().Channels);
+            Assert.Equal(1, ai0.SampleCount);
+            Assert.Equal(1.0, ai0.MaxValue);
+
+            stats.Dispose(); // idempotent
+            stats.Record(new AnalogChannel(0), Sample(Epoch, 5.0)); // ignored, not thrown
+            Assert.Equal(1, stats.Snapshot().TotalSampleCount);
+        }
+
+        #endregion
+
+        #region Cost
+
+        [Fact]
+        public void Record_AfterTheFirstSamplePerChannel_AllocatesNothing()
+        {
+            using var stats = new AcquisitionStatistics();
+            var channel = new AnalogChannel(0);
+            var sample = Sample(Epoch, 1.0);
+
+            // Warm up: JIT the path and create the channel's accumulator, the one allocation there is.
+            for (var i = 0; i < 100; i++)
+            {
+                stats.Record(channel, sample);
+            }
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < 10_000; i++)
+            {
+                stats.Record(channel, sample);
+            }
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.True(allocated == 0, $"recording 10,000 samples allocated {allocated} bytes; expected none");
+        }
+
+        [Fact]
+        public void AttachedToDevice_CostsTheDecodePathNoMoreThanAnEmptySubscriber()
+        {
+            // The honest baseline is a subscriber that does nothing, not no subscriber at all: the
+            // per-sample SampleReceivedEventArgs is allocated by the channel for whoever is listening,
+            // and it is charged to any subscriber equally. What this pins is that the aggregator adds
+            // nothing of its own on top of that. (Detached, it is not merely cheap but absent — no
+            // handler is subscribed, and no code on the decode path changed to accommodate one.)
+            const int frames = 2_000;
+
+            var inert = MeasureDecodeAllocations(frames, attach: false);
+            var recording = MeasureDecodeAllocations(frames, attach: true);
+            var perFrame = (recording - inert) / (double)frames;
+
+            Assert.True(
+                perFrame < 1.0,
+                $"attached recording added {perFrame:F2} bytes per frame ({recording - inert} bytes over {frames} frames)");
+        }
+
+        private static long MeasureDecodeAllocations(int frames, bool attach)
+        {
+            var device = CreateStreaming(analogCount: 2);
+            EnableAllChannels(device);
+            device.StartStreaming();
+
+            using var stats = attach ? new AcquisitionStatistics(device) : null;
+            if (!attach)
+            {
+                foreach (var channel in device.Channels)
+                {
+                    channel.SampleReceived += Inert;
+                }
+            }
+
+            var frame = AnalogFrame(0, 1.0f, 2.0f);
+
+            void Push(int count, uint firstTick)
+            {
+                for (var i = 0; i < count; i++)
+                {
+                    frame.MsgTimeStamp = firstTick + (uint)i * 50_000u;
+                    device.InvokeStreamMessage(frame);
+                }
+            }
+
+            Push(200, 50_000u); // warm up the JIT, the decoder's channel cache and the accumulators
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            Push(frames, 50_000_000u);
+            return GC.GetAllocatedBytesForCurrentThread() - before;
+
+            static void Inert(object? sender, SampleReceivedEventArgs e)
+            {
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static IDataSample Sample(DateTime timestamp, double value) =>
+            new DataSample(timestamp, value);
+
+        private static void EnableAllChannels(DaqifiStreamingDevice device)
+        {
+            foreach (var channel in device.Channels)
+            {
+                channel.IsEnabled = true;
+            }
+        }
+
+        private static DaqifiOutMessage StatusMessage(int analogCount)
+        {
+            var status = new DaqifiOutMessage
+            {
+                AnalogInPortNum = (uint)analogCount,
+                DigitalPortNum = 0,
+                AnalogInRes = 65535,
+            };
+            for (var i = 0; i < analogCount; i++)
+            {
+                status.AnalogInPortRange.Add(1.0f);
+            }
+
+            return status;
+        }
+
+        private static StatisticsDevice CreateStreaming(int analogCount)
+        {
+            var device = new StatisticsDevice("TestDevice");
+            device.Connect();
+            device.PopulateChannelsFromStatus(StatusMessage(analogCount));
+            return device;
+        }
+
+        private static DaqifiOutMessage AnalogFrame(uint timestamp, params float[] values)
+        {
+            var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+            foreach (var value in values)
+            {
+                frame.AnalogInDataFloat.Add(value);
+            }
+
+            return frame;
+        }
+
+        /// <summary>
+        /// A streaming device with no transport whose stream frames are injected by the test, mirroring
+        /// the double the live-stream tests use.
+        /// </summary>
+        private sealed class StatisticsDevice : DaqifiStreamingDevice
+        {
+            public StatisticsDevice(string name) : base(name) { }
+
+            public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+
+            public override void Send<T>(IOutboundMessage<T> message) { /* no transport in tests */ }
+        }
+
+        /// <summary>
+        /// A host clock the test moves by hand, so arrival rates and latencies are exact rather than
+        /// whatever the machine happened to be doing.
+        /// </summary>
+        private sealed class TestClock
+        {
+            private long _ticks;
+
+            public TestClock(DateTime start) => _ticks = start.Ticks;
+
+            public DateTime Now => Read();
+
+            public DateTime Read() => new DateTime(Volatile.Read(ref _ticks), DateTimeKind.Local);
+
+            public void Advance(TimeSpan by) => Volatile.Write(ref _ticks, _ticks + by.Ticks);
+
+            public void Set(DateTime now) => Volatile.Write(ref _ticks, now.Ticks);
+        }
+
+        #endregion
+    }
+}

--- a/src/Daqifi.Core/Device/AcquisitionStatistics.cs
+++ b/src/Daqifi.Core/Device/AcquisitionStatistics.cs
@@ -313,6 +313,7 @@ namespace Daqifi.Core.Device
         /// jitter bounds.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// A negative gap is not a gap. <c>TimestampProcessor</c> reconstructs a time that moves
         /// backwards when the device sends a frame out of order, and folding that in would report a
         /// negative minimum interval — a number that reads as jitter but is really a statement about
@@ -320,6 +321,15 @@ namespace Daqifi.Core.Device
         /// <see cref="TimestampGapDetector"/> already applies to non-positive deltas. Zero, on the
         /// other hand, is kept: firmware that stamps consecutive samples with the same tick value at
         /// high rates is telling the truth about its own clock.
+        /// </para>
+        /// <para>
+        /// "Out of order" here means behind the channel's high-water mark, not merely behind the
+        /// sample recorded immediately before — so a run of samples that all sit behind it is counted
+        /// once each. That is the definition
+        /// <see cref="ChannelAcquisitionStatistics.OutOfOrderSampleCount"/> documents, and the one
+        /// that keeps a rewind from being followed by a compensating forward jump that would be
+        /// reported as a gap.
+        /// </para>
         /// </remarks>
         /// <param name="state">The channel's accumulators.</param>
         /// <param name="intervalTicks">

--- a/src/Daqifi.Core/Device/AcquisitionStatistics.cs
+++ b/src/Daqifi.Core/Device/AcquisitionStatistics.cs
@@ -322,7 +322,10 @@ namespace Daqifi.Core.Device
         /// high rates is telling the truth about its own clock.
         /// </remarks>
         /// <param name="state">The channel's accumulators.</param>
-        /// <param name="intervalTicks">The gap since the previously recorded sample, which may be negative.</param>
+        /// <param name="intervalTicks">
+        /// The gap since the furthest-advanced timestamp seen on this channel, which is negative
+        /// exactly when this sample's timestamp precedes it.
+        /// </param>
         private static void RecordInterval(ChannelState state, long intervalTicks)
         {
             if (intervalTicks < 0)
@@ -404,7 +407,12 @@ namespace Daqifi.Core.Device
                         state.MaxValue = value;
                     }
 
-                    RecordInterval(state, timestamp.Ticks - state.PreviousTimestamp.Ticks);
+                    // Measured against the furthest-advanced timestamp seen, not against whichever
+                    // sample happened to be recorded last. A stale frame rewinds the clock and the
+                    // frame after it jumps forward again to roughly where it was; measuring that
+                    // jump from the rewound value would report the whole rewind as a gap, which is
+                    // an artifact of the reordering rather than a stall in the data.
+                    RecordInterval(state, timestamp.Ticks - state.LatestTimestamp.Ticks);
 
                     // Extremes rather than first-and-last, so the span the device-clock rate is
                     // measured over survives a timestamp that moves backwards. Identical to
@@ -421,7 +429,6 @@ namespace Daqifi.Core.Device
                 }
 
                 state.ValueSum += value;
-                state.PreviousTimestamp = timestamp;
                 state.LastReceivedAt = now;
                 state.SampleCount++;
 
@@ -512,12 +519,6 @@ namespace Daqifi.Core.Device
             /// <summary>The extremes of the timestamps seen, which the device-clock span is measured over.</summary>
             internal DateTime EarliestTimestamp;
             internal DateTime LatestTimestamp;
-
-            /// <summary>
-            /// The previously recorded sample's timestamp — recording order, not time order, because
-            /// an interval is the gap between two samples as they arrived.
-            /// </summary>
-            internal DateTime PreviousTimestamp;
 
             internal DateTime FirstReceivedAt;
             internal DateTime LastReceivedAt;

--- a/src/Daqifi.Core/Device/AcquisitionStatistics.cs
+++ b/src/Daqifi.Core/Device/AcquisitionStatistics.cs
@@ -1,0 +1,477 @@
+using System;
+using System.Collections.Generic;
+using Daqifi.Core.Channel;
+
+#nullable enable
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Measures the health of a live acquisition as the host actually experiences it: how many
+    /// samples each channel produced, the rate they really arrived at, how far apart they were, and
+    /// the range of values they carried. Attach one to a streaming device, stream, then read a
+    /// <see cref="Snapshot"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// "Am I actually getting 1 kHz, or am I losing frames?" is the first question about any
+    /// acquisition, and nothing in Core could answer it. <see cref="TimestampGapDetector"/> flags
+    /// individual gaps as they happen and <see cref="DaqifiStreamingDevice.DroppedLiveSampleCount"/>
+    /// counts what a slow consumer discarded, but neither adds up to a measured rate; the device's
+    /// own <c>SYSTem:STReam:STATS?</c> counters describe what the firmware believes it sent, not what
+    /// arrived. This is the host-side account, ported from daqifi-desktop's <c>SummaryLogger</c>
+    /// (issue #502) so every Core consumer has it rather than just the desktop app.
+    /// </para>
+    /// <para>
+    /// <b>Opt-in, and free when nobody opts in.</b> This is an observer over the per-channel
+    /// <see cref="IChannel.SampleReceived"/> events the decode pipeline already raises — the same
+    /// seam <see cref="DaqifiStreamingDevice.StreamSamplesAsync"/> uses — not a second decode path
+    /// and not a hook inside the existing one. With no instance attached there is no subscriber, so
+    /// the decode path runs exactly the code it ran before this type existed. With one attached,
+    /// recording a sample allocates nothing.
+    /// </para>
+    /// <para>
+    /// Two ways to feed it, and they can be mixed:
+    /// </para>
+    /// <code>
+    /// // Attached: every decoded sample on every channel, for as long as it is not disposed.
+    /// using var stats = new AcquisitionStatistics(device);
+    /// device.StartStreaming();
+    /// await Task.Delay(TimeSpan.FromSeconds(5));
+    /// var snapshot = stats.Snapshot();
+    ///
+    /// // Fed by hand: whatever a consumer chooses to pass it.
+    /// var stats = new AcquisitionStatistics();
+    /// await foreach (var sample in device.StreamSamplesAsync(ct)) stats.Record(sample);
+    /// </code>
+    /// <para>
+    /// An attached instance follows the device across a status message that replaces the channel
+    /// objects: it resubscribes to the new channels, and because a channel is tracked by its type and
+    /// number rather than by object identity, its statistics carry across the swap instead of
+    /// splitting in two.
+    /// </para>
+    /// <para>
+    /// Thread-safe. Samples arrive on the device's message-consumer thread while
+    /// <see cref="Snapshot"/> and <see cref="Reset"/> are called from wherever the consumer lives.
+    /// </para>
+    /// <para>
+    /// <b>Deliberate departures from the desktop original</b>, each a defect there rather than a
+    /// design choice: minimum and maximum value are seeded from the first sample (desktop left them
+    /// at zero, so a channel sitting at 4.5 V reported a minimum of 0); means divide by the number of
+    /// samples actually seen (desktop divided by a configured window size, so a partly-filled window
+    /// under-reported and an over-filled one over-reported); and a window runs until it is
+    /// <see cref="Reset"/> rather than being swapped out automatically every N samples.
+    /// </para>
+    /// </remarks>
+    public sealed class AcquisitionStatistics : IDisposable
+    {
+        /// <summary>
+        /// The host clock. Local time, matching <see cref="TimestampProcessor"/> — the timestamps on
+        /// the samples being measured against it are local, and subtracting a UTC reading from one of
+        /// those would report the machine's UTC offset as acquisition latency.
+        /// </summary>
+        private static readonly Func<DateTime> SystemClock = () => DateTime.Now;
+
+        /// <summary>
+        /// Guards every mutable field below. Held for the duration of a record, which is a handful of
+        /// comparisons on already-extracted values — no channel property is read and no event is
+        /// raised while it is held.
+        /// </summary>
+        private readonly object _lock = new object();
+
+        /// <summary>
+        /// Per-channel accumulators, keyed by channel type and number rather than by channel
+        /// instance: a status message replaces the device's channel objects wholesale, and keying by
+        /// instance would restart every channel's statistics each time that happened.
+        /// </summary>
+        private readonly Dictionary<(ChannelType Type, int Number), ChannelState> _channels =
+            new Dictionary<(ChannelType Type, int Number), ChannelState>();
+
+        private readonly Func<DateTime> _clock;
+
+        /// <summary>
+        /// The device this instance attached to, or <c>null</c> when it is fed by hand. Held only to
+        /// unsubscribe from <see cref="IStreamingDevice.ChannelsPopulated"/> on disposal.
+        /// </summary>
+        private readonly IStreamingDevice? _device;
+
+        /// <summary>
+        /// The channels currently subscribed to. Replaced wholesale when the device repopulates.
+        /// </summary>
+        private IReadOnlyList<IChannel> _subscribed = Array.Empty<IChannel>();
+
+        private bool _disposed;
+
+        private DateTime _startedAt;
+        private long _totalSampleCount;
+        private DateTime _firstReceivedAt;
+        private DateTime _lastReceivedAt;
+        private long _minLatencyTicks;
+        private long _maxLatencyTicks;
+
+        /// <summary>
+        /// Running total of per-sample latency, in ticks, as a <see cref="double"/> so a long
+        /// acquisition cannot overflow the accumulator. Ticks are integral and far below 2^53 even
+        /// for hours of streaming, so the sum stays exact.
+        /// </summary>
+        private double _latencyTicksSum;
+
+        /// <summary>
+        /// Creates an aggregator that records only what is handed to <see cref="Record(LiveSample)"/>
+        /// or <see cref="Record(IChannel, IDataSample)"/>, subscribing to nothing.
+        /// </summary>
+        public AcquisitionStatistics()
+            : this(null, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates an aggregator attached to a device: every sample decoded on any of its channels is
+        /// recorded until this instance is disposed.
+        /// </summary>
+        /// <remarks>
+        /// Attaching does not start or stop streaming, and samples that arrived before it was created
+        /// are not recovered — the measurement window begins here.
+        /// </remarks>
+        /// <param name="device">The device whose channels to observe.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="device"/> is <c>null</c>.</exception>
+        public AcquisitionStatistics(IStreamingDevice device)
+            : this(device ?? throw new ArgumentNullException(nameof(device)), null)
+        {
+        }
+
+        /// <summary>
+        /// Shared constructor; the <paramref name="clock"/> seam lets tests drive host-time readings
+        /// (arrival rate, latency) deterministically instead of racing the wall clock.
+        /// </summary>
+        /// <param name="device">The device to attach to, or <c>null</c> to record only what is handed over.</param>
+        /// <param name="clock">The host clock to read, or <c>null</c> for <see cref="DateTime.Now"/>.</param>
+        internal AcquisitionStatistics(IStreamingDevice? device, Func<DateTime>? clock)
+        {
+            _clock = clock ?? SystemClock;
+            _startedAt = _clock();
+            _device = device;
+
+            if (device == null)
+            {
+                return;
+            }
+
+            device.ChannelsPopulated += OnChannelsPopulated;
+            Subscribe(device.GetChannelsSnapshot());
+        }
+
+        /// <summary>
+        /// Takes a point-in-time reading of the current measurement window.
+        /// </summary>
+        /// <remarks>
+        /// Allocates — it builds an immutable result — so poll it at a display cadence rather than per
+        /// sample. Remains readable after disposal, so a consumer can detach and then report.
+        /// </remarks>
+        /// <returns>The statistics accumulated since construction or the last <see cref="Reset"/>.</returns>
+        public AcquisitionStatisticsSnapshot Snapshot()
+        {
+            lock (_lock)
+            {
+                var channels = new List<ChannelAcquisitionStatistics>(_channels.Count);
+                foreach (var pair in _channels)
+                {
+                    var state = pair.Value;
+                    channels.Add(new ChannelAcquisitionStatistics(
+                        pair.Key.Type,
+                        pair.Key.Number,
+                        state.Name,
+                        state.SampleCount,
+                        state.FirstTimestamp,
+                        state.LastTimestamp,
+                        state.FirstReceivedAt,
+                        state.LastReceivedAt,
+                        new TimeSpan(state.MinIntervalTicks),
+                        new TimeSpan(state.MaxIntervalTicks),
+                        state.MinValue,
+                        state.MaxValue,
+
+                        // An entry exists only because a sample created it, so the count is never zero.
+                        state.ValueSum / state.SampleCount));
+                }
+
+                // Device order — analog first, then digital, ascending within each — so a caller
+                // rendering these next to the device's own Channels collection sees the same order
+                // rather than whatever the ChannelType enum happens to declare.
+                channels.Sort(static (left, right) =>
+                {
+                    var byType = TypeRank(left.ChannelType).CompareTo(TypeRank(right.ChannelType));
+                    return byType != 0
+                        ? byType
+                        : left.ChannelNumber.CompareTo(right.ChannelNumber);
+                });
+
+                var hasSamples = _totalSampleCount > 0;
+                return new AcquisitionStatisticsSnapshot(
+                    _startedAt,
+                    _totalSampleCount,
+                    hasSamples ? _firstReceivedAt : DateTime.MinValue,
+                    hasSamples ? _lastReceivedAt : DateTime.MinValue,
+                    hasSamples ? new TimeSpan(_minLatencyTicks) : TimeSpan.Zero,
+                    hasSamples ? new TimeSpan(_maxLatencyTicks) : TimeSpan.Zero,
+                    hasSamples ? new TimeSpan((long)(_latencyTicksSum / _totalSampleCount)) : TimeSpan.Zero,
+                    channels);
+            }
+        }
+
+        /// <summary>
+        /// Discards everything accumulated so far and starts a new measurement window. Attachment is
+        /// unaffected — an attached instance keeps recording into the new window.
+        /// </summary>
+        public void Reset()
+        {
+            var now = _clock();
+            lock (_lock)
+            {
+                _channels.Clear();
+                _startedAt = now;
+                _totalSampleCount = 0;
+                _firstReceivedAt = default;
+                _lastReceivedAt = default;
+                _minLatencyTicks = 0;
+                _maxLatencyTicks = 0;
+                _latencyTicksSum = 0.0;
+            }
+        }
+
+        /// <summary>
+        /// Records one sample from <see cref="DaqifiStreamingDevice.StreamSamplesAsync"/>.
+        /// </summary>
+        /// <param name="sample">The channel-attributed sample to record.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="sample"/> is <c>null</c>.</exception>
+        public void Record(LiveSample sample)
+        {
+            ArgumentNullException.ThrowIfNull(sample);
+            Record(sample.Channel, sample.Sample);
+        }
+
+        /// <summary>
+        /// Records one sample against a channel.
+        /// </summary>
+        /// <remarks>
+        /// Ignored once this instance has been disposed. Disposal exists to detach from a live device,
+        /// and a sample already in flight on the decode thread when that happens must not turn into an
+        /// exception thrown from an event handler on the decode path.
+        /// </remarks>
+        /// <param name="channel">The channel the sample belongs to.</param>
+        /// <param name="sample">The sample to record.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="channel"/> or <paramref name="sample"/> is <c>null</c>.</exception>
+        public void Record(IChannel channel, IDataSample sample)
+        {
+            ArgumentNullException.ThrowIfNull(channel);
+            ArgumentNullException.ThrowIfNull(sample);
+
+            // Channel and sample members are read here rather than under the lock: the channel's
+            // properties take the channel's own lock, and reaching for one while holding this one
+            // would nest the two locks on the decode thread for no benefit.
+            RecordCore(channel.Type, channel.ChannelNumber, channel.Name, sample.Timestamp, sample.Value);
+        }
+
+        /// <summary>
+        /// Detaches from the device, if one was attached. The accumulated statistics remain readable.
+        /// </summary>
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+
+                if (_device != null)
+                {
+                    _device.ChannelsPopulated -= OnChannelsPopulated;
+                }
+
+                foreach (var channel in _subscribed)
+                {
+                    channel.SampleReceived -= OnSampleReceived;
+                }
+
+                _subscribed = Array.Empty<IChannel>();
+            }
+        }
+
+        /// <summary>
+        /// Orders channel types the way a device lists its channels: analog first, then digital.
+        /// </summary>
+        private static int TypeRank(ChannelType type) => type == ChannelType.Analog ? 0 : 1;
+
+        /// <summary>
+        /// Folds one sample into the accumulators.
+        /// </summary>
+        /// <param name="type">The sample's channel type.</param>
+        /// <param name="number">The sample's channel number.</param>
+        /// <param name="name">The channel's name as it reads now.</param>
+        /// <param name="timestamp">The sample's device-derived timestamp.</param>
+        /// <param name="value">The sample's scaled value.</param>
+        private void RecordCore(ChannelType type, int number, string name, DateTime timestamp, double value)
+        {
+            var now = _clock();
+
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                var key = (type, number);
+                if (!_channels.TryGetValue(key, out var state))
+                {
+                    state = new ChannelState();
+                    _channels[key] = state;
+                }
+
+                state.Name = name;
+
+                if (state.SampleCount == 0)
+                {
+                    state.FirstTimestamp = timestamp;
+                    state.FirstReceivedAt = now;
+
+                    // Seeded from the first sample, not left at zero: a channel that never reads
+                    // anywhere near zero must not report zero as its extreme.
+                    state.MinValue = value;
+                    state.MaxValue = value;
+                }
+                else
+                {
+                    if (value < state.MinValue)
+                    {
+                        state.MinValue = value;
+                    }
+
+                    if (value > state.MaxValue)
+                    {
+                        state.MaxValue = value;
+                    }
+
+                    var intervalTicks = timestamp.Ticks - state.LastTimestamp.Ticks;
+                    if (state.SampleCount == 1)
+                    {
+                        state.MinIntervalTicks = intervalTicks;
+                        state.MaxIntervalTicks = intervalTicks;
+                    }
+                    else
+                    {
+                        if (intervalTicks < state.MinIntervalTicks)
+                        {
+                            state.MinIntervalTicks = intervalTicks;
+                        }
+
+                        if (intervalTicks > state.MaxIntervalTicks)
+                        {
+                            state.MaxIntervalTicks = intervalTicks;
+                        }
+                    }
+                }
+
+                state.ValueSum += value;
+                state.LastTimestamp = timestamp;
+                state.LastReceivedAt = now;
+                state.SampleCount++;
+
+                var latencyTicks = now.Ticks - timestamp.Ticks;
+                if (_totalSampleCount == 0)
+                {
+                    _firstReceivedAt = now;
+                    _minLatencyTicks = latencyTicks;
+                    _maxLatencyTicks = latencyTicks;
+                }
+                else
+                {
+                    if (latencyTicks < _minLatencyTicks)
+                    {
+                        _minLatencyTicks = latencyTicks;
+                    }
+
+                    if (latencyTicks > _maxLatencyTicks)
+                    {
+                        _maxLatencyTicks = latencyTicks;
+                    }
+                }
+
+                _latencyTicksSum += latencyTicks;
+                _lastReceivedAt = now;
+                _totalSampleCount++;
+            }
+        }
+
+        /// <summary>
+        /// Moves the subscription to the channel objects a status message has just installed.
+        /// </summary>
+        private void OnChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e) =>
+            Subscribe(e.Channels);
+
+        /// <summary>
+        /// Subscribes to a set of channels, dropping whatever was subscribed before.
+        /// </summary>
+        /// <param name="channels">
+        /// A snapshot of the device's channels. Both callers hand over a copy the device has already
+        /// taken under its own lock, so it is safe to hold on to.
+        /// </param>
+        private void Subscribe(IReadOnlyList<IChannel> channels)
+        {
+            // Swap and resubscribe as one step. Two populations racing each other could otherwise
+            // interleave into a channel that is subscribed twice and never fully unsubscribed —
+            // every sample on it counted twice, for the rest of the session. Safe to hold across the
+            // event accessors: they are field-like events, so they take no lock of their own, and a
+            // sample arriving concurrently has already read everything it needs off its channel
+            // before it reaches for this lock.
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                foreach (var channel in _subscribed)
+                {
+                    channel.SampleReceived -= OnSampleReceived;
+                }
+
+                _subscribed = channels;
+
+                foreach (var channel in channels)
+                {
+                    channel.SampleReceived += OnSampleReceived;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The decode path's entry point into this aggregator. Records unconditionally: what a sample
+        /// is worth measuring is the caller's business, not this handler's.
+        /// </summary>
+        private void OnSampleReceived(object? sender, SampleReceivedEventArgs e) =>
+            RecordCore(e.Channel.Type, e.Channel.ChannelNumber, e.Channel.Name, e.Sample.Timestamp, e.Sample.Value);
+
+        /// <summary>
+        /// One channel's mutable accumulators. A class rather than a struct so it can be updated in
+        /// place through a dictionary lookup, which is what keeps recording allocation-free.
+        /// </summary>
+        private sealed class ChannelState
+        {
+            internal string Name = string.Empty;
+            internal long SampleCount;
+            internal DateTime FirstTimestamp;
+            internal DateTime LastTimestamp;
+            internal DateTime FirstReceivedAt;
+            internal DateTime LastReceivedAt;
+            internal long MinIntervalTicks;
+            internal long MaxIntervalTicks;
+            internal double MinValue;
+            internal double MaxValue;
+            internal double ValueSum;
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/AcquisitionStatistics.cs
+++ b/src/Daqifi.Core/Device/AcquisitionStatistics.cs
@@ -55,6 +55,13 @@ namespace Daqifi.Core.Device
     /// <see cref="Snapshot"/> and <see cref="Reset"/> are called from wherever the consumer lives.
     /// </para>
     /// <para>
+    /// A device that sends a frame out of order gets a reconstructed timestamp that moves backwards
+    /// (see <c>TimestampProcessor</c>), which the device-clock figures are built to survive rather
+    /// than to hide: the backwards step is excluded from the jitter bounds, the span the device-clock
+    /// rate is measured over runs between the earliest and latest timestamps seen, and
+    /// <see cref="ChannelAcquisitionStatistics.OutOfOrderSampleCount"/> reports that it happened.
+    /// </para>
+    /// <para>
     /// <b>Deliberate departures from the desktop original</b>, each a defect there rather than a
     /// design choice: minimum and maximum value are seeded from the first sample (desktop left them
     /// at zero, so a channel sitting at 4.5 V reported a minimum of 0); means divide by the number of
@@ -182,12 +189,13 @@ namespace Daqifi.Core.Device
                         pair.Key.Number,
                         state.Name,
                         state.SampleCount,
-                        state.FirstTimestamp,
-                        state.LastTimestamp,
+                        state.EarliestTimestamp,
+                        state.LatestTimestamp,
                         state.FirstReceivedAt,
                         state.LastReceivedAt,
                         new TimeSpan(state.MinIntervalTicks),
                         new TimeSpan(state.MaxIntervalTicks),
+                        state.OutOfOrderCount,
                         state.MinValue,
                         state.MaxValue,
 
@@ -301,6 +309,46 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
+        /// Folds the gap between one sample's timestamp and the previous one's into a channel's
+        /// jitter bounds.
+        /// </summary>
+        /// <remarks>
+        /// A negative gap is not a gap. <c>TimestampProcessor</c> reconstructs a time that moves
+        /// backwards when the device sends a frame out of order, and folding that in would report a
+        /// negative minimum interval — a number that reads as jitter but is really a statement about
+        /// frame ordering. It is counted instead, which is the same policy
+        /// <see cref="TimestampGapDetector"/> already applies to non-positive deltas. Zero, on the
+        /// other hand, is kept: firmware that stamps consecutive samples with the same tick value at
+        /// high rates is telling the truth about its own clock.
+        /// </remarks>
+        /// <param name="state">The channel's accumulators.</param>
+        /// <param name="intervalTicks">The gap since the previously recorded sample, which may be negative.</param>
+        private static void RecordInterval(ChannelState state, long intervalTicks)
+        {
+            if (intervalTicks < 0)
+            {
+                state.OutOfOrderCount++;
+                return;
+            }
+
+            if (state.ForwardIntervalCount == 0)
+            {
+                state.MinIntervalTicks = intervalTicks;
+                state.MaxIntervalTicks = intervalTicks;
+            }
+            else if (intervalTicks < state.MinIntervalTicks)
+            {
+                state.MinIntervalTicks = intervalTicks;
+            }
+            else if (intervalTicks > state.MaxIntervalTicks)
+            {
+                state.MaxIntervalTicks = intervalTicks;
+            }
+
+            state.ForwardIntervalCount++;
+        }
+
+        /// <summary>
         /// Orders channel types the way a device lists its channels: analog first, then digital.
         /// </summary>
         private static int TypeRank(ChannelType type) => type == ChannelType.Analog ? 0 : 1;
@@ -335,7 +383,8 @@ namespace Daqifi.Core.Device
 
                 if (state.SampleCount == 0)
                 {
-                    state.FirstTimestamp = timestamp;
+                    state.EarliestTimestamp = timestamp;
+                    state.LatestTimestamp = timestamp;
                     state.FirstReceivedAt = now;
 
                     // Seeded from the first sample, not left at zero: a channel that never reads
@@ -355,28 +404,24 @@ namespace Daqifi.Core.Device
                         state.MaxValue = value;
                     }
 
-                    var intervalTicks = timestamp.Ticks - state.LastTimestamp.Ticks;
-                    if (state.SampleCount == 1)
-                    {
-                        state.MinIntervalTicks = intervalTicks;
-                        state.MaxIntervalTicks = intervalTicks;
-                    }
-                    else
-                    {
-                        if (intervalTicks < state.MinIntervalTicks)
-                        {
-                            state.MinIntervalTicks = intervalTicks;
-                        }
+                    RecordInterval(state, timestamp.Ticks - state.PreviousTimestamp.Ticks);
 
-                        if (intervalTicks > state.MaxIntervalTicks)
-                        {
-                            state.MaxIntervalTicks = intervalTicks;
-                        }
+                    // Extremes rather than first-and-last, so the span the device-clock rate is
+                    // measured over survives a timestamp that moves backwards. Identical to
+                    // first-and-last whenever the device's timestamps advance, which is the norm.
+                    if (timestamp < state.EarliestTimestamp)
+                    {
+                        state.EarliestTimestamp = timestamp;
+                    }
+
+                    if (timestamp > state.LatestTimestamp)
+                    {
+                        state.LatestTimestamp = timestamp;
                     }
                 }
 
                 state.ValueSum += value;
-                state.LastTimestamp = timestamp;
+                state.PreviousTimestamp = timestamp;
                 state.LastReceivedAt = now;
                 state.SampleCount++;
 
@@ -463,12 +508,30 @@ namespace Daqifi.Core.Device
         {
             internal string Name = string.Empty;
             internal long SampleCount;
-            internal DateTime FirstTimestamp;
-            internal DateTime LastTimestamp;
+
+            /// <summary>The extremes of the timestamps seen, which the device-clock span is measured over.</summary>
+            internal DateTime EarliestTimestamp;
+            internal DateTime LatestTimestamp;
+
+            /// <summary>
+            /// The previously recorded sample's timestamp — recording order, not time order, because
+            /// an interval is the gap between two samples as they arrived.
+            /// </summary>
+            internal DateTime PreviousTimestamp;
+
             internal DateTime FirstReceivedAt;
             internal DateTime LastReceivedAt;
             internal long MinIntervalTicks;
             internal long MaxIntervalTicks;
+
+            /// <summary>
+            /// How many non-negative intervals have been folded in; zero means the bounds above are
+            /// unseeded. Not the same as <see cref="SampleCount"/> minus one once
+            /// <see cref="OutOfOrderCount"/> is non-zero.
+            /// </summary>
+            internal long ForwardIntervalCount;
+
+            internal long OutOfOrderCount;
             internal double MinValue;
             internal double MaxValue;
             internal double ValueSum;

--- a/src/Daqifi.Core/Device/AcquisitionStatisticsSnapshot.cs
+++ b/src/Daqifi.Core/Device/AcquisitionStatisticsSnapshot.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// A point-in-time reading of an <see cref="AcquisitionStatistics"/> measurement window: the
+    /// device-wide totals plus one <see cref="ChannelAcquisitionStatistics"/> per channel that has
+    /// produced a sample. Immutable, and detached from the aggregator that produced it — samples
+    /// recorded after the snapshot was taken do not change it.
+    /// </summary>
+    /// <param name="StartedAt">
+    /// The host clock reading when this measurement window began — construction, or the most recent
+    /// <see cref="AcquisitionStatistics.Reset"/>. Present even when no samples arrived, so "nothing
+    /// came in for the last 30 seconds" is expressible.
+    /// </param>
+    /// <param name="TotalSampleCount">The number of samples recorded across every channel.</param>
+    /// <param name="FirstReceivedAt">
+    /// The host clock reading when the first sample of the window was recorded, or
+    /// <see cref="DateTime.MinValue"/> when none were.
+    /// </param>
+    /// <param name="LastReceivedAt">
+    /// The host clock reading when the most recent sample was recorded, or
+    /// <see cref="DateTime.MinValue"/> when none were.
+    /// </param>
+    /// <param name="MinLatency">The smallest observed latency (see <see cref="MeanLatency"/>).</param>
+    /// <param name="MaxLatency">The largest observed latency (see <see cref="MeanLatency"/>).</param>
+    /// <param name="MeanLatency">
+    /// The mean of <c>received-at minus sample timestamp</c> across every recorded sample: how far
+    /// behind the device's own account of when a sample was taken the host was when it saw it.
+    /// Because the device timestamp is reconstructed from an anchor taken at the first frame of the
+    /// session, this measures transport delay <em>plus</em> accumulated drift between the two clocks,
+    /// and it can legitimately be negative if the device clock outruns the host's.
+    /// </param>
+    /// <param name="Channels">
+    /// Per-channel statistics in the device's own channel order — analog channels first, then
+    /// digital, ascending by channel number within each. A channel that produced no samples in this
+    /// window is absent rather than present-and-empty.
+    /// </param>
+    public sealed record AcquisitionStatisticsSnapshot(
+        DateTime StartedAt,
+        long TotalSampleCount,
+        DateTime FirstReceivedAt,
+        DateTime LastReceivedAt,
+        TimeSpan MinLatency,
+        TimeSpan MaxLatency,
+        TimeSpan MeanLatency,
+        IReadOnlyList<ChannelAcquisitionStatistics> Channels)
+    {
+        /// <summary>
+        /// Gets the host-clock span from the first recorded sample to the most recent one, or
+        /// <see cref="TimeSpan.Zero"/> when no samples were recorded.
+        /// </summary>
+        /// <remarks>
+        /// Measured between samples rather than from <see cref="StartedAt"/>, so it describes how long
+        /// data has been flowing rather than how long the aggregator has existed.
+        /// </remarks>
+        public TimeSpan Duration => TotalSampleCount > 0
+            ? LastReceivedAt - FirstReceivedAt
+            : TimeSpan.Zero;
+    }
+}

--- a/src/Daqifi.Core/Device/ChannelAcquisitionStatistics.cs
+++ b/src/Daqifi.Core/Device/ChannelAcquisitionStatistics.cs
@@ -52,21 +52,21 @@ namespace Daqifi.Core.Device
     /// <param name="FirstReceivedAt">The host clock reading when the first sample was recorded.</param>
     /// <param name="LastReceivedAt">The host clock reading when the most recent sample was recorded.</param>
     /// <param name="MinSampleInterval">
-    /// The smallest gap between consecutive sample timestamps (device clock). Firmware that stamps
-    /// several samples with the same tick value reports <see cref="TimeSpan.Zero"/> here, which is a
-    /// true statement about the timestamps rather than a defect in the measurement. Backwards steps
-    /// are excluded — they are counted by <see cref="OutOfOrderSampleCount"/> instead, since a
-    /// negative number is not a gap.
+    /// The smallest gap between a sample's timestamp and the latest timestamp seen before it (device
+    /// clock). Firmware that stamps several samples with the same tick value reports
+    /// <see cref="TimeSpan.Zero"/> here, which is a true statement about the timestamps rather than a
+    /// defect in the measurement. Samples counted by <see cref="OutOfOrderSampleCount"/> contribute
+    /// no interval at all, since a negative number is not a gap.
     /// </param>
     /// <param name="MaxSampleInterval">
-    /// The largest gap between consecutive sample timestamps (device clock) — the jitter figure that
-    /// matters, since a single stalled interval is what a dropped block of samples looks like.
+    /// The largest such gap — the jitter figure that matters, since a single stalled interval is what
+    /// a dropped block of samples looks like.
     /// </param>
     /// <param name="OutOfOrderSampleCount">
-    /// How many samples carried a timestamp earlier than the sample before them. Normally zero; a
-    /// non-zero value means the device's timestamps did not advance monotonically, so every
-    /// device-clock figure here describes a stream that moved backwards at some point and should be
-    /// read as approximate. The host-clock figures are unaffected.
+    /// How many samples carried a timestamp earlier than the latest one already seen on this channel.
+    /// Normally zero; a non-zero value means the device's timestamps did not advance monotonically,
+    /// so every device-clock figure here describes a stream that moved backwards at some point and
+    /// should be read as approximate. The host-clock figures are unaffected.
     /// </param>
     /// <param name="MinValue">The smallest scaled value seen, seeded from the first sample.</param>
     /// <param name="MaxValue">The largest scaled value seen, seeded from the first sample.</param>

--- a/src/Daqifi.Core/Device/ChannelAcquisitionStatistics.cs
+++ b/src/Daqifi.Core/Device/ChannelAcquisitionStatistics.cs
@@ -23,6 +23,14 @@ namespace Daqifi.Core.Device
     /// interval is <see cref="TimeSpan.Zero"/>, since <c>n - 1</c> intervals exist for <c>n</c>
     /// samples.
     /// </para>
+    /// <para>
+    /// Device timestamps are not guaranteed to advance. <c>TimestampProcessor</c> deliberately
+    /// reconstructs a time that moves <em>backwards</em> when the device sends a frame out of order,
+    /// so the device-clock figures here are built to survive that: the span they are measured over
+    /// runs between the earliest and latest timestamps seen rather than the first and last recorded,
+    /// which is the same thing for a well-behaved stream but cannot collapse to zero or go negative
+    /// for a misbehaving one. <see cref="OutOfOrderSampleCount"/> says whether it happened at all.
+    /// </para>
     /// </remarks>
     /// <param name="ChannelType">The type of the channel these statistics describe.</param>
     /// <param name="ChannelNumber">The channel number these statistics describe.</param>
@@ -33,21 +41,32 @@ namespace Daqifi.Core.Device
     /// channel's statistics intact when a status message replaces the channel objects mid-session.
     /// </param>
     /// <param name="SampleCount">The number of samples recorded for this channel in the window.</param>
-    /// <param name="FirstSampleTimestamp">
-    /// The <see cref="IDataSample.Timestamp"/> of the first sample recorded — device time, not
-    /// arrival time.
+    /// <param name="EarliestSampleTimestamp">
+    /// The earliest <see cref="IDataSample.Timestamp"/> seen — device time, not arrival time. The
+    /// timestamp of the first sample recorded unless the device sent one out of order.
     /// </param>
-    /// <param name="LastSampleTimestamp">The <see cref="IDataSample.Timestamp"/> of the most recent sample recorded.</param>
+    /// <param name="LatestSampleTimestamp">
+    /// The latest <see cref="IDataSample.Timestamp"/> seen, likewise the most recent one recorded
+    /// unless the device sent one out of order.
+    /// </param>
     /// <param name="FirstReceivedAt">The host clock reading when the first sample was recorded.</param>
     /// <param name="LastReceivedAt">The host clock reading when the most recent sample was recorded.</param>
     /// <param name="MinSampleInterval">
     /// The smallest gap between consecutive sample timestamps (device clock). Firmware that stamps
     /// several samples with the same tick value reports <see cref="TimeSpan.Zero"/> here, which is a
-    /// true statement about the timestamps rather than a defect in the measurement.
+    /// true statement about the timestamps rather than a defect in the measurement. Backwards steps
+    /// are excluded — they are counted by <see cref="OutOfOrderSampleCount"/> instead, since a
+    /// negative number is not a gap.
     /// </param>
     /// <param name="MaxSampleInterval">
     /// The largest gap between consecutive sample timestamps (device clock) — the jitter figure that
     /// matters, since a single stalled interval is what a dropped block of samples looks like.
+    /// </param>
+    /// <param name="OutOfOrderSampleCount">
+    /// How many samples carried a timestamp earlier than the sample before them. Normally zero; a
+    /// non-zero value means the device's timestamps did not advance monotonically, so every
+    /// device-clock figure here describes a stream that moved backwards at some point and should be
+    /// read as approximate. The host-clock figures are unaffected.
     /// </param>
     /// <param name="MinValue">The smallest scaled value seen, seeded from the first sample.</param>
     /// <param name="MaxValue">The largest scaled value seen, seeded from the first sample.</param>
@@ -57,12 +76,13 @@ namespace Daqifi.Core.Device
         int ChannelNumber,
         string Name,
         long SampleCount,
-        DateTime FirstSampleTimestamp,
-        DateTime LastSampleTimestamp,
+        DateTime EarliestSampleTimestamp,
+        DateTime LatestSampleTimestamp,
         DateTime FirstReceivedAt,
         DateTime LastReceivedAt,
         TimeSpan MinSampleInterval,
         TimeSpan MaxSampleInterval,
+        long OutOfOrderSampleCount,
         double MinValue,
         double MaxValue,
         double MeanValue)
@@ -80,22 +100,25 @@ namespace Daqifi.Core.Device
 
         /// <summary>
         /// Gets the sample rate the device's own timestamps claim, in Hz:
-        /// <c>(SampleCount - 1) / (LastSampleTimestamp - FirstSampleTimestamp)</c>.
+        /// <c>(SampleCount - 1) / (LatestSampleTimestamp - EarliestSampleTimestamp)</c>.
         /// </summary>
         /// <remarks>
         /// Compare against <see cref="MeasuredSampleRateHz"/>. The two agreeing but sitting below the
         /// commanded rate means samples went missing; the two disagreeing means the device's clock and
         /// real time have parted company, and it is the measured rate that describes what the host got.
         /// </remarks>
-        public double DeviceClockSampleRateHz => Rate(SampleCount, LastSampleTimestamp - FirstSampleTimestamp);
+        public double DeviceClockSampleRateHz => Rate(SampleCount, LatestSampleTimestamp - EarliestSampleTimestamp);
 
         /// <summary>
         /// Gets the mean gap between consecutive sample timestamps (device clock) — the exact mean of
         /// the intervals <see cref="MinSampleInterval"/> and <see cref="MaxSampleInterval"/> bound,
-        /// since consecutive intervals telescope to <c>(Last - First) / (SampleCount - 1)</c>.
+        /// since consecutive intervals telescope to
+        /// <c>(Latest - Earliest) / (SampleCount - 1)</c>. Approximate rather than exact once
+        /// <see cref="OutOfOrderSampleCount"/> is non-zero, because a timestamp that moved backwards
+        /// is still counted in the denominator.
         /// </summary>
         public TimeSpan MeanSampleInterval => SampleCount > 1
-            ? (LastSampleTimestamp - FirstSampleTimestamp) / (SampleCount - 1)
+            ? (LatestSampleTimestamp - EarliestSampleTimestamp) / (SampleCount - 1)
             : TimeSpan.Zero;
 
         /// <summary>

--- a/src/Daqifi.Core/Device/ChannelAcquisitionStatistics.cs
+++ b/src/Daqifi.Core/Device/ChannelAcquisitionStatistics.cs
@@ -1,0 +1,114 @@
+using System;
+using Daqifi.Core.Channel;
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// Host-observed acquisition statistics for a single channel over one measurement window — the
+    /// per-channel half of <see cref="AcquisitionStatisticsSnapshot"/>. Immutable; taking a new
+    /// snapshot produces a new instance.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two clocks are reported side by side, and the difference between them is the point.
+    /// <see cref="DeviceClockSampleRateHz"/> is derived from the timestamps the device itself put on
+    /// the samples (<see cref="IDataSample.Timestamp"/>, reconstructed from the device tick counter);
+    /// <see cref="MeasuredSampleRateHz"/> is derived from when the host actually received them. Data
+    /// the host never received depresses both, so either one answers "am I losing samples?" — but
+    /// only their disagreement can tell you that the device's own clock is not keeping real time,
+    /// which no amount of device-reported bookkeeping can reveal on its own.
+    /// </para>
+    /// <para>
+    /// A window with a single sample has no interval and no rate to report: every rate is 0 and every
+    /// interval is <see cref="TimeSpan.Zero"/>, since <c>n - 1</c> intervals exist for <c>n</c>
+    /// samples.
+    /// </para>
+    /// </remarks>
+    /// <param name="ChannelType">The type of the channel these statistics describe.</param>
+    /// <param name="ChannelNumber">The channel number these statistics describe.</param>
+    /// <param name="Name">
+    /// The channel's name as it read when the most recent sample was recorded. Names are mutable, so
+    /// this is the last observed value rather than an identity — <paramref name="ChannelType"/> plus
+    /// <paramref name="ChannelNumber"/> is what a channel is tracked by, which is also what keeps a
+    /// channel's statistics intact when a status message replaces the channel objects mid-session.
+    /// </param>
+    /// <param name="SampleCount">The number of samples recorded for this channel in the window.</param>
+    /// <param name="FirstSampleTimestamp">
+    /// The <see cref="IDataSample.Timestamp"/> of the first sample recorded — device time, not
+    /// arrival time.
+    /// </param>
+    /// <param name="LastSampleTimestamp">The <see cref="IDataSample.Timestamp"/> of the most recent sample recorded.</param>
+    /// <param name="FirstReceivedAt">The host clock reading when the first sample was recorded.</param>
+    /// <param name="LastReceivedAt">The host clock reading when the most recent sample was recorded.</param>
+    /// <param name="MinSampleInterval">
+    /// The smallest gap between consecutive sample timestamps (device clock). Firmware that stamps
+    /// several samples with the same tick value reports <see cref="TimeSpan.Zero"/> here, which is a
+    /// true statement about the timestamps rather than a defect in the measurement.
+    /// </param>
+    /// <param name="MaxSampleInterval">
+    /// The largest gap between consecutive sample timestamps (device clock) — the jitter figure that
+    /// matters, since a single stalled interval is what a dropped block of samples looks like.
+    /// </param>
+    /// <param name="MinValue">The smallest scaled value seen, seeded from the first sample.</param>
+    /// <param name="MaxValue">The largest scaled value seen, seeded from the first sample.</param>
+    /// <param name="MeanValue">The arithmetic mean of every scaled value seen in the window.</param>
+    public sealed record ChannelAcquisitionStatistics(
+        ChannelType ChannelType,
+        int ChannelNumber,
+        string Name,
+        long SampleCount,
+        DateTime FirstSampleTimestamp,
+        DateTime LastSampleTimestamp,
+        DateTime FirstReceivedAt,
+        DateTime LastReceivedAt,
+        TimeSpan MinSampleInterval,
+        TimeSpan MaxSampleInterval,
+        double MinValue,
+        double MaxValue,
+        double MeanValue)
+    {
+        /// <summary>
+        /// Gets the sample rate the host actually received this channel at, in Hz, measured against
+        /// the host clock: <c>(SampleCount - 1) / (LastReceivedAt - FirstReceivedAt)</c>.
+        /// </summary>
+        /// <remarks>
+        /// This is the answer to "am I really getting 1 kHz?". It is measured over the whole window,
+        /// so transport batching — a USB or WiFi stack handing over several frames at once — averages
+        /// out rather than showing up as a rate error, but genuinely missing samples do not.
+        /// </remarks>
+        public double MeasuredSampleRateHz => Rate(SampleCount, LastReceivedAt - FirstReceivedAt);
+
+        /// <summary>
+        /// Gets the sample rate the device's own timestamps claim, in Hz:
+        /// <c>(SampleCount - 1) / (LastSampleTimestamp - FirstSampleTimestamp)</c>.
+        /// </summary>
+        /// <remarks>
+        /// Compare against <see cref="MeasuredSampleRateHz"/>. The two agreeing but sitting below the
+        /// commanded rate means samples went missing; the two disagreeing means the device's clock and
+        /// real time have parted company, and it is the measured rate that describes what the host got.
+        /// </remarks>
+        public double DeviceClockSampleRateHz => Rate(SampleCount, LastSampleTimestamp - FirstSampleTimestamp);
+
+        /// <summary>
+        /// Gets the mean gap between consecutive sample timestamps (device clock) — the exact mean of
+        /// the intervals <see cref="MinSampleInterval"/> and <see cref="MaxSampleInterval"/> bound,
+        /// since consecutive intervals telescope to <c>(Last - First) / (SampleCount - 1)</c>.
+        /// </summary>
+        public TimeSpan MeanSampleInterval => SampleCount > 1
+            ? (LastSampleTimestamp - FirstSampleTimestamp) / (SampleCount - 1)
+            : TimeSpan.Zero;
+
+        /// <summary>
+        /// Samples per second over a span, or 0 when there is no interval to measure over.
+        /// </summary>
+        /// <remarks>
+        /// <c>SampleCount - 1</c> rather than <c>SampleCount</c>: the span runs from the first sample
+        /// to the last, which encloses one fewer interval than there are samples. Counting samples
+        /// instead would over-report the rate, most visibly on short windows.
+        /// </remarks>
+        internal static double Rate(long sampleCount, TimeSpan span) =>
+            sampleCount > 1 && span.Ticks > 0
+                ? (sampleCount - 1) / span.TotalSeconds
+                : 0.0;
+    }
+}


### PR DESCRIPTION
### What was wrong

If you streamed from a DAQiFi device and wanted to know whether you were actually getting the rate you asked for, Core could not tell you. You could ask for 1 kHz and get something else — because frames were lost, or because the device's clock was not keeping real time — and nothing in the library would say so. The pieces that existed each answered a narrower question: the gap detector flags individual stalls as they happen, the dropped-sample counter reports only what a slow consumer of your own threw away, and the device's `SYSTem:STReam:STATS?` counters describe what the firmware believes it sent rather than what your application received. Anyone who wanted the actual answer had to re-implement it, which is what the desktop app did.

### How it was fixed

A new `AcquisitionStatistics` you attach for the duration of an acquisition and then read a snapshot from. Per channel it reports the sample count, the rate the host really received at, the rate the device's own timestamps claim, the smallest/largest/mean gap between samples, and the value range and mean; device-wide it reports the totals and how far behind the device's account of the time the host was.

The two rates are reported side by side deliberately, and that is the part worth pushing back on if you disagree: both dropping below the commanded rate means samples went missing, while the two *disagreeing* means the device clock and real time have parted company — a distinction no single number can carry. The bench run below is exactly that case.

It hooks nothing. It subscribes to the per-channel sample events the decode pipeline already raises — the same seam `StreamSamplesAsync` uses — so no decode-path code changed at all, and a consumer that never attaches one is unaffected. Recording a sample allocates nothing.

The device's timestamps are not assumed to advance. `TimestampProcessor` deliberately reconstructs an earlier time when a frame arrives out of order, so a backwards step is excluded from the jitter bounds, the device-clock span is measured between the earliest and latest timestamps seen, and a per-channel `OutOfOrderSampleCount` reports that it happened rather than smoothing it away.

Three things the desktop original got wrong are fixed on the way across, so a `SummaryLogger` replacement is not a like-for-like port: value extremes are now seeded from the first sample (desktop left them at zero, so a channel sitting at 4.5 V reported a minimum of 0 V), means divide by the samples actually seen rather than a configured window size, and a window runs until you `Reset()` it instead of being swapped out automatically every N samples.

### Verification

Full suite green on **net9.0** (3069 Core + 86 Mcp) and **net10.0** (3069), 0 warnings; 26 new tests. Six mutations confirm the tests bite: zero-seeded extremes (6 failures), an off-by-one in the rate denominator (3), a missed unsubscribe on channel repopulation (1), a removed post-dispose guard (1), a negative interval folded into the jitter bounds (1), and a device-clock span taken from first-and-last instead of the extremes (1).

**Bench — Nq1 fw 3.7.2 on `/dev/cu.usbmodem1101`, serial, non-destructive** (connect, enable AI0-2, stream, stop, disconnect; no reboot/format/delete/`SD:GET`/firmware/LAN writes). Commanded 1000 Hz for 3 s:

```
channel  n      measured Hz  devclock Hz  min int ms  mean int ms  max int ms
Analog  0   2383      794.44      1000.03       0.000        1.000       2.000
Analog  1   2383      794.59      1000.03       0.000        1.000       2.000
Analog  2   2383      794.59      1000.03       0.000        1.000       2.000
latency: min -2.04 ms  mean 306.99 ms  max 617.71 ms
```

The device's clock says 1000.03 Hz; the host received 794.4 Hz — the 79.4 % ratio this bench unit has shown on every fire, and the firmware clock defect (daqifi-nyquist-firmware #716) that motivated reporting both. The numbers are self-consistent: 3 s × (1 − 794/1000) = 618 ms of accumulated drift, which is the 617.71 ms maximum latency. The alternating 0 ms / 2 ms intervals are the duplicate-timestamp quirk (firmware #717) showing up as jitter. A 500 Hz run and a mid-stream `Reset()` behaved the same way.

`closes #502`

Not merging — for review.
