### PR TITLE
chore(device): one connected-guard instead of fifty copies of it

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -1,0 +1,193 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Internal;
+using Daqifi.Core.Device.SdCard;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.Internal;
+
+/// <summary>
+/// Unit tests for <see cref="ConnectionGuard"/>, the single up-front connectivity guard that
+/// replaced fifty hand-rolled <c>if (!IsConnected) { throw ... }</c> blocks (#482).
+/// </summary>
+/// <remarks>
+/// <para>
+/// That each individual operation still refuses a disconnected device is already pinned across the
+/// suite — <c>DeviceNotConnectedExceptionTests</c>, <c>DaqifiStreamingDeviceTests</c>,
+/// <c>SdCardOperationsTests</c> and the rest — and none of those were touched. They are the
+/// evidence the replacement changed nothing, so they are not repeated here.
+/// </para>
+/// <para>
+/// These pin the part the call sites now delegate: the exception the guard throws, and the order it
+/// checks connectivity against cancellation. The ordering matters because a caller that cancels a
+/// request against a device that has also gone away should be told the device went away — that is
+/// what the hand-rolled code did, connectivity first and the token second, and it is the detail a
+/// future edit to the shared helper could silently flip for all fifty sites at once.
+/// </para>
+/// </remarks>
+public class ConnectionGuardTests
+{
+    [Fact]
+    public void EnsureConnected_WhenConnected_DoesNotThrow()
+    {
+        ConnectionGuard.EnsureConnected(isConnected: true);
+    }
+
+    [Fact]
+    public void EnsureConnected_WhenNotConnected_ThrowsWithTheHistoricalMessage()
+    {
+        var ex = Assert.Throws<DeviceNotConnectedException>(
+            () => ConnectionGuard.EnsureConnected(isConnected: false));
+
+        // Byte-for-byte what every hand-rolled guard threw, and still an
+        // InvalidOperationException so pre-existing catch sites keep working.
+        Assert.Equal("Device is not connected.", ex.Message);
+        Assert.False(ex.IsShuttingDown);
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
+    }
+
+    [Fact]
+    public void EnsureConnected_WhenConnectedAndTokenLive_DoesNotThrow()
+    {
+        using var cts = new CancellationTokenSource();
+
+        ConnectionGuard.EnsureConnected(isConnected: true, cts.Token);
+    }
+
+    [Fact]
+    public void EnsureConnected_WhenConnectedAndTokenAlreadyCancelled_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(
+            () => ConnectionGuard.EnsureConnected(isConnected: true, cts.Token));
+    }
+
+    [Fact]
+    public void EnsureConnected_WhenNotConnectedAndTokenAlreadyCancelled_ReportsTheDisconnect()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Connectivity is checked first, exactly as the hand-rolled blocks did: the guard came
+        // before the ThrowIfCancellationRequested that followed it.
+        Assert.Throws<DeviceNotConnectedException>(
+            () => ConnectionGuard.EnsureConnected(isConnected: false, cts.Token));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EnsureConnected_OnAnOperationHost_ReadsIsConnectedAndNothingElse(bool isConnected)
+    {
+        // The fake throws on every other member, so a guard that started reaching for the
+        // transport, the channels lock or device I/O would fail loudly here.
+        var host = new GuardOnlyOperationHost { IsConnected = isConnected };
+
+        if (isConnected)
+        {
+            host.EnsureConnected();
+            host.EnsureConnected(CancellationToken.None);
+        }
+        else
+        {
+            Assert.Throws<DeviceNotConnectedException>(() => host.EnsureConnected());
+            Assert.Throws<DeviceNotConnectedException>(() => host.EnsureConnected(CancellationToken.None));
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EnsureConnected_OnATextExchangeHost_ReadsIsConnectedAndNothingElse(bool isConnected)
+    {
+        var host = new GuardOnlyTextExchangeHost { IsConnected = isConnected };
+
+        if (isConnected)
+        {
+            host.EnsureConnected();
+            host.EnsureConnected(CancellationToken.None);
+        }
+        else
+        {
+            Assert.Throws<DeviceNotConnectedException>(() => host.EnsureConnected());
+            Assert.Throws<DeviceNotConnectedException>(() => host.EnsureConnected(CancellationToken.None));
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IDeviceOperationHost"/> that answers <see cref="IsConnected"/> and refuses
+    /// everything else.
+    /// </summary>
+    private sealed class GuardOnlyOperationHost : IDeviceOperationHost
+    {
+        public bool IsConnected { get; set; }
+
+        public bool IsUsbConnection => throw new NotSupportedException();
+        public bool IsStreaming { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public int StreamingFrequency => throw new NotSupportedException();
+        public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
+        public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
+        public DeviceMetadata Metadata => throw new NotSupportedException();
+        public long ChannelStateVersion => throw new NotSupportedException();
+        public void StopStreaming() => throw new NotSupportedException();
+        public void Send<T>(IOutboundMessage<T> message) => throw new NotSupportedException();
+        public void Disconnect() => throw new NotSupportedException();
+        public IReadOnlyList<IChannel> SnapshotChannels() => throw new NotSupportedException();
+        public void WithChannelsLock(Action action) => throw new NotSupportedException();
+        public Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            Action setupAction,
+            int responseTimeoutMs = 1000,
+            int completionTimeoutMs = 250,
+            CancellationToken cancellationToken = default,
+            Func<CancellationToken, Task>? prepareAsync = null,
+            Func<Task>? finalizeAsync = null) => throw new NotSupportedException();
+        public Task<IReadOnlyList<string>> DrainErrorQueueAsync(
+            int maxIterations = 256,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task ExecuteRawCaptureAsync(
+            Func<Stream, CancellationToken, Task> rawAction,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public void EnsureSupported(DeviceFeature feature) => throw new NotSupportedException();
+        public FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
+            => throw new NotSupportedException();
+        public void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => throw new NotSupportedException();
+        public void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e) => throw new NotSupportedException();
+        public void RaiseGapDetected(TimestampGapEventArgs e) => throw new NotSupportedException();
+        public void RaiseRawStreamFrame(DaqifiOutMessage message) => throw new NotSupportedException();
+        public void RaiseStreamDecodeFailure(Exception error) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// An <see cref="ITextExchangeHost"/> that answers <see cref="IsConnected"/> and refuses
+    /// everything else.
+    /// </summary>
+    private sealed class GuardOnlyTextExchangeHost : ITextExchangeHost
+    {
+        public bool IsConnected { get; set; }
+
+        public bool IsShuttingDown => throw new NotSupportedException();
+        public IStreamTransport? Transport => throw new NotSupportedException();
+        public IMessageConsumer<DaqifiOutMessage>? MessageConsumer => throw new NotSupportedException();
+        public bool HoldsOperationLock => throw new NotSupportedException();
+        public bool IsInsideTextExchange { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public ILogger Logger => throw new NotSupportedException();
+        public void AttachInboundHandler(IMessageConsumer<DaqifiOutMessage> consumer) => throw new NotSupportedException();
+        public void DetachInboundHandler(IMessageConsumer<DaqifiOutMessage> consumer) => throw new NotSupportedException();
+        public Task WaitForOperationLockAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public void EnterOperationLockOwnership() => throw new NotSupportedException();
+        public void ExitOperationLockOwnership() => throw new NotSupportedException();
+        public Task DrainOutboundQueueAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public IDisposable SubscribeConsumerErrors(IMessageConsumer<string> consumer) => throw new NotSupportedException();
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -44,6 +44,29 @@ namespace Daqifi.Core.Device
         public bool IsConnected => Status == ConnectionStatus.Connected;
 
         /// <summary>
+        /// Throws <see cref="DeviceNotConnectedException"/> when this device is not connected.
+        /// </summary>
+        /// <remarks>
+        /// The device-side face of <see cref="ConnectionGuard"/>: the operation collaborators run
+        /// the same guard through their host seam (<c>_host.EnsureConnected()</c>), while the few
+        /// guards that live on the device itself go through here. Declared as an instance method
+        /// rather than another <see cref="ConnectionGuard"/> extension so that a call inside this
+        /// class or <see cref="DaqifiStreamingDevice"/> — which also implements the host interfaces
+        /// — binds here unambiguously.
+        /// </remarks>
+        /// <exception cref="DeviceNotConnectedException">The device is not connected.</exception>
+        internal void EnsureConnected() => ConnectionGuard.EnsureConnected(IsConnected);
+
+        /// <summary>
+        /// Throws <see cref="DeviceNotConnectedException"/> when this device is not connected, then
+        /// throws if <paramref name="cancellationToken"/> has already been cancelled.
+        /// </summary>
+        /// <param name="cancellationToken">The caller's cancellation token.</param>
+        /// <exception cref="DeviceNotConnectedException">The device is not connected.</exception>
+        internal void EnsureConnected(CancellationToken cancellationToken)
+            => ConnectionGuard.EnsureConnected(IsConnected, cancellationToken);
+
+        /// <summary>
         /// Gets the device metadata containing part number, firmware version, etc.
         /// </summary>
         public DeviceMetadata Metadata { get; } = new DeviceMetadata();
@@ -2056,10 +2079,7 @@ namespace Daqifi.Core.Device
         /// </exception>
         public virtual void Send<T>(IOutboundMessage<T> message)
         {
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            EnsureConnected();
 
             // Checked before the message can be parked. A null used to fail loudly at the producer;
             // deferred, it would instead fail on a background flush where the exception is logged
@@ -2588,10 +2608,7 @@ namespace Daqifi.Core.Device
         public virtual async Task<CapabilityDocument?> ReadCapabilityDocumentAsync(
             CancellationToken cancellationToken = default)
         {
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            EnsureConnected();
 
             if (!Supports(DeviceFeature.CapabilityDocument))
             {

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -278,10 +278,7 @@ namespace Daqifi.Core.Device
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         public void StartStreaming()
         {
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            EnsureConnected();
 
             if (IsStreaming) return;
 
@@ -311,10 +308,7 @@ namespace Daqifi.Core.Device
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         public void StopStreaming()
         {
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            EnsureConnected();
 
             if (!IsStreaming) return;
 
@@ -954,10 +948,7 @@ namespace Daqifi.Core.Device
             // a disconnected device, not be masked by DeviceNotConnectedException.
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            EnsureConnected();
 
             Send(ScpiMessageProducer.RebootDevice);
 

--- a/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
@@ -38,12 +38,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <inheritdoc />
         public async Task<IReadOnlyList<SystemLogEntry>> GetSystemLogAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.GetSystemLog),
@@ -64,12 +59,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <inheritdoc />
         public async Task ClearSystemLogAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.ClearSystemLog),
@@ -89,12 +79,7 @@ namespace Daqifi.Core.Device.Diagnostics
             // connection state, matching SetAnalogOutput / SetDioDirection.
             var command = ScpiMessageProducer.SetLogLevel(module, level);
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(command),
@@ -121,12 +106,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <inheritdoc />
         public async Task<IReadOnlyList<string>> GetCommandHistoryAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.GetCommandHistory),
@@ -146,12 +126,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <inheritdoc />
         public async Task TestSystemLogAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.TestSystemLog),
@@ -166,12 +141,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <inheritdoc />
         public async Task<int> GetSystemErrorCountAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.GetSystemErrorCount),
@@ -199,12 +169,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <inheritdoc />
         public async Task<StreamStats> GetStreamStatsAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.GetStreamStats),
@@ -224,12 +189,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <inheritdoc />
         public async Task<MemoryDiagnostics> GetMemoryDiagnosticsAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.GetMemoryDiagnostics),

--- a/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
@@ -78,10 +78,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.DisableAllChannels" />
         internal void DisableAllChannels()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             (bool HasChannels, uint Mask) adcMask = default;
             (bool HasChannels, bool AnyEnabled) dioState = default;
@@ -130,10 +127,7 @@ namespace Daqifi.Core.Device.Internal
                 throw new ArgumentOutOfRangeException(nameof(direction), direction, "Direction must be Input or Output.");
             }
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             EnsureChannelBelongs(channel);
             EnsurePwmNotEnabled(channel);
@@ -157,10 +151,7 @@ namespace Daqifi.Core.Device.Internal
                 throw new ArgumentException("A digital output value can only be set on digital channels.", nameof(channel));
             }
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             EnsureChannelBelongs(channel);
             EnsurePwmNotEnabled(channel);
@@ -210,10 +201,7 @@ namespace Daqifi.Core.Device.Internal
                     nameof(channel));
             }
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             EnsureChannelBelongs(channel);
 
@@ -261,10 +249,7 @@ namespace Daqifi.Core.Device.Internal
                     "Duty cycle must be 1-100 percent. To stop the output, use SetPwmEnabled(channel, false).");
             }
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             EnsureChannelBelongs(channel);
 
@@ -286,10 +271,7 @@ namespace Daqifi.Core.Device.Internal
                     $"PWM frequency must be {DaqifiStreamingDevice.MinPwmFrequencyHz}-{DaqifiStreamingDevice.MaxPwmFrequencyHz} Hz.");
             }
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             // Skip the redundant round-trip when the device already has this frequency (from a
             // send earlier this connection). The cache is cleared on disconnect so a fresh
@@ -336,10 +318,7 @@ namespace Daqifi.Core.Device.Internal
                 throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
             }
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             // Analog-output (DAC) channels are addressed by number; they are not part of the
             // populated Channels collection (PopulateChannelsFromStatus creates analog *input*
@@ -355,10 +334,7 @@ namespace Daqifi.Core.Device.Internal
         /// </summary>
         private void SetChannelsEnabled(IReadOnlyList<IChannel> channels, bool enabled)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             // Validate everything up front so a bad entry can't leave a partially-applied state.
             foreach (var channel in channels)

--- a/src/Daqifi.Core/Device/Internal/ConnectionGuard.cs
+++ b/src/Daqifi.Core/Device/Internal/ConnectionGuard.cs
@@ -1,0 +1,82 @@
+using System.Threading;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Internal
+{
+    /// <summary>
+    /// The single up-front connectivity guard every device operation runs before it touches the
+    /// wire.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Before this existed the guard was written out by hand — <c>if (!_host.IsConnected) { throw
+    /// new DeviceNotConnectedException(); }</c> — at fifty call sites across nine files, usually
+    /// followed by a <see cref="CancellationToken.ThrowIfCancellationRequested"/>. Identical
+    /// boilerplate is not just noise: it means there is nowhere to change the guard. Enriching the
+    /// message with the device's name, or setting
+    /// <see cref="DeviceNotConnectedException.IsShuttingDown"/> when the device is mid-teardown
+    /// rather than never-connected, would otherwise be a fifty-site edit with fifty chances to miss
+    /// one.
+    /// </para>
+    /// <para>
+    /// The overloads that take a <see cref="CancellationToken"/> fold in the
+    /// <see cref="CancellationToken.ThrowIfCancellationRequested"/> that followed the guard at most
+    /// call sites, in that order: connectivity first, then cancellation, exactly as the hand-rolled
+    /// code did. Sites that did <em>not</em> check the token immediately after the guard call the
+    /// token-less overload, so no call site gains or loses a cancellation check.
+    /// </para>
+    /// </remarks>
+    internal static class ConnectionGuard
+    {
+        /// <summary>
+        /// Throws <see cref="DeviceNotConnectedException"/> when <paramref name="isConnected"/> is
+        /// <c>false</c>.
+        /// </summary>
+        /// <param name="isConnected">The device's current connectivity state.</param>
+        /// <exception cref="DeviceNotConnectedException">The device is not connected.</exception>
+        internal static void EnsureConnected(bool isConnected)
+        {
+            if (!isConnected)
+            {
+                throw new DeviceNotConnectedException();
+            }
+        }
+
+        /// <summary>
+        /// Throws <see cref="DeviceNotConnectedException"/> when <paramref name="isConnected"/> is
+        /// <c>false</c>, then throws <see cref="System.OperationCanceledException"/> if
+        /// <paramref name="cancellationToken"/> has already been cancelled.
+        /// </summary>
+        /// <param name="isConnected">The device's current connectivity state.</param>
+        /// <param name="cancellationToken">The caller's cancellation token.</param>
+        /// <exception cref="DeviceNotConnectedException">The device is not connected.</exception>
+        internal static void EnsureConnected(bool isConnected, CancellationToken cancellationToken)
+        {
+            EnsureConnected(isConnected);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <inheritdoc cref="EnsureConnected(bool)"/>
+        /// <param name="host">The device seam the operation works through.</param>
+        internal static void EnsureConnected(this IDeviceOperationHost host)
+            => EnsureConnected(host.IsConnected);
+
+        /// <inheritdoc cref="EnsureConnected(bool, CancellationToken)"/>
+        /// <param name="host">The device seam the operation works through.</param>
+        /// <param name="cancellationToken">The caller's cancellation token.</param>
+        internal static void EnsureConnected(this IDeviceOperationHost host, CancellationToken cancellationToken)
+            => EnsureConnected(host.IsConnected, cancellationToken);
+
+        /// <inheritdoc cref="EnsureConnected(bool)"/>
+        /// <param name="host">The device seam the text exchange works through.</param>
+        internal static void EnsureConnected(this ITextExchangeHost host)
+            => EnsureConnected(host.IsConnected);
+
+        /// <inheritdoc cref="EnsureConnected(bool, CancellationToken)"/>
+        /// <param name="host">The device seam the text exchange works through.</param>
+        /// <param name="cancellationToken">The caller's cancellation token.</param>
+        internal static void EnsureConnected(this ITextExchangeHost host, CancellationToken cancellationToken)
+            => EnsureConnected(host.IsConnected, cancellationToken);
+    }
+}

--- a/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
@@ -60,12 +60,7 @@ namespace Daqifi.Core.Device.Internal
                     nameof(name));
             }
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             _host.Send(ScpiMessageProducer.SetDeviceName(name));
             _host.Send(ScpiMessageProducer.SaveDeviceName);
@@ -77,10 +72,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.Reboot" />
         internal void Reboot()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.RebootDevice);
 
@@ -92,10 +84,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.SaveAdcCalibration" />
         internal void SaveAdcCalibration()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.SaveAdcCalibration);
         }
@@ -103,10 +92,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.LoadAdcCalibration" />
         internal void LoadAdcCalibration()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.LoadAdcCalibration);
         }
@@ -116,10 +102,7 @@ namespace Daqifi.Core.Device.Internal
         {
             ValidateChannelNumber(channelNumber);
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.SetAdcCalibrationSlope(channelNumber, calM));
         }
@@ -129,10 +112,7 @@ namespace Daqifi.Core.Device.Internal
         {
             ValidateChannelNumber(channelNumber);
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.SetAdcCalibrationOffset(channelNumber, calB));
         }
@@ -140,10 +120,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.SaveFactoryAdcCalibration" />
         internal void SaveFactoryAdcCalibration()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.SaveFactoryAdcCalibration);
         }
@@ -151,10 +128,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.LoadFactoryAdcCalibration" />
         internal void LoadFactoryAdcCalibration()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.LoadFactoryAdcCalibration);
         }
@@ -164,10 +138,7 @@ namespace Daqifi.Core.Device.Internal
         {
             ValidateBank(bank);
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.UseAdcCalibration(bank));
         }
@@ -175,10 +146,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.SaveVoltagePrecision" />
         internal void SaveVoltagePrecision()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.SaveVoltagePrecision);
         }
@@ -186,10 +154,7 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.LoadVoltagePrecision" />
         internal void LoadVoltagePrecision()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.LoadVoltagePrecision);
         }
@@ -274,12 +239,7 @@ namespace Daqifi.Core.Device.Internal
         /// </remarks>
         private async Task SendConfirmedAsync(IOutboundMessage<string> command, CancellationToken cancellationToken)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             await _host.DrainErrorQueueAsync(ErrorQueueDrainCap, cancellationToken).ConfigureAwait(false);
 

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -80,12 +80,7 @@ namespace Daqifi.Core.Device.Internal
             Func<Stream, CancellationToken, Task> rawAction,
             CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             // A capture is a consumer swap, so it obeys the same nesting rule an exchange does: one
             // swap at a time per flow. The lock does not cover this — a nested call runs nested by
@@ -145,10 +140,7 @@ namespace Daqifi.Core.Device.Internal
                         isShuttingDown: true);
                 }
 
-                if (!_host.IsConnected)
-                {
-                    throw new DeviceNotConnectedException();
-                }
+                _host.EnsureConnected();
 
                 var transport = _host.Transport;
                 if (transport == null)
@@ -296,10 +288,7 @@ namespace Daqifi.Core.Device.Internal
                         isShuttingDown: true);
                 }
 
-                if (!_host.IsConnected)
-                {
-                    throw new DeviceNotConnectedException();
-                }
+                _host.EnsureConnected();
 
                 var transport = _host.Transport;
                 if (transport == null)

--- a/src/Daqifi.Core/Device/LanChipInfoOperations.cs
+++ b/src/Daqifi.Core/Device/LanChipInfoOperations.cs
@@ -26,10 +26,7 @@ namespace Daqifi.Core.Device
         /// <inheritdoc />
         public async Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             var lines = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.GetLanChipInfo),

--- a/src/Daqifi.Core/Device/Network/NetworkConfigurationOperations.cs
+++ b/src/Daqifi.Core/Device/Network/NetworkConfigurationOperations.cs
@@ -47,10 +47,7 @@ namespace Daqifi.Core.Device.Network
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             // Stop streaming if active
             if (_host.IsStreaming)
@@ -182,10 +179,7 @@ namespace Daqifi.Core.Device.Network
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             // Re-check right before the state-changing send so a cancellation requested after the
             // entry guard still short-circuits the command (matches the pattern accepted in #324).
@@ -199,10 +193,7 @@ namespace Daqifi.Core.Device.Network
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             // Re-check right before the state-changing send so a cancellation requested after the
             // entry guard still short-circuits the command (matches the pattern accepted in #324).

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -108,10 +108,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         internal void PrepareSdInterface()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             if (_host.IsUsbConnection)
             {
@@ -130,10 +127,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         internal void PrepareLanInterface()
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.DisableStorageSd);
 
@@ -216,10 +210,7 @@ namespace Daqifi.Core.Device.SdCard
         /// </remarks>
         internal async Task<IReadOnlyList<SdCardFileInfo>> GetSdCardFilesAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             EnsureSdFileTransferSupportedOnTransport();
 
@@ -415,10 +406,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <exception cref="SdCardOperationException">Thrown when the device returned a SCPI error or an unparseable response.</exception>
         internal async Task<SdCardStorageInfo> GetSdCardStorageAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             if (_isLoggingToSdCard)
             {
@@ -545,10 +533,7 @@ namespace Daqifi.Core.Device.SdCard
                 throw new ArgumentOutOfRangeException(nameof(bytes), bytes, "Minimum free space cannot be negative.");
             }
 
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             _host.Send(ScpiMessageProducer.SetSdMinFreeSpace(bytes));
         }
@@ -591,10 +576,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
         internal async Task<SdCardLoggingSession> StartSdCardLoggingSessionAsync(string? fileName = null, string? channelMask = null, SdCardLogFormat format = SdCardLogFormat.Protobuf, CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             if (!_host.IsUsbConnection)
             {
@@ -665,12 +647,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
         internal Task StopSdCardLoggingAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
+            _host.EnsureConnected(cancellationToken);
 
             // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
             _host.Send(ScpiMessageProducer.StopStreaming);
@@ -712,10 +689,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
         internal async Task DeleteSdCardFileAsync(string fileName, CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             if (_isLoggingToSdCard)
             {
@@ -794,10 +768,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
         internal Task FormatSdCardAsync(CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             if (_isLoggingToSdCard)
             {
@@ -892,10 +863,7 @@ namespace Daqifi.Core.Device.SdCard
             IProgress<SdCardTransferProgress>? progress = null,
             CancellationToken cancellationToken = default)
         {
-            if (!_host.IsConnected)
-            {
-                throw new DeviceNotConnectedException();
-            }
+            _host.EnsureConnected();
 
             // Over WiFi/TCP this requires firmware >= v3.7.0 (#598/#599); over USB it is always
             // available on SD-capable firmware. Older firmware over WiFi gets a typed


### PR DESCRIPTION
### What was wrong

Nothing was broken for users — this is the kind of thing that bites later. Every device operation in Core starts by checking that the device is actually connected, and that check was copy-pasted by hand at **50 places across 9 files**: the same `if (!IsConnected) throw new DeviceNotConnectedException();`, usually followed by a cancellation check. Because there was no single place the guard lived, any improvement to it — putting the device's name in the message, or distinguishing "you disconnected me" from "you never connected" using the `IsShuttingDown` flag the exception already carries — meant editing 50 sites and hoping none were missed.

### How it was fixed

All 50 now call one internal helper, `EnsureConnected()`. There is one place to change the guard from here on. The exception type, its message and its `IsShuttingDown` value are unchanged at every call site, so nothing a caller can observe is different.

The one thing worth a reviewer's eye: the helper has an overload that takes a `CancellationToken` and folds in the `ThrowIfCancellationRequested()` that followed the guard — connectivity first, cancellation second, exactly as the hand-written code did. Only the **12** sites that actually had that check use it; the other **38** use the token-less overload, so no call site gained or lost a cancellation check. The separate guards that throw with `isShuttingDown: true` were left alone.

Mechanically it is two seams: extension methods on the two host interfaces the operation collaborators work through, plus an instance method on `DaqifiDevice` for the five guards that live on the device itself (an instance method rather than a third extension, so a call inside `DaqifiStreamingDevice` — which implements both host interfaces — binds unambiguously).

### Verification

- **No existing test was edited.** That is the equivalence check: the ~50 guard behaviours are already pinned by `DeviceNotConnectedExceptionTests`, `DaqifiStreamingDeviceTests`, the SD-card and diagnostics suites, and they all still pass untouched.
- 9 new tests (`ConnectionGuardTests`) pin the helper itself: the exception's type/message/`IsShuttingDown`, and that connectivity is reported ahead of cancellation when both apply.
- Full suite green on **net9.0** and **net10.0** — 3104 passed / 2 skipped each, plus 86 Daqifi.Mcp tests. 0 warnings.
- **Bench (real Nyquist, fw 3.7.2, USB, non-destructive):** connect + status, SD storage, SD file list (48 files), and two live streams (100 Hz and 200 Hz, 3 analog channels) — 791 samples in 5 s at 200 Hz, clean stop and disconnect. That exercises the guards in `DaqifiDevice`, `DaqifiStreamingDevice`, `SdCardOperations`, `ChannelControlOperations` and `TextExchangeEngine` against real hardware.

closes #482

*Not merging — opened for your review.*