### PR TITLE
feat(mcp): an agent can read a measurement, not just configure one

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceLiveStreamTests.cs
@@ -153,6 +153,48 @@ namespace Daqifi.Core.Tests.Device
             }
         }
 
+        // The live stream is reachable through a capability interface (#498) so a consumer holding a
+        // device — the MCP server, or any typed caller of the package — can read data without naming
+        // DaqifiStreamingDevice itself. Enumerating through that reference here is what proves the
+        // members are actually on it: an interface the device satisfied only by coincidence would
+        // still compile against a cast, but not against these calls.
+        [Fact]
+        public async Task LiveStream_IsReachableThroughTheCapabilityInterface()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            var ai0 = AnalogChannel(device, 0);
+            ai0.IsEnabled = true;
+            device.StartStreaming();
+
+            var live = Assert.IsAssignableFrom<ILiveSampleSource>(device);
+
+            await using var e = live.StreamSamplesAsync(CancellationToken.None).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync();
+            device.InvokeStreamMessage(AnalogFrame(1000, 1.5f));
+
+            Assert.True(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+            Assert.Same(ai0, e.Current.Channel);
+            Assert.Equal(1.5, e.Current.Sample.Value);
+        }
+
+        [Fact]
+        public async Task DroppedLiveSampleCount_IsVisibleThroughTheCapabilityInterface()
+        {
+            var device = CreateStreaming(analogCount: 1);
+            AnalogChannel(device, 0).IsEnabled = true;
+            device.StartStreaming();
+
+            ILiveSampleSource live = device;
+
+            await using var e = live.StreamSamplesAsync(CancellationToken.None, bufferCapacity: 2).GetAsyncEnumerator();
+            var moveNext = e.MoveNextAsync();
+            for (uint i = 0; i < 20; i++) device.InvokeStreamMessage(AnalogFrame(1000 + i * 10, i));
+
+            Assert.True(await moveNext.AsTask().WaitAsync(MoveNextTimeout));
+            Assert.Equal(device.DroppedLiveSampleCount, live.DroppedLiveSampleCount);
+            Assert.True(live.DroppedLiveSampleCount > 0);
+        }
+
         #region Helpers
 
         private static LiveStreamDevice CreateStreaming(int analogCount)

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -27,7 +27,7 @@ namespace Daqifi.Core.Device
     /// Represents a DAQiFi device that supports data streaming functionality.
     /// Extends the base DaqifiDevice with streaming-specific operations.
     /// </summary>
-    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost
+    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, ILiveSampleSource, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost
     {
         /// <summary>
         /// Response window allowed for the USB stream-interface command sent during

--- a/src/Daqifi.Core/Device/ILiveSampleSource.cs
+++ b/src/Daqifi.Core/Device/ILiveSampleSource.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Threading;
+using Daqifi.Core.Channel;
+
+#nullable enable
+
+namespace Daqifi.Core.Device
+{
+    /// <summary>
+    /// A device that can hand its decoded samples to a caller as they arrive, as an
+    /// <see cref="IAsyncEnumerable{T}"/> of <see cref="LiveSample"/>. Implemented by
+    /// <see cref="DaqifiStreamingDevice"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A capability interface rather than members on <see cref="IStreamingDevice"/>, matching
+    /// <see cref="SdCard.ISdCardOperations"/>: a caller holding a device asks
+    /// <c>if (device is ILiveSampleSource live)</c> and gets the live stream without casting to a
+    /// concrete class. That is what this interface is for — before it, reading live data required
+    /// naming <see cref="DaqifiStreamingDevice"/> itself, which every typed consumer of the package
+    /// had to do even though nothing about the operation is specific to that class (#498).
+    /// </para>
+    /// <para>
+    /// Not to be confused with <see cref="Logging.Export.ISampleSource"/>, which is the offline
+    /// side: an already-recorded set of samples being replayed into an exporter. This one is the
+    /// live device, and its enumeration ends when the device's connection does.
+    /// </para>
+    /// </remarks>
+    public interface ILiveSampleSource
+    {
+        /// <inheritdoc cref="DaqifiStreamingDevice.DroppedLiveSampleCount"/>
+        long DroppedLiveSampleCount { get; }
+
+        /// <inheritdoc cref="DaqifiStreamingDevice.StreamSamplesAsync"/>
+        IAsyncEnumerable<LiveSample> StreamSamplesAsync(
+            CancellationToken cancellationToken = default,
+            int? bufferCapacity = null);
+    }
+}

--- a/src/Daqifi.Mcp.Tests/LiveDataToolsTests.cs
+++ b/src/Daqifi.Mcp.Tests/LiveDataToolsTests.cs
@@ -458,12 +458,34 @@ public class SampleRowSinkTests
         // the sample that triggered it is not kept, so no half-row rides along behind the budget.
         Assert.False(sink.Add(Sample(ChannelType.Analog, 0, 3.0, T0.AddMilliseconds(2))));
         Assert.True(sink.IsComplete);
+        Assert.True(sink.RowBudgetFilled, "this capture really did end on its budget, and says so");
 
         var rows = sink.Complete();
         Assert.Equal(2, rows.Count);
         Assert.Equal(new double?[] { 1.0 }, rows[0].Values);
         Assert.Equal(new double?[] { 2.0 }, rows[1].Values);
         Assert.Equal(2, sink.SampleCount);
+    }
+
+    // The final flush can bring the row count up to the budget on a capture the budget had nothing
+    // to do with. "Was there more data?" is the sink's state when the capture stopped, not the row
+    // count afterwards — a caller told rowLimitReached on a capture that simply ran out of time
+    // would go back for a continuation that does not exist.
+    [Fact]
+    public void ARowFlushedAfterTheCapture_DoesNotCountAsHavingFilledTheBudget()
+    {
+        var sink = NewSink(maxRows: 2, Key(ChannelType.Analog, 0));
+
+        // Where a window-bounded capture ends: one row closed, one still being filled.
+        sink.Add(Sample(ChannelType.Analog, 0, 1.0, T0));
+        sink.Add(Sample(ChannelType.Analog, 0, 2.0, T0.AddMilliseconds(1)));
+
+        // The flush brings the row count up to the budget all by itself...
+        Assert.Equal(2, sink.Complete().Count);
+        Assert.True(sink.IsComplete);
+
+        // ...but the budget is not why this capture ended, and the caller is not told it was.
+        Assert.False(sink.RowBudgetFilled);
     }
 
     // A capture bounded by time can stop part-way through a tick. That row is real data, one

--- a/src/Daqifi.Mcp.Tests/LiveDataToolsTests.cs
+++ b/src/Daqifi.Mcp.Tests/LiveDataToolsTests.cs
@@ -1,0 +1,520 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Mcp.Tests;
+
+/// <summary>
+/// Contract tests for the live-data tools (#498) — <c>read_channel_values</c> and
+/// <c>capture_samples</c>, the pair that finally lets an agent read a measurement instead of only
+/// configuring one.
+/// </summary>
+/// <remarks>
+/// No device is attached here. What these pin is everything the tools decide around the wire: what
+/// a caller is told when nothing is connected, how a caller's budget is clamped, and — the part
+/// that actually shapes the data — how a stream of per-channel samples becomes the latest value
+/// per channel or a table of timestamp-aligned rows.
+/// </remarks>
+public class LiveDataAgentGuardTests
+{
+    private static DaqifiAgent NewAgent(bool readOnly = false) =>
+        new(new ServerOptions { ReadOnly = readOnly });
+
+    [Fact]
+    public async Task ReadChannelValues_UnknownDevice_PointsAtConnectDevice()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent().ReadChannelValuesAsync("serial:NOPE", 2000, CancellationToken.None));
+        Assert.Contains("connect_device", ex.Message);
+    }
+
+    [Fact]
+    public async Task CaptureSamples_UnknownDevice_PointsAtConnectDevice()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => NewAgent().CaptureSamplesAsync("serial:NOPE", 1000, 500, CancellationToken.None));
+        Assert.Contains("connect_device", ex.Message);
+    }
+
+    // Reading a stream that is already running changes nothing on the device, so --read-only is
+    // not a blanket refusal for these two the way it is for delete_sd_file: the refusal only
+    // applies when the call would have to START the stream, which cannot be known before the
+    // device is in hand. These fail for want of a device, never for want of permission.
+    [Theory]
+    [InlineData("read")]
+    [InlineData("capture")]
+    public async Task LiveTools_InReadOnlyMode_AreNotRefusedBeforeTheDeviceIsEvenKnown(string operation)
+    {
+        var agent = NewAgent(readOnly: true);
+
+        Task Call() => operation == "read"
+            ? agent.ReadChannelValuesAsync("serial:NOPE", 2000, CancellationToken.None)
+            : agent.CaptureSamplesAsync("serial:NOPE", 1000, 500, CancellationToken.None);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(Call);
+        Assert.DoesNotContain("read-only", ex.Message);
+        Assert.Contains("not connected", ex.Message);
+    }
+
+    // The device is streaming already: nothing has to be started, so nothing is refused, and the
+    // caller does not own the stream (it must be left running when the read is done).
+    [Fact]
+    public void StreamAlreadyRunning_IsReadWithoutBeingOwned_EvenInReadOnlyMode()
+    {
+        Assert.False(DaqifiAgent.DecideStreamOwnership(isStreaming: true, readOnly: false));
+        Assert.False(DaqifiAgent.DecideStreamOwnership(isStreaming: true, readOnly: true));
+    }
+
+    [Fact]
+    public void IdleDevice_IsStartedByTheCaller_WhoThenOwnsTheStream()
+    {
+        Assert.True(DaqifiAgent.DecideStreamOwnership(isStreaming: false, readOnly: false));
+    }
+
+    [Fact]
+    public void IdleDeviceInReadOnlyMode_IsRefused_AndSaysWhyItCouldStillWork()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => DaqifiAgent.DecideStreamOwnership(isStreaming: false, readOnly: true));
+
+        Assert.Contains("read-only", ex.Message);
+        Assert.Contains("already running", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(0, DaqifiAgent.MinReadTimeoutMs)]
+    [InlineData(-5, DaqifiAgent.MinReadTimeoutMs)]
+    [InlineData(2000, 2000)]
+    [InlineData(int.MaxValue, DaqifiAgent.MaxReadTimeoutMs)]
+    public void ReadTimeout_IsClampedIntoTheSupportedRange(int requestedMs, int expectedMs)
+    {
+        var window = DaqifiAgent.ClampLiveWindow(
+            requestedMs, DaqifiAgent.MinReadTimeoutMs, DaqifiAgent.MaxReadTimeoutMs);
+        Assert.Equal(expectedMs, window.TotalMilliseconds);
+    }
+
+    [Theory]
+    [InlineData(0, DaqifiAgent.MinCaptureDurationMs)]
+    [InlineData(1000, 1000)]
+    [InlineData(600_000, DaqifiAgent.MaxCaptureDurationMs)]
+    public void CaptureDuration_IsClampedIntoTheSupportedRange(int requestedMs, int expectedMs)
+    {
+        var window = DaqifiAgent.ClampLiveWindow(
+            requestedMs, DaqifiAgent.MinCaptureDurationMs, DaqifiAgent.MaxCaptureDurationMs);
+        Assert.Equal(expectedMs, window.TotalMilliseconds);
+    }
+}
+
+/// <summary>
+/// Tests for the driver that reads Core's live stream into a sink for a bounded window.
+/// </summary>
+public class LiveSampleCaptureTests
+{
+    /// <summary>
+    /// Upper bound on every wait in this file. The drain reads an unbounded stream by design, so a
+    /// regression in its stop conditions would otherwise park the run forever; bounded waits turn
+    /// that into a fast, named failure instead.
+    /// </summary>
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(10);
+
+    // The device stream must not be started until the enumeration is subscribed, or the first
+    // samples of a capture are decoded while nothing is listening. Core subscribes in the
+    // synchronous prefix of its iterator body, which is what makes this orderable at all.
+    [Fact]
+    public async Task DrainAsync_StartsTheStreamOnlyAfterTheEnumerationHasSubscribed()
+    {
+        var order = new List<string>();
+        var samples = Channel.CreateUnbounded<LiveSample>();
+        var stream = Stream(samples.Reader, onSubscribe: () => order.Add("subscribed"));
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0) });
+
+        var drain = LiveSampleCapture.DrainAsync(
+            stream, sink, TimeSpan.FromSeconds(5), () => order.Add("stream started"), CancellationToken.None);
+
+        samples.Writer.TryWrite(Sample(ChannelType.Analog, 0, 1.5));
+        await drain.WaitAsync(Bound);
+
+        Assert.Equal(new[] { "subscribed", "stream started" }, order);
+    }
+
+    [Fact]
+    public async Task DrainAsync_ReturnsAsSoonAsTheSinkIsComplete_WithoutWaitingOutTheWindow()
+    {
+        var samples = Channel.CreateUnbounded<LiveSample>();
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0), Key(ChannelType.Digital, 1) });
+
+        samples.Writer.TryWrite(Sample(ChannelType.Analog, 0, 1.5));
+        samples.Writer.TryWrite(Sample(ChannelType.Digital, 1, 1));
+        samples.Writer.TryWrite(Sample(ChannelType.Analog, 0, 1.6));
+
+        // A window far longer than the test could afford to wait for: completing early is the only
+        // way this returns in time.
+        var outcome = await LiveSampleCapture
+            .DrainAsync(Stream(samples.Reader), sink, TimeSpan.FromMinutes(5), null, CancellationToken.None)
+            .WaitAsync(Bound);
+
+        Assert.Equal(2, outcome.SampleCount);
+        Assert.True(sink.IsComplete);
+    }
+
+    // A capture that has to start the device's stream sees nothing for its first ~100 ms. Timing
+    // the data from the first sample rather than from the call is what stops that wait from being
+    // charged to the device as a lower measured rate — badly, on a short capture.
+    [Fact]
+    public async Task DrainAsync_TimesTheDataSeparatelyFromTheWaitForItToStart()
+    {
+        var samples = Channel.CreateUnbounded<LiveSample>();
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0), Key(ChannelType.Analog, 1) });
+
+        var drain = LiveSampleCapture.DrainAsync(
+            Stream(samples.Reader), sink, TimeSpan.FromSeconds(30), null, CancellationToken.None);
+
+        await Task.Delay(300);
+        samples.Writer.TryWrite(Sample(ChannelType.Analog, 0, 1.0));
+        samples.Writer.TryWrite(Sample(ChannelType.Analog, 1, 2.0));
+
+        var outcome = await drain.WaitAsync(Bound);
+
+        Assert.True(outcome.Elapsed >= TimeSpan.FromMilliseconds(250), $"elapsed was {outcome.Elapsed}");
+        Assert.True(
+            outcome.DataElapsed < outcome.Elapsed - TimeSpan.FromMilliseconds(100),
+            $"the 300 ms wait for the first sample was charged to the data: elapsed {outcome.Elapsed}, data {outcome.DataElapsed}");
+    }
+
+    [Fact]
+    public async Task DrainAsync_WindowElapsesWithNoSamples_ReturnsEmptyRatherThanThrowing()
+    {
+        var samples = Channel.CreateUnbounded<LiveSample>();
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0) });
+
+        var outcome = await LiveSampleCapture
+            .DrainAsync(Stream(samples.Reader), sink, TimeSpan.FromMilliseconds(50), null, CancellationToken.None)
+            .WaitAsync(Bound);
+
+        Assert.Equal(0, outcome.SampleCount);
+        Assert.False(sink.IsComplete);
+    }
+
+    [Fact]
+    public async Task DrainAsync_StreamEnds_ReturnsWhatItHad()
+    {
+        var samples = Channel.CreateUnbounded<LiveSample>();
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0), Key(ChannelType.Analog, 1) });
+
+        samples.Writer.TryWrite(Sample(ChannelType.Analog, 0, 1.5));
+        samples.Writer.Complete();
+
+        var outcome = await LiveSampleCapture
+            .DrainAsync(Stream(samples.Reader), sink, TimeSpan.FromMinutes(5), null, CancellationToken.None)
+            .WaitAsync(Bound);
+
+        Assert.Equal(1, outcome.SampleCount);
+        Assert.False(sink.IsComplete); // AI1 never reported, and the stream is over
+    }
+
+    // The window ending is how a timed capture finishes; the caller's own cancellation is a
+    // different thing and has to reach the caller.
+    [Fact]
+    public async Task DrainAsync_CallerCancels_Propagates()
+    {
+        var samples = Channel.CreateUnbounded<LiveSample>();
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0) });
+        using var cts = new CancellationTokenSource();
+
+        var drain = LiveSampleCapture.DrainAsync(
+            Stream(samples.Reader), sink, TimeSpan.FromMinutes(5), null, cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => drain.WaitAsync(Bound));
+    }
+
+    // A device that drops out mid-capture must not look like a capture that simply ended.
+    [Fact]
+    public async Task DrainAsync_StreamFails_SurfacesTheFailure()
+    {
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0) });
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => LiveSampleCapture
+                .DrainAsync(FailingStream(), sink, TimeSpan.FromMinutes(5), null, CancellationToken.None)
+                .WaitAsync(Bound));
+    }
+
+    // Starting the stream can fail (an unplug between connecting and reading). The enumeration is
+    // already in flight at that point, and disposing an async iterator mid-read throws
+    // NotSupportedException — which would replace the failure the caller needs with a meaningless one.
+    [Fact]
+    public async Task DrainAsync_StartingTheStreamFails_SurfacesThatFailure_NotADisposalOne()
+    {
+        var samples = Channel.CreateUnbounded<LiveSample>();
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0) });
+
+        var ex = await Assert.ThrowsAsync<DeviceNotConnectedException>(
+            () => LiveSampleCapture
+                .DrainAsync(
+                    Stream(samples.Reader),
+                    sink,
+                    TimeSpan.FromMinutes(5),
+                    () => throw new DeviceNotConnectedException(),
+                    CancellationToken.None)
+                .WaitAsync(Bound));
+
+        Assert.IsType<DeviceNotConnectedException>(ex);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /// <summary>
+    /// Stands in for Core's live stream, and deliberately has the same shape: an async iterator
+    /// whose subscription runs in the synchronous prefix of the body, before the first await.
+    /// </summary>
+    private static async IAsyncEnumerable<LiveSample> Stream(
+        ChannelReader<LiveSample> reader,
+        Action? onSubscribe = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        onSubscribe?.Invoke();
+
+        await foreach (var sample in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return sample;
+        }
+    }
+
+    private static async IAsyncEnumerable<LiveSample> FailingStream()
+    {
+        await Task.Yield();
+        throw new DeviceNotConnectedException();
+#pragma warning disable CS0162 // Unreachable: an iterator needs a yield to be one at all.
+        yield break;
+#pragma warning restore CS0162
+    }
+
+    internal static ChannelKey Key(ChannelType type, int number) => new(type, number);
+
+    internal static LiveSample Sample(ChannelType type, int number, double value, DateTime? timestamp = null, uint? deviceTimestamp = null)
+    {
+        IChannel channel = type == ChannelType.Analog
+            ? new AnalogChannel(number)
+            : new DigitalChannel(number);
+
+        return new LiveSample(
+            channel,
+            new DataSample(timestamp ?? new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Local), value, rawValue: null, deviceTimestamp));
+    }
+}
+
+/// <summary>
+/// Tests for the sink behind <c>read_channel_values</c>: the latest sample per channel.
+/// </summary>
+public class LatestValueSinkTests
+{
+    [Fact]
+    public void KeepsTheMostRecentValuePerChannel()
+    {
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0) });
+
+        sink.Add(Sample(ChannelType.Analog, 0, 1.0));
+        sink.Add(Sample(ChannelType.Analog, 0, 2.0));
+
+        Assert.Equal(2.0, sink.Latest(Key(ChannelType.Analog, 0))!.Value);
+    }
+
+    // A device numbers its analog inputs and its digital pins from 0 independently, so a sink keyed
+    // by number alone would have DIO0's 0/1 overwrite AI0's volts.
+    [Fact]
+    public void AnalogAndDigitalChannelsWithTheSameNumber_AreDifferentChannels()
+    {
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0), Key(ChannelType.Digital, 0) });
+
+        sink.Add(Sample(ChannelType.Analog, 0, 4.5));
+        sink.Add(Sample(ChannelType.Digital, 0, 1));
+
+        Assert.Equal(4.5, sink.Latest(Key(ChannelType.Analog, 0))!.Value);
+        Assert.Equal(1, sink.Latest(Key(ChannelType.Digital, 0))!.Value);
+        Assert.Equal(2, sink.ReportedChannelCount);
+    }
+
+    [Fact]
+    public void IsComplete_OnlyOnceEveryExpectedChannelHasReported()
+    {
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0), Key(ChannelType.Analog, 1) });
+
+        sink.Add(Sample(ChannelType.Analog, 0, 1.0));
+        Assert.False(sink.IsComplete);
+
+        sink.Add(Sample(ChannelType.Analog, 1, 1.0));
+        Assert.True(sink.IsComplete);
+    }
+
+    [Fact]
+    public void ChannelNeverReported_ReadsAsNoDataRatherThanZero()
+    {
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0) });
+
+        Assert.Null(sink.Latest(Key(ChannelType.Analog, 0)));
+        Assert.Equal(0, sink.ReportedChannelCount);
+    }
+
+    // Someone enabling a channel while the read runs: it has no slot in the answer the caller
+    // asked for, so it is counted and reported rather than quietly dropped.
+    [Fact]
+    public void SampleForAnUnexpectedChannel_IsCountedNotFiled()
+    {
+        var sink = new LatestValueSink(new[] { Key(ChannelType.Analog, 0) });
+
+        sink.Add(Sample(ChannelType.Analog, 7, 1.0));
+
+        Assert.Equal(1, sink.UnexpectedSampleCount);
+        Assert.Equal(0, sink.ReportedChannelCount);
+        Assert.False(sink.IsComplete);
+    }
+
+    private static ChannelKey Key(ChannelType type, int number) => LiveSampleCaptureTests.Key(type, number);
+
+    private static LiveSample Sample(ChannelType type, int number, double value) =>
+        LiveSampleCaptureTests.Sample(type, number, value);
+}
+
+/// <summary>
+/// Tests for the sink behind <c>capture_samples</c>: per-channel samples grouped into
+/// timestamp-aligned rows.
+/// </summary>
+public class SampleRowSinkTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 13, 12, 0, 0, DateTimeKind.Local);
+
+    [Fact]
+    public void SamplesSharingATimestamp_BecomeOneRowInColumnOrder()
+    {
+        var sink = NewSink(maxRows: 10, Key(ChannelType.Analog, 0), Key(ChannelType.Analog, 1));
+
+        sink.Add(Sample(ChannelType.Analog, 0, 1.0, T0));
+        sink.Add(Sample(ChannelType.Analog, 1, 2.0, T0));
+
+        var rows = sink.Complete();
+        Assert.Single(rows);
+        Assert.Equal(new double?[] { 1.0, 2.0 }, rows[0].Values);
+        Assert.Equal(T0, rows[0].Timestamp);
+        Assert.Equal(2, sink.SampleCount);
+    }
+
+    [Fact]
+    public void ANewTimestamp_StartsANewRow()
+    {
+        var sink = NewSink(maxRows: 10, Key(ChannelType.Analog, 0));
+
+        sink.Add(Sample(ChannelType.Analog, 0, 1.0, T0));
+        sink.Add(Sample(ChannelType.Analog, 0, 2.0, T0.AddMilliseconds(1)));
+
+        var rows = sink.Complete();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(1.0, rows[0].Values[0]);
+        Assert.Equal(2.0, rows[1].Values[0]);
+    }
+
+    // Firmware 3.7.2 hands consecutive frames the same timestamp at high sample rates. Grouping on
+    // the timestamp alone would let the second frame's value overwrite the first's and lose a
+    // sample; a channel reporting twice is itself the signal that a new tick has started.
+    [Fact]
+    public void AChannelReportingTwiceUnderOneTimestamp_StartsANewRowInsteadOfOverwriting()
+    {
+        var sink = NewSink(maxRows: 10, Key(ChannelType.Analog, 0), Key(ChannelType.Analog, 1));
+
+        sink.Add(Sample(ChannelType.Analog, 0, 1.0, T0));
+        sink.Add(Sample(ChannelType.Analog, 1, 2.0, T0));
+        sink.Add(Sample(ChannelType.Analog, 0, 3.0, T0));
+        sink.Add(Sample(ChannelType.Analog, 1, 4.0, T0));
+
+        var rows = sink.Complete();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(new double?[] { 1.0, 2.0 }, rows[0].Values);
+        Assert.Equal(new double?[] { 3.0, 4.0 }, rows[1].Values);
+    }
+
+    [Fact]
+    public void AChannelMissingFromATick_LeavesItsColumnEmptyRatherThanZero()
+    {
+        var sink = NewSink(maxRows: 10, Key(ChannelType.Analog, 0), Key(ChannelType.Analog, 1));
+
+        sink.Add(Sample(ChannelType.Analog, 0, 1.0, T0));
+
+        var rows = sink.Complete();
+        Assert.Single(rows);
+        Assert.Equal(1.0, rows[0].Values[0]);
+        Assert.Null(rows[0].Values[1]);
+    }
+
+    [Fact]
+    public void RowBudgetReached_StopsTheCapture()
+    {
+        var sink = NewSink(maxRows: 2, Key(ChannelType.Analog, 0));
+
+        Assert.True(sink.Add(Sample(ChannelType.Analog, 0, 1.0, T0)));
+        Assert.True(sink.Add(Sample(ChannelType.Analog, 0, 2.0, T0.AddMilliseconds(1))));
+
+        // The third sample closes the second row, which fills the budget: the sink asks to stop and
+        // the sample that triggered it is not kept, so no half-row rides along behind the budget.
+        Assert.False(sink.Add(Sample(ChannelType.Analog, 0, 3.0, T0.AddMilliseconds(2))));
+        Assert.True(sink.IsComplete);
+
+        var rows = sink.Complete();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(new double?[] { 1.0 }, rows[0].Values);
+        Assert.Equal(new double?[] { 2.0 }, rows[1].Values);
+        Assert.Equal(2, sink.SampleCount);
+    }
+
+    // A capture bounded by time can stop part-way through a tick. That row is real data, one
+    // channel short — dropping it would lose a sample the device did send.
+    [Fact]
+    public void Complete_FlushesTheRowStillBeingFilled()
+    {
+        var sink = NewSink(maxRows: 10, Key(ChannelType.Analog, 0), Key(ChannelType.Analog, 1));
+
+        sink.Add(Sample(ChannelType.Analog, 0, 1.0, T0));
+        sink.Add(Sample(ChannelType.Analog, 1, 2.0, T0));
+        sink.Add(Sample(ChannelType.Analog, 0, 3.0, T0.AddMilliseconds(1)));
+
+        var rows = sink.Complete();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(new double?[] { 3.0, null }, rows[1].Values);
+    }
+
+    [Fact]
+    public void SampleForAColumnThatDoesNotExist_IsCountedNotFiled()
+    {
+        var sink = NewSink(maxRows: 10, Key(ChannelType.Analog, 0));
+
+        sink.Add(Sample(ChannelType.Digital, 0, 1, T0));
+
+        Assert.Equal(1, sink.UnexpectedSampleCount);
+        Assert.Empty(sink.Complete());
+    }
+
+    [Fact]
+    public void DeviceTimestamp_IsCarriedOnTheRow()
+    {
+        var sink = NewSink(maxRows: 10, Key(ChannelType.Analog, 0));
+
+        sink.Add(LiveSampleCaptureTests.Sample(ChannelType.Analog, 0, 1.0, T0, deviceTimestamp: 4242u));
+
+        Assert.Equal(4242u, sink.Complete()[0].DeviceTimestamp);
+    }
+
+    [Theory]
+    [InlineData(ChannelType.Analog, 3, "AI3")]
+    [InlineData(ChannelType.Digital, 3, "DIO3")]
+    public void ColumnLabels_NameTheChannelTheWayTheRestOfTheToolsDo(ChannelType type, int number, string expected)
+    {
+        Assert.Equal(expected, Key(type, number).Label);
+    }
+
+    private static SampleRowSink NewSink(int maxRows, params ChannelKey[] columns) => new(columns, maxRows);
+
+    private static ChannelKey Key(ChannelType type, int number) => LiveSampleCaptureTests.Key(type, number);
+
+    private static LiveSample Sample(ChannelType type, int number, double value, DateTime timestamp) =>
+        LiveSampleCaptureTests.Sample(type, number, value, timestamp);
+}

--- a/src/Daqifi.Mcp/Daqifi.Mcp.csproj
+++ b/src/Daqifi.Mcp/Daqifi.Mcp.csproj
@@ -14,7 +14,7 @@
     <ToolCommandName>daqifi-mcp</ToolCommandName>
     <PackageId>Daqifi.Mcp</PackageId>
     <Authors>DAQiFi</Authors>
-    <Description>Model Context Protocol (MCP) server for DAQiFi Nyquist data-acquisition devices. Lets an AI agent discover, connect, configure channels, and run on-device SD-card logging.</Description>
+    <Description>Model Context Protocol (MCP) server for DAQiFi Nyquist data-acquisition devices. Lets an AI agent discover, connect, configure channels, read live measurements, and run on-device SD-card logging.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -89,6 +89,42 @@ public sealed class DaqifiAgent
     internal const int MinDiscoveryTimeoutMs = 1000;
 
     /// <summary>
+    /// Bounds on <c>read_channel_values</c>' wait. The floor covers the one thing a caller cannot
+    /// see coming: a device that is not streaming yet sends nothing for the first
+    /// 85-110 ms after the start command (bench-measured on a Nyquist over USB, firmware 3.7.2,
+    /// six consecutive runs), so a shorter budget expires before the first frame could arrive and
+    /// reports every channel as silent — the same wrong answer <see cref="MinDiscoveryTimeoutMs"/>
+    /// exists to prevent, and it was measured the same way, by watching a 100 ms budget report
+    /// nothing on a healthy device. The ceiling keeps a spot check from holding the device's
+    /// operation lock for half a minute.
+    /// </summary>
+    internal const int MinReadTimeoutMs = 500;
+
+    /// <inheritdoc cref="MinReadTimeoutMs"/>
+    internal const int MaxReadTimeoutMs = 30_000;
+
+    /// <summary>
+    /// Bounds on a <c>capture_samples</c> window. The floor is the same stream-start cost
+    /// <see cref="MinReadTimeoutMs"/> covers: a capture that has to start the stream spends its
+    /// first ~100 ms with nothing arriving, so a window much shorter than this returns an empty
+    /// capture from a working device. A capture holds the device exclusively for its whole duration
+    /// (see <see cref="RunLiveCaptureAsync"/>), so the ceiling is what stops one tool call from
+    /// owning the device indefinitely; an agent wanting more takes several captures.
+    /// </summary>
+    internal const int MinCaptureDurationMs = 250;
+
+    /// <inheritdoc cref="MinCaptureDurationMs"/>
+    internal const int MaxCaptureDurationMs = 60_000;
+
+    /// <summary>
+    /// Ceiling on the rows one capture returns. Every row travels to the agent as JSON, so this is
+    /// a limit on the answer's size rather than on the device: 10,000 rows is a 10-second capture
+    /// at 1 kHz, and past that an agent wants a file (SD logging plus <c>download_sd_file</c>)
+    /// rather than a tool result.
+    /// </summary>
+    internal const int MaxCaptureRows = 10_000;
+
+    /// <summary>
     /// Write buffer for the CSV a download exports. An exported CSV is several times the size of
     /// the log it came from — a row per timestamp, a column per channel — so it is worth more than
     /// the 4 KB a <see cref="FileStream"/> defaults to.
@@ -993,6 +1029,268 @@ public sealed class DaqifiAgent
 
         return trimmed;
     }
+
+    // ------------------------------------------------------------------ live data
+
+    /// <summary>
+    /// Reads the most recent value on every enabled channel. Waits only as long as it has to: the
+    /// read ends as soon as every enabled channel has reported once, and gives up at
+    /// <paramref name="timeoutMs"/>.
+    /// </summary>
+    /// <remarks>
+    /// Attaches to the device's live stream, and starts one only if nothing is streaming yet — in
+    /// which case it stops it again afterwards, leaving the device as it found it. A session the
+    /// caller already had running is never stopped.
+    /// </remarks>
+    public async Task<ChannelReadings> ReadChannelValuesAsync(
+        string deviceId, int timeoutMs, CancellationToken cancellationToken)
+    {
+        var run = await RunLiveCaptureAsync(
+            deviceId,
+            channels => new LatestValueSink(channels),
+            ClampLiveWindow(timeoutMs, MinReadTimeoutMs, MaxReadTimeoutMs),
+            cancellationToken).ConfigureAwait(false);
+
+        var readings = run.Channels.Select(key =>
+        {
+            var sample = run.Sink.Latest(key);
+            return new ChannelReading(
+                key.Label,
+                key.Number,
+                key.Type.ToString(),
+                sample?.Value,
+                sample?.Timestamp,
+                sample?.DeviceTimestamp,
+                sample?.RawValue);
+        }).ToList();
+
+        return new ChannelReadings(
+            deviceId,
+            run.SampleRateHz,
+            run.StartedStream,
+            run.Sink.ReportedChannelCount,
+            Math.Round(run.Outcome.Elapsed.TotalSeconds, 3),
+            run.DroppedSampleCount,
+            run.Sink.UnexpectedSampleCount,
+            readings);
+    }
+
+    /// <summary>
+    /// Captures a bounded block of live data: one row per sample tick, one column per enabled
+    /// channel. Ends at whichever budget runs out first — <paramref name="durationMs"/> or
+    /// <paramref name="maxRows"/>.
+    /// </summary>
+    /// <inheritdoc cref="ReadChannelValuesAsync" path="/remarks"/>
+    public async Task<CaptureResult> CaptureSamplesAsync(
+        string deviceId, int durationMs, int maxRows, CancellationToken cancellationToken)
+    {
+        var rowBudget = Math.Clamp(maxRows, 1, MaxCaptureRows);
+
+        var run = await RunLiveCaptureAsync(
+            deviceId,
+            channels => new SampleRowSink(channels, rowBudget),
+            ClampLiveWindow(durationMs, MinCaptureDurationMs, MaxCaptureDurationMs),
+            cancellationToken).ConfigureAwait(false);
+
+        var rows = run.Sink.Complete();
+
+        return new CaptureResult(
+            deviceId,
+            run.SampleRateHz,
+            run.StartedStream,
+            Math.Round(run.Outcome.Elapsed.TotalSeconds, 3),
+            rows.Count,
+            run.Sink.SampleCount,
+            run.DroppedSampleCount,
+            run.Sink.UnexpectedSampleCount,
+            RateHz(rows.Count, run.Outcome.DataElapsed),
+            RateHz(rows.Count, rows.Count > 1 ? rows[^1].Timestamp - rows[0].Timestamp : TimeSpan.Zero),
+            rows.Count >= rowBudget,
+            run.Channels.Select(c => c.Label).ToList(),
+            rows);
+    }
+
+    /// <summary>
+    /// Rows per second over <paramref name="span"/>, which covers the gaps <i>between</i> the rows —
+    /// hence one interval fewer than there are rows. Zero when there is no span to divide by, which
+    /// is every capture short enough to hold one row or none.
+    /// </summary>
+    private static double RateHz(int rowCount, TimeSpan span) =>
+        rowCount > 1 && span > TimeSpan.Zero ? Math.Round((rowCount - 1) / span.TotalSeconds, 1) : 0;
+
+    /// <summary>Everything one live-data tool call comes back with, all of it decided under the device's lock.</summary>
+    private readonly record struct LiveRun<TSink>(
+        TSink Sink,
+        IReadOnlyList<ChannelKey> Channels,
+        LiveCaptureOutcome Outcome,
+        long DroppedSampleCount,
+        bool StartedStream,
+        int SampleRateHz);
+
+    /// <summary>
+    /// Runs one live-data tool call: takes the device exclusively, decides whether this call has to
+    /// start the stream, builds the sink over the channels that are enabled at that moment, reads
+    /// into it for <paramref name="window"/>, and stops the stream again if it started one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every decision is made <b>inside</b> the exclusive block on purpose. Deciding outside it —
+    /// the obvious shape, since the answers are all readable without the lock — leaves room for
+    /// another tool call to land in between and turn each answer stale: a capture would stop a
+    /// stream someone else had started, or align its columns to a channel set that was
+    /// reconfigured while it waited for the lock.
+    /// </para>
+    /// <para>
+    /// The device is held for the whole capture, which is far longer than the sequences the other
+    /// tools hold it for, and that is the point: a <c>configure_*</c> landing mid-capture would
+    /// change the channel set the rows are aligned to and the data would silently stop meaning what
+    /// its columns say. The budgets that bound a capture are what keep that block bounded.
+    /// </para>
+    /// </remarks>
+    private async Task<LiveRun<TSink>> RunLiveCaptureAsync<TSink>(
+        string deviceId,
+        Func<IReadOnlyList<ChannelKey>, TSink> createSink,
+        TimeSpan window,
+        CancellationToken cancellationToken)
+        where TSink : ILiveSampleSink
+    {
+        var (device, streaming, live) = RequireLiveSamples(deviceId);
+
+        return await device.RunExclusiveAsync(async ct =>
+        {
+            RequireNotLoggingToSdCard(device, deviceId);
+            var startStream = DecideStreamOwnership(streaming.IsStreaming, _options.ReadOnly);
+            var channels = RequireEnabledChannels(device, deviceId);
+            var sink = createSink(channels);
+
+            // A device-wide running total, so what this capture cost is the difference across it.
+            var droppedBefore = live.DroppedLiveSampleCount;
+            try
+            {
+                var outcome = await LiveSampleCapture.DrainAsync(
+                    live.StreamSamplesAsync(),
+                    sink,
+                    window,
+                    startStream ? streaming.StartStreaming : null,
+                    ct).ConfigureAwait(false);
+
+                return new LiveRun<TSink>(
+                    sink,
+                    channels,
+                    outcome,
+                    live.DroppedLiveSampleCount - droppedBefore,
+                    startStream,
+                    streaming.StreamingFrequency);
+            }
+            finally
+            {
+                if (startStream)
+                {
+                    try
+                    {
+                        streaming.StopStreaming();
+                    }
+                    catch (DeviceNotConnectedException)
+                    {
+                        // The device went away mid-capture, which the capture itself is already
+                        // throwing about. Nothing to stop, and that exception is the useful one.
+                    }
+                }
+            }
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves a device id to the three views the live-data tools need, failing when the device
+    /// cannot supply live samples at all. Only the parts that cannot change under a running
+    /// server — a device's identity and what it implements — are settled here; everything about its
+    /// current state is decided under its lock, in <see cref="RunLiveCaptureAsync"/>.
+    /// </summary>
+    private (DaqifiDevice Device, IStreamingDevice Streaming, ILiveSampleSource Live) RequireLiveSamples(string deviceId)
+    {
+        var (device, streaming) = RequireStreaming(deviceId);
+
+        if (device is not ILiveSampleSource live)
+        {
+            throw new InvalidOperationException(
+                $"Device '{deviceId}' does not support reading live samples.");
+        }
+
+        return (device, streaming, live);
+    }
+
+    /// <summary>
+    /// Refuses a live read while the device is recording to its SD card. A card recording routes
+    /// the device's data to the card instead of to this machine, so a capture would wait out its
+    /// whole window and return nothing — and, because a recording also reads as "streaming", it
+    /// would look to the rest of this path like a session someone else had started.
+    /// </summary>
+    private static void RequireNotLoggingToSdCard(DaqifiDevice device, string deviceId)
+    {
+        if (device is ISdCardOperations { IsLoggingToSdCard: true })
+        {
+            throw new InvalidOperationException(
+                $"Device '{deviceId}' is logging to its SD card, which sends the data to the card "
+                + "instead of to this machine, so no live samples arrive here. Call stop_sd_logging "
+                + "first, then read live values or download_sd_file to read what was recorded.");
+        }
+    }
+
+    /// <summary>
+    /// The whole of the live tools' <c>--read-only</c> rule, kept apart from the device so it can be
+    /// tested without one: reading a stream that is already running changes nothing on the device
+    /// and stays available; starting one does not.
+    /// </summary>
+    /// <returns><c>true</c> when the caller must start the stream (and stop it again afterwards).</returns>
+    internal static bool DecideStreamOwnership(bool isStreaming, bool readOnly)
+    {
+        if (isStreaming)
+        {
+            return false;
+        }
+
+        if (readOnly)
+        {
+            throw new InvalidOperationException(
+                "Server is running in --read-only mode and this device is not streaming, so there "
+                + "is nothing to read: starting its stream is a change this mode does not allow. "
+                + "Reading from a stream that is already running is still available.");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The enabled channels a capture reads, analog first and each type in channel order — the
+    /// column order every row is aligned to.
+    /// </summary>
+    private static IReadOnlyList<ChannelKey> RequireEnabledChannels(DaqifiDevice device, string deviceId)
+    {
+        var channels = Snapshot(device)
+            .Where(c => c.IsEnabled)
+            .Select(ChannelKey.For)
+            .OrderBy(k => k.Type == ChannelType.Analog ? 0 : 1)
+            .ThenBy(k => k.Number)
+            .ToList();
+
+        if (channels.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No channels are enabled on '{deviceId}', so the device has nothing to send. "
+                + "Enable at least one with configure_analog_channels or configure_digital_channels.");
+        }
+
+        return channels;
+    }
+
+    /// <summary>
+    /// Clamps a caller-supplied millisecond budget into the range a capture supports. Clamped
+    /// rather than rejected: unlike a sample rate, a budget outside the range still has an obvious
+    /// intent ("as long as you'll give me"), and the result reports the duration actually used.
+    /// Internal for testing.
+    /// </summary>
+    internal static TimeSpan ClampLiveWindow(int milliseconds, int minimum, int maximum) =>
+        TimeSpan.FromMilliseconds(Math.Clamp(milliseconds, minimum, maximum));
 
     // ------------------------------------------------------------------ shutdown
 

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -1105,7 +1105,7 @@ public sealed class DaqifiAgent
             run.Sink.UnexpectedSampleCount,
             RateHz(rows.Count, run.Outcome.DataElapsed),
             RateHz(rows.Count, rows.Count > 1 ? rows[^1].Timestamp - rows[0].Timestamp : TimeSpan.Zero),
-            rows.Count >= rowBudget,
+            run.Sink.RowBudgetFilled,
             run.Channels.Select(c => c.Label).ToList(),
             rows);
     }

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -234,3 +234,119 @@ public sealed record SdDownloadReport(
 
 /// <summary>Result of deleting a file from the SD card.</summary>
 public sealed record SdDeleteResult(string DeviceId, string FileName);
+
+/// <summary>
+/// The most recent live value on one channel.
+/// </summary>
+/// <param name="Column">The channel's label — <c>AI0</c>, <c>DIO3</c>.</param>
+/// <param name="Channel">The channel number, which repeats across types (AI0 and DIO0 both exist).</param>
+/// <param name="Type">Analog or Digital.</param>
+/// <param name="Value">
+/// The decoded value — volts for an analog channel, 0/1 for a digital one — or <c>null</c> when this
+/// channel produced no sample inside the read window. Null is not zero: it means no data arrived.
+/// </param>
+/// <param name="Timestamp">When the sample was taken, reconstructed from the device clock.</param>
+/// <param name="DeviceTimestamp">The device's own clock ticks for the sample, verbatim.</param>
+/// <param name="RawValue">
+/// The raw ADC count the value was decoded from, or <c>null</c> when the device sent an
+/// already-scaled value (the USB float path does) or the channel is digital.
+/// </param>
+public sealed record ChannelReading(
+    string Column,
+    int Channel,
+    string Type,
+    double? Value,
+    DateTime? Timestamp,
+    uint? DeviceTimestamp,
+    int? RawValue);
+
+/// <summary>
+/// A spot reading of every enabled channel.
+/// </summary>
+/// <param name="SampleRateHz">The device's streaming rate while the reading was taken.</param>
+/// <param name="StartedStream">
+/// Whether this call started the device's stream (and stopped it again afterwards). <c>false</c>
+/// means a stream was already running and was left running.
+/// </param>
+/// <param name="ChannelsReported">How many of the listed channels actually produced a value.</param>
+/// <param name="DurationSeconds">How long the read waited — well under the timeout once every channel has reported.</param>
+/// <param name="DroppedSampleCount">Samples the device produced faster than this server consumed them.</param>
+/// <param name="IgnoredSampleCount">
+/// Samples that arrived for a channel outside the enabled set this call snapshotted — someone
+/// enabled a channel while the read was running.
+/// </param>
+public sealed record ChannelReadings(
+    string DeviceId,
+    int SampleRateHz,
+    bool StartedStream,
+    int ChannelsReported,
+    double DurationSeconds,
+    long DroppedSampleCount,
+    long IgnoredSampleCount,
+    IReadOnlyList<ChannelReading> Channels);
+
+/// <summary>
+/// One row of a capture: a single sample tick, with one entry per column in
+/// <see cref="CaptureResult.Columns"/> order.
+/// </summary>
+/// <param name="Timestamp">The tick's timestamp, reconstructed from the device clock.</param>
+/// <param name="DeviceTimestamp">The device's own clock ticks for the row, verbatim.</param>
+/// <param name="Values">
+/// One value per column, in <see cref="CaptureResult.Columns"/> order. An entry is <c>null</c> when
+/// that channel had no value on this tick, which in practice happens only at the two ends: the
+/// device's first frame after a stream starts can carry the digital port without the analog
+/// readings, and a capture that runs out of time mid-tick keeps the part of the tick it got.
+/// </param>
+public sealed record CaptureRow(DateTime Timestamp, uint? DeviceTimestamp, IReadOnlyList<double?> Values);
+
+/// <summary>
+/// A bounded block of live data.
+/// </summary>
+/// <param name="SampleRateHz">The rate the device was asked to stream at.</param>
+/// <param name="StartedStream">
+/// Whether this call started the device's stream (and stopped it again afterwards). <c>false</c>
+/// means it attached to a stream that was already running and left it running.
+/// </param>
+/// <param name="DurationSeconds">How long the capture actually ran.</param>
+/// <param name="RowCount">Rows returned.</param>
+/// <param name="SampleCount">Individual channel samples those rows hold.</param>
+/// <param name="DroppedSampleCount">
+/// Samples the device produced faster than this server consumed them, so they never reached a row.
+/// Non-zero means the capture has gaps — the rows themselves cannot show that.
+/// </param>
+/// <param name="IgnoredSampleCount">
+/// Samples that arrived for a channel outside the enabled set this call snapshotted — someone
+/// enabled a channel while the capture was running.
+/// </param>
+/// <param name="MeasuredRateHz">
+/// Rows per second actually achieved, timed by this machine's clock from the first row to the last
+/// (so the wait for the device's stream to start is not counted against it). Compare it with
+/// <paramref name="SampleRateHz"/>: a large gap means the device is not streaming at the rate it
+/// was asked for.
+/// </param>
+/// <param name="DeviceClockRateHz">
+/// Rows per second according to the device's <b>own</b> clock — the timestamps on the rows rather
+/// than this machine's stopwatch. It is reported alongside <paramref name="MeasuredRateHz"/>
+/// because the two disagreeing is its own diagnosis: either alone can only say "slower than
+/// requested", while a device whose clock claims the full rate while real time says otherwise has a
+/// clock that is not keeping real time, and its timestamps cannot be trusted as durations. Zero
+/// when fewer than two rows were captured.
+/// </param>
+/// <param name="RowLimitReached">
+/// Whether the capture stopped because it filled its row budget rather than because its time ran
+/// out — so there was more data available.
+/// </param>
+public sealed record CaptureResult(
+    string DeviceId,
+    int SampleRateHz,
+    bool StartedStream,
+    double DurationSeconds,
+    int RowCount,
+    long SampleCount,
+    long DroppedSampleCount,
+    long IgnoredSampleCount,
+    double MeasuredRateHz,
+    double DeviceClockRateHz,
+    bool RowLimitReached,
+    IReadOnlyList<string> Columns,
+    IReadOnlyList<CaptureRow> Rows);

--- a/src/Daqifi.Mcp/LiveSampleCapture.cs
+++ b/src/Daqifi.Mcp/LiveSampleCapture.cs
@@ -1,0 +1,296 @@
+using System.Diagnostics;
+using Daqifi.Core.Channel;
+
+namespace Daqifi.Mcp;
+
+/// <summary>
+/// Identifies a channel within a capture: type <b>and</b> number. The number alone is ambiguous —
+/// a device numbers its analog inputs and its digital pins from 0 independently, so AI0 and DIO0
+/// are different channels with the same number.
+/// </summary>
+internal readonly record struct ChannelKey(ChannelType Type, int Number)
+{
+    internal static ChannelKey For(IChannel channel) => new(channel.Type, channel.ChannelNumber);
+
+    /// <summary>
+    /// The column label an agent sees. <c>AI0</c>/<c>DIO0</c> rather than Core's "Analog Channel 0",
+    /// matching the naming the SD-card CSV export already uses for analog columns.
+    /// </summary>
+    internal string Label => Type == ChannelType.Digital ? $"DIO{Number}" : $"AI{Number}";
+}
+
+/// <summary>
+/// Where a capture puts the samples it reads. Two implementations, one per tool: the latest value
+/// per channel (<see cref="LatestValueSink"/>) and timestamp-aligned rows (<see cref="SampleRowSink"/>).
+/// </summary>
+internal interface ILiveSampleSink
+{
+    /// <summary>Files one sample.</summary>
+    /// <returns><c>false</c> when this sink has all it can hold and the capture should stop.</returns>
+    bool Add(LiveSample sample);
+
+    /// <summary>Whether the sink has everything it was asked for, so the capture can stop early.</summary>
+    bool IsComplete { get; }
+
+    /// <summary>
+    /// Samples that arrived for a channel outside the set the capture was built for — a channel
+    /// enabled by another caller after the capture started. Reported rather than silently dropped.
+    /// </summary>
+    long UnexpectedSampleCount { get; }
+}
+
+/// <summary>What a capture run did, as opposed to what it collected (which the sink holds).</summary>
+/// <param name="SampleCount">Samples read off the live stream, including any the sink did not want.</param>
+/// <param name="Elapsed">Wall-clock time the capture actually ran for.</param>
+/// <param name="DataElapsed">
+/// Wall-clock time between the first sample and the last — <see cref="Elapsed"/> without the wait
+/// for the device to get going, which is 85-110 ms when the capture had to start the stream itself.
+/// This is what a measured rate has to be divided by; dividing by <see cref="Elapsed"/> would
+/// under-report the device by that wait, which on a short capture is most of it. Zero when fewer
+/// than two samples arrived.
+/// </param>
+internal readonly record struct LiveCaptureOutcome(long SampleCount, TimeSpan Elapsed, TimeSpan DataElapsed);
+
+/// <summary>
+/// Drives the device's live sample stream into a sink for a bounded window — the shared engine
+/// behind <c>read_channel_values</c> and <c>capture_samples</c> (#498).
+/// </summary>
+internal static class LiveSampleCapture
+{
+    /// <summary>
+    /// Reads samples into <paramref name="sink"/> until it is complete, the window elapses, or the
+    /// stream ends.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="onSubscribed"/> is where the caller starts the device's stream, and it runs
+    /// where it does on purpose. Core's live stream subscribes to the channels' sample events in
+    /// the part of its iterator body that runs <i>synchronously</i>, before the first await — so the
+    /// subscription is in place once <c>MoveNextAsync</c> has returned, whether or not it has
+    /// completed. Starting the device stream at that point rather than before the enumeration is
+    /// what keeps the first samples of a capture from being decoded while nothing is listening.
+    /// </para>
+    /// <para>
+    /// The window ending is not a failure: it is how a timed capture finishes, so the cancellation
+    /// it raises is swallowed here. The caller's own <paramref name="cancellationToken"/> is not —
+    /// that propagates, as does a <c>DeviceNotConnectedException</c> from an unplug mid-capture,
+    /// because a capture cut short must not be indistinguishable from a complete one.
+    /// </para>
+    /// </remarks>
+    /// <param name="samples">The device's live sample stream.</param>
+    /// <param name="sink">Where samples are filed.</param>
+    /// <param name="window">How long to read for.</param>
+    /// <param name="onSubscribed">Run once the enumeration is subscribed; null when nothing is needed.</param>
+    /// <param name="cancellationToken">The caller's token.</param>
+    internal static async Task<LiveCaptureOutcome> DrainAsync(
+        IAsyncEnumerable<LiveSample> samples,
+        ILiveSampleSink sink,
+        TimeSpan window,
+        Action? onSubscribed,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        using var windowCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        windowCts.CancelAfter(window);
+
+        long sampleCount = 0;
+        TimeSpan firstSampleAt = TimeSpan.Zero;
+        TimeSpan lastSampleAt = TimeSpan.Zero;
+        await using var enumerator = samples.GetAsyncEnumerator(windowCts.Token);
+
+        var pending = enumerator.MoveNextAsync();
+
+        try
+        {
+            onSubscribed?.Invoke();
+        }
+        catch
+        {
+            // Starting the stream failed. The read already in flight has to be ended before the
+            // enumerator can be disposed — disposing an async iterator with a MoveNextAsync
+            // outstanding throws NotSupportedException, which would replace the failure the caller
+            // actually needs to see with a meaningless one.
+            windowCts.Cancel();
+            try
+            {
+                await pending.ConfigureAwait(false);
+            }
+            catch
+            {
+                // The read we just cancelled, or the same failure again. Either way the original
+                // exception below is the one worth reporting.
+            }
+
+            throw;
+        }
+
+        try
+        {
+            while (await pending.ConfigureAwait(false))
+            {
+                lastSampleAt = stopwatch.Elapsed;
+                if (sampleCount++ == 0)
+                {
+                    firstSampleAt = lastSampleAt;
+                }
+
+                if (!sink.Add(enumerator.Current) || sink.IsComplete)
+                {
+                    break;
+                }
+
+                pending = enumerator.MoveNextAsync();
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The capture window elapsed.
+        }
+
+        return new LiveCaptureOutcome(sampleCount, stopwatch.Elapsed, lastSampleAt - firstSampleAt);
+    }
+}
+
+/// <summary>
+/// Keeps the most recent sample per channel — what <c>read_channel_values</c> answers with. Completes
+/// as soon as every expected channel has reported once, so a spot check on a healthy device returns
+/// in about one sample period rather than waiting out its timeout.
+/// </summary>
+internal sealed class LatestValueSink : ILiveSampleSink
+{
+    private readonly Dictionary<ChannelKey, LiveSample> _latest = new();
+    private readonly HashSet<ChannelKey> _expected;
+
+    internal LatestValueSink(IEnumerable<ChannelKey> expected)
+    {
+        _expected = expected.ToHashSet();
+    }
+
+    public long UnexpectedSampleCount { get; private set; }
+
+    public bool IsComplete => _latest.Count >= _expected.Count;
+
+    public bool Add(LiveSample sample)
+    {
+        var key = ChannelKey.For(sample.Channel);
+        if (!_expected.Contains(key))
+        {
+            UnexpectedSampleCount++;
+            return true;
+        }
+
+        _latest[key] = sample;
+        return true;
+    }
+
+    /// <summary>The latest sample for <paramref name="key"/>, or null when that channel never reported.</summary>
+    internal IDataSample? Latest(ChannelKey key) => _latest.TryGetValue(key, out var sample) ? sample.Sample : null;
+
+    /// <summary>How many of the expected channels have reported at least once.</summary>
+    internal int ReportedChannelCount => _latest.Count;
+}
+
+/// <summary>
+/// Groups samples into timestamp-aligned rows — what <c>capture_samples</c> returns. One row is one
+/// device sample tick with a column per channel, the same shape as the SD-card CSV export.
+/// </summary>
+/// <remarks>
+/// A row is closed when the timestamp changes <b>or</b> when a channel that already has a value in
+/// the open row reports again. The second rule is what keeps a value from being overwritten on a
+/// device whose clock hands out the same timestamp to consecutive frames — which firmware 3.7.2
+/// does at high sample rates.
+/// </remarks>
+internal sealed class SampleRowSink : ILiveSampleSink
+{
+    private readonly IReadOnlyList<ChannelKey> _columns;
+    private readonly Dictionary<ChannelKey, int> _columnIndex;
+    private readonly int _maxRows;
+    private readonly List<CaptureRow> _rows;
+
+    private double?[]? _open;
+    private DateTime _openTimestamp;
+    private uint? _openDeviceTimestamp;
+
+    internal SampleRowSink(IReadOnlyList<ChannelKey> columns, int maxRows)
+    {
+        _columns = columns;
+        _columnIndex = new Dictionary<ChannelKey, int>(columns.Count);
+        for (var i = 0; i < columns.Count; i++)
+        {
+            _columnIndex[columns[i]] = i;
+        }
+
+        _maxRows = maxRows;
+        _rows = new List<CaptureRow>(Math.Min(maxRows, 1024));
+    }
+
+    public long UnexpectedSampleCount { get; private set; }
+
+    public bool IsComplete => _rows.Count >= _maxRows;
+
+    /// <summary>Samples that landed in a row. Lower than the capture's sample count when channels were unexpected.</summary>
+    internal long SampleCount { get; private set; }
+
+    public bool Add(LiveSample sample)
+    {
+        if (IsComplete)
+        {
+            return false;
+        }
+
+        var key = ChannelKey.For(sample.Channel);
+        if (!_columnIndex.TryGetValue(key, out var index))
+        {
+            UnexpectedSampleCount++;
+            return true;
+        }
+
+        var timestamp = sample.Sample.Timestamp;
+        if (_open is null)
+        {
+            OpenRow(timestamp, sample.Sample.DeviceTimestamp);
+        }
+        else if (timestamp != _openTimestamp || _open[index].HasValue)
+        {
+            CloseRow();
+            if (IsComplete)
+            {
+                return false;
+            }
+
+            OpenRow(timestamp, sample.Sample.DeviceTimestamp);
+        }
+
+        _open![index] = sample.Sample.Value;
+        SampleCount++;
+        return true;
+    }
+
+    /// <summary>
+    /// Closes the row still being filled when the capture ended. A capture bounded by time can stop
+    /// part-way through a tick, and that row is real data — one channel short, not wrong.
+    /// </summary>
+    internal IReadOnlyList<CaptureRow> Complete()
+    {
+        if (_open is not null && !IsComplete)
+        {
+            CloseRow();
+        }
+
+        return _rows;
+    }
+
+    private void OpenRow(DateTime timestamp, uint? deviceTimestamp)
+    {
+        _open = new double?[_columns.Count];
+        _openTimestamp = timestamp;
+        _openDeviceTimestamp = deviceTimestamp;
+    }
+
+    private void CloseRow()
+    {
+        _rows.Add(new CaptureRow(_openTimestamp, _openDeviceTimestamp, _open!));
+        _open = null;
+    }
+}

--- a/src/Daqifi.Mcp/LiveSampleCapture.cs
+++ b/src/Daqifi.Mcp/LiveSampleCapture.cs
@@ -229,6 +229,19 @@ internal sealed class SampleRowSink : ILiveSampleSink
 
     public bool IsComplete => _rows.Count >= _maxRows;
 
+    /// <summary>
+    /// Whether the row budget filled while the capture was <b>still running</b> — the honest answer
+    /// to "was there more data?".
+    /// </summary>
+    /// <remarks>
+    /// Latched here rather than left to be read off the row count afterwards, which is the same
+    /// number for two different outcomes: <see cref="Complete"/> closes the row that was still being
+    /// filled when the window ended, and that flush alone can bring the count up to the budget on a
+    /// capture the budget had nothing to do with. A caller told the budget stopped it would go back
+    /// for a continuation that does not exist.
+    /// </remarks>
+    internal bool RowBudgetFilled { get; private set; }
+
     /// <summary>Samples that landed in a row. Lower than the capture's sample count when channels were unexpected.</summary>
     internal long SampleCount { get; private set; }
 
@@ -253,7 +266,7 @@ internal sealed class SampleRowSink : ILiveSampleSink
         }
         else if (timestamp != _openTimestamp || _open[index].HasValue)
         {
-            CloseRow();
+            CloseRow(duringCapture: true);
             if (IsComplete)
             {
                 return false;
@@ -275,7 +288,7 @@ internal sealed class SampleRowSink : ILiveSampleSink
     {
         if (_open is not null && !IsComplete)
         {
-            CloseRow();
+            CloseRow(duringCapture: false);
         }
 
         return _rows;
@@ -288,9 +301,18 @@ internal sealed class SampleRowSink : ILiveSampleSink
         _openDeviceTimestamp = deviceTimestamp;
     }
 
-    private void CloseRow()
+    /// <param name="duringCapture">
+    /// False for the final flush from <see cref="Complete"/>, which is what keeps that row from
+    /// being mistaken for the budget filling — see <see cref="RowBudgetFilled"/>.
+    /// </param>
+    private void CloseRow(bool duringCapture)
     {
         _rows.Add(new CaptureRow(_openTimestamp, _openDeviceTimestamp, _open!));
         _open = null;
+
+        if (duringCapture && IsComplete)
+        {
+            RowBudgetFilled = true;
+        }
     }
 }

--- a/src/Daqifi.Mcp/README.md
+++ b/src/Daqifi.Mcp/README.md
@@ -2,7 +2,8 @@
 
 A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets an AI agent
 (Claude Desktop, Claude Code, Cursor, Codex, …) drive a DAQiFi Nyquist data-acquisition device:
-discover it, connect, configure analog channels and sample rate, and run on-device SD-card logging.
+discover it, connect, configure analog channels and sample rate, read live measurements, and run
+on-device SD-card logging.
 
 It is a thin layer over [`Daqifi.Core`](../Daqifi.Core) — all device/protocol logic lives there.
 The server speaks MCP over **stdio**, so the client launches it as a subprocess.
@@ -24,6 +25,8 @@ The server speaks MCP over **stdio**, so the client launches it as a subprocess.
 | `set_pwm_output` | Start PWM on a capable channel: duty 1-100%, shared frequency 6-50000 Hz. |
 | `disable_pwm` | Stop PWM on a channel (pin is left high-impedance). |
 | `set_sample_rate` | Set sample rate in Hz (ceiling depends on the enabled channel count; over-cap requests are rejected). |
+| `read_channel_values` | Latest value on every enabled channel, with the timestamp it was sampled at. |
+| `capture_samples` | A block of live data as rows: one row per sample tick, one column per channel. |
 | `start_sd_logging` | Start on-device SD logging (**requires a USB/serial connection**). |
 | `stop_sd_logging` | Stop SD logging. |
 | `list_sd_files` | List the log files on the SD card, with size and creation date. |
@@ -31,9 +34,16 @@ The server speaks MCP over **stdio**, so the client launches it as a subprocess.
 | `download_sd_file` | Fetch a log file to this machine and (by default) parse it into a CSV. |
 | `delete_sd_file` | Delete a file from the SD card. Destructive; blocked by `--read-only`. |
 
-> SD logging is on-device: the device writes to its own SD card while the log runs. Nothing streams
-> back live in this version — you retrieve the data afterwards with `download_sd_file`, which writes
-> the raw file and a CSV into this machine's temp directory and returns both paths.
+> **Two ways to get data, for two different jobs.** `read_channel_values` and `capture_samples`
+> stream live to the agent — good for spot checks and short captures, bounded by a duration and a
+> row budget so the answer stays a tool result rather than a file. SD logging is on-device: the
+> device writes to its own card at full rate for as long as you like, and you retrieve it afterwards
+> with `download_sd_file`, which writes the raw file and a CSV into this machine's temp directory.
+>
+> Both live tools start the device's stream only if nothing is streaming yet, and stop it again
+> afterwards; a session that was already running is read and left alone. Neither works while the
+> device is logging to its SD card — the data goes to the card instead of to this machine, so those
+> calls are refused with that explanation rather than returning nothing.
 >
 > **Retrieve before you stream.** A live streaming session collapses the device's SD buffer
 > (firmware #703), after which downloads come back empty until the device is reconnected or another
@@ -66,6 +76,10 @@ DIO/PWM output, start/stop logging, and `delete_sd_file`. Reading data back is s
 `list_sd_files`, `get_sd_storage` and `download_sd_file` all work, since they change nothing on the
 device (the download does write its two files into this machine's temp directory, which is the only
 way the data can reach the agent at all).
+
+The live tools sit on the line: reading a stream that is **already** running changes nothing and is
+allowed, but starting one is a change, so `read_channel_values` and `capture_samples` are refused
+under `--read-only` when the device is idle — and say so.
 
 ## Point your agent at it
 
@@ -101,6 +115,8 @@ During development, point the client at the source build instead:
 Then plug in a DAQiFi over USB (or join its WiFi) and ask, e.g.:
 *"Discover my DAQiFi, connect, enable analog channels 0–3 at 1 kHz, and start logging to the SD card."*
 *"Stop the log, then download it and tell me the average on AI0."*
+*"What voltage is on AI1 right now?"*
+*"Capture two seconds off channels 0–3 and tell me if anything looks noisy."*
 
 ## Notes
 

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -171,6 +171,25 @@ public static class DaqifiTools
         CancellationToken cancellationToken = default)
         => GuardAsync(() => agent.DeleteSdFileAsync(deviceId, fileName, cancellationToken));
 
+    [McpServerTool(Name = "read_channel_values")]
+    [Description("Read the latest value on every enabled channel: volts for analog inputs, 0/1 for digital ones, each with the timestamp it was sampled at. Returns as soon as every enabled channel has reported, so it normally costs one sample period rather than the full timeout; a channel that reported nothing comes back with a null value rather than a zero. Configure and enable channels first — with none enabled the device sends nothing and the call is refused. If the device is not already streaming this starts its stream and stops it again afterwards (refused in --read-only mode, since that is a change); a stream that was already running is read and left running.")]
+    public static Task<ChannelReadings> ReadChannelValues(
+        DaqifiAgent agent,
+        [Description("The device_id to read.")] string deviceId,
+        [Description("How long to wait for every enabled channel to report, in milliseconds (default 2000; clamped to 500..30000). Reached only when a channel stays silent: a device already streaming at 1 kHz answers in a few milliseconds, and one that has to be started answers in about 100 ms — which is why the floor is where it is.")] int timeoutMs = 2000,
+        CancellationToken cancellationToken = default)
+        => GuardAsync(() => agent.ReadChannelValuesAsync(deviceId, timeoutMs, cancellationToken));
+
+    [McpServerTool(Name = "capture_samples")]
+    [Description("Capture a block of live data as rows: one row per sample tick, one column per enabled channel (columns are named AI0/DIO0 and listed in the result). The capture ends at whichever budget runs out first, the duration or the row count, and reports what it actually got — rows, the rate it achieved, and the number of samples dropped because this server could not keep up. Compare measuredRateHz (this machine's clock) with sampleRateHz to see whether the device is streaming as fast as it was asked to, and with deviceClockRateHz (the device's own timestamps) to see whether its clock is keeping real time. Configure channels and the sample rate first. If the device is not already streaming this starts its stream and stops it again afterwards (refused in --read-only mode); a stream that was already running is read and left running. The device is held exclusively for the whole capture, so other tool calls on it wait.")]
+    public static Task<CaptureResult> CaptureSamples(
+        DaqifiAgent agent,
+        [Description("The device_id to capture from.")] string deviceId,
+        [Description("How long to capture for, in milliseconds (default 1000; clamped to 250..60000). The floor is bench-measured: a device that is not streaming yet sends nothing for the first ~100 ms after the start command, so a shorter window would come back empty from a healthy device.")] int durationMs = 1000,
+        [Description("Most rows to return (default 500; clamped to 1..10000). A row is one sample tick across all enabled channels, so 1000 rows at 1 kHz is one second of data. rowLimitReached in the result tells you the capture stopped on this budget rather than on time — i.e. there was more data.")] int maxRows = 500,
+        CancellationToken cancellationToken = default)
+        => GuardAsync(() => agent.CaptureSamplesAsync(deviceId, durationMs, maxRows, cancellationToken));
+
     // Surface real exception messages (validation + Core errors) to the agent rather than a
     // generic "An error occurred". Cancellation is allowed to propagate untouched.
     private static T Guard<T>(Func<T> action)


### PR DESCRIPTION
## What was wrong

The MCP server shipped fifteen tools and not one of them could answer *"what is the voltage on AI0?"*. An agent could find a device, connect to it, enable channels, set the sample rate, drive DIO and PWM, and start an SD recording — and then had to wait for the recording to finish and download a file to see a single number. Reading data is the whole point of a DAQ, and it was the one thing the agent could not do.

## How it was fixed

Two tools, both reading the live-sample stream Core already had:

- **`read_channel_values`** — the latest value on every enabled channel, with the timestamp it was sampled at. It returns as soon as every channel has reported (about 100 ms on the bench), not when its timeout expires, and a channel that said nothing comes back `null` rather than `0`.
- **`capture_samples`** — a bounded block of data as rows: one row per sample tick, one column per channel (`AI0`, `DIO3`). It ends on whichever budget runs out first, the duration or the row count, and reports what it actually got: the rate achieved, the rate the device's own clock claims, and how many samples were dropped.

Both start the device's stream only if nothing is streaming yet and stop it again afterwards — a session the caller already had running is read and left alone — and both are refused while the device is recording to its SD card, because a card recording routes the data away from this machine and a capture would just wait out its window and return nothing.

Three things a reviewer may want to push back on:

- **`ILiveSampleSource` instead of putting the members on `IStreamingDevice`.** The issue asked for the promotion onto `IStreamingDevice`; that interface is public and implementable outside the library, so adding abstract members to it breaks every external implementer. A capability interface gets the same benefit — a typed consumer reads live data without naming `DaqifiStreamingDevice` — and is additive. `ISdCardOperations` is exactly this shape already.
- **A capture holds the device exclusively for its whole window** (up to 60 s), so a concurrent tool call on the same device waits. That is deliberate: a `configure_*` landing mid-capture would change the channel set the columns are aligned to, and the rows would silently stop meaning what they say.
- **Two rate numbers.** `measuredRateHz` is this machine's clock, `deviceClockRateHz` is the device's own timestamps. Either alone can only say "slower than requested"; the two disagreeing is what identifies a device clock that is not keeping real time — which is exactly what this bench unit does (789-796 Hz measured against a device clock insisting on 1000 Hz, firmware #716).

## Verification

**Tests:** +37 (Core 3135 → 3137, MCP 86 → 123). Full suite green on **net9.0 + net10.0**, 0 warnings. The MCP tests cover the grouping rules that shape the data — including a channel reporting twice under one timestamp starting a new row rather than overwriting, which is what firmware 3.7.2 does at high rates — plus the drain's stop conditions and the `--read-only` rule.

**Bench (real Nyquist, firmware 3.7.2, USB, non-destructive — streaming and SCPI only): 24/24 checks.** The issue's criterion, 4 channels at 1 kHz for 10 s, returned **7863 rows / 31,452 samples with 0 dropped and 0 rows missing** from the sequence the device's own clock accounts for. A mixed analog+digital capture came back with columns `AI0..AI3, DIO0, DIO1` in that order, and both tools left the device not streaming.

Two things the bench changed in the code: the minimum budgets are now 500 ms (read) and 250 ms (capture), because a device that is not streaming yet sends nothing for the first 85-110 ms and a 100 ms budget reported a healthy device as silent; and `measuredRateHz` is timed from the first sample rather than from the call, so that start-up wait is not charged to the device as a lower rate.

closes #498

Not merging — this is for your review.