### PR TITLE
feat(channel): say what a reading means, not just what it measures

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -823,6 +823,39 @@ arrives outside a streaming session is still re-raised via `MessageReceived` but
 samples. `GetChannelsSnapshot()` is used above (rather than the live `Channels` property) because the
 channel list can be repopulated concurrently when a new device status message arrives.
 
+#### Engineering units (`ChannelScaling`)
+
+A raw reading is volts; what the terminal is actually measuring depends on what is wired to it. Give
+an analog channel a `ChannelScaling` and every sample decoded from then on carries the converted
+reading and its unit alongside the volts:
+
+```csharp
+using Daqifi.Core.Channel;
+
+var ai0 = device.GetChannelsSnapshot().First(c => c.Type == ChannelType.Analog && c.ChannelNumber == 0);
+
+// 0-5 V from a 0-100 PSI transducer.
+((IScaledChannel)ai0).Scaling = new ChannelScaling(gain: 20.0, offset: 0.0, unit: "PSI");
+
+ai0.SampleReceived += (sender, e) =>
+{
+    // e.g. "AI0: 49.6 PSI (2.48 V)"
+    Console.WriteLine($"{e.Channel.Name}: {e.Sample.ScaledValue} {e.Sample.Unit} ({e.Sample.Value} V)");
+};
+```
+
+- `Value` is unchanged — the volts the device reported. `ScaledValue` is `Value * Gain + Offset`, and
+  equals `Value` when no scaling is configured, so existing consumers see exactly what they saw before.
+- `Scaling` is immutable and is stamped onto each sample as it is decoded, so reconfiguring a channel
+  never retroactively reinterprets readings that were already taken. Nothing is mutated in place.
+- Reading the device's capability document (which `InitializeAsync` does on connect, firmware v3.5.0+)
+  fills in the device's own unit — `"V"` on a Nyquist — as an identity scaling, so `Unit` is populated
+  before anyone configures anything. It never overwrites a scaling you have set.
+- A configuration whose arithmetic overflows for a particular reading yields the unscaled value for
+  that reading rather than `NaN`/`Infinity`; the decode thread never throws over scaling.
+- `IScaledChannel` is a capability interface — test for it with `if (channel is IScaledChannel scaled)`.
+  Digital channels do not implement it (a pin's 0/1 state has no engineering quantity to convert).
+
 #### Live async stream (`await foreach`)
 
 `StreamSamplesAsync` exposes the same decoded samples as an `IAsyncEnumerable<LiveSample>`, so a

--- a/src/Daqifi.Core.Tests/Channel/AnalogChannelTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/AnalogChannelTests.cs
@@ -518,4 +518,101 @@ public class AnalogChannelTests
         // Assert
         Assert.Equal("Test Channel", result);
     }
+
+    #region Engineering units (#501)
+
+    [Fact]
+    public void Scaling_IsNullUntilSomethingStatesOne()
+    {
+        var channel = new AnalogChannel(0);
+
+        Assert.Null(channel.Scaling);
+        Assert.Null(((IScaledChannel)channel).Unit);
+    }
+
+    [Fact]
+    public void Unit_IsShorthandForTheScalingsUnit()
+    {
+        IScaledChannel channel = new AnalogChannel(0) { Scaling = new ChannelScaling(2.0, 0.0, "PSI") };
+
+        Assert.Equal("PSI", channel.Unit);
+    }
+
+    [Fact]
+    public void SetActiveSample_StampsTheChannelsScalingOntoTheSample()
+    {
+        // The value overload builds the sample itself, so it is the only place that can attach the
+        // scaling — a sample from here has to report engineering units exactly as a decoded one does.
+        var channel = new AnalogChannel(0) { Scaling = new ChannelScaling(gain: 20.0, unit: "PSI") };
+
+        channel.SetActiveSample(2.5, DateTime.UtcNow);
+
+        Assert.Equal(2.5, channel.ActiveSample!.Value);
+        Assert.Equal(50.0, channel.ActiveSample.ScaledValue);
+        Assert.Equal("PSI", channel.ActiveSample.Unit);
+    }
+
+    [Fact]
+    public void SetActiveSample_WithACallerSuppliedSample_LeavesItExactlyAsGiven()
+    {
+        // The counterpart rule: a caller who hands over a whole sample has already said what it
+        // carries, so the channel does not overwrite its scaling.
+        var channel = new AnalogChannel(0) { Scaling = new ChannelScaling(20.0, unit: "PSI") };
+
+        channel.SetActiveSample(new DataSample(DateTime.UtcNow, 2.5));
+
+        Assert.Null(channel.ActiveSample!.Scaling);
+        Assert.Equal(2.5, channel.ActiveSample.ScaledValue);
+    }
+
+    [Fact]
+    public void ReconfiguringScaling_DoesNotReinterpretSamplesAlreadyTaken()
+    {
+        // The reason the scaling travels on the sample rather than being read back off the channel:
+        // a reading taken in volts must not silently become a pressure an hour later.
+        var channel = new AnalogChannel(0) { Scaling = new ChannelScaling(1.0, unit: "V") };
+        channel.SetActiveSample(2.5, DateTime.UtcNow);
+        var before = channel.ActiveSample!;
+
+        channel.Scaling = new ChannelScaling(20.0, unit: "PSI");
+
+        Assert.Equal(2.5, before.ScaledValue);
+        Assert.Equal("V", before.Unit);
+    }
+
+    [Fact]
+    public void Scaling_CanBeClearedBackToNull()
+    {
+        var channel = new AnalogChannel(0) { Scaling = new ChannelScaling(20.0, unit: "PSI") };
+
+        channel.Scaling = null;
+        channel.SetActiveSample(2.5, DateTime.UtcNow);
+
+        Assert.Null(channel.ActiveSample!.Unit);
+        Assert.Equal(2.5, channel.ActiveSample.ScaledValue);
+    }
+
+    [Fact]
+    public void Scaling_SitsAboveTheDeviceCalibration_RatherThanReplacingIt()
+    {
+        // Two conversions, in order: counts -> volts by the device's calibration, volts ->
+        // engineering units by the caller's scaling. Getting this backwards (or collapsing the two)
+        // is the failure this pins.
+        var channel = new AnalogChannel(0, resolution: 65535)
+        {
+            PortRange = 10.0,
+            CalibrationM = 1.0,
+            InternalScaleM = 1.0,
+            CalibrationB = 0.0,
+            Scaling = new ChannelScaling(gain: 20.0, unit: "PSI")
+        };
+
+        var volts = channel.GetScaledValue(32768); // ~5 V
+        channel.SetActiveSample(volts, DateTime.UtcNow);
+
+        Assert.Equal(5.0, channel.ActiveSample!.Value, precision: 2);
+        Assert.Equal(100.0, channel.ActiveSample.ScaledValue, precision: 1);
+    }
+
+    #endregion
 }

--- a/src/Daqifi.Core.Tests/Channel/ChannelScalingTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/ChannelScalingTests.cs
@@ -100,6 +100,10 @@ public class ChannelScalingTests
     [Fact]
     public void Apply_OnANonFiniteInput_ReturnsTheInput()
     {
+        // The other half of the contract, and the half that is easy to overstate: Apply never
+        // *introduces* a non-finite value, but it does not launder one either. A reading that
+        // arrives broken comes back broken rather than being disguised as a real measurement, so a
+        // caller who needs a finite number still has to check for one.
         var scaling = new ChannelScaling(gain: 2.0);
 
         Assert.True(double.IsNaN(scaling.Apply(double.NaN)));

--- a/src/Daqifi.Core.Tests/Channel/ChannelScalingTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/ChannelScalingTests.cs
@@ -1,0 +1,164 @@
+using Daqifi.Core.Channel;
+
+namespace Daqifi.Core.Tests.Channel;
+
+/// <summary>
+/// Unit tests for <see cref="ChannelScaling"/>, the engineering-unit conversion a caller attaches
+/// to a channel (#501).
+/// </summary>
+/// <remarks>
+/// The split of responsibility this file pins: coefficients are validated at <b>construction</b>,
+/// on the caller's thread, where an exception is a usable error message; <see cref="ChannelScaling.Apply"/>
+/// runs on the decode thread and therefore never throws and never emits a non-finite value. Both
+/// halves are needed — the constructor cannot see a value that only overflows for one reading.
+/// </remarks>
+public class ChannelScalingTests
+{
+    [Fact]
+    public void Constructor_KeepsGainAndOffset()
+    {
+        var scaling = new ChannelScaling(gain: 20.0, offset: -1.5, unit: "PSI");
+
+        Assert.Equal(20.0, scaling.Gain);
+        Assert.Equal(-1.5, scaling.Offset);
+        Assert.Equal("PSI", scaling.Unit);
+    }
+
+    [Fact]
+    public void Constructor_WithOnlyAGain_DefaultsOffsetAndUnit()
+    {
+        var scaling = new ChannelScaling(2.0);
+
+        Assert.Equal(0.0, scaling.Offset);
+        Assert.Null(scaling.Unit);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void Constructor_WithNonFiniteGain_Throws(double gain)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ChannelScaling(gain));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void Constructor_WithNonFiniteOffset_Throws(double offset)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ChannelScaling(1.0, offset));
+    }
+
+    [Fact]
+    public void Constructor_WithZeroGain_IsAllowed()
+    {
+        // Degenerate but not an error: a caller who wants a constant is entitled to one, and
+        // rejecting it would be a trap with no safety benefit. Documented on the property.
+        var scaling = new ChannelScaling(gain: 0.0, offset: 7.0);
+
+        Assert.Equal(7.0, scaling.Apply(1234.5));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_WithBlankUnit_NormalizesToNull(string? unit)
+    {
+        // "Not stated" gets exactly one representation, so a consumer never has to test for both
+        // null and "".
+        Assert.Null(new ChannelScaling(1.0, 0.0, unit).Unit);
+    }
+
+    [Fact]
+    public void Constructor_TrimsTheUnit()
+    {
+        Assert.Equal("PSI", new ChannelScaling(1.0, 0.0, "  PSI  ").Unit);
+    }
+
+    [Fact]
+    public void Apply_IsGainThenOffset()
+    {
+        var scaling = new ChannelScaling(gain: 20.0, offset: 3.0);
+
+        Assert.Equal(53.0, scaling.Apply(2.5));
+    }
+
+    [Fact]
+    public void Apply_OnAnOverflowingResult_ReturnsTheUnscaledValue()
+    {
+        // The guarantee that keeps the decode thread honest: a configuration whose arithmetic blows
+        // up for one reading yields that reading unscaled, rather than filling the stream with
+        // Infinity or throwing where nobody can catch it.
+        var scaling = new ChannelScaling(gain: 1e308);
+
+        Assert.Equal(1e10, scaling.Apply(1e10));
+    }
+
+    [Fact]
+    public void Apply_OnANonFiniteInput_ReturnsTheInput()
+    {
+        var scaling = new ChannelScaling(gain: 2.0);
+
+        Assert.True(double.IsNaN(scaling.Apply(double.NaN)));
+        Assert.Equal(double.PositiveInfinity, scaling.Apply(double.PositiveInfinity));
+    }
+
+    [Fact]
+    public void Identity_LeavesValuesAlone_AndStatesNoUnit()
+    {
+        Assert.Equal(4.25, ChannelScaling.Identity.Apply(4.25));
+        Assert.Null(ChannelScaling.Identity.Unit);
+        Assert.True(ChannelScaling.Identity.IsIdentity);
+    }
+
+    [Fact]
+    public void IsIdentity_IgnoresTheUnitLabel()
+    {
+        // A unit is a statement about what the number means, not a transform of it. The capability
+        // document relies on this: it attaches "V" without changing a single reading.
+        Assert.True(new ChannelScaling(1.0, 0.0, "V").IsIdentity);
+        Assert.False(new ChannelScaling(2.0, 0.0, "V").IsIdentity);
+        Assert.False(new ChannelScaling(1.0, 0.5, "V").IsIdentity);
+    }
+
+    [Fact]
+    public void WithUnit_KeepsTheCoefficients()
+    {
+        var scaling = new ChannelScaling(gain: 20.0, offset: 3.0, unit: "V").WithUnit("PSI");
+
+        Assert.Equal(20.0, scaling.Gain);
+        Assert.Equal(3.0, scaling.Offset);
+        Assert.Equal("PSI", scaling.Unit);
+    }
+
+    [Fact]
+    public void WithUnit_WithTheSameUnit_ReturnsTheSameInstance()
+    {
+        // Every capability refresh runs this path over every channel; re-deriving an identical
+        // instance each time would churn allocations for no change.
+        var scaling = new ChannelScaling(1.0, 0.0, "V");
+
+        Assert.Same(scaling, scaling.WithUnit("V"));
+        Assert.Same(scaling, scaling.WithUnit(" V "));
+    }
+
+    [Fact]
+    public void WithUnit_DoesNotMutateTheOriginal()
+    {
+        var original = ChannelScaling.Identity;
+
+        original.WithUnit("PSI");
+
+        Assert.Null(original.Unit);
+    }
+
+    [Fact]
+    public void Equality_IsByValue()
+    {
+        Assert.Equal(new ChannelScaling(2.0, 1.0, "PSI"), new ChannelScaling(2.0, 1.0, "PSI"));
+        Assert.NotEqual(new ChannelScaling(2.0, 1.0, "PSI"), new ChannelScaling(2.0, 1.0, "V"));
+    }
+}

--- a/src/Daqifi.Core.Tests/Channel/DataSampleTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/DataSampleTests.cs
@@ -81,4 +81,83 @@ public class DataSampleTests
         Assert.Contains("12:30:45", result);
         Assert.Contains("42.5", result);
     }
+
+    #region Engineering units (#501)
+
+    [Fact]
+    public void WithNoScaling_ScaledValueIsTheValue_AndThereIsNoUnit()
+    {
+        // The compatibility guarantee: a consumer that never configures scaling sees exactly the
+        // numbers it saw before the feature existed.
+        var sample = new DataSample(DateTime.UtcNow, 2.5);
+
+        Assert.Null(sample.Scaling);
+        Assert.Equal(2.5, sample.ScaledValue);
+        Assert.Null(sample.Unit);
+    }
+
+    [Fact]
+    public void WithScaling_ScaledValueIsConverted_AndValueIsUntouched()
+    {
+        var sample = new DataSample(DateTime.UtcNow, 2.5, rawValue: 512, deviceTimestamp: 7)
+        {
+            Scaling = new ChannelScaling(gain: 20.0, offset: 1.0, unit: "PSI")
+        };
+
+        Assert.Equal(51.0, sample.ScaledValue);
+        Assert.Equal(2.5, sample.Value); // nothing is converted in place
+        Assert.Equal("PSI", sample.Unit);
+        Assert.Equal(512, sample.RawValue);
+    }
+
+    [Fact]
+    public void ScaledValue_TracksALaterValueWrite()
+    {
+        // Derived on read rather than stored at construction. Value still has a setter, and a
+        // ScaledValue frozen at construction would silently disagree with it.
+        var sample = new DataSample(DateTime.UtcNow, 1.0) { Scaling = new ChannelScaling(10.0) };
+
+        sample.Value = 3.0;
+
+        Assert.Equal(30.0, sample.ScaledValue);
+    }
+
+    [Fact]
+    public void ScaledValue_OnAnOverflowingScaling_FallsBackToTheUnscaledValue()
+    {
+        var sample = new DataSample(DateTime.UtcNow, 1e10) { Scaling = new ChannelScaling(1e308) };
+
+        Assert.Equal(1e10, sample.ScaledValue);
+    }
+
+    [Fact]
+    public void AnImplementationPredatingScaling_StillSatisfiesTheInterface()
+    {
+        // What makes this an additive change rather than a breaking one: IDataSample's three new
+        // members are defaulted, so an implementation written before they existed compiles and
+        // reports "no scaling" — which is exactly what it has. This test would not compile if the
+        // members were made abstract.
+        IDataSample sample = new LegacySample(DateTime.UtcNow, 4.0);
+
+        Assert.Null(sample.Scaling);
+        Assert.Equal(4.0, sample.ScaledValue);
+        Assert.Null(sample.Unit);
+    }
+
+    /// <summary>
+    /// An <see cref="IDataSample"/> implementing only the members that existed before #501 — a
+    /// stand-in for a consumer's own type out in the wild.
+    /// </summary>
+    private sealed class LegacySample(DateTime timestamp, double value) : IDataSample
+    {
+        public DateTime Timestamp { get; } = timestamp;
+
+        public double Value { get; set; } = value;
+
+        public int? RawValue => null;
+
+        public uint? DeviceTimestamp => null;
+    }
+
+    #endregion
 }

--- a/src/Daqifi.Core.Tests/Device/Capabilities/CapabilityChannelUnitsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Capabilities/CapabilityChannelUnitsTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Device.Capabilities;
+
+namespace Daqifi.Core.Tests.Device.Capabilities;
+
+/// <summary>
+/// Unit tests for <see cref="CapabilityChannelUnits"/> — the consumer that finally reads the
+/// capability document's per-channel <c>unit</c> and puts it on the channel (#501).
+/// </summary>
+/// <remarks>
+/// Applying it through the device is covered by <c>DaqifiDeviceCapabilityDocumentTests</c>; what
+/// these add is the matching rules, which are only visible here: the kind+id join, and the refusal
+/// to overwrite a conversion the caller configured.
+/// </remarks>
+public class CapabilityChannelUnitsTests
+{
+    [Fact]
+    public void AppliesTheDocumentsUnitAsAnIdentityScaling()
+    {
+        var ai0 = new AnalogChannel(0);
+
+        var applied = CapabilityChannelUnits.Apply(
+            new IChannel[] { ai0 },
+            Document(AnalogInput(0, "V")));
+
+        Assert.Equal(1, applied);
+        Assert.Equal("V", ai0.Scaling!.Unit);
+
+        // An identity scaling: a label, not a transform. Readings must be untouched.
+        Assert.True(ai0.Scaling.IsIdentity);
+        Assert.Equal(2.5, ai0.Scaling.Apply(2.5));
+    }
+
+    [Fact]
+    public void MatchesOnKindAsWellAsId()
+    {
+        // The document numbers analog inputs and digital pins from 0 independently, so an id alone
+        // is ambiguous. A digital-io entry must never hand its unit to the analog channel that
+        // happens to share its number.
+        var ai0 = new AnalogChannel(0);
+
+        var applied = CapabilityChannelUnits.Apply(
+            new IChannel[] { ai0 },
+            Document(new CapabilityChannel { Id = 0, Kind = CapabilityChannelKind.DigitalIo, Unit = "bogus" }));
+
+        Assert.Equal(0, applied);
+        Assert.Null(ai0.Scaling);
+    }
+
+    [Fact]
+    public void MatchesEachChannelToItsOwnEntry()
+    {
+        var ai0 = new AnalogChannel(0);
+        var ai1 = new AnalogChannel(1);
+
+        CapabilityChannelUnits.Apply(
+            new IChannel[] { ai1, ai0 }, // deliberately out of order
+            Document(AnalogInput(0, "V"), AnalogInput(1, "Cel")));
+
+        Assert.Equal("V", ai0.Scaling!.Unit);
+        Assert.Equal("Cel", ai1.Scaling!.Unit);
+    }
+
+    [Fact]
+    public void NeverOverwritesAScalingTheCallerConfigured()
+    {
+        // This runs again on every capability refresh — the MCP layer re-reads the document after
+        // each channel-configuration call — so clobbering here would quietly undo a transducer
+        // conversion minutes after it was set.
+        var configured = new ChannelScaling(gain: 20.0, unit: "PSI");
+        var ai0 = new AnalogChannel(0) { Scaling = configured };
+
+        var applied = CapabilityChannelUnits.Apply(
+            new IChannel[] { ai0 },
+            Document(AnalogInput(0, "V")));
+
+        Assert.Equal(0, applied);
+        Assert.Same(configured, ai0.Scaling);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ADocumentStatingNoUnit_LeavesTheChannelAlone(string? unit)
+    {
+        // "Not stated" must not become a scaling with a null unit — that would then block the next
+        // refresh, which reads a null Scaling as "nothing has claimed this channel yet".
+        var ai0 = new AnalogChannel(0);
+
+        var applied = CapabilityChannelUnits.Apply(new IChannel[] { ai0 }, Document(AnalogInput(0, unit)));
+
+        Assert.Equal(0, applied);
+        Assert.Null(ai0.Scaling);
+    }
+
+    [Fact]
+    public void AChannelTheDocumentDoesNotDescribe_IsLeftAlone()
+    {
+        var ai3 = new AnalogChannel(3);
+
+        Assert.Equal(0, CapabilityChannelUnits.Apply(new IChannel[] { ai3 }, Document(AnalogInput(0, "V"))));
+        Assert.Null(ai3.Scaling);
+    }
+
+    [Fact]
+    public void DigitalChannelsAreSkipped()
+    {
+        var dio0 = new DigitalChannel(0);
+
+        Assert.Equal(0, CapabilityChannelUnits.Apply(new IChannel[] { dio0 }, Document(AnalogInput(0, "V"))));
+    }
+
+    [Fact]
+    public void NullOrEmptyInputs_AreNoOps()
+    {
+        Assert.Equal(0, CapabilityChannelUnits.Apply(null, Document(AnalogInput(0, "V"))));
+        Assert.Equal(0, CapabilityChannelUnits.Apply(new IChannel[] { new AnalogChannel(0) }, null));
+        Assert.Equal(0, CapabilityChannelUnits.Apply(Array.Empty<IChannel>(), Document(AnalogInput(0, "V"))));
+    }
+
+    private static CapabilityDocument Document(params CapabilityChannel[] channels)
+        => new() { SchemaVersion = 2, Channels = new List<CapabilityChannel>(channels) };
+
+    private static CapabilityChannel AnalogInput(int id, string? unit)
+        => new() { Id = id, Kind = CapabilityChannelKind.AnalogInput, Unit = unit };
+}

--- a/src/Daqifi.Core.Tests/Device/Capabilities/DaqifiDeviceCapabilityDocumentTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Capabilities/DaqifiDeviceCapabilityDocumentTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Capabilities;
@@ -212,6 +213,66 @@ public class DaqifiDeviceCapabilityDocumentTests
         {
             Assert.Equal(supported, device.Supports(feature));
         }
+    }
+
+    [Fact]
+    public async Task ReadCapabilityDocumentAsync_GivesAnalogChannelsTheDocumentsUnit()
+    {
+        // The document is the only place the device says what its readings are measured in, and
+        // until #501 nothing read it. On the bench Nq1 every analog input states "V".
+        var device = CreateSupportedDevice();
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage { AnalogInPortNum = 2, DigitalPortNum = 2 });
+        device.Responses[ApiVersionCommand] = ["2"];
+        device.Responses[DocumentCommand] = [CapabilityDocumentSamples.Nyquist1Firmware372];
+
+        await device.ReadCapabilityDocumentAsync();
+
+        var analog = device.GetChannelsSnapshot().OfType<IAnalogChannel>().ToList();
+        Assert.Equal(2, analog.Count);
+        Assert.All(analog, c => Assert.Equal("V", ((IScaledChannel)c).Unit));
+
+        // A unit, not a conversion: readings must be untouched.
+        Assert.All(analog, c => Assert.True(((IScaledChannel)c).Scaling!.IsIdentity));
+
+        // Digital channels have no engineering quantity, so they stay bare.
+        Assert.All(
+            device.GetChannelsSnapshot().Where(c => c.Type == ChannelType.Digital),
+            c => Assert.False(c is IScaledChannel));
+    }
+
+    [Fact]
+    public async Task ReadCapabilityDocumentAsync_DoesNotOverwriteAConfiguredScaling()
+    {
+        // A refresh runs this again — the MCP layer re-reads the document after every
+        // channel-configuration call — so a caller's transducer conversion has to survive it.
+        var device = CreateSupportedDevice();
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage { AnalogInPortNum = 2, DigitalPortNum = 0 });
+        var ai0 = (IScaledChannel)device.GetChannelsSnapshot().OfType<IAnalogChannel>().First();
+        var configured = new ChannelScaling(gain: 20.0, unit: "PSI");
+        ai0.Scaling = configured;
+
+        device.Responses[ApiVersionCommand] = ["2"];
+        device.Responses[DocumentCommand] = [CapabilityDocumentSamples.Nyquist1Firmware372];
+        await device.ReadCapabilityDocumentAsync();
+        await device.ReadCapabilityDocumentAsync();
+
+        Assert.Same(configured, ai0.Scaling);
+    }
+
+    [Fact]
+    public async Task ReadCapabilityDocumentAsync_OnADocumentItDoesNotTrust_LeavesUnitsAlone()
+    {
+        // The units ride on the same "is this document trustworthy" decision as everything else:
+        // a document that was not applied must not have applied half of itself.
+        var device = CreateSupportedDevice();
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage { AnalogInPortNum = 2, DigitalPortNum = 0 });
+        device.Responses[ApiVersionCommand] = ["2"];
+        device.Responses[DocumentCommand] = ["not json"];
+
+        Assert.Null(await device.ReadCapabilityDocumentAsync());
+        Assert.All(
+            device.GetChannelsSnapshot().OfType<IAnalogChannel>(),
+            c => Assert.Null(((IScaledChannel)c).Scaling));
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -498,6 +498,153 @@ public class StreamFrameDecoderTests
 
     #endregion
 
+    #region Engineering units (#501)
+
+    /// <summary>
+    /// The USB path is the one that bypasses <see cref="IAnalogChannel.GetScaledValue"/> entirely —
+    /// the firmware already sent volts — so it is the path an engineering-unit conversion is most
+    /// easily forgotten on.
+    /// </summary>
+    [Fact]
+    public void PreScaledFloatSample_CarriesTheChannelsScaling()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        ai0.Scaling = new ChannelScaling(gain: 20.0, offset: 1.0, unit: "PSI");
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(AnalogFrame(1000, 2.5f));
+
+        var sample = ai0.ActiveSample!;
+        Assert.Equal(2.5, sample.Value, 3);   // the volts the device reported, untouched
+        Assert.Equal(51.0, sample.ScaledValue, 3);
+        Assert.Equal("PSI", sample.Unit);
+    }
+
+    /// <summary>
+    /// The WiFi path, where the calibration conversion runs first. Both conversions must apply, in
+    /// that order.
+    /// </summary>
+    [Fact]
+    public void RawCountSample_IsCalibratedThenScaled()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        ai0.PortRange = 10.0;
+        ai0.Scaling = new ChannelScaling(gain: 2.0, unit: "PSI");
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(RawCountFrame(1000, 32768));
+
+        var sample = ai0.ActiveSample!;
+        var volts = ai0.GetScaledValue(32768);
+        Assert.Equal(volts, sample.Value, 6);
+        Assert.Equal(32768, sample.RawValue);
+        Assert.Equal(volts * 2.0, sample.ScaledValue, 6);
+    }
+
+    [Fact]
+    public void WithNoScalingConfigured_SamplesReportTheirValueUnchanged()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(AnalogFrame(1000, 2.5f));
+
+        Assert.Null(ai0.ActiveSample!.Scaling);
+        Assert.Equal(2.5, ai0.ActiveSample.ScaledValue, 3);
+        Assert.Null(ai0.ActiveSample.Unit);
+    }
+
+    /// <summary>
+    /// Scaling is per channel, and the decoder reads it per channel. One channel's transducer
+    /// conversion leaking onto its neighbours would be the worst kind of silent error.
+    /// </summary>
+    [Fact]
+    public void ScalingIsAppliedPerChannel()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        var ai1 = host.AddAnalog(1, enabled: true);
+        ai0.Scaling = new ChannelScaling(gain: 10.0, unit: "PSI");
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(FullAnalogFrame(1000, 1.0f, 2.0f));
+
+        Assert.Equal(10.0, ai0.ActiveSample!.ScaledValue, 3);
+        Assert.Equal(2.0, ai1.ActiveSample!.ScaledValue, 3);
+        Assert.Null(ai1.ActiveSample.Unit);
+    }
+
+    /// <summary>
+    /// Scaling can be reconfigured at any time, and unlike enablement it does not bump the channel
+    /// state version the decoder's channel cache keys off — so reading it once per cache rebuild
+    /// would leave the change invisible until something else happened to invalidate the cache.
+    /// </summary>
+    [Fact]
+    public void ScalingChangedMidStream_TakesEffectOnTheNextFrame_WithoutAChannelStateChange()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(AnalogFrame(1000, 2.0f));
+        Assert.Equal(2.0, ai0.ActiveSample!.ScaledValue, 3);
+        var versionBefore = host.ChannelStateVersion;
+
+        ai0.Scaling = new ChannelScaling(gain: 100.0, unit: "PSI");
+        decoder.ProcessFrame(AnalogFrame(2000, 2.0f));
+
+        Assert.Equal(versionBefore, host.ChannelStateVersion); // nothing invalidated the cache
+        Assert.Equal(200.0, ai0.ActiveSample!.ScaledValue, 3);
+    }
+
+    /// <summary>
+    /// Decoding runs on the consumer thread, where a throw is a dropped stream. A scaling whose
+    /// arithmetic overflows for a reading has to degrade to that reading, not blow up the frame.
+    /// </summary>
+    [Fact]
+    public void AnOverflowingScaling_DoesNotDisturbTheDecode()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var ai0 = host.AddAnalog(0, enabled: true);
+        ai0.Scaling = new ChannelScaling(gain: 1e308, unit: "PSI");
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        decoder.ProcessFrame(AnalogFrame(1000, 1e10f));
+
+        Assert.Null(host.LastDecodeFailure);
+        Assert.Equal(1e10, ai0.ActiveSample!.ScaledValue, 0);
+    }
+
+    [Fact]
+    public void DigitalSamples_CarryNoScaling()
+    {
+        // A pin's 0/1 state has no engineering quantity to convert, so DigitalChannel deliberately
+        // does not implement IScaledChannel and its samples stay bare.
+        var host = new FakeHost { IsStreaming = true };
+        host.AddAnalog(0, enabled: true);
+        var di0 = host.AddDigital(0, enabled: true);
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, 100);
+
+        var frame = AnalogFrame(1000, 1.0f);
+        frame.DigitalData = ByteString.CopyFrom(0x01);
+        decoder.ProcessFrame(frame);
+
+        Assert.Null(di0.ActiveSample!.Scaling);
+        Assert.Equal(1.0, di0.ActiveSample.ScaledValue);
+    }
+
+    #endregion
+
     #region Helpers
 
     private static ThrowSwitch AttachThrowingSubscriber(IChannel channel)
@@ -517,6 +664,20 @@ public class StreamFrameDecoderTests
     {
         var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
         frame.AnalogInDataFloat.Add(value);
+        return frame;
+    }
+
+    /// <summary>
+    /// A frame carrying raw ADC counts rather than pre-scaled floats — the WiFi firmware's shape,
+    /// which is the branch that runs the per-channel calibration.
+    /// </summary>
+    private static DaqifiOutMessage RawCountFrame(uint timestamp, params int[] counts)
+    {
+        var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+        foreach (var count in counts)
+        {
+            frame.AnalogInData.Add(count);
+        }
         return frame;
     }
 

--- a/src/Daqifi.Core/Channel/AnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogChannel.cs
@@ -3,7 +3,7 @@ namespace Daqifi.Core.Channel;
 /// <summary>
 /// Represents an analog input/output channel with scaling and calibration capabilities.
 /// </summary>
-public class AnalogChannel : IAnalogChannel, IChannelEnablementNotifier
+public class AnalogChannel : IAnalogChannel, IScaledChannel, IChannelEnablementNotifier
 {
     /// <summary>
     /// Smallest <see cref="Resolution"/> (maximum raw count) accepted as a physically plausible ADC
@@ -46,6 +46,7 @@ public class AnalogChannel : IAnalogChannel, IChannelEnablementNotifier
     private double _portRange;
     private uint _resolution;
     private bool _resolutionIsAssumed;
+    private ChannelScaling? _scaling;
 
     /// <summary>
     /// Gets the channel number/index.
@@ -122,6 +123,22 @@ public class AnalogChannel : IAnalogChannel, IChannelEnablementNotifier
                 return _activeSample;
             }
         }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The one piece of channel state read without taking <c>_lock</c>, and the reason is specific:
+    /// a <see cref="ChannelScaling"/> is immutable and stands alone, so a reader either sees the
+    /// whole old instance or the whole new one — there is no torn state to protect and no invariant
+    /// shared with the calibration fields. That matters because the decode path reads this once per
+    /// sample on the USB float path, which otherwise takes no lock at all;
+    /// <see cref="Volatile"/> keeps the publication safe without putting a lock back into the hot
+    /// path.
+    /// </remarks>
+    public ChannelScaling? Scaling
+    {
+        get => Volatile.Read(ref _scaling);
+        set => Volatile.Write(ref _scaling, value);
     }
 
     /// <summary>
@@ -324,9 +341,15 @@ public class AnalogChannel : IAnalogChannel, IChannelEnablementNotifier
     /// </summary>
     /// <param name="value">The raw or scaled value.</param>
     /// <param name="timestamp">The timestamp when the sample was taken.</param>
+    /// <remarks>
+    /// The channel's current <see cref="Scaling"/> is stamped onto the sample, so a value pushed
+    /// through this overload reports engineering units exactly as a decoded one does. The
+    /// <see cref="SetActiveSample(IDataSample)"/> overload does not: a caller who supplies a whole
+    /// sample has already said what it carries.
+    /// </remarks>
     public void SetActiveSample(double value, DateTime timestamp)
     {
-        SetActiveSample(new DataSample(timestamp, value));
+        SetActiveSample(new DataSample(timestamp, value) { Scaling = Scaling });
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Channel/ChannelScaling.cs
+++ b/src/Daqifi.Core/Channel/ChannelScaling.cs
@@ -1,0 +1,118 @@
+namespace Daqifi.Core.Channel;
+
+/// <summary>
+/// A channel's engineering-unit conversion: the linear transform
+/// <c>scaled = value * <see cref="Gain"/> + <see cref="Offset"/></c> and the unit label the result
+/// is expressed in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This sits <em>above</em> the device's own calibration. The decode pipeline turns a raw ADC count
+/// into volts using the per-channel calibration coefficients
+/// (<see cref="IAnalogChannel.GetScaledValue"/>); a <see cref="ChannelScaling"/> then turns those
+/// volts into whatever the transducer wired to the terminal actually measures — 12.4 PSI rather
+/// than 2.48 V. Gain and offset are the user's transducer constants, not the device's.
+/// </para>
+/// <para>
+/// Immutable, and deliberately so: a sample keeps a reference to the scaling that was in force when
+/// it was decoded, so a later reconfiguration cannot silently reinterpret readings that were
+/// already taken. Sharing one instance across every sample of a channel is what keeps this free of
+/// per-sample allocation in the decode path.
+/// </para>
+/// <para>
+/// <see cref="Gain"/> and <see cref="Offset"/> are validated when the instance is constructed —
+/// on the caller's thread, where an exception is a usable error message. <see cref="Apply"/> itself
+/// never throws and never returns a non-finite value: a configuration whose arithmetic overflows
+/// for a particular reading degrades to the unscaled value for that reading rather than poisoning
+/// the stream, because it runs on the decode thread where there is nobody to catch it.
+/// </para>
+/// </remarks>
+public sealed record ChannelScaling
+{
+    /// <summary>
+    /// The no-op transform: gain 1, offset 0, no unit. Useful as a base for
+    /// <see cref="WithUnit"/> when only a unit label is known.
+    /// </summary>
+    public static ChannelScaling Identity { get; } = new(1.0, 0.0);
+
+    /// <summary>
+    /// Gets the multiplier applied to the channel's value. A gain of <c>0</c> is permitted and
+    /// flattens the channel to a constant <see cref="Offset"/>; it is the caller's business, not an
+    /// error.
+    /// </summary>
+    public double Gain { get; }
+
+    /// <summary>Gets the constant added after <see cref="Gain"/> has been applied.</summary>
+    public double Offset { get; }
+
+    /// <summary>
+    /// Gets the unit the scaled value is expressed in (e.g. <c>"V"</c>, <c>"PSI"</c>), or
+    /// <c>null</c> when no unit is known. Blank input is normalized to <c>null</c> so
+    /// "not stated" has exactly one representation.
+    /// </summary>
+    public string? Unit { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this transform leaves values untouched (gain 1, offset 0).
+    /// A unit label alone does not make a scaling non-identity.
+    /// </summary>
+    public bool IsIdentity => Gain == 1.0 && Offset == 0.0;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChannelScaling"/> class.
+    /// </summary>
+    /// <param name="gain">The multiplier applied to the channel's value.</param>
+    /// <param name="offset">The constant added after the gain is applied.</param>
+    /// <param name="unit">The unit the scaled value is expressed in; blank is treated as unstated.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="gain"/> or <paramref name="offset"/> is not finite. A NaN or
+    /// infinite coefficient would make every future reading meaningless, so it is rejected here
+    /// rather than silently discarded per-sample by <see cref="Apply"/>.
+    /// </exception>
+    public ChannelScaling(double gain, double offset = 0.0, string? unit = null)
+    {
+        if (!double.IsFinite(gain))
+        {
+            throw new ArgumentOutOfRangeException(nameof(gain), gain, "Gain must be a finite number.");
+        }
+
+        if (!double.IsFinite(offset))
+        {
+            throw new ArgumentOutOfRangeException(nameof(offset), offset, "Offset must be a finite number.");
+        }
+
+        Gain = gain;
+        Offset = offset;
+        Unit = Normalize(unit);
+    }
+
+    /// <summary>
+    /// Applies the transform to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The channel value to convert, typically volts.</param>
+    /// <returns>
+    /// The converted value, or <paramref name="value"/> unchanged when the conversion would produce
+    /// a non-finite result (an overflow, or an infinite input). Raw values keep flowing rather than
+    /// the stream filling with NaN.
+    /// </returns>
+    public double Apply(double value)
+    {
+        var scaled = value * Gain + Offset;
+        return double.IsFinite(scaled) ? scaled : value;
+    }
+
+    /// <summary>
+    /// Returns a copy of this scaling with a different unit label, leaving
+    /// <see cref="Gain"/> and <see cref="Offset"/> as they are.
+    /// </summary>
+    /// <param name="unit">The unit the scaled value is expressed in; blank is treated as unstated.</param>
+    /// <returns>This instance when the unit is already the requested one; otherwise a new instance.</returns>
+    public ChannelScaling WithUnit(string? unit)
+    {
+        var normalized = Normalize(unit);
+        return normalized == Unit ? this : new ChannelScaling(Gain, Offset, normalized);
+    }
+
+    private static string? Normalize(string? unit)
+        => string.IsNullOrWhiteSpace(unit) ? null : unit.Trim();
+}

--- a/src/Daqifi.Core/Channel/ChannelScaling.cs
+++ b/src/Daqifi.Core/Channel/ChannelScaling.cs
@@ -22,9 +22,11 @@ namespace Daqifi.Core.Channel;
 /// <para>
 /// <see cref="Gain"/> and <see cref="Offset"/> are validated when the instance is constructed —
 /// on the caller's thread, where an exception is a usable error message. <see cref="Apply"/> itself
-/// never throws and never returns a non-finite value: a configuration whose arithmetic overflows
-/// for a particular reading degrades to the unscaled value for that reading rather than poisoning
-/// the stream, because it runs on the decode thread where there is nobody to catch it.
+/// never throws and never <em>introduces</em> a non-finite value: a configuration whose arithmetic
+/// overflows for a particular reading degrades to the unscaled value for that reading rather than
+/// poisoning the stream, because it runs on the decode thread where there is nobody to catch it.
+/// It does not launder one either — a reading that arrives NaN or infinite comes back unchanged, so
+/// a caller who needs a finite number still has to check for one.
 /// </para>
 /// </remarks>
 public sealed record ChannelScaling
@@ -92,8 +94,9 @@ public sealed record ChannelScaling
     /// <param name="value">The channel value to convert, typically volts.</param>
     /// <returns>
     /// The converted value, or <paramref name="value"/> unchanged when the conversion would produce
-    /// a non-finite result (an overflow, or an infinite input). Raw values keep flowing rather than
-    /// the stream filling with NaN.
+    /// a non-finite result — so a finite reading is never turned into NaN or infinity by an
+    /// overflowing coefficient, and a reading that was already non-finite is handed back as it came
+    /// rather than being disguised as a real measurement.
     /// </returns>
     public double Apply(double value)
     {

--- a/src/Daqifi.Core/Channel/DataSample.cs
+++ b/src/Daqifi.Core/Channel/DataSample.cs
@@ -28,6 +28,23 @@ public class DataSample : IDataSample
     public uint? DeviceTimestamp { get; init; }
 
     /// <summary>
+    /// Gets the engineering-unit conversion that was in force on the channel when this sample was
+    /// decoded, or <c>null</c> when the channel had none.
+    /// </summary>
+    public ChannelScaling? Scaling { get; init; }
+
+    /// <summary>
+    /// Gets <see cref="Value"/> converted into engineering units by <see cref="Scaling"/>, or
+    /// <see cref="Value"/> itself when there is no scaling.
+    /// </summary>
+    public double ScaledValue => Scaling is { } scaling ? scaling.Apply(Value) : Value;
+
+    /// <summary>
+    /// Gets the unit <see cref="ScaledValue"/> is expressed in, or <c>null</c> when no unit is known.
+    /// </summary>
+    public string? Unit => Scaling?.Unit;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="DataSample"/> class.
     /// </summary>
     public DataSample()

--- a/src/Daqifi.Core/Channel/IDataSample.cs
+++ b/src/Daqifi.Core/Channel/IDataSample.cs
@@ -31,4 +31,33 @@ public interface IDataSample
     /// stream frame. Unlike <see cref="Timestamp"/> this value is not rollover-adjusted.
     /// </summary>
     uint? DeviceTimestamp { get; }
+
+    /// <summary>
+    /// Gets the engineering-unit conversion that was in force on the channel when this sample was
+    /// decoded, or <c>null</c> when the channel had none. Kept on the sample rather than read back
+    /// from the channel so a later reconfiguration cannot reinterpret a reading that has already
+    /// been taken.
+    /// </summary>
+    /// <remarks>
+    /// Defaulted here so that adding engineering-unit support did not break implementations of this
+    /// interface outside the library: one that predates it reports "no scaling", which is exactly
+    /// what it has.
+    /// </remarks>
+    ChannelScaling? Scaling => null;
+
+    /// <summary>
+    /// Gets <see cref="Value"/> converted into engineering units by <see cref="Scaling"/>, or
+    /// <see cref="Value"/> itself when the channel has no scaling configured.
+    /// </summary>
+    /// <remarks>
+    /// Derived on read rather than stored, so it stays consistent with <see cref="Value"/> even
+    /// though that property has a setter. Nothing is ever mutated in place to produce it.
+    /// </remarks>
+    double ScaledValue => Scaling is { } scaling ? scaling.Apply(Value) : Value;
+
+    /// <summary>
+    /// Gets the unit <see cref="ScaledValue"/> is expressed in (e.g. <c>"V"</c>, <c>"PSI"</c>), or
+    /// <c>null</c> when no unit is known.
+    /// </summary>
+    string? Unit => Scaling?.Unit;
 }

--- a/src/Daqifi.Core/Channel/IScaledChannel.cs
+++ b/src/Daqifi.Core/Channel/IScaledChannel.cs
@@ -1,0 +1,46 @@
+namespace Daqifi.Core.Channel;
+
+/// <summary>
+/// A channel that can convert its readings into engineering units — the seam a caller uses to say
+/// "this terminal has a 0-100 PSI transducer on it" and have every subsequent sample carry the
+/// pressure alongside the volts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately a separate capability interface rather than members on <see cref="IChannel"/> or
+/// <see cref="IAnalogChannel"/>: those are implemented outside this library, and widening them
+/// would break every existing implementation. Test for it the way the rest of the library tests for
+/// optional device capabilities — <c>if (channel is IScaledChannel scaled)</c>.
+/// </para>
+/// <para>
+/// Implemented by <see cref="AnalogChannel"/>. Digital channels deliberately do not implement it:
+/// their samples are a pin's 0/1 state, and there is no engineering quantity to convert.
+/// </para>
+/// </remarks>
+public interface IScaledChannel
+{
+    /// <summary>
+    /// Gets or sets the engineering-unit conversion applied to this channel's samples, or
+    /// <c>null</c> for no conversion and no unit.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set it and every sample decoded from then on carries it; samples already taken keep the
+    /// scaling that was in force when they were decoded, so historical readings are never
+    /// retroactively reinterpreted.
+    /// </para>
+    /// <para>
+    /// Left <c>null</c> until something states a unit. Reading the device's capability document
+    /// (<see cref="Device.DaqifiDevice.ReadCapabilityDocumentAsync"/>) fills in the device-reported
+    /// unit as an identity scaling — a unit label with no arithmetic — and never overwrites a
+    /// scaling a caller has already set.
+    /// </para>
+    /// </remarks>
+    ChannelScaling? Scaling { get; set; }
+
+    /// <summary>
+    /// Gets the unit this channel's scaled samples are expressed in, or <c>null</c> when no unit is
+    /// known. Shorthand for <c>Scaling?.Unit</c>.
+    /// </summary>
+    string? Unit => Scaling?.Unit;
+}

--- a/src/Daqifi.Core/Device/Capabilities/CapabilityChannelUnits.cs
+++ b/src/Daqifi.Core/Device/Capabilities/CapabilityChannelUnits.cs
@@ -1,0 +1,90 @@
+using Daqifi.Core.Channel;
+
+namespace Daqifi.Core.Device.Capabilities;
+
+/// <summary>
+/// Copies the unit each analog input advertises in the capability document onto the matching
+/// channel, so a sample can say what its number means without the caller having to look the unit up
+/// themselves (#501).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The document has carried <see cref="CapabilityChannel.Unit"/> since the parser was written and
+/// nothing ever read it; this is the consumer.
+/// </para>
+/// <para>
+/// The unit arrives as an <em>identity</em> <see cref="ChannelScaling"/> — a label with no
+/// arithmetic — because that is exactly what the device is stating: these readings are volts. A
+/// caller who later configures a transducer conversion replaces the whole scaling, unit included,
+/// which is correct: once volts have become PSI, keeping the device's "V" would be a lie.
+/// </para>
+/// </remarks>
+internal static class CapabilityChannelUnits
+{
+    /// <summary>
+    /// Applies the document's analog-input units to <paramref name="channels"/>.
+    /// </summary>
+    /// <param name="channels">The device's channels, typically a snapshot.</param>
+    /// <param name="document">The parsed capability document.</param>
+    /// <returns>How many channels were given a unit, for logging.</returns>
+    internal static int Apply(IReadOnlyList<IChannel>? channels, CapabilityDocument? document)
+    {
+        if (channels == null || document == null || channels.Count == 0)
+        {
+            return 0;
+        }
+
+        var applied = 0;
+        foreach (var channel in channels)
+        {
+            // Only analog inputs have a unit worth stating, and only a channel that can hold one
+            // can be given one.
+            if (channel is not IAnalogChannel || channel is not IScaledChannel scaled)
+            {
+                continue;
+            }
+
+            // Never overwrite what a caller configured. This runs again on every capability
+            // refresh — the MCP layer re-reads the document after each channel-configuration call —
+            // so clobbering here would quietly undo a transducer conversion minutes after it was
+            // set.
+            if (scaled.Scaling != null)
+            {
+                continue;
+            }
+
+            var unit = FindAnalogInputUnit(document, channel.ChannelNumber);
+            if (unit == null)
+            {
+                continue;
+            }
+
+            scaled.Scaling = ChannelScaling.Identity.WithUnit(unit);
+            applied++;
+        }
+
+        return applied;
+    }
+
+    /// <summary>
+    /// The unit the document states for analog input <paramref name="channelNumber"/>, or
+    /// <c>null</c> when it states none.
+    /// </summary>
+    /// <remarks>
+    /// Matched on <see cref="CapabilityChannel.Kind"/> as well as <see cref="CapabilityChannel.Id"/>
+    /// because the document numbers analog inputs and digital pins from 0 independently, so an id
+    /// alone is ambiguous — the same trap <see cref="SampleRateCap"/> documents.
+    /// </remarks>
+    private static string? FindAnalogInputUnit(CapabilityDocument document, int channelNumber)
+    {
+        foreach (var candidate in document.Channels)
+        {
+            if (candidate.Kind == CapabilityChannelKind.AnalogInput && candidate.Id == channelNumber)
+            {
+                return string.IsNullOrWhiteSpace(candidate.Unit) ? null : candidate.Unit;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -2674,6 +2674,19 @@ namespace Daqifi.Core.Device
             }
 
             Metadata.ApplyCapabilityDocument(document);
+
+            // The document is the only place the device says what its analog readings are measured
+            // in, so this is where a channel learns its unit (#501). Never overwrites a scaling a
+            // caller configured, which matters because this method is re-run on every capability
+            // refresh.
+            var unitsApplied = CapabilityChannelUnits.Apply(GetChannelsSnapshot(), document);
+            if (unitsApplied > 0)
+            {
+                SafeLog(() => _logger.LogDebug(
+                    "[ReadCapabilityDocumentAsync] Applied the document's unit to {ChannelCount} analog channel(s).",
+                    unitsApplied));
+            }
+
             return document;
         }
 

--- a/src/Daqifi.Core/Device/Internal/StreamFrameDecoder.cs
+++ b/src/Daqifi.Core/Device/Internal/StreamFrameDecoder.cs
@@ -569,7 +569,15 @@ namespace Daqifi.Core.Device.Internal
                     raw = rawValue;
                 }
 
-                channel.SetActiveSample(new DataSample(hostTimestamp, scaled, raw, deviceTimestamp));
+                // The engineering-unit conversion, if the caller configured one. Stamped onto the
+                // sample rather than applied to its Value: the volts stay readable next to the
+                // converted reading, and nothing about the sample is mutated after the fact. Read
+                // per sample because scaling can change at any time without a channel-state version
+                // bump, which is what the cached channel array keys off (#501).
+                var scaling = channel is IScaledChannel scaledChannel ? scaledChannel.Scaling : null;
+
+                channel.SetActiveSample(
+                    new DataSample(hostTimestamp, scaled, raw, deviceTimestamp) { Scaling = scaling });
             }
         }
 

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -82,8 +82,11 @@ public sealed record DeviceStatus(
 /// A single channel on a device. <see cref="OutputValue"/> is the last commanded output level
 /// for digital channels; <see cref="PwmCapable"/>/<see cref="PwmEnabled"/> report PWM hardware
 /// support and the last commanded PWM state (all three are null for analog channels).
+/// <see cref="Unit"/> is the engineering unit this channel's readings are expressed in — the
+/// device's own (typically <c>"V"</c>) until a caller configures a transducer conversion, and
+/// <c>null</c> until the capability document has been read.
 /// </summary>
-public sealed record ChannelInfo(int ChannelNumber, string Type, string Name, bool Enabled, string Direction, bool? OutputValue, bool? PwmCapable, bool? PwmEnabled)
+public sealed record ChannelInfo(int ChannelNumber, string Type, string Name, bool Enabled, string Direction, bool? OutputValue, bool? PwmCapable, bool? PwmEnabled, string? Unit = null)
 {
     public static ChannelInfo From(IChannel ch)
     {
@@ -96,7 +99,8 @@ public sealed record ChannelInfo(int ChannelNumber, string Type, string Name, bo
             ch.Direction.ToString(),
             digital?.OutputValue,
             digital?.IsPwmCapable,
-            digital?.IsPwmEnabled);
+            digital?.IsPwmEnabled,
+            (ch as IScaledChannel)?.Unit);
     }
 }
 


### PR DESCRIPTION
## What was wrong

If you wire a 0-100 PSI transducer to an analog terminal, the library gave you back volts and left the conversion to you. It even knew better: the device's capability document states each channel's unit, Core parsed it, and then dropped it on the floor — no consumer ever read it. So anyone who wanted "12.4 PSI" instead of "2.48 V" wrote their own scaling, and the desktop app duly did, mutating each sample in place as it went.

## How it was fixed

An analog channel now takes a `ChannelScaling` — a gain, an offset, and a unit label:

```csharp
((IScaledChannel)ai0).Scaling = new ChannelScaling(gain: 20.0, offset: 0.0, unit: "PSI");
// sample.Value      -> 2.48   (the volts the device reported, unchanged)
// sample.ScaledValue -> 49.6
// sample.Unit        -> "PSI"
```

Every sample decoded from then on carries it. Two decisions a reviewer might want to push on:

- **The scaling travels on the sample, not looked up from the channel.** That is what stops a reconfiguration from retroactively reinterpreting readings that were already taken, and it means nothing is ever mutated in place. It costs one reference per sample — the scaling object is shared, so there is no per-sample allocation.
- **`Value` keeps its old meaning.** The converted number lives on the new `ScaledValue`, which equals `Value` when no scaling is set, so no existing consumer's numbers move.

The whole change is additive: `IScaledChannel` is a new capability interface (`if (channel is IScaledChannel scaled)`) rather than new members on `IChannel`/`IAnalogChannel`, and `IDataSample`'s three new members are defaulted — an implementation written before this existed still compiles and reports "no scaling", which is what it has. There is a test that would stop compiling if that ever stopped being true.

Connecting now also copies the device's own unit onto each analog channel as an *identity* scaling — a label, no arithmetic — and never overwrites a scaling you configured, which matters because the MCP layer re-reads the capability document after every channel-configuration call.

This is Tier 1 of the issue (linear scaling, no new dependency). Tier 2 — expression-based scaling — is deliberately left as the separate decision the issue frames it as.

## Verified

- **+54 tests.** Full suite green on **net9.0 + net10.0**: 3189 passed / 2 skipped each, plus 86 in `Daqifi.Mcp.Tests`, 0 warnings.
- **Bench, real Nyquist (fw 3.7.2, USB, non-destructive — streaming and SCPI only).** All 16 analog channels picked up `Unit="V"` from the device's own capability document on connect, as an identity scaling, with the digital channels correctly left bare. A live channel was then given a 20x + 1 PSI conversion and streamed at 200 Hz: 1,095 samples, `ScaledValue == Value * gain + offset` to 0.00E+00 max deviation on real firmware data (0.0085-0.0110 V → 1.1709-1.2197 PSI), with the volts still readable alongside. Reconfiguring the gain mid-stream took effect on the next frame without any channel-set change, the 778 samples already taken kept their original scaling object, the neighbouring channel stayed on plain volts, and a capability re-read did not clobber the configured conversion.

closes #501

*Not merging — opened for review.*
