### PR TITLE
perf(sdcard): parsing an SD log no longer loads the whole file into memory first

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardStreamingParseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardStreamingParseTests.cs
@@ -1,0 +1,490 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Device.SdCard;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+/// <summary>
+/// Pins the lazy-read contract the three SD card parsers promise: a session hands back samples
+/// as the file is read, rather than decoding the whole file before the first one appears.
+/// </summary>
+public class SdCardStreamingParseTests
+{
+    /// <summary>
+    /// A file big enough that reading all of it is obvious in the byte counter, while still
+    /// building fast enough for a unit test.
+    /// </summary>
+    private const int LargeFileMessageCount = 20_000;
+
+    #region Protobuf
+
+    [Fact]
+    public async Task ParseAsync_LargeBinFile_FirstSampleDoesNotReadWholeFile()
+    {
+        var builder = new SdCardTestFileBuilder();
+        builder.AddMessage(SdCardTestFileBuilder.CreateStatusMessage());
+        for (var i = 0; i < LargeFileMessageCount; i++)
+        {
+            builder.AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: (uint)((i + 1) * 1000),
+                analogFloatValues: new[] { (float)i, i + 0.5f, i + 1.5f, i + 2.5f }));
+        }
+
+        using var inner = builder.Build();
+        await using var counting = new CountingStream(inner);
+        var options = new SdCardParseOptions { BufferSize = 4096 };
+
+        var session = await new SdCardFileParser().ParseAsync(counting, "big.bin", options);
+
+        var enumerator = session.Samples.GetAsyncEnumerator();
+        await using (enumerator.ConfigureAwait(false))
+        {
+            Assert.True(await enumerator.MoveNextAsync());
+        }
+
+        // The configuration look-ahead plus one read buffer — nowhere near the whole file.
+        Assert.True(
+            counting.BytesRead < counting.Length / 4,
+            $"Read {counting.BytesRead} of {counting.Length} bytes to produce one sample.");
+    }
+
+    [Fact]
+    public async Task ParseAsync_LargeBinFile_StreamsEverySampleWithoutHoldingTheFile()
+    {
+        var builder = new SdCardTestFileBuilder();
+        builder.AddMessage(SdCardTestFileBuilder.CreateStatusMessage());
+        for (var i = 0; i < LargeFileMessageCount; i++)
+        {
+            builder.AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: (uint)((i + 1) * 1000),
+                analogFloatValues: new[] { (float)i }));
+        }
+
+        using var stream = builder.Build();
+        var session = await new SdCardFileParser().ParseAsync(stream, "big.bin");
+
+        var count = 0;
+        var lastValue = double.NaN;
+        await foreach (var sample in session.Samples)
+        {
+            count++;
+            lastValue = sample.AnalogValues[0];
+        }
+
+        Assert.Equal(LargeFileMessageCount, count);
+        Assert.Equal(LargeFileMessageCount - 1, lastValue);
+    }
+
+    [Fact]
+    public async Task ParseAsync_BinSamples_CanBeEnumeratedMoreThanOnce()
+    {
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 1000))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(1000, analogFloatValues: new[] { 1.0f }))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(2000, analogFloatValues: new[] { 2.0f }));
+
+        using var stream = builder.Build();
+        var session = await new SdCardFileParser().ParseAsync(stream, "twice.bin");
+
+        var first = await ToListAsync(session.Samples);
+        var second = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, first.Count);
+        Assert.Equal(
+            first.Select(s => (s.Timestamp, s.AnalogValues[0])),
+            second.Select(s => (s.Timestamp, s.AnalogValues[0])));
+    }
+
+    [Fact]
+    public async Task ParseAsync_ForwardOnlyStream_StillParses()
+    {
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 1000))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(1000, analogFloatValues: new[] { 1.0f }))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(2000, analogFloatValues: new[] { 2.0f }));
+
+        using var inner = builder.Build();
+        await using var forwardOnly = new ForwardOnlyStream(inner);
+
+        var session = await new SdCardFileParser().ParseAsync(forwardOnly, "forward.bin");
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+        Assert.Equal(1000u, session.DeviceConfig!.TimestampFrequency);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ConfigurationScanLimit_BoundsHowFarTheConfigScanReads()
+    {
+        // The serial number only shows up well past the look-ahead window.
+        var builder = new SdCardTestFileBuilder();
+        for (var i = 0; i < 40; i++)
+        {
+            builder.AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: (uint)((i + 1) * 1000),
+                analogFloatValues: new[] { (float)i }));
+        }
+
+        var late = SdCardTestFileBuilder.CreateStreamMessage(41_000, analogFloatValues: new[] { 41f });
+        late.DeviceSn = 4242;
+        builder.AddMessage(late);
+
+        using var bounded = builder.Build();
+        var boundedSession = await new SdCardFileParser().ParseAsync(
+            bounded, "late.bin", new SdCardParseOptions { ConfigurationScanMessageLimit = 10 });
+
+        using var unbounded = builder.Build();
+        var unboundedSession = await new SdCardFileParser().ParseAsync(
+            unbounded, "late.bin", new SdCardParseOptions { ConfigurationScanMessageLimit = 0 });
+
+        Assert.Null(boundedSession.DeviceConfig?.DeviceSerialNumber);
+        Assert.Equal("4242", unboundedSession.DeviceConfig?.DeviceSerialNumber);
+
+        // Bounding the config scan must not cost samples.
+        Assert.Equal(41, (await ToListAsync(boundedSession.Samples)).Count);
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_Bin_SamplesReadableAfterTheCallReturns()
+    {
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 1000))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(1000, analogFloatValues: new[] { 1.0f }))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(2000, analogFloatValues: new[] { 2.0f }));
+
+        using var temp = new TempFile(".bin");
+        await File.WriteAllBytesAsync(temp.Path, builder.Build().ToArray());
+
+        var session = await new SdCardFileParser().ParseFileAsync(temp.Path);
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+    }
+
+    #endregion
+
+    #region CSV
+
+    [Fact]
+    public async Task ParseAsync_LargeCsvFile_FirstSampleDoesNotReadWholeFile()
+    {
+        var rows = Enumerable.Range(0, LargeFileMessageCount)
+            .Select(i => ((uint)(i * 100), new[] { (double)i, i + 1.0, i + 2.0, i + 3.0 }))
+            .ToArray();
+
+        using var inner = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp("Nq1", "SN1", 1000u, rows);
+        await using var counting = new CountingStream(inner);
+
+        var session = await new SdCardCsvFileParser().ParseAsync(counting, "big.csv");
+
+        var enumerator = session.Samples.GetAsyncEnumerator();
+        await using (enumerator.ConfigureAwait(false))
+        {
+            Assert.True(await enumerator.MoveNextAsync());
+        }
+
+        Assert.True(
+            counting.BytesRead < counting.Length / 4,
+            $"Read {counting.BytesRead} of {counting.Length} bytes to produce one sample.");
+    }
+
+    [Fact]
+    public async Task ParseAsync_CsvSamples_CanBeEnumeratedMoreThanOnce()
+    {
+        using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nq1", "SN1", 1000u,
+            new[] { (0u, new[] { 1.0 }), (100u, new[] { 2.0 }) });
+
+        var session = await new SdCardCsvFileParser().ParseAsync(stream, "twice.csv");
+
+        var first = await ToListAsync(session.Samples);
+        var second = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, first.Count);
+        Assert.Equal(
+            first.Select(s => (s.Timestamp, s.AnalogValues[0])),
+            second.Select(s => (s.Timestamp, s.AnalogValues[0])));
+    }
+
+    [Fact]
+    public async Task ParseAsync_CsvForwardOnlyStream_StillParses()
+    {
+        using var inner = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nq1", "SN1", 1000u,
+            new[] { (0u, new[] { 1.0 }), (100u, new[] { 2.0 }) });
+        await using var forwardOnly = new ForwardOnlyStream(inner);
+
+        var session = await new SdCardCsvFileParser().ParseAsync(forwardOnly, "forward.csv");
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+        Assert.Equal("SN1", session.DeviceConfig!.DeviceSerialNumber);
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_Csv_SamplesReadableAfterTheCallReturns()
+    {
+        using var built = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nq1", "SN1", 1000u,
+            new[] { (0u, new[] { 1.0 }), (100u, new[] { 2.0 }) });
+
+        using var temp = new TempFile(".csv");
+        await File.WriteAllBytesAsync(temp.Path, built.ToArray());
+
+        var session = await new SdCardCsvFileParser().ParseFileAsync(temp.Path);
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+    }
+
+    #endregion
+
+    #region JSON
+
+    [Fact]
+    public async Task ParseAsync_LargeJsonFile_FirstSampleDoesNotReadWholeFile()
+    {
+        var lines = Enumerable.Range(0, LargeFileMessageCount)
+            .Select(i => ((uint)i, new[] { (double)i, i + 1.0, i + 2.0, i + 3.0 }, "01"))
+            .ToArray();
+
+        using var inner = SdCardTestJsonFileBuilder.BuildJsonFile(lines);
+        await using var counting = new CountingStream(inner);
+
+        var session = await new SdCardJsonFileParser().ParseAsync(
+            counting, "big.json", new SdCardParseOptions { FallbackTimestampFrequency = 1000 });
+
+        var enumerator = session.Samples.GetAsyncEnumerator();
+        await using (enumerator.ConfigureAwait(false))
+        {
+            Assert.True(await enumerator.MoveNextAsync());
+        }
+
+        Assert.True(
+            counting.BytesRead < counting.Length / 4,
+            $"Read {counting.BytesRead} of {counting.Length} bytes to produce one sample.");
+    }
+
+    [Fact]
+    public async Task ParseAsync_JsonSamples_CanBeEnumeratedMoreThanOnce()
+    {
+        using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (0u, new[] { 1.0 }, ""),
+            (100u, new[] { 2.0 }, ""));
+
+        var session = await new SdCardJsonFileParser().ParseAsync(
+            stream, "twice.json", new SdCardParseOptions { FallbackTimestampFrequency = 1000 });
+
+        var first = await ToListAsync(session.Samples);
+        var second = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, first.Count);
+        Assert.Equal(
+            first.Select(s => (s.Timestamp, s.AnalogValues[0])),
+            second.Select(s => (s.Timestamp, s.AnalogValues[0])));
+    }
+
+    [Fact]
+    public async Task ParseAsync_JsonForwardOnlyStream_StillParses()
+    {
+        using var inner = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (0u, new[] { 1.0 }, ""),
+            (100u, new[] { 2.0 }, ""));
+        await using var forwardOnly = new ForwardOnlyStream(inner);
+
+        var session = await new SdCardJsonFileParser().ParseAsync(
+            forwardOnly, "forward.json", new SdCardParseOptions { FallbackTimestampFrequency = 1000 });
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_Json_SamplesReadableAfterTheCallReturns()
+    {
+        using var built = SdCardTestJsonFileBuilder.BuildJsonFile(
+            (0u, new[] { 1.0 }, ""),
+            (100u, new[] { 2.0 }, ""));
+
+        using var temp = new TempFile(".json");
+        await File.WriteAllBytesAsync(temp.Path, built.ToArray());
+
+        var session = await new SdCardJsonFileParser().ParseFileAsync(
+            temp.Path, new SdCardParseOptions { FallbackTimestampFrequency = 1000 });
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+    }
+
+    #endregion
+
+    #region Factory
+
+    [Theory]
+    [InlineData(".bin")]
+    [InlineData(".csv")]
+    [InlineData(".json")]
+    public async Task Factory_ParseFileAsync_SamplesReadableAfterTheCallReturns(string extension)
+    {
+        using var temp = new TempFile(extension);
+        await File.WriteAllBytesAsync(temp.Path, BuildTwoSampleFile(extension));
+
+        var session = await SdCardFileParserFactory.ParseFileAsync(
+            temp.Path, new SdCardParseOptions { FallbackTimestampFrequency = 1000 });
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(2, samples.Count);
+    }
+
+    private static byte[] BuildTwoSampleFile(string extension)
+    {
+        switch (extension)
+        {
+            case ".bin":
+                using (var bin = new SdCardTestFileBuilder()
+                           .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 1000))
+                           .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(1000, analogFloatValues: new[] { 1.0f }))
+                           .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(2000, analogFloatValues: new[] { 2.0f }))
+                           .Build())
+                {
+                    return bin.ToArray();
+                }
+
+            case ".csv":
+                using (var csv = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+                           "Nq1", "SN1", 1000u,
+                           new[] { (0u, new[] { 1.0 }), (100u, new[] { 2.0 }) }))
+                {
+                    return csv.ToArray();
+                }
+
+            default:
+                using (var json = SdCardTestJsonFileBuilder.BuildJsonFile(
+                           (0u, new[] { 1.0 }, ""),
+                           (100u, new[] { 2.0 }, "")))
+                {
+                    return json.ToArray();
+                }
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var list = new List<T>();
+        await foreach (var item in source)
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// A seekable pass-through that records how many bytes the parser actually pulled.
+    /// Byte counting is what makes "does not read the whole file" a deterministic assertion
+    /// rather than an allocation measurement at the mercy of the GC.
+    /// </summary>
+    private sealed class CountingStream(Stream inner) : Stream
+    {
+        public long BytesRead { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = inner.Read(buffer, offset, count);
+            BytesRead += read;
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            BytesRead += read;
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void Flush() => inner.Flush();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A stream that cannot be rewound, standing in for a pipe or socket.
+    /// </summary>
+    private sealed class ForwardOnlyStream(Stream inner) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => inner.ReadAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void Flush() => inner.Flush();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class TempFile : IDisposable
+    {
+        public TempFile(string extension)
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"daqifi_sd_{Guid.NewGuid():N}{extension}");
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                File.Delete(Path);
+            }
+            catch (IOException)
+            {
+                // A leftover temp file is not worth failing a test over.
+            }
+        }
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardStreamingParseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardStreamingParseTests.cs
@@ -323,6 +323,109 @@ public class SdCardStreamingParseTests
 
     #endregion
 
+    #region Shared-stream safety and progress
+
+    [Fact]
+    public async Task ParseAsync_StreamBackedSession_RefusesOverlappingEnumerations()
+    {
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 1000))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(1000, analogFloatValues: new[] { 1.0f }))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(2000, analogFloatValues: new[] { 2.0f }));
+
+        using var stream = builder.Build();
+        var session = await new SdCardFileParser().ParseAsync(stream, "overlap.bin");
+
+        // One stream, one read position: a second reader while the first is mid-file would
+        // silently interleave, so it is refused instead.
+        var first = session.Samples.GetAsyncEnumerator();
+        await using (first.ConfigureAwait(false))
+        {
+            Assert.True(await first.MoveNextAsync());
+
+            var second = session.Samples.GetAsyncEnumerator();
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await second.MoveNextAsync());
+            await second.DisposeAsync();
+        }
+
+        // Once the first enumeration is disposed, the session is readable again.
+        Assert.Equal(2, (await ToListAsync(session.Samples)).Count);
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_FileBackedSession_AllowsOverlappingEnumerations()
+    {
+        var builder = new SdCardTestFileBuilder()
+            .AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 1000))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(1000, analogFloatValues: new[] { 1.0f }))
+            .AddMessage(SdCardTestFileBuilder.CreateStreamMessage(2000, analogFloatValues: new[] { 2.0f }));
+
+        using var temp = new TempFile(".bin");
+        await File.WriteAllBytesAsync(temp.Path, builder.Build().ToArray());
+
+        var session = await new SdCardFileParser().ParseFileAsync(temp.Path);
+
+        // A path-backed session reads the file independently for each enumeration, so two
+        // readers cannot interfere.
+        var a = session.Samples.GetAsyncEnumerator();
+        var b = session.Samples.GetAsyncEnumerator();
+        await using (a.ConfigureAwait(false))
+        await using (b.ConfigureAwait(false))
+        {
+            Assert.True(await a.MoveNextAsync());
+            Assert.True(await b.MoveNextAsync());
+            Assert.Equal(a.Current.AnalogValues[0], b.Current.AnalogValues[0]);
+        }
+    }
+
+    [Theory]
+    [InlineData(".csv")]
+    [InlineData(".json")]
+    public async Task ParseAsync_TextProgress_ReachesTheFileLength(string extension)
+    {
+        var bytes = extension == ".csv"
+            ? BuildCsvRows(500)
+            : BuildJsonRows(500);
+
+        using var stream = new MemoryStream(bytes);
+
+        SdCardParseProgress? last = null;
+        var options = new SdCardParseOptions
+        {
+            FallbackTimestampFrequency = 1000,
+            Progress = new SynchronousProgress<SdCardParseProgress>(p => last = p)
+        };
+
+        var session = await SdCardFileParserFactory.ParseAsync(stream, $"log_20240101_120000{extension}", options);
+        var samples = await ToListAsync(session.Samples);
+
+        Assert.Equal(500, samples.Count);
+        Assert.NotNull(last);
+        Assert.Equal(500, last!.MessagesRead);
+
+        // Progress is in bytes and the preamble is part of the file, so a completed read has to
+        // land on the file's length rather than stopping short of it.
+        Assert.Equal(bytes.Length, last.TotalBytes);
+        Assert.Equal(bytes.Length, last.BytesRead);
+    }
+
+    private static byte[] BuildCsvRows(int rows)
+    {
+        using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            "Nq1", "SN1", 1000u,
+            Enumerable.Range(0, rows).Select(i => ((uint)(i * 10), new[] { (double)i })).ToArray());
+        return stream.ToArray();
+    }
+
+    private static byte[] BuildJsonRows(int rows)
+    {
+        using var stream = SdCardTestJsonFileBuilder.BuildJsonFile(
+            Enumerable.Range(0, rows).Select(i => ((uint)(i * 10), new[] { (double)i }, "")).ToArray());
+        return stream.ToArray();
+    }
+
+    #endregion
+
     #region Factory
 
     [Theory]

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -43,24 +43,80 @@ public sealed class SdCardCsvFileParser
 
         options ??= new SdCardParseOptions();
 
+        var source = SdCardParseSource.TryCreate(fileStream);
+        if (source != null)
+        {
+            return await BuildSessionAsync(
+                token => SdCardTextLineReader.ReadLinesAsync(source, token),
+                () => source.TotalBytes,
+                fileName,
+                options,
+                ct).ConfigureAwait(false);
+        }
+
+        // A forward-only stream can only be read once, so it has to be read up front.
+        // Callers that want the streaming parse hand the parser a seekable stream or a path.
+        var lines = new List<string>();
+        await foreach (var line in SdCardTextLineReader.ReadLinesAsync(fileStream, ct).ConfigureAwait(false))
+        {
+            lines.Add(line);
+        }
+
+        return await BuildSessionAsync(
+            _ => SdCardTextLineReader.ToAsyncEnumerable(lines),
+            () => lines.Sum(l => (long)l.Length + 1),
+            fileName,
+            options,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Parses an SD card CSV log file from a file path.
+    /// </summary>
+    /// <param name="filePath">The path to the CSV log file.</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    /// <remarks>
+    /// The returned session opens its own read of the file each time
+    /// <see cref="SdCardLogSession.Samples"/> is enumerated, so the file must still exist then.
+    /// </remarks>
+    public async Task<SdCardLogSession> ParseFileAsync(
+        string filePath,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        options ??= new SdCardParseOptions();
+
+        var source = SdCardParseSource.ForFile(filePath, options.BufferSize);
+
+        return await BuildSessionAsync(
+            token => SdCardTextLineReader.ReadLinesAsync(source, token),
+            () => source.TotalBytes,
+            Path.GetFileName(filePath),
+            options,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads the header region, then hands the session a sample iterator that re-reads the
+    /// file lazily rather than holding its lines in memory.
+    /// </summary>
+    private static async Task<SdCardLogSession> BuildSessionAsync(
+        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        Func<long> totalBytes,
+        string fileName,
+        SdCardParseOptions options,
+        CancellationToken ct)
+    {
         var fileCreatedDate = options.SessionStartTime
                               ?? SdCardFileListParser.TryParseDateFromLogFileName(fileName);
 
-        // Read all lines into memory (similar to protobuf parser reading all messages)
-        var lines = new List<string>();
-        using (var reader = new StreamReader(fileStream, leaveOpen: true))
-        {
-            string? line;
-            while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
-            {
-                if (!string.IsNullOrWhiteSpace(line))
-                {
-                    lines.Add(line);
-                }
-            }
-        }
+        var header = await ReadHeaderAsync(openLines, ct).ConfigureAwait(false);
 
-        if (lines.Count == 0)
+        if (!header.SawAnyLine)
         {
             // Empty file
             return new SdCardLogSession(
@@ -70,20 +126,16 @@ public sealed class SdCardCsvFileParser
                 EmptySamples());
         }
 
-        var (headerConfig, columnLayout) = ParseHeader(lines, options);
-        var config = MergeConfiguration(headerConfig, options.ConfigurationOverride);
+        var config = MergeConfiguration(header.Config, options.ConfigurationOverride);
 
         var (timestampFrequency, timestampSource) = SdCardTimestampFrequencyResolver.Resolve(
-            headerConfig.TimestampFrequency,
+            header.Config.TimestampFrequency,
             options.ConfigurationOverride?.TimestampFrequency ?? 0u,
             options.FallbackTimestampFrequency);
 
         config = config with { TimestampFrequency = timestampFrequency };
 
-        // Find the index of the first data row (after comments and column header)
-        var dataStartIndex = FindDataStartIndex(lines);
-
-        if (dataStartIndex >= lines.Count)
+        if (header.DataStartIndex < 0)
         {
             // Only header, no data
             return new SdCardLogSession(
@@ -98,46 +150,23 @@ public sealed class SdCardCsvFileParser
         }
 
         var samples = ParseCsvLines(
-            lines,
-            dataStartIndex,
+            openLines,
+            header.DataStartIndex,
+            totalBytes,
             config,
-            columnLayout,
-            fileCreatedDate,
-            options);
+            header.Layout,
+            // Anchored once, here, rather than inside the iterator: a session whose samples can
+            // be enumerated more than once must not shift its timestamps between reads when the
+            // file name carries no date.
+            fileCreatedDate ?? DateTime.UtcNow,
+            options.Progress,
+            ct);
 
         return new SdCardLogSession(fileName, fileCreatedDate, config, samples)
         {
             TimestampFrequency = timestampFrequency,
             TimestampFrequencySource = timestampSource
         };
-    }
-
-    /// <summary>
-    /// Parses an SD card CSV log file from a file path.
-    /// </summary>
-    /// <param name="filePath">The path to the CSV log file.</param>
-    /// <param name="options">Optional parse options.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
-    public async Task<SdCardLogSession> ParseFileAsync(
-        string filePath,
-        SdCardParseOptions? options = null,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(filePath);
-
-        var fileStream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: options?.BufferSize ?? 64 * 1024,
-            useAsync: true);
-
-        await using (fileStream.ConfigureAwait(false))
-        {
-            return await ParseAsync(fileStream, Path.GetFileName(filePath), options, ct).ConfigureAwait(false);
-        }
     }
 
     /// <summary>
@@ -148,11 +177,26 @@ public sealed class SdCardCsvFileParser
     private sealed record CsvColumnLayout(int AnalogPairCount, bool HasDigitalPair);
 
     /// <summary>
-    /// Parses device metadata and column layout from the comment header lines.
+    /// The result of the header scan: everything the sample pass needs to know before it
+    /// starts reading data rows.
     /// </summary>
-    private static (SdCardDeviceConfiguration Config, CsvColumnLayout Layout) ParseHeader(
-        List<string> lines,
-        SdCardParseOptions options)
+    /// <param name="SawAnyLine">Whether the file contained any non-blank line at all.</param>
+    /// <param name="DataStartIndex">Index of the first data row among the non-blank lines, or -1 when the file has no data rows.</param>
+    /// <param name="Config">Device metadata stated by the file itself.</param>
+    /// <param name="Layout">The column layout stated by the column-header row.</param>
+    private sealed record CsvHeader(
+        bool SawAnyLine,
+        int DataStartIndex,
+        SdCardDeviceConfiguration Config,
+        CsvColumnLayout Layout);
+
+    /// <summary>
+    /// Reads the header region — comment metadata and the column header — and locates the
+    /// first data row. Stops at that row, so this never reads more than the file's preamble.
+    /// </summary>
+    private static async Task<CsvHeader> ReadHeaderAsync(
+        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        CancellationToken ct)
     {
         string? deviceName = null;
         string? serialNumber = null;
@@ -165,9 +209,16 @@ public sealed class SdCardCsvFileParser
         var digitalChannelCount = 0;
         var hasDigitalPair = false;
 
-        foreach (var line in lines)
+        var index = 0;
+        var dataStartIndex = -1;
+        var sawAnyLine = false;
+        var headerDone = false;
+
+        await foreach (var line in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
         {
-            if (line.StartsWith('#'))
+            sawAnyLine = true;
+
+            if (!headerDone && line.StartsWith('#'))
             {
                 // # Device: Nyquist 1
                 // # Serial Number: 7E2815916200E898
@@ -197,43 +248,54 @@ public sealed class SdCardCsvFileParser
                     }
                 }
 
+                index++;
                 continue;
             }
 
             if (IsColumnHeaderLine(line))
             {
-                // Column header: ain0_ts,ain0_val,ain1_ts,ain1_val,...,dio_ts,dio_val
-                // Count channel pairs and identify digital columns
-                var cols = line.Split(',');
-                var totalPairs = cols.Length / 2;
-
-                // Check each pair to distinguish analog from digital
-                for (var p = 0; p < totalPairs; p++)
+                if (!headerDone)
                 {
-                    var nameCol = cols[p * 2]; // e.g., "ain0_ts" or "dio_ts"
-                    if (nameCol.StartsWith("dio", StringComparison.OrdinalIgnoreCase))
+                    // Column header: ain0_ts,ain0_val,ain1_ts,ain1_val,...,dio_ts,dio_val
+                    // Count channel pairs and identify digital columns
+                    var cols = line.Split(',');
+                    var totalPairs = cols.Length / 2;
+
+                    // Check each pair to distinguish analog from digital
+                    for (var p = 0; p < totalPairs; p++)
                     {
-                        hasDigitalPair = true;
-                        digitalChannelCount = 1;
+                        var nameCol = cols[p * 2]; // e.g., "ain0_ts" or "dio_ts"
+                        if (nameCol.StartsWith("dio", StringComparison.OrdinalIgnoreCase))
+                        {
+                            hasDigitalPair = true;
+                            digitalChannelCount = 1;
+                        }
+                        else
+                        {
+                            analogChannelCount++;
+                        }
                     }
-                    else
-                    {
-                        analogChannelCount++;
-                    }
+
+                    // Only the first column header states the layout; anything after it is
+                    // no longer part of the metadata region.
+                    headerDone = true;
                 }
 
-                break;
-            }
-
-            if (IsHeaderNoiseLine(line))
-            {
-                // Malformed header-region noise (e.g. a stray "ch") before the real
-                // column header. Skip it and keep scanning so the real header — and its
-                // channel layout — isn't lost. Must stay consistent with FindDataStartIndex.
+                index++;
                 continue;
             }
 
-            // First data row reached without finding a column header.
+            if (IsHeaderNoiseLine(line) || line.StartsWith('#'))
+            {
+                // Malformed header-region noise (e.g. a stray "ch") before the real
+                // column header. Skip it and keep scanning so the real header — and its
+                // channel layout — isn't lost.
+                index++;
+                continue;
+            }
+
+            // First data row.
+            dataStartIndex = index;
             break;
         }
 
@@ -246,47 +308,18 @@ public sealed class SdCardCsvFileParser
             FirmwareRevision: null,
             CalibrationValues: null);
 
-        var layout = new CsvColumnLayout(analogChannelCount, hasDigitalPair);
-
-        return (config, layout);
-    }
-
-    /// <summary>
-    /// Finds the index of the first data row (skipping comments and the column header).
-    /// </summary>
-    private static int FindDataStartIndex(List<string> lines)
-    {
-        for (var i = 0; i < lines.Count; i++)
-        {
-            var line = lines[i];
-            if (line.StartsWith('#'))
-            {
-                continue;  // Comment line
-            }
-
-            if (IsColumnHeaderLine(line))
-            {
-                continue;  // Column header line
-            }
-
-            if (IsHeaderNoiseLine(line))
-            {
-                // Malformed header-region noise (e.g. a stray "ch") — skip it rather than
-                // treating it as the first data row, so the scan lands on the real data.
-                continue;
-            }
-
-            return i;  // First data row
-        }
-
-        return lines.Count;  // No data found
+        return new CsvHeader(
+            sawAnyLine,
+            dataStartIndex,
+            config,
+            new CsvColumnLayout(analogChannelCount, hasDigitalPair));
     }
 
     /// <summary>
     /// Determines whether a line is a CSV column header
     /// (e.g. <c>ain0_ts,ain0_val,...,dio_ts,dio_val</c> or a <c>ch...</c>/<c>ain...</c> variant).
-    /// Shared by <see cref="ParseHeader"/> and <see cref="FindDataStartIndex"/> so both agree on
-    /// what a header looks like. The <c>line.Length &gt; 2</c> guard protects the <c>line[2]</c>
+    /// Used by <see cref="ReadHeaderAsync"/> both to read the layout and to find where the data
+    /// starts, so the two agree on what a header looks like. The <c>line.Length &gt; 2</c> guard protects the <c>line[2]</c>
     /// access: <c>StartsWith("ch")</c> only guarantees length &gt;= 2, so a bare "ch" line would
     /// otherwise throw <see cref="IndexOutOfRangeException"/> (closes #365).
     /// </summary>
@@ -305,16 +338,16 @@ public sealed class SdCardCsvFileParser
     private static bool IsHeaderNoiseLine(string line) =>
         line.StartsWith("ch", StringComparison.OrdinalIgnoreCase) && !IsColumnHeaderLine(line);
 
-#pragma warning disable CS1998 // Async iterator: yield return requires async; method has no real awaits.
     private static async IAsyncEnumerable<SdCardLogEntry> ParseCsvLines(
-        List<string> lines,
+        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
         int dataStartIndex,
+        Func<long> totalBytesProvider,
         SdCardDeviceConfiguration config,
         CsvColumnLayout columnLayout,
-        DateTime? fileCreatedDate,
-        SdCardParseOptions options)
+        DateTime baseTime,
+        IProgress<SdCardParseProgress>? progress,
+        [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var baseTime = fileCreatedDate ?? DateTime.UtcNow;
         var timestampFreq = config.TimestampFrequency;
         var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
 
@@ -322,13 +355,21 @@ public sealed class SdCardCsvFileParser
         var elapsedSeconds = 0.0;
         var linesProcessed = 0;
         var bytesRead = 0L;
+        var totalBytes = totalBytesProvider();
+        var skipped = 0;
 
-        var progress = options.Progress;
-        var totalBytes = lines.Sum(l => l.Length + 1); // +1 for newline
-
-        for (var i = dataStartIndex; i < lines.Count; i++)
+        await foreach (var line in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
         {
-            var line = lines[i];
+            // Re-reading the file means walking the header region again; it is bounded by the
+            // preamble, and skipping it costs nothing next to decoding a data row.
+            if (skipped < dataStartIndex)
+            {
+                skipped++;
+                continue;
+            }
+
+            ct.ThrowIfCancellationRequested();
+
             linesProcessed++;
             bytesRead += line.Length + 1;
 
@@ -378,7 +419,6 @@ public sealed class SdCardCsvFileParser
         // Final progress report
         progress?.Report(new SdCardParseProgress(bytesRead, totalBytes, linesProcessed));
     }
-#pragma warning restore CS1998
 
     /// <summary>
     /// Parses a firmware CSV data row with interleaved per-channel timestamp/value pairs.

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -32,6 +32,13 @@ public sealed class SdCardCsvFileParser
     /// <param name="options">Optional parse options.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    /// <remarks>
+    /// The session reads <paramref name="fileStream"/> lazily: keep the stream open and do not
+    /// read from it yourself until you have finished enumerating
+    /// <see cref="SdCardLogSession.Samples"/>. A seekable stream is re-read from its starting
+    /// position on each enumeration, and only one enumeration may be in flight at a time; a
+    /// forward-only stream cannot be re-read, so its contents are decoded up front instead.
+    /// </remarks>
     public async Task<SdCardLogSession> ParseAsync(
         Stream fileStream,
         string fileName,
@@ -56,7 +63,7 @@ public sealed class SdCardCsvFileParser
 
         // A forward-only stream can only be read once, so it has to be read up front.
         // Callers that want the streaming parse hand the parser a seekable stream or a path.
-        var lines = new List<string>();
+        var lines = new List<SdCardLogLine>();
         await foreach (var line in SdCardTextLineReader.ReadLinesAsync(fileStream, ct).ConfigureAwait(false))
         {
             lines.Add(line);
@@ -64,7 +71,7 @@ public sealed class SdCardCsvFileParser
 
         return await BuildSessionAsync(
             _ => SdCardTextLineReader.ToAsyncEnumerable(lines),
-            () => lines.Sum(l => (long)l.Length + 1),
+            () => lines.Count > 0 ? lines[^1].BytesRead : 0,
             fileName,
             options,
             ct).ConfigureAwait(false);
@@ -105,7 +112,7 @@ public sealed class SdCardCsvFileParser
     /// file lazily rather than holding its lines in memory.
     /// </summary>
     private static async Task<SdCardLogSession> BuildSessionAsync(
-        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        Func<CancellationToken, IAsyncEnumerable<SdCardLogLine>> openLines,
         Func<long> totalBytes,
         string fileName,
         SdCardParseOptions options,
@@ -195,7 +202,7 @@ public sealed class SdCardCsvFileParser
     /// first data row. Stops at that row, so this never reads more than the file's preamble.
     /// </summary>
     private static async Task<CsvHeader> ReadHeaderAsync(
-        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        Func<CancellationToken, IAsyncEnumerable<SdCardLogLine>> openLines,
         CancellationToken ct)
     {
         string? deviceName = null;
@@ -214,8 +221,9 @@ public sealed class SdCardCsvFileParser
         var sawAnyLine = false;
         var headerDone = false;
 
-        await foreach (var line in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
+        await foreach (var entry in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
         {
+            var line = entry.Text;
             sawAnyLine = true;
 
             if (!headerDone && line.StartsWith('#'))
@@ -339,7 +347,7 @@ public sealed class SdCardCsvFileParser
         line.StartsWith("ch", StringComparison.OrdinalIgnoreCase) && !IsColumnHeaderLine(line);
 
     private static async IAsyncEnumerable<SdCardLogEntry> ParseCsvLines(
-        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        Func<CancellationToken, IAsyncEnumerable<SdCardLogLine>> openLines,
         int dataStartIndex,
         Func<long> totalBytesProvider,
         SdCardDeviceConfiguration config,
@@ -358,8 +366,12 @@ public sealed class SdCardCsvFileParser
         var totalBytes = totalBytesProvider();
         var skipped = 0;
 
-        await foreach (var line in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
+        await foreach (var entry in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
         {
+            // The preamble still counts towards bytes read — it is part of the file the caller
+            // is waiting on — so progress can reach the file's length.
+            bytesRead = entry.BytesRead;
+
             // Re-reading the file means walking the header region again; it is bounded by the
             // preamble, and skipping it costs nothing next to decoding a data row.
             if (skipped < dataStartIndex)
@@ -370,8 +382,8 @@ public sealed class SdCardCsvFileParser
 
             ct.ThrowIfCancellationRequested();
 
+            var line = entry.Text;
             linesProcessed++;
-            bytesRead += line.Length + 1;
 
             var parsed = TryParseCsvDataRow(line, columnLayout);
             if (parsed == null)

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -47,37 +47,119 @@ public sealed class SdCardFileParser
             throw new ArgumentOutOfRangeException(nameof(options), "BufferSize must be greater than zero.");
         }
 
+        var source = SdCardParseSource.TryCreate(fileStream);
+        if (source != null)
+        {
+            return await BuildSessionAsync(
+                (progress, token) => ReadMessagesAsync(source, options, progress, token),
+                fileName,
+                options,
+                ct).ConfigureAwait(false);
+        }
+
+        // A forward-only stream can only be read once, so it has to be decoded up front.
+        // Callers that want the streaming parse hand the parser a seekable stream or a path.
+        var buffered = new List<DaqifiOutMessage>();
+        await foreach (var message in ReadMessagesAsync(fileStream, options, options.Progress, -1L, ct)
+                           .WithCancellation(ct).ConfigureAwait(false))
+        {
+            buffered.Add(message);
+        }
+
+        return await BuildSessionAsync(
+            (_, _) => SdCardTextLineReader.ToAsyncEnumerable(buffered),
+            fileName,
+            options,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Convenience overload that opens a file by path.
+    /// </summary>
+    /// <param name="filePath">Absolute or relative path to the <c>.bin</c> file.</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    /// <remarks>
+    /// The returned session opens its own read of the file each time
+    /// <see cref="SdCardLogSession.Samples"/> is enumerated, so the file must still exist then.
+    /// </remarks>
+    public async Task<SdCardLogSession> ParseFileAsync(
+        string filePath,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        options ??= new SdCardParseOptions();
+
+        if (options.BufferSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "BufferSize must be greater than zero.");
+        }
+
+        var source = SdCardParseSource.ForFile(filePath, options.BufferSize);
+
+        return await BuildSessionAsync(
+            (progress, token) => ReadMessagesAsync(source, options, progress, token),
+            Path.GetFileName(filePath),
+            options,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves the session's configuration from a short prefix of the log, then hands the
+    /// session a sample iterator that re-reads the log lazily.
+    /// </summary>
+    private static async Task<SdCardLogSession> BuildSessionAsync(
+        Func<IProgress<SdCardParseProgress>?, CancellationToken, IAsyncEnumerable<DaqifiOutMessage>> openMessages,
+        string fileName,
+        SdCardParseOptions options,
+        CancellationToken ct)
+    {
         var fileCreatedDate = options.SessionStartTime
                               ?? SdCardFileListParser.TryParseDateFromLogFileName(fileName);
 
-        // Read all messages from the stream.
-        var allMessages = await ReadAllMessagesAsync(fileStream, options, ct).ConfigureAwait(false);
+        // Only the leading messages are held, never the whole file: firmware states the
+        // configuration in the status message or in the first handful of stream messages.
+        // No progress is reported for this pass — it is not the caller's read of the file.
+        var prefix = new List<DaqifiOutMessage>();
+        var limit = options.ConfigurationScanMessageLimit;
+        await foreach (var message in openMessages(null, ct).WithCancellation(ct).ConfigureAwait(false))
+        {
+            prefix.Add(message);
+            if (limit > 0 && prefix.Count >= limit)
+            {
+                break;
+            }
+        }
 
         SdCardDeviceConfiguration? config = null;
-        var streamStartIndex = 0;
 
         // First, check if the first message is a dedicated status message.
         // Some firmware versions embed config fields (e.g., AnalogInPortNum/TimestampFreq)
         // inside stream messages, so we only treat the first message as status when it
         // has no stream payload.
-        if (allMessages.Count > 0 && !HasStreamPayload(allMessages[0]))
+        if (prefix.Count > 0 && !HasStreamPayload(prefix[0]))
         {
-            config = ExtractDeviceConfiguration(allMessages[0]);
-            streamStartIndex = 1;
+            config = ExtractDeviceConfiguration(prefix[0]);
         }
 
         // If no dedicated status message was found, or the status message had no TimestampFreq,
-        // scan all messages for config fields. Device firmware often embeds config fields
+        // scan the leading messages for config fields. Device firmware often embeds config fields
         // (TimestampFreq, DeviceSn, etc.) in streaming data messages rather than writing
         // a separate status header.
         if (config == null || config.TimestampFrequency == 0)
         {
-            var scannedConfig = ScanMessagesForConfiguration(allMessages);
+            var scannedConfig = ScanMessagesForConfiguration(prefix);
             if (scannedConfig != null)
             {
                 config = MergeConfigurations(config, scannedConfig);
             }
         }
+
+        // The prefix has served its purpose; the sample pass re-reads the log from the start.
+        prefix.Clear();
 
         // Whatever the file itself stated, captured before the override is merged in so the
         // two sources stay distinguishable when reporting which one was used.
@@ -102,9 +184,11 @@ public sealed class SdCardFileParser
             : 0.0;
 
         var samples = ProduceSamples(
-            allMessages,
-            streamStartIndex,
-            fileCreatedDate,
+            token => openMessages(options.Progress, token),
+            // Anchored once, here, rather than inside the iterator: a session whose samples can
+            // be enumerated more than once must not shift its timestamps between reads when the
+            // file name carries no date.
+            fileCreatedDate ?? DateTime.UtcNow,
             tickPeriod,
             config,
             ct);
@@ -117,54 +201,41 @@ public sealed class SdCardFileParser
     }
 
     /// <summary>
-    /// Convenience overload that opens a file by path.
+    /// Streams the protobuf messages of the source, re-opening it from the start each time.
     /// </summary>
-    /// <param name="filePath">Absolute or relative path to the <c>.bin</c> file.</param>
-    /// <param name="options">Optional parse options.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
-    public async Task<SdCardLogSession> ParseFileAsync(
-        string filePath,
-        SdCardParseOptions? options = null,
-        CancellationToken ct = default)
+    private static async IAsyncEnumerable<DaqifiOutMessage> ReadMessagesAsync(
+        SdCardParseSource source,
+        SdCardParseOptions options,
+        IProgress<SdCardParseProgress>? progress,
+        [EnumeratorCancellation] CancellationToken ct)
     {
-        ArgumentNullException.ThrowIfNull(filePath);
-
-        options ??= new SdCardParseOptions();
-
-        if (options.BufferSize <= 0)
+        var lease = source.Open();
+        await using (lease.ConfigureAwait(false))
         {
-            throw new ArgumentOutOfRangeException(nameof(options), "BufferSize must be greater than zero.");
-        }
-
-        var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            options.BufferSize,
-            useAsync: true);
-
-        await using (stream.ConfigureAwait(false))
-        {
-            return await ParseAsync(stream, Path.GetFileName(filePath), options, ct).ConfigureAwait(false);
+            await foreach (var message in ReadMessagesAsync(lease.Stream, options, progress, source.TotalBytes, ct)
+                               .WithCancellation(ct).ConfigureAwait(false))
+            {
+                yield return message;
+            }
         }
     }
 
     /// <summary>
-    /// Reads and deserializes all protobuf messages from the stream.
+    /// Deserializes protobuf messages from the stream, holding at most one read buffer plus
+    /// the bytes of a straddling frame.
     /// </summary>
-    private static async Task<List<DaqifiOutMessage>> ReadAllMessagesAsync(
+    private static async IAsyncEnumerable<DaqifiOutMessage> ReadMessagesAsync(
         Stream stream,
         SdCardParseOptions options,
-        CancellationToken ct)
+        IProgress<SdCardParseProgress>? progress,
+        long totalBytes,
+        [EnumeratorCancellation] CancellationToken ct)
     {
         var parser = new ProtobufMessageParser();
-        var messages = new List<DaqifiOutMessage>();
         var buffer = new byte[options.BufferSize];
         var carry = Array.Empty<byte>();
         long totalBytesRead = 0;
-        var totalBytes = stream.CanSeek ? stream.Length : -1L;
+        var messagesRead = 0;
 
         while (true)
         {
@@ -186,12 +257,8 @@ public sealed class SdCardFileParser
 
             var parsed = parser.ParseMessages(chunk, out var consumed);
 
-            foreach (var msg in parsed)
-            {
-                messages.Add(msg.Data);
-            }
-
-            // Carry unconsumed bytes forward
+            // Carry unconsumed bytes forward. Computed before yielding so the reader's state
+            // is already consistent when the consumer pauses mid-chunk.
             if (consumed < chunk.Length)
             {
                 carry = new byte[chunk.Length - consumed];
@@ -202,7 +269,13 @@ public sealed class SdCardFileParser
                 carry = Array.Empty<byte>();
             }
 
-            options.Progress?.Report(new SdCardParseProgress(totalBytesRead, totalBytes, messages.Count));
+            foreach (var msg in parsed)
+            {
+                messagesRead++;
+                yield return msg.Data;
+            }
+
+            progress?.Report(new SdCardParseProgress(totalBytesRead, totalBytes, messagesRead));
         }
 
         // Try to parse any remaining carry bytes (may contain a partial final message)
@@ -211,139 +284,151 @@ public sealed class SdCardFileParser
             var parsed = parser.ParseMessages(carry, out _);
             foreach (var msg in parsed)
             {
-                messages.Add(msg.Data);
+                messagesRead++;
+                yield return msg.Data;
             }
 
-            options.Progress?.Report(new SdCardParseProgress(totalBytesRead, totalBytes, messages.Count));
+            progress?.Report(new SdCardParseProgress(totalBytesRead, totalBytes, messagesRead));
         }
-
-        return messages;
     }
 
-#pragma warning disable CS1998 // Async iterator: yield return requires async; method has no real awaits.
     /// <summary>
-    /// Produces <see cref="SdCardLogEntry"/> samples from the parsed messages.
+    /// Produces <see cref="SdCardLogEntry"/> samples, decoding the log as they are consumed.
     /// </summary>
     private static async IAsyncEnumerable<SdCardLogEntry> ProduceSamples(
-        List<DaqifiOutMessage> messages,
-        int startIndex,
-        DateTime? anchorTime,
+        Func<CancellationToken, IAsyncEnumerable<DaqifiOutMessage>> openMessages,
+        DateTime baseTime,
         double tickPeriod,
         SdCardDeviceConfiguration? config,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var baseTime = anchorTime ?? DateTime.UtcNow;
         uint? previousTimestamp = null;
         var elapsedSeconds = 0.0;
 
-        for (var i = startIndex; i < messages.Count; i++)
+        var enumerator = openMessages(ct).GetAsyncEnumerator(ct);
+        await using (enumerator.ConfigureAwait(false))
         {
-            ct.ThrowIfCancellationRequested();
+            var current = await enumerator.MoveNextAsync().ConfigureAwait(false)
+                ? enumerator.Current
+                : null;
 
-            var msg = messages[i];
-
-            // Skip non-stream messages (no analog and no digital data)
-            if (msg.AnalogInData.Count == 0 &&
-                msg.AnalogInDataFloat.Count == 0 &&
-                msg.DigitalData.Length == 0)
+            while (current != null)
             {
-                continue;
-            }
+                ct.ThrowIfCancellationRequested();
 
-            // Merge consecutive messages at the same timestamp into a single entry.
-            // Device firmware often sends separate analog and digital messages per sample
-            // period with the same MsgTimeStamp.
-            while (i + 1 < messages.Count && messages[i + 1].MsgTimeStamp == msg.MsgTimeStamp)
-            {
-                var next = messages[i + 1];
-                if (!HasStreamPayload(next))
+                var msg = current;
+                current = await enumerator.MoveNextAsync().ConfigureAwait(false)
+                    ? enumerator.Current
+                    : null;
+
+                // Skip non-stream messages (no analog and no digital data)
+                if (!HasStreamPayload(msg))
                 {
-                    break;
+                    continue;
                 }
 
-                i++;
+                // Merge consecutive messages at the same timestamp into a single entry.
+                // Device firmware often sends separate analog and digital messages per sample
+                // period with the same MsgTimeStamp. A message without stream payload ends the
+                // merge without being consumed, so the loop above skips it on the next turn.
+                while (current != null &&
+                       current.MsgTimeStamp == msg.MsgTimeStamp &&
+                       HasStreamPayload(current))
+                {
+                    var next = current;
+                    current = await enumerator.MoveNextAsync().ConfigureAwait(false)
+                        ? enumerator.Current
+                        : null;
 
-                // Take analog data from whichever message has it
-                if (msg.AnalogInDataFloat.Count == 0 && next.AnalogInDataFloat.Count > 0)
-                {
-                    msg.AnalogInDataFloat.AddRange(next.AnalogInDataFloat);
-                }
-                else if (msg.AnalogInData.Count == 0 && next.AnalogInData.Count > 0)
-                {
-                    msg.AnalogInData.AddRange(next.AnalogInData);
+                    // Take analog data from whichever message has it
+                    if (msg.AnalogInDataFloat.Count == 0 && next.AnalogInDataFloat.Count > 0)
+                    {
+                        msg.AnalogInDataFloat.AddRange(next.AnalogInDataFloat);
+                    }
+                    else if (msg.AnalogInData.Count == 0 && next.AnalogInData.Count > 0)
+                    {
+                        msg.AnalogInData.AddRange(next.AnalogInData);
+                    }
+
+                    // Take digital data from whichever message has it
+                    if (msg.DigitalData.Length == 0 && next.DigitalData.Length > 0)
+                    {
+                        msg.DigitalData = next.DigitalData;
+                    }
+
+                    // Take per-channel timestamps from whichever message has them
+                    if (msg.AnalogInDataTs.Count == 0 && next.AnalogInDataTs.Count > 0)
+                    {
+                        msg.AnalogInDataTs.AddRange(next.AnalogInDataTs);
+                    }
                 }
 
-                // Take digital data from whichever message has it
-                if (msg.DigitalData.Length == 0 && next.DigitalData.Length > 0)
+                // Reconstruct timestamp
+                var timestamp = baseTime;
+                var hasDeviceTimestamp = msg.MsgTimeStamp != 0 && tickPeriod > 0;
+                if (hasDeviceTimestamp)
                 {
-                    msg.DigitalData = next.DigitalData;
+                    if (previousTimestamp == null)
+                    {
+                        // First stream message — anchor to base time
+                        previousTimestamp = msg.MsgTimeStamp;
+                    }
+                    else
+                    {
+                        var delta = ComputeTickDelta(previousTimestamp.Value, msg.MsgTimeStamp);
+                        elapsedSeconds += delta * tickPeriod;
+                        previousTimestamp = msg.MsgTimeStamp;
+                    }
+
+                    timestamp = baseTime.AddSeconds(elapsedSeconds);
                 }
 
-                // Take per-channel timestamps from whichever message has them
-                if (msg.AnalogInDataTs.Count == 0 && next.AnalogInDataTs.Count > 0)
+                // Extract analog values (prefer float, fall back to scaled raw int)
+                IReadOnlyList<double> analogValues;
+                if (msg.AnalogInDataFloat.Count > 0)
                 {
-                    msg.AnalogInDataTs.AddRange(next.AnalogInDataTs);
-                }
-            }
+                    // Hand-rolled rather than LINQ: this runs once per sample in the file.
+                    var floats = msg.AnalogInDataFloat;
+                    var converted = new double[floats.Count];
+                    for (var v = 0; v < floats.Count; v++)
+                    {
+                        converted[v] = floats[v];
+                    }
 
-            // Reconstruct timestamp
-            var timestamp = baseTime;
-            var hasDeviceTimestamp = msg.MsgTimeStamp != 0 && tickPeriod > 0;
-            if (hasDeviceTimestamp)
-            {
-                if (previousTimestamp == null)
+                    analogValues = converted;
+                }
+                else if (msg.AnalogInData.Count > 0)
                 {
-                    // First stream message — anchor to base time
-                    previousTimestamp = msg.MsgTimeStamp;
+                    analogValues = SdCardAnalogScaling.ScaleRawAnalogValues(msg.AnalogInData, config);
                 }
                 else
                 {
-                    var delta = ComputeTickDelta(previousTimestamp.Value, msg.MsgTimeStamp);
-                    elapsedSeconds += delta * tickPeriod;
-                    previousTimestamp = msg.MsgTimeStamp;
+                    analogValues = Array.Empty<double>();
                 }
 
-                timestamp = baseTime.AddSeconds(elapsedSeconds);
-            }
-
-            // Extract analog values (prefer float, fall back to scaled raw int)
-            IReadOnlyList<double> analogValues;
-            if (msg.AnalogInDataFloat.Count > 0)
-            {
-                analogValues = msg.AnalogInDataFloat.Select(v => (double)v).ToArray();
-            }
-            else if (msg.AnalogInData.Count > 0)
-            {
-                analogValues = SdCardAnalogScaling.ScaleRawAnalogValues(msg.AnalogInData, config);
-            }
-            else
-            {
-                analogValues = Array.Empty<double>();
-            }
-
-            // Extract digital data
-            var digitalData = 0u;
-            if (msg.DigitalData.Length > 0)
-            {
-                var bytes = msg.DigitalData.ToByteArray();
-                for (var b = 0; b < bytes.Length && b < 4; b++)
+                // Extract digital data
+                var digitalData = 0u;
+                if (msg.DigitalData.Length > 0)
                 {
-                    digitalData |= (uint)bytes[b] << (b * 8);
+                    var bytes = msg.DigitalData.ToByteArray();
+                    for (var b = 0; b < bytes.Length && b < 4; b++)
+                    {
+                        digitalData |= (uint)bytes[b] << (b * 8);
+                    }
                 }
+
+                // Per-channel timestamps
+                IReadOnlyList<uint>? analogTimestamps = msg.AnalogInDataTs.Count > 0
+                    ? msg.AnalogInDataTs.ToArray()
+                    : null;
+
+                yield return new SdCardLogEntry(timestamp, analogValues, digitalData, analogTimestamps)
+                {
+                    HasDeviceTimestamp = hasDeviceTimestamp
+                };
             }
-
-            // Per-channel timestamps
-            IReadOnlyList<uint>? analogTimestamps = msg.AnalogInDataTs.Count > 0
-                ? msg.AnalogInDataTs.ToArray()
-                : null;
-
-            yield return new SdCardLogEntry(timestamp, analogValues, digitalData, analogTimestamps)
-            {
-                HasDeviceTimestamp = hasDeviceTimestamp
-            };
         }
     }
-#pragma warning restore CS1998
 
     /// <summary>
     /// Computes the tick delta between two uint32 timestamps, handling rollover.

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -31,6 +31,13 @@ public sealed class SdCardFileParser
     /// <param name="options">Optional parse options.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    /// <remarks>
+    /// The session reads <paramref name="fileStream"/> lazily: keep the stream open and do not
+    /// read from it yourself until you have finished enumerating
+    /// <see cref="SdCardLogSession.Samples"/>. A seekable stream is re-read from its starting
+    /// position on each enumeration, and only one enumeration may be in flight at a time; a
+    /// forward-only stream cannot be re-read, so its contents are decoded up front instead.
+    /// </remarks>
     public async Task<SdCardLogSession> ParseAsync(
         Stream fileStream,
         string fileName,

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
@@ -54,6 +54,13 @@ public static class SdCardFileParserFactory
     /// <param name="options">Optional parse options.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    /// <remarks>
+    /// The session reads <paramref name="fileStream"/> lazily: keep the stream open and do not
+    /// read from it yourself until you have finished enumerating
+    /// <see cref="SdCardLogSession.Samples"/>. A seekable stream is re-read from its starting
+    /// position on each enumeration, and only one enumeration may be in flight at a time; a
+    /// forward-only stream cannot be re-read, so its contents are decoded up front instead.
+    /// </remarks>
     public static async Task<SdCardLogSession> ParseAsync(
         Stream fileStream,
         string fileName,
@@ -76,6 +83,13 @@ public static class SdCardFileParserFactory
     /// <param name="options">Optional parse options.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    /// <remarks>
+    /// The session reads <paramref name="fileStream"/> lazily: keep the stream open and do not
+    /// read from it yourself until you have finished enumerating
+    /// <see cref="SdCardLogSession.Samples"/>. A seekable stream is re-read from its starting
+    /// position on each enumeration, and only one enumeration may be in flight at a time; a
+    /// forward-only stream cannot be re-read, so its contents are decoded up front instead.
+    /// </remarks>
     public static Task<SdCardLogSession> ParseWithFormatAsync(
         Stream fileStream,
         string fileName,

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParserFactory.cs
@@ -26,26 +26,24 @@ public static class SdCardFileParserFactory
     /// <param name="options">Optional parse options.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
-    public static async Task<SdCardLogSession> ParseFileAsync(
+    /// <remarks>
+    /// The returned session opens its own read of the file each time
+    /// <see cref="SdCardLogSession.Samples"/> is enumerated, so the file must still exist then.
+    /// </remarks>
+    public static Task<SdCardLogSession> ParseFileAsync(
         string filePath,
         SdCardParseOptions? options = null,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(filePath);
 
-        var format = DetectFormat(filePath);
-        var stream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: options?.BufferSize ?? 64 * 1024,
-            useAsync: true);
-
-        await using (stream.ConfigureAwait(false))
+        return DetectFormat(filePath) switch
         {
-            return await ParseWithFormatAsync(stream, Path.GetFileName(filePath), format, options, ct).ConfigureAwait(false);
-        }
+            SdCardLogFormat.Protobuf => new SdCardFileParser().ParseFileAsync(filePath, options, ct),
+            SdCardLogFormat.Json => new SdCardJsonFileParser().ParseFileAsync(filePath, options, ct),
+            SdCardLogFormat.Csv => new SdCardCsvFileParser().ParseFileAsync(filePath, options, ct),
+            var format => throw new ArgumentException($"Unsupported format: {format}", nameof(filePath))
+        };
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -24,6 +24,13 @@ public sealed class SdCardJsonFileParser
     /// <param name="options">Optional parse options.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    /// <remarks>
+    /// The session reads <paramref name="fileStream"/> lazily: keep the stream open and do not
+    /// read from it yourself until you have finished enumerating
+    /// <see cref="SdCardLogSession.Samples"/>. A seekable stream is re-read from its starting
+    /// position on each enumeration, and only one enumeration may be in flight at a time; a
+    /// forward-only stream cannot be re-read, so its contents are decoded up front instead.
+    /// </remarks>
     public async Task<SdCardLogSession> ParseAsync(
         Stream fileStream,
         string fileName,
@@ -48,7 +55,7 @@ public sealed class SdCardJsonFileParser
 
         // A forward-only stream can only be read once, so it has to be read up front.
         // Callers that want the streaming parse hand the parser a seekable stream or a path.
-        var lines = new List<string>();
+        var lines = new List<SdCardLogLine>();
         await foreach (var line in SdCardTextLineReader.ReadLinesAsync(fileStream, ct).ConfigureAwait(false))
         {
             lines.Add(line);
@@ -56,7 +63,7 @@ public sealed class SdCardJsonFileParser
 
         return await BuildSessionAsync(
             _ => SdCardTextLineReader.ToAsyncEnumerable(lines),
-            () => lines.Sum(l => (long)l.Length + 1),
+            () => lines.Count > 0 ? lines[^1].BytesRead : 0,
             fileName,
             options,
             ct).ConfigureAwait(false);
@@ -97,7 +104,7 @@ public sealed class SdCardJsonFileParser
     /// iterator that re-reads the file lazily rather than holding its lines in memory.
     /// </summary>
     private static async Task<SdCardLogSession> BuildSessionAsync(
-        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        Func<CancellationToken, IAsyncEnumerable<SdCardLogLine>> openLines,
         Func<long> totalBytes,
         string fileName,
         SdCardParseOptions options,
@@ -110,7 +117,7 @@ public sealed class SdCardJsonFileParser
         string? firstLine = null;
         await foreach (var line in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
         {
-            firstLine = line;
+            firstLine = line.Text;
             break;
         }
 
@@ -155,7 +162,7 @@ public sealed class SdCardJsonFileParser
     }
 
     private static async IAsyncEnumerable<SdCardLogEntry> ParseJsonLines(
-        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        Func<CancellationToken, IAsyncEnumerable<SdCardLogLine>> openLines,
         Func<long> totalBytesProvider,
         SdCardDeviceConfiguration config,
         DateTime baseTime,
@@ -171,12 +178,13 @@ public sealed class SdCardJsonFileParser
         var bytesRead = 0L;
         var totalBytes = totalBytesProvider();
 
-        await foreach (var line in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
+        await foreach (var entry in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
         {
             ct.ThrowIfCancellationRequested();
 
+            var line = entry.Text;
             linesProcessed++;
-            bytesRead += line.Length + 1;
+            bytesRead = entry.BytesRead;
 
             var parsed = TryParseJsonLine(line);
             if (parsed == null)

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -35,24 +35,86 @@ public sealed class SdCardJsonFileParser
 
         options ??= new SdCardParseOptions();
 
+        var source = SdCardParseSource.TryCreate(fileStream);
+        if (source != null)
+        {
+            return await BuildSessionAsync(
+                token => SdCardTextLineReader.ReadLinesAsync(source, token),
+                () => source.TotalBytes,
+                fileName,
+                options,
+                ct).ConfigureAwait(false);
+        }
+
+        // A forward-only stream can only be read once, so it has to be read up front.
+        // Callers that want the streaming parse hand the parser a seekable stream or a path.
+        var lines = new List<string>();
+        await foreach (var line in SdCardTextLineReader.ReadLinesAsync(fileStream, ct).ConfigureAwait(false))
+        {
+            lines.Add(line);
+        }
+
+        return await BuildSessionAsync(
+            _ => SdCardTextLineReader.ToAsyncEnumerable(lines),
+            () => lines.Sum(l => (long)l.Length + 1),
+            fileName,
+            options,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Parses an SD card JSON log file from a file path.
+    /// </summary>
+    /// <param name="filePath">The path to the JSON log file.</param>
+    /// <param name="options">Optional parse options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
+    /// <remarks>
+    /// The returned session opens its own read of the file each time
+    /// <see cref="SdCardLogSession.Samples"/> is enumerated, so the file must still exist then.
+    /// </remarks>
+    public async Task<SdCardLogSession> ParseFileAsync(
+        string filePath,
+        SdCardParseOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        options ??= new SdCardParseOptions();
+
+        var source = SdCardParseSource.ForFile(filePath, options.BufferSize);
+
+        return await BuildSessionAsync(
+            token => SdCardTextLineReader.ReadLinesAsync(source, token),
+            () => source.TotalBytes,
+            Path.GetFileName(filePath),
+            options,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads the first line to infer the channel layout, then hands the session a sample
+    /// iterator that re-reads the file lazily rather than holding its lines in memory.
+    /// </summary>
+    private static async Task<SdCardLogSession> BuildSessionAsync(
+        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        Func<long> totalBytes,
+        string fileName,
+        SdCardParseOptions options,
+        CancellationToken ct)
+    {
         var fileCreatedDate = options.SessionStartTime
                               ?? SdCardFileListParser.TryParseDateFromLogFileName(fileName);
 
-        // Read all lines into memory (similar to protobuf parser reading all messages)
-        var lines = new List<string>();
-        using (var reader = new StreamReader(fileStream, leaveOpen: true))
+        // Only the first line is needed to infer the layout — JSONL carries no separate header.
+        string? firstLine = null;
+        await foreach (var line in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
         {
-            string? line;
-            while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
-            {
-                if (!string.IsNullOrWhiteSpace(line))
-                {
-                    lines.Add(line);
-                }
-            }
+            firstLine = line;
+            break;
         }
 
-        if (lines.Count == 0)
+        if (firstLine == null)
         {
             // Empty file
             return new SdCardLogSession(
@@ -62,7 +124,7 @@ public sealed class SdCardJsonFileParser
                 EmptySamples());
         }
 
-        var config = InferConfiguration(lines[0], options);
+        var config = InferConfiguration(firstLine, options);
 
         // JSON log lines carry raw tick counts and no frequency of their own, so the file can
         // only ever contribute 0 here; a connected device's frequency is what stands between
@@ -75,10 +137,15 @@ public sealed class SdCardJsonFileParser
         config = config with { TimestampFrequency = timestampFrequency };
 
         var samples = ParseJsonLines(
-            lines,
+            openLines,
+            totalBytes,
             config,
-            fileCreatedDate,
-            options);
+            // Anchored once, here, rather than inside the iterator: a session whose samples can
+            // be enumerated more than once must not shift its timestamps between reads when the
+            // file name carries no date.
+            fileCreatedDate ?? DateTime.UtcNow,
+            options.Progress,
+            ct);
 
         return new SdCardLogSession(fileName, fileCreatedDate, config, samples)
         {
@@ -87,42 +154,14 @@ public sealed class SdCardJsonFileParser
         };
     }
 
-    /// <summary>
-    /// Parses an SD card JSON log file from a file path.
-    /// </summary>
-    /// <param name="filePath">The path to the JSON log file.</param>
-    /// <param name="options">Optional parse options.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>An <see cref="SdCardLogSession"/> providing lazy access to sample data.</returns>
-    public async Task<SdCardLogSession> ParseFileAsync(
-        string filePath,
-        SdCardParseOptions? options = null,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(filePath);
-
-        var fileStream = new FileStream(
-            filePath,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.Read,
-            bufferSize: options?.BufferSize ?? 64 * 1024,
-            useAsync: true);
-
-        await using (fileStream.ConfigureAwait(false))
-        {
-            return await ParseAsync(fileStream, Path.GetFileName(filePath), options, ct).ConfigureAwait(false);
-        }
-    }
-
-#pragma warning disable CS1998 // Async iterator: yield return requires async; method has no real awaits.
     private static async IAsyncEnumerable<SdCardLogEntry> ParseJsonLines(
-        List<string> lines,
+        Func<CancellationToken, IAsyncEnumerable<string>> openLines,
+        Func<long> totalBytesProvider,
         SdCardDeviceConfiguration config,
-        DateTime? fileCreatedDate,
-        SdCardParseOptions options)
+        DateTime baseTime,
+        IProgress<SdCardParseProgress>? progress,
+        [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var baseTime = fileCreatedDate ?? DateTime.UtcNow;
         var timestampFreq = config.TimestampFrequency;
         var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
 
@@ -130,12 +169,12 @@ public sealed class SdCardJsonFileParser
         var elapsedSeconds = 0.0;
         var linesProcessed = 0;
         var bytesRead = 0L;
+        var totalBytes = totalBytesProvider();
 
-        var progress = options.Progress;
-        var totalBytes = lines.Sum(l => l.Length + 1); // +1 for newline
-
-        foreach (var line in lines)
+        await foreach (var line in openLines(ct).WithCancellation(ct).ConfigureAwait(false))
         {
+            ct.ThrowIfCancellationRequested();
+
             linesProcessed++;
             bytesRead += line.Length + 1;
 
@@ -185,7 +224,6 @@ public sealed class SdCardJsonFileParser
         // Final progress report
         progress?.Report(new SdCardParseProgress(bytesRead, totalBytes, linesProcessed));
     }
-#pragma warning restore CS1998
 
     private static (uint timestamp, IReadOnlyList<double> analog, uint digital)? TryParseJsonLine(string line)
     {

--- a/src/Daqifi.Core/Device/SdCard/SdCardLogSession.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardLogSession.cs
@@ -27,6 +27,14 @@ public sealed class SdCardLogSession
     /// <summary>
     /// Gets streaming access to sample data. Samples are produced lazily as the file is read.
     /// </summary>
+    /// <remarks>
+    /// Nothing is decoded until this is enumerated, and the log is re-read from the start on
+    /// each enumeration, so the source must still be readable: a session parsed from a path
+    /// needs the file to still exist, and a session parsed from a stream needs that stream
+    /// still open and left alone. Enumerate a stream-backed session's samples one at a time —
+    /// a stream has a single read position, so a second, overlapping enumeration throws
+    /// rather than silently interleaving reads.
+    /// </remarks>
     public IAsyncEnumerable<SdCardLogEntry> Samples { get; }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardParseOptions.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardParseOptions.cs
@@ -21,7 +21,26 @@ public sealed class SdCardParseOptions
     /// <summary>
     /// Gets or sets an optional progress reporter.
     /// </summary>
+    /// <remarks>
+    /// Progress is reported while <see cref="SdCardLogSession.Samples"/> is being enumerated,
+    /// because that is when the file is actually read.
+    /// </remarks>
     public IProgress<SdCardParseProgress>? Progress { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many leading protobuf messages are examined when looking for the
+    /// device configuration fields (timestamp clock, calibration, port counts) that firmware
+    /// embeds in the log. Default is 512; set to 0 to scan the whole file.
+    /// </summary>
+    /// <remarks>
+    /// Firmware writes these fields in the status message or in the first handful of stream
+    /// messages, so a short look-ahead finds everything a full scan would. The bound is what
+    /// keeps opening a multi-gigabyte log cheap: without it, a log that never states one of
+    /// the fields forces a read of the entire file before the first sample is produced.
+    /// Applies to <c>.bin</c> logs only — the CSV and JSON headers are at the top of the file
+    /// by construction.
+    /// </remarks>
+    public int ConfigurationScanMessageLimit { get; set; } = 512;
 
     /// <summary>
     /// Gets or sets a fallback timestamp frequency (in Hz) to use when no

--- a/src/Daqifi.Core/Device/SdCard/SdCardParseSource.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardParseSource.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Daqifi.Core.Device.SdCard;
@@ -19,6 +20,13 @@ internal sealed class SdCardParseSource
     private readonly long _origin;
     private readonly string? _filePath;
     private readonly int _bufferSize;
+
+    /// <summary>
+    /// 1 while a lease over the caller's stream is outstanding. A caller-supplied stream has a
+    /// single read cursor, so two overlapping reads would silently interleave and hand back
+    /// corrupt samples; refusing the second read turns that into an exception instead.
+    /// </summary>
+    private int _leaseHeld;
 
     private SdCardParseSource(Stream stream)
     {
@@ -69,6 +77,10 @@ internal sealed class SdCardParseSource
     /// is finished; it closes the stream only when the source owns it.
     /// </summary>
     /// <returns>A lease over a readable stream positioned at the start of the source.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// A read of a caller-supplied stream is already in flight. Two reads cannot share one
+    /// cursor, so the samples of a stream-backed session must be enumerated one at a time.
+    /// </exception>
     public Lease Open()
     {
         if (_filePath is not null)
@@ -82,22 +94,45 @@ internal sealed class SdCardParseSource
                 useAsync: true);
 
             TotalBytes = fileStream.CanSeek ? fileStream.Length : -1;
-            return new Lease(fileStream, ownsStream: true);
+            return new Lease(this, fileStream, ownsStream: true);
         }
 
-        _stream!.Position = _origin;
-        return new Lease(_stream, ownsStream: false);
+        if (Interlocked.CompareExchange(ref _leaseHeld, 1, 0) != 0)
+        {
+            throw new InvalidOperationException(
+                "The samples of a log parsed from a Stream are already being read. A stream has a " +
+                "single read position, so its samples cannot be enumerated twice at once; finish " +
+                "(or dispose) the first enumeration first, or parse from a file path, which reads " +
+                "the file independently for each enumeration.");
+        }
+
+        try
+        {
+            _stream!.Position = _origin;
+        }
+        catch
+        {
+            Volatile.Write(ref _leaseHeld, 0);
+            throw;
+        }
+
+        return new Lease(this, _stream, ownsStream: false);
     }
+
+    private void Release() => Volatile.Write(ref _leaseHeld, 0);
 
     /// <summary>
     /// A borrowed read over an <see cref="SdCardParseSource"/>.
     /// </summary>
-    internal readonly struct Lease : IAsyncDisposable
+    internal sealed class Lease : IAsyncDisposable
     {
+        private readonly SdCardParseSource _source;
         private readonly bool _ownsStream;
+        private bool _disposed;
 
-        internal Lease(Stream stream, bool ownsStream)
+        internal Lease(SdCardParseSource source, Stream stream, bool ownsStream)
         {
+            _source = source;
             Stream = stream;
             _ownsStream = ownsStream;
         }
@@ -108,6 +143,23 @@ internal sealed class SdCardParseSource
         public Stream Stream { get; }
 
         /// <inheritdoc />
-        public ValueTask DisposeAsync() => _ownsStream ? Stream.DisposeAsync() : default;
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            if (_ownsStream)
+            {
+                await Stream.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                _source.Release();
+            }
+        }
     }
 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardParseSource.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardParseSource.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// A parse source that can be read from the beginning more than once.
+/// <para>
+/// This is what lets <see cref="SdCardLogSession.Samples"/> stay lazy. The parsers read a
+/// short prefix to work out the device configuration, then hand the session an iterator that
+/// re-reads the source from the start each time it is enumerated — so no more than one read
+/// buffer of the file is ever resident.
+/// </para>
+/// </summary>
+internal sealed class SdCardParseSource
+{
+    private readonly Stream? _stream;
+    private readonly long _origin;
+    private readonly string? _filePath;
+    private readonly int _bufferSize;
+
+    private SdCardParseSource(Stream stream)
+    {
+        _stream = stream;
+        _origin = stream.Position;
+        TotalBytes = stream.Length;
+    }
+
+    private SdCardParseSource(string filePath, int bufferSize)
+    {
+        _filePath = filePath;
+        _bufferSize = bufferSize;
+        TotalBytes = -1;
+    }
+
+    /// <summary>
+    /// Gets the total size of the source in bytes, or <c>-1</c> when it is not yet known
+    /// (a file source learns its length when it is first opened).
+    /// </summary>
+    public long TotalBytes { get; private set; }
+
+    /// <summary>
+    /// Wraps a caller-supplied stream, or returns <c>null</c> when the stream cannot be
+    /// rewound and therefore can only be read once.
+    /// </summary>
+    /// <param name="stream">The stream to wrap.</param>
+    /// <returns>A rewindable source, or <c>null</c> for a forward-only stream.</returns>
+    public static SdCardParseSource? TryCreate(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        return stream.CanSeek ? new SdCardParseSource(stream) : null;
+    }
+
+    /// <summary>
+    /// Creates a source that opens its own <see cref="FileStream"/> on every read.
+    /// </summary>
+    /// <param name="filePath">The path to read.</param>
+    /// <param name="bufferSize">The stream buffer size in bytes.</param>
+    /// <returns>A rewindable source over the file.</returns>
+    public static SdCardParseSource ForFile(string filePath, int bufferSize)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        return new SdCardParseSource(filePath, bufferSize);
+    }
+
+    /// <summary>
+    /// Opens the source positioned at its start. Dispose the returned lease when the read
+    /// is finished; it closes the stream only when the source owns it.
+    /// </summary>
+    /// <returns>A lease over a readable stream positioned at the start of the source.</returns>
+    public Lease Open()
+    {
+        if (_filePath is not null)
+        {
+            var fileStream = new FileStream(
+                _filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                _bufferSize,
+                useAsync: true);
+
+            TotalBytes = fileStream.CanSeek ? fileStream.Length : -1;
+            return new Lease(fileStream, ownsStream: true);
+        }
+
+        _stream!.Position = _origin;
+        return new Lease(_stream, ownsStream: false);
+    }
+
+    /// <summary>
+    /// A borrowed read over an <see cref="SdCardParseSource"/>.
+    /// </summary>
+    internal readonly struct Lease : IAsyncDisposable
+    {
+        private readonly bool _ownsStream;
+
+        internal Lease(Stream stream, bool ownsStream)
+        {
+            Stream = stream;
+            _ownsStream = ownsStream;
+        }
+
+        /// <summary>
+        /// Gets the readable stream, positioned at the start of the source.
+        /// </summary>
+        public Stream Stream { get; }
+
+        /// <inheritdoc />
+        public ValueTask DisposeAsync() => _ownsStream ? Stream.DisposeAsync() : default;
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardTextLineReader.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTextLineReader.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Streams the non-blank lines of a text log, one at a time, without holding the file in memory.
+/// </summary>
+internal static class SdCardTextLineReader
+{
+    /// <summary>
+    /// Reads the non-blank lines of the source, re-opening it from the start on each enumeration.
+    /// </summary>
+    /// <param name="source">The rewindable source to read.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The file's non-blank lines, in order.</returns>
+    public static async IAsyncEnumerable<string> ReadLinesAsync(
+        SdCardParseSource source,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var lease = source.Open();
+        await using (lease.ConfigureAwait(false))
+        {
+            await foreach (var line in ReadLinesAsync(lease.Stream, ct).ConfigureAwait(false))
+            {
+                yield return line;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the non-blank lines of a stream from its current position.
+    /// </summary>
+    /// <param name="stream">The stream to read. It is left open.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The stream's non-blank lines, in order.</returns>
+    public static async IAsyncEnumerable<string> ReadLinesAsync(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        using var reader = new StreamReader(stream, leaveOpen: true);
+
+        string? line;
+        while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                yield return line;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Presents an already-materialized sequence as an async sequence, so the streaming and
+    /// forward-only-stream code paths can share one sample producer.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="items">The materialized items.</param>
+    /// <returns>The same items, as an async sequence.</returns>
+#pragma warning disable CS1998 // Async iterator: yield return requires async; nothing here awaits.
+    public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+#pragma warning restore CS1998
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardTextLineReader.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTextLineReader.cs
@@ -7,6 +7,18 @@ using System.Threading.Tasks;
 namespace Daqifi.Core.Device.SdCard;
 
 /// <summary>
+/// A non-blank line of a text log, together with how far into the file reading it has got.
+/// </summary>
+/// <param name="Text">The line, without its terminator.</param>
+/// <param name="BytesRead">
+/// Bytes consumed from the source so far. For a seekable source this is the stream's real
+/// position, which advances a read buffer at a time and lands exactly on the file length at the
+/// end; for a source that has already been read into memory it is the running total of the line
+/// lengths, which is the same figure the parsers reported before they became lazy.
+/// </param>
+internal readonly record struct SdCardLogLine(string Text, long BytesRead);
+
+/// <summary>
 /// Streams the non-blank lines of a text log, one at a time, without holding the file in memory.
 /// </summary>
 internal static class SdCardTextLineReader
@@ -17,7 +29,7 @@ internal static class SdCardTextLineReader
     /// <param name="source">The rewindable source to read.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The file's non-blank lines, in order.</returns>
-    public static async IAsyncEnumerable<string> ReadLinesAsync(
+    public static async IAsyncEnumerable<SdCardLogLine> ReadLinesAsync(
         SdCardParseSource source,
         [EnumeratorCancellation] CancellationToken ct)
     {
@@ -37,18 +49,24 @@ internal static class SdCardTextLineReader
     /// <param name="stream">The stream to read. It is left open.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The stream's non-blank lines, in order.</returns>
-    public static async IAsyncEnumerable<string> ReadLinesAsync(
+    public static async IAsyncEnumerable<SdCardLogLine> ReadLinesAsync(
         Stream stream,
         [EnumeratorCancellation] CancellationToken ct)
     {
         using var reader = new StreamReader(stream, leaveOpen: true);
 
+        var seekable = stream.CanSeek;
+        var estimatedBytes = 0L;
+
         string? line;
         while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
         {
+            // +1 for the terminator, matching what the parsers counted before they became lazy.
+            estimatedBytes += line.Length + 1;
+
             if (!string.IsNullOrWhiteSpace(line))
             {
-                yield return line;
+                yield return new SdCardLogLine(line, seekable ? stream.Position : estimatedBytes);
             }
         }
     }


### PR DESCRIPTION
## What was wrong

Opening an SD card log read the **entire file into memory before handing back a single sample** — all three parsers did it, `.bin`, `.csv` and `.json` alike, even though the API advertises "lazy access to sample data". On a 30 MB protobuf log that meant about **940 MB of live objects** and a **1.1 second wait** before the first sample appeared. Anyone recording for an hour at a few hundred hertz ends up with a file large enough that the parse runs the process out of memory before it emits anything, and there is no way for a caller to work around it.

## How it was fixed

Each parser now reads a short prefix of the file to work out the device configuration, then streams the rest as the caller consumes samples, re-opening the file from the start on each enumeration. Peak memory is one read buffer, whatever the file size.

Two things a reviewer should push back on if they disagree:

- **The configuration scan is now bounded** to the first 512 protobuf messages (`SdCardParseOptions.ConfigurationScanMessageLimit`, set to 0 for the old whole-file behaviour). Firmware states these fields in the status message or the first few stream messages; without a bound, a log that never states one field forces a full read before the first sample, which is the thing being fixed.
- **The stream you hand `ParseAsync` must stay open until you have finished enumerating `Samples`.** Both in-tree callers (the MCP CSV export and the example CLI) already do this, and the `ParseFileAsync` overloads manage their own file handles. A forward-only stream — a pipe or socket — cannot be re-read, so it still falls back to the old decode-up-front behaviour rather than failing.

One incidental fix came out of this: when a log's file name carries no date, the timestamp anchor was `DateTime.UtcNow` read *inside* the iterator, so enumerating the same session twice produced different timestamps. It is now captured once, at parse time.

## Verification

- Full suite green on net9 and net10 (3060 passed / 2 skipped, plus 86 MCP tests), 0 warnings. The 408 existing SD card tests pass **unchanged** — no test edits were needed, which is the equivalence check. 17 new tests cover the streaming contract: first sample without reading the file, re-enumeration, the forward-only fallback, the scan bound, and `ParseFileAsync` on all three formats plus the factory.
- **Measured, 30 MB `.bin`, this branch vs `main`:** peak RSS 988 MB → **64 MB**; first sample 1101 ms → **21 ms**; full parse 1355 ms → **543 ms**; identical 715,967 samples. A **300 MB** log now parses in 65 MB RSS and 3.2 s — on `main` it would need roughly 9 GB.
- Same comparison on 10 MB `.csv` and 12 MB `.json`: RSS 108 MB → 61 MB and 112 MB → 64 MB, CSV export **byte-identical** in both cases.
- **Bench (real Nyquist 1, fw 3.7.2, non-destructive):** captured a live 8 s stream at 200 Hz over USB (25,379 bytes of real firmware protobuf, 1,269 samples), then exported it to CSV through the old and the new parser — **byte-identical, 44,458 bytes**. `SD:GET` on this unit currently returns empty transfers (known firmware issue #703), so the real-bytes check was done on a live capture instead of a downloaded log.

closes #489

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)