### PR TITLE
chore(firmware): the bootloader's wire constants were written down twice

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderWireFormatTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderWireFormatTests.cs
@@ -1,0 +1,188 @@
+using System.Reflection;
+using Daqifi.Core.Firmware;
+
+namespace Daqifi.Core.Tests.Firmware;
+
+/// <summary>
+/// Locks down the single-sourced PIC32 bootloader wire format two ways: the byte values are
+/// pinned against a silent edit, and the opcode the producer sends is shown to be the opcode the
+/// consumer expects back — without either class's copy of the value being written down here.
+/// </summary>
+public class Pic32BootloaderWireFormatTests
+{
+    #region Pinned values
+
+    // The literals below are restated on purpose. Now that the producer and the consumer read the
+    // same constants, editing those constants no longer breaks anything by disagreeing with the
+    // other side — it just changes what Core puts on the wire, in every flash session, quietly.
+    // This file is the second copy that has to be edited too, and the firmware's own bootloader
+    // is the authority for what these values are allowed to be.
+
+    [Fact]
+    public void FramingBytes_AreTheValuesTheFirmwareFramesWith()
+    {
+        Assert.Equal(0x01, Pic32BootloaderWireFormat.StartOfHeader);
+        Assert.Equal(0x04, Pic32BootloaderWireFormat.EndOfTransmission);
+        Assert.Equal(0x10, Pic32BootloaderWireFormat.DataLinkEscape);
+    }
+
+    [Fact]
+    public void CommandOpcodes_AreTheValuesTheFirmwareDispatchesOn()
+    {
+        Assert.Equal(0x01, Pic32BootloaderWireFormat.RequestVersionCommand);
+        Assert.Equal(0x02, Pic32BootloaderWireFormat.EraseFlashCommand);
+        Assert.Equal(0x03, Pic32BootloaderWireFormat.ProgramFlashCommand);
+        Assert.Equal(0x04, Pic32BootloaderWireFormat.ReadCrcCommand);
+        Assert.Equal(0x05, Pic32BootloaderWireFormat.JumpToApplicationCommand);
+    }
+
+    [Fact]
+    public void RequestVersionOpcode_CollidesWithStartOfHeader_WhichIsWhyItIsAlwaysEscaped()
+    {
+        // Not a coincidence to be tidied away: the version decode path depends on the opcode
+        // arriving DLE-escaped precisely because it is the same byte as SOH.
+        Assert.Equal(Pic32BootloaderWireFormat.StartOfHeader, Pic32BootloaderWireFormat.RequestVersionCommand);
+    }
+
+    [Fact]
+    public void ReadCrcOpcode_CollidesWithEndOfTransmission_WhichIsWhyItIsAlwaysEscaped()
+    {
+        Assert.Equal(Pic32BootloaderWireFormat.EndOfTransmission, Pic32BootloaderWireFormat.ReadCrcCommand);
+    }
+
+    #endregion
+
+    #region Producer/consumer agreement
+
+    // No opcode is written down in these tests. Each one takes the opcode out of a message the
+    // producer actually built and hands it to the consumer, so they fail if either class ever
+    // goes back to declaring its own copy of an opcode.
+
+    [Fact]
+    public void EraseFlashAcknowledgment_UsesTheSameOpcodeTheProducerSent()
+    {
+        var sent = Pic32BootloaderMessageProducer.CreateEraseFlashMessage();
+
+        var acknowledgment = new[] { sent[0], OpcodeOf(sent) };
+
+        Assert.True(Pic32BootloaderMessageConsumer.DecodeEraseFlashResponse(acknowledgment));
+    }
+
+    [Fact]
+    public void ProgramFlashAcknowledgment_UsesTheSameOpcodeTheProducerSent()
+    {
+        var sent = Pic32BootloaderMessageProducer.CreateProgramFlashMessage([0x08, 0x00, 0x20, 0x00, 0xAA]);
+
+        var acknowledgment = new[] { sent[0], OpcodeOf(sent) };
+
+        Assert.True(Pic32BootloaderMessageConsumer.DecodeProgramFlashResponse(acknowledgment));
+    }
+
+    [Fact]
+    public void VersionResponse_UsesTheSameOpcodeTheProducerSent()
+    {
+        var sent = Pic32BootloaderMessageProducer.CreateRequestVersionMessage();
+
+        // The version response is the one frame the consumer unescapes inline: SOH, DLE, opcode,
+        // major, minor.
+        var response = new[]
+        {
+            sent[0], Pic32BootloaderWireFormat.DataLinkEscape, OpcodeOf(sent), (byte)2, (byte)5
+        };
+
+        Assert.Equal("2.5", Pic32BootloaderMessageConsumer.DecodeVersionResponse(response));
+    }
+
+    [Fact]
+    public void ReadCrcResponse_UsesTheSameOpcodeTheProducerSent()
+    {
+        var sent = Pic32BootloaderMessageProducer.CreateReadCrcMessage(0x9D000000, 0x200000);
+        const ushort flashCrc = 0xABCD;
+
+        // The firmware echoes the opcode, then the flash CRC, then a framing CRC over those three
+        // bytes; the whole body is then SOH/EOT-framed with escaping.
+        byte[] content = [OpcodeOf(sent), (byte)(flashCrc & 0xFF), (byte)(flashCrc >> 8)];
+        var frameCrc = new Crc16(content).Crc;
+        var response = Frame([.. content, (byte)(frameCrc & 0xFF), (byte)(frameCrc >> 8)]);
+
+        Assert.Equal(flashCrc, Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(response));
+    }
+
+    #endregion
+
+    #region Single-declaration guard
+
+    [Theory]
+    [InlineData(typeof(Pic32BootloaderMessageProducer))]
+    [InlineData(typeof(Pic32BootloaderMessageConsumer))]
+    public void MessageClasses_DeclareNoWireConstantsOfTheirOwn(Type messageClass)
+    {
+        var declared = messageClass
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(byte))
+            .Select(f => f.Name)
+            .ToList();
+
+        Assert.Empty(declared);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    /// <summary>
+    /// The command opcode inside a message the producer built: the first payload byte, once the
+    /// leading SOH is dropped and DLE escaping is undone.
+    /// </summary>
+    private static byte OpcodeOf(byte[] producedMessage)
+    {
+        var payload = new List<byte>();
+        var escaped = false;
+        for (var i = 1; i < producedMessage.Length; i++)
+        {
+            var b = producedMessage[i];
+            if (escaped)
+            {
+                payload.Add(b);
+                escaped = false;
+                continue;
+            }
+
+            if (b == Pic32BootloaderWireFormat.DataLinkEscape)
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (b == Pic32BootloaderWireFormat.EndOfTransmission)
+            {
+                break;
+            }
+
+            payload.Add(b);
+        }
+
+        Assert.NotEmpty(payload);
+        return payload[0];
+    }
+
+    /// <summary>SOH/EOT-frames a response body with DLE escaping, the way the firmware does.</summary>
+    private static byte[] Frame(byte[] body)
+    {
+        var framed = new List<byte> { Pic32BootloaderWireFormat.StartOfHeader };
+        foreach (var b in body)
+        {
+            if (b is Pic32BootloaderWireFormat.StartOfHeader
+                  or Pic32BootloaderWireFormat.EndOfTransmission
+                  or Pic32BootloaderWireFormat.DataLinkEscape)
+            {
+                framed.Add(Pic32BootloaderWireFormat.DataLinkEscape);
+            }
+            framed.Add(b);
+        }
+        framed.Add(Pic32BootloaderWireFormat.EndOfTransmission);
+        return framed.ToArray();
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderMessageConsumer.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderMessageConsumer.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using static Daqifi.Core.Firmware.Pic32BootloaderWireFormat;
 
 namespace Daqifi.Core.Firmware;
 
@@ -6,16 +7,12 @@ namespace Daqifi.Core.Firmware;
 /// Decodes PIC32 bootloader protocol response messages.
 /// Handles SOH framing validation and DLE-unescaping.
 /// </summary>
+/// <remarks>
+/// The framing bytes and opcodes matched here come from <see cref="Pic32BootloaderWireFormat"/>,
+/// shared with <see cref="Pic32BootloaderMessageProducer"/> so the two sides cannot drift apart.
+/// </remarks>
 public static class Pic32BootloaderMessageConsumer
 {
-    private const byte START_OF_HEADER = 0x01;
-    private const byte END_OF_TRANSMISSION = 0x04;
-    private const byte DATA_LINK_ESCAPE = 0x10;
-    private const byte REQUEST_VERSION_COMMAND = 0x01;
-    private const byte ERASE_FLASH_COMMAND = 0x02;
-    private const byte PROGRAM_FLASH_COMMAND = 0x03;
-    private const byte READ_CRC_COMMAND = 0x04;
-
     /// <summary>
     /// Decodes a version response from the bootloader.
     /// </summary>
@@ -28,24 +25,24 @@ public static class Pic32BootloaderMessageConsumer
 
         if (data.Length < 2) return "Error";
 
-        if (data[0] != START_OF_HEADER) return "Error";
+        if (data[0] != StartOfHeader) return "Error";
 
         // The command byte (0x01) matches SOH, so it will be DLE-escaped.
         // Minimum valid version response: SOH + DLE + cmd + major + minor = 5 bytes
         // With DLE-escaped version bytes it can be up to 7 bytes
-        if (data.Length >= 5 && data[1] == DATA_LINK_ESCAPE && data[2] == REQUEST_VERSION_COMMAND)
+        if (data.Length >= 5 && data[1] == DataLinkEscape && data[2] == RequestVersionCommand)
         {
             var pointer = 3;
 
             if (pointer < data.Length)
             {
-                majorVersion = data[pointer] == DATA_LINK_ESCAPE && pointer + 1 < data.Length ? data[++pointer] : data[pointer];
+                majorVersion = data[pointer] == DataLinkEscape && pointer + 1 < data.Length ? data[++pointer] : data[pointer];
                 pointer++;
             }
 
             if (pointer < data.Length)
             {
-                minorVersion = data[pointer] == DATA_LINK_ESCAPE && pointer + 1 < data.Length ? data[++pointer] : data[pointer];
+                minorVersion = data[pointer] == DataLinkEscape && pointer + 1 < data.Length ? data[++pointer] : data[pointer];
             }
         }
 
@@ -60,9 +57,9 @@ public static class Pic32BootloaderMessageConsumer
     public static bool DecodeProgramFlashResponse(byte[] data)
     {
         if (data.Length < 2) return false;
-        if (data[0] != START_OF_HEADER) return false;
+        if (data[0] != StartOfHeader) return false;
 
-        return data[1] == PROGRAM_FLASH_COMMAND;
+        return data[1] == ProgramFlashCommand;
     }
 
     /// <summary>
@@ -73,9 +70,9 @@ public static class Pic32BootloaderMessageConsumer
     public static bool DecodeEraseFlashResponse(byte[] data)
     {
         if (data.Length < 2) return false;
-        if (data[0] != START_OF_HEADER) return false;
+        if (data[0] != StartOfHeader) return false;
 
-        return data[1] == ERASE_FLASH_COMMAND;
+        return data[1] == EraseFlashCommand;
     }
 
     /// <summary>
@@ -95,7 +92,7 @@ public static class Pic32BootloaderMessageConsumer
     {
         ArgumentNullException.ThrowIfNull(data);
 
-        if (data.Length < 2 || data[0] != START_OF_HEADER)
+        if (data.Length < 2 || data[0] != StartOfHeader)
         {
             throw new InvalidDataException("READ_CRC response did not begin with SOH framing.");
         }
@@ -117,13 +114,13 @@ public static class Pic32BootloaderMessageConsumer
                 continue;
             }
 
-            if (b == DATA_LINK_ESCAPE)
+            if (b == DataLinkEscape)
             {
                 escaped = true;
                 continue;
             }
 
-            if (b == END_OF_TRANSMISSION)
+            if (b == EndOfTransmission)
             {
                 terminated = true;
                 break;
@@ -143,7 +140,7 @@ public static class Pic32BootloaderMessageConsumer
                 $"READ_CRC response was too short ({payload.Count} payload byte(s); expected 5).");
         }
 
-        if (payload[0] != READ_CRC_COMMAND)
+        if (payload[0] != ReadCrcCommand)
         {
             throw new InvalidDataException(
                 $"READ_CRC response had unexpected command byte 0x{payload[0]:X2}.");

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderMessageProducer.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderMessageProducer.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using static Daqifi.Core.Firmware.Pic32BootloaderWireFormat;
 
 namespace Daqifi.Core.Firmware;
 
@@ -6,24 +7,19 @@ namespace Daqifi.Core.Firmware;
 /// Produces PIC32 bootloader protocol messages with SOH/EOT framing,
 /// DLE byte escaping, and CRC-16 checksums.
 /// </summary>
+/// <remarks>
+/// The framing bytes and opcodes come from <see cref="Pic32BootloaderWireFormat"/>, shared with
+/// <see cref="Pic32BootloaderMessageConsumer"/> so the two sides cannot drift apart.
+/// </remarks>
 public static class Pic32BootloaderMessageProducer
 {
-    private const byte START_OF_HEADER = 0x01;
-    private const byte END_OF_TRANSMISSION = 0x04;
-    private const byte DATA_LINK_ESCAPE = 0x10;
-    private const byte REQUEST_VERSION_COMMAND = 0x01;
-    private const byte ERASE_FLASH_COMMAND = 0x02;
-    private const byte PROGRAM_FLASH_COMMAND = 0x03;
-    private const byte READ_CRC_COMMAND = 0x04;
-    private const byte JUMP_TO_APPLICATION_COMMAND = 0x05;
-
     /// <summary>
     /// Creates a message to request the bootloader version.
     /// </summary>
     /// <returns>The framed and escaped message bytes.</returns>
     public static byte[] CreateRequestVersionMessage()
     {
-        return ConstructDataPacket(REQUEST_VERSION_COMMAND);
+        return ConstructDataPacket(RequestVersionCommand);
     }
 
     /// <summary>
@@ -32,7 +28,7 @@ public static class Pic32BootloaderMessageProducer
     /// <returns>The framed and escaped message bytes.</returns>
     public static byte[] CreateEraseFlashMessage()
     {
-        return ConstructDataPacket(ERASE_FLASH_COMMAND);
+        return ConstructDataPacket(EraseFlashCommand);
     }
 
     /// <summary>
@@ -46,7 +42,7 @@ public static class Pic32BootloaderMessageProducer
         ArgumentNullException.ThrowIfNull(hexRecord);
 
         var command = new byte[1 + hexRecord.Length];
-        command[0] = PROGRAM_FLASH_COMMAND;
+        command[0] = ProgramFlashCommand;
         Array.Copy(hexRecord, 0, command, 1, hexRecord.Length);
         return ConstructDataPacket(command);
     }
@@ -63,7 +59,7 @@ public static class Pic32BootloaderMessageProducer
     public static byte[] CreateReadCrcMessage(uint address, uint length)
     {
         var command = new byte[9];
-        command[0] = READ_CRC_COMMAND;
+        command[0] = ReadCrcCommand;
         BinaryPrimitives.WriteUInt32LittleEndian(command.AsSpan(1, 4), address);
         BinaryPrimitives.WriteUInt32LittleEndian(command.AsSpan(5, 4), length);
         return ConstructDataPacket(command);
@@ -75,7 +71,7 @@ public static class Pic32BootloaderMessageProducer
     /// <returns>The framed and escaped message bytes.</returns>
     public static byte[] CreateJumpToApplicationMessage()
     {
-        return ConstructDataPacket(JUMP_TO_APPLICATION_COMMAND);
+        return ConstructDataPacket(JumpToApplicationCommand);
     }
 
     private static byte[] ConstructDataPacket(byte command)
@@ -93,18 +89,18 @@ public static class Pic32BootloaderMessageProducer
         commandAndCrc[command.Length] = crc.Low;
         commandAndCrc[command.Length + 1] = crc.High;
 
-        packet.Add(START_OF_HEADER);
+        packet.Add(StartOfHeader);
 
         foreach (var item in commandAndCrc)
         {
-            if (item is START_OF_HEADER or END_OF_TRANSMISSION or DATA_LINK_ESCAPE)
+            if (item is StartOfHeader or EndOfTransmission or DataLinkEscape)
             {
-                packet.Add(DATA_LINK_ESCAPE);
+                packet.Add(DataLinkEscape);
             }
             packet.Add(item);
         }
 
-        packet.Add(END_OF_TRANSMISSION);
+        packet.Add(EndOfTransmission);
         return packet.ToArray();
     }
 }

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderWireFormat.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderWireFormat.cs
@@ -1,0 +1,59 @@
+namespace Daqifi.Core.Firmware;
+
+/// <summary>
+/// Wire-format constants for the PIC32 bootloader protocol — the SOH/EOT framing bytes, the DLE
+/// escape byte, and the command opcodes shared by
+/// <see cref="Pic32BootloaderMessageProducer"/> and <see cref="Pic32BootloaderMessageConsumer"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These values are the wire contract with the device's bootloader, so the producer that writes
+/// them and the consumer that matches them off the wire must agree byte for byte. A disagreement
+/// between the two would not fail loudly — it would mis-frame a live flash session on real
+/// hardware. Declaring them once is what makes that disagreement impossible to introduce.
+/// </para>
+/// <para>
+/// The authority for the values is the DAQiFi firmware's own bootloader, not this file. Nothing
+/// here may be changed to "fix" a decode problem: a mismatch means the firmware moved, and the
+/// pinning tests in <c>Pic32BootloaderWireFormatTests</c> exist so that such a change has to be
+/// deliberate and visible rather than quiet.
+/// </para>
+/// </remarks>
+internal static class Pic32BootloaderWireFormat
+{
+    /// <summary>Start-of-header byte that opens every framed message in both directions.</summary>
+    internal const byte StartOfHeader = 0x01;
+
+    /// <summary>End-of-transmission byte that closes every framed message in both directions.</summary>
+    internal const byte EndOfTransmission = 0x04;
+
+    /// <summary>
+    /// Escape byte. A payload byte that collides with <see cref="StartOfHeader"/>,
+    /// <see cref="EndOfTransmission"/>, or this byte is preceded by it and taken literally.
+    /// </summary>
+    internal const byte DataLinkEscape = 0x10;
+
+    /// <summary>
+    /// Opcode asking the bootloader for its version. Note that it collides with
+    /// <see cref="StartOfHeader"/>, so it is always DLE-escaped on the wire.
+    /// </summary>
+    internal const byte RequestVersionCommand = 0x01;
+
+    /// <summary>Opcode erasing the application flash partition.</summary>
+    internal const byte EraseFlashCommand = 0x02;
+
+    /// <summary>Opcode programming one HEX record into flash; the record follows the opcode.</summary>
+    internal const byte ProgramFlashCommand = 0x03;
+
+    /// <summary>
+    /// Opcode asking the bootloader to checksum a flash region; a 4-byte little-endian address and
+    /// a 4-byte little-endian length follow the opcode.
+    /// </summary>
+    internal const byte ReadCrcCommand = 0x04;
+
+    /// <summary>
+    /// Opcode telling the bootloader to jump to the application. Producer-only — the device leaves
+    /// the bootloader rather than answering, so there is no response to decode.
+    /// </summary>
+    internal const byte JumpToApplicationCommand = 0x05;
+}


### PR DESCRIPTION
### What was wrong

The bytes that make up the PIC32 bootloader protocol — the start/end framing bytes, the escape byte, and the command opcodes — were written down twice, once in the class that sends messages to the bootloader and once in the class that reads its replies. Both copies were in use. Nothing checked that they still agreed, and nothing would have complained if they stopped: a one-sided edit would simply mis-frame a live firmware flash on real hardware, which is the worst place in this library to find out you have two sources of truth.

### How it was fixed

The values now live in one internal `Pic32BootloaderWireFormat` class that both sides read from, unchanged byte for byte. The one thing worth pushing back on is that consolidating quietly removes a safety net: while there were two copies, a bad edit to one of them broke the other, and now a bad edit to the single copy just changes what Core puts on the wire. So the new tests restate the byte values explicitly — the second copy is now a test that has to be edited too, rather than a second copy in production code — and separately prove that the opcode the producer sends is the one the consumer expects back, without either value being named in the test.

### Verification

- Every existing `Pic32*` test is unmodified and green; they hardcode the byte values independently, so they are the check that nothing moved.
- 10 new tests. Proven catchers: changing an opcode value in the new class fails 10 tests (2 of them new); re-declaring a diverging opcode inside the consumer fails the matching agreement test plus the guard that forbids either class from declaring wire constants of its own — mutation-verified for all four opcodes.
- **Byte-for-byte equivalence to `main` was measured, not assumed.** A throwaway harness dumped every message the producer builds (including 256 program-flash records chosen to exercise DLE escaping) and every decode outcome across the full 0–255 byte range, built against this branch and against `origin/main`: 1,285 lines, identical.
- Full suite green on net9.0 and net10.0 (3,053 Core + 86 MCP), 0 warnings.
- No bench run: the only code path this touches is a bootloader flash session, which needs a device reboot into the bootloader and is destructive by nature. The equivalence dump above is the substitute, and it is a stronger check than a single bench pass would have been.

closes #483

Not merging — for review.