### PR TITLE
test(mcp): the MCP tool layer had no tests of what it does with a device attached

### DIFF
--- a/src/Daqifi.Mcp.Tests/DeviceDouble.cs
+++ b/src/Daqifi.Mcp.Tests/DeviceDouble.cs
@@ -1,0 +1,206 @@
+using System.Collections.Concurrent;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Capabilities;
+using Daqifi.Core.Device.SdCard;
+
+namespace Daqifi.Mcp.Tests;
+
+/// <summary>
+/// A <see cref="DaqifiStreamingDevice"/> that behaves like an attached Nyquist without a wire:
+/// channels are populated from a status message, outbound SCPI is captured instead of written,
+/// and the capability document is re-issued on request the way real firmware re-issues it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is what lets the MCP tool surface be tested past <c>Require</c> (#465). Everything the
+/// tools actually decide — which channel numbers exist, what order the digital/PWM commands go
+/// out in, whether a live sample rate still fits under the device's cap — is downstream of a
+/// connected device, so without a double the suite could only ever assert the "nothing is
+/// connected" refusals.
+/// </para>
+/// <para>
+/// It is deliberately a real <see cref="DaqifiStreamingDevice"/> rather than a hand-written
+/// <c>IStreamingDevice</c>: the bitmask arithmetic, the PWM-capability mask, the channel
+/// snapshotting and <see cref="SampleRateCap"/> are Core's own and are exactly the parts a fake
+/// would get to re-specify (and therefore never catch).
+/// </para>
+/// </remarks>
+internal sealed class FakeStreamingDevice : DaqifiStreamingDevice, ISdCardOperations
+{
+    /// <summary>Board ceiling, high enough that the per-configuration cap is what binds.</summary>
+    internal const int HardwareMaximumRateHz = 30_000;
+
+    private readonly ConcurrentQueue<string> _sent = new();
+
+    private FakeStreamingDevice(string name) : base(name)
+    {
+    }
+
+    /// <summary>Every SCPI command the tools caused, in the order they were issued.</summary>
+    internal IReadOnlyList<string> Sent => _sent.ToList();
+
+    /// <summary>How many times a tool asked the device to re-read its capability document.</summary>
+    internal int CapabilityReads { get; private set; }
+
+    /// <summary>
+    /// What the device answers as its cap for the analog channels enabled at the moment it is
+    /// asked. Default mirrors an NQ1: a fixed per-tick budget shared by the enabled inputs.
+    /// </summary>
+    internal Func<int, int> CapForEnabledAnalogCount { get; set; } =
+        enabled => enabled == 0 ? 0 : 20_000 / enabled;
+
+    internal void ClearSent()
+    {
+        while (_sent.TryDequeue(out _))
+        {
+        }
+    }
+
+    /// <summary>
+    /// Builds a connected device with <paramref name="analogChannels"/> analog inputs and
+    /// <paramref name="digitalChannels"/> digital channels, and its capability document already
+    /// read once — the state a device is in the moment <c>connect_device</c> returns.
+    /// </summary>
+    internal static FakeStreamingDevice CreateConnected(int analogChannels = 4, int digitalChannels = 8)
+    {
+        var device = new FakeStreamingDevice("Fake Nq1");
+        device.PopulateChannelsFromStatus(new DaqifiOutMessage
+        {
+            AnalogInPortNum = (uint)analogChannels,
+            AnalogInRes = 65535,
+            DigitalPortNum = (uint)digitalChannels,
+        });
+
+        device.Metadata.Capabilities.MaxSamplingRate = HardwareMaximumRateHz;
+        device.Connect();
+        device.ApplyCapabilityDocumentForCurrentChannels();
+        device.ClearSent();
+        return device;
+    }
+
+    public override void Send<T>(IOutboundMessage<T> message)
+    {
+        if (message is IOutboundMessage<string> text)
+        {
+            _sent.Enqueue(text.Data);
+        }
+    }
+
+    /// <summary>
+    /// Re-issues the capability document for the channel set enabled right now, which is what a
+    /// real device does: <c>CurrentMaximumRateHz</c> describes the selection that was live when
+    /// the document was read, so the number only moves when the document is re-read.
+    /// </summary>
+    public override Task<CapabilityDocument?> ReadCapabilityDocumentAsync(
+        CancellationToken cancellationToken = default)
+    {
+        CapabilityReads++;
+        return Task.FromResult<CapabilityDocument?>(ApplyCapabilityDocumentForCurrentChannels());
+    }
+
+    // --------------------------------------------------------------------- SD card
+    //
+    // Re-implemented rather than overridden: Core's SD members are non-virtual forwards to an
+    // internal collaborator, so an explicit re-implementation of the interface is the only way to
+    // give the tool layer a card to talk to. Only the members the tools call are replaced; the
+    // rest keep their inherited behavior.
+
+    /// <summary>Files the card reports; empty by default, which the tools must read as an empty card.</summary>
+    internal List<SdCardFileInfo> SdFiles { get; } = new();
+
+    /// <summary>Storage figures the card reports.</summary>
+    internal SdCardStorageInfo SdStorage { get; set; } = new(FreeBytes: 750, TotalBytes: 1000);
+
+    /// <summary>When set, every card query fails with it — how a busy or collapsed card behaves.</summary>
+    internal Exception? SdFailure { get; set; }
+
+    /// <summary>The logging session the last <c>start_sd_logging</c> opened, if any.</summary>
+    internal SdCardLoggingSession? StartedSession { get; private set; }
+
+    private bool _logging;
+
+    bool ISdCardOperations.IsLoggingToSdCard => _logging;
+
+    Task<IReadOnlyList<SdCardFileInfo>> ISdCardOperations.GetSdCardFilesAsync(CancellationToken cancellationToken) =>
+        SdFailure is { } failure
+            ? Task.FromException<IReadOnlyList<SdCardFileInfo>>(failure)
+            : Task.FromResult<IReadOnlyList<SdCardFileInfo>>(SdFiles.ToList());
+
+    Task<SdCardStorageInfo> ISdCardOperations.GetSdCardStorageAsync(CancellationToken cancellationToken) =>
+        SdFailure is { } failure
+            ? Task.FromException<SdCardStorageInfo>(failure)
+            : Task.FromResult(SdStorage);
+
+    Task<SdCardLoggingSession> ISdCardOperations.StartSdCardLoggingSessionAsync(
+        string? fileName, string? channelMask, SdCardLogFormat format, CancellationToken cancellationToken)
+    {
+        if (SdFailure is { } failure)
+        {
+            return Task.FromException<SdCardLoggingSession>(failure);
+        }
+
+        _logging = true;
+        StartedSession = new SdCardLoggingSession(
+            string.IsNullOrWhiteSpace(fileName) ? "log_20260813_000000" : fileName!, format);
+        return Task.FromResult(StartedSession);
+    }
+
+    Task ISdCardOperations.StopSdCardLoggingAsync(CancellationToken cancellationToken)
+    {
+        _logging = false;
+        return Task.CompletedTask;
+    }
+
+    private CapabilityDocument ApplyCapabilityDocumentForCurrentChannels()
+    {
+        var enabledAnalog = GetChannelsSnapshot()
+            .Count(c => c.Type == ChannelType.Analog && c.Direction == ChannelDirection.Input && c.IsEnabled);
+
+        var document = new CapabilityDocument
+        {
+            SchemaVersion = 1,
+            Streaming = new CapabilityStreaming
+            {
+                MaximumSampleRateHz = HardwareMaximumRateHz,
+                CurrentMaximumRateHz = CapForEnabledAnalogCount(enabledAnalog),
+            },
+        };
+
+        Metadata.ApplyCapabilityDocument(document);
+        return document;
+    }
+}
+
+/// <summary>
+/// Convenience for the contract tests: an agent with one device already filed under
+/// <c>serial:FAKE</c>, so a test can go straight to the tool call it is about.
+/// </summary>
+/// <remarks>
+/// Nothing here needs disposing. The double is connected without a transport, so it owns no OS
+/// handle and starts no reader; the registry that takes ownership of it is collected with the
+/// agent. Tests that are <i>about</i> teardown (disconnect, shutdown) drive it through the tools,
+/// which is the behavior they are checking rather than cleanup.
+/// </remarks>
+internal static class AgentHarness
+{
+    internal const string DeviceId = "serial:FAKE";
+
+    internal static (DaqifiAgent Agent, FakeStreamingDevice Device) WithConnectedDevice(
+        bool readOnly = false,
+        int? maxSampleRateHz = null,
+        int analogChannels = 4,
+        int digitalChannels = 8)
+    {
+        var agent = new DaqifiAgent(new ServerOptions
+        {
+            ReadOnly = readOnly,
+            MaxSampleRateHz = maxSampleRateHz,
+        });
+
+        var device = FakeStreamingDevice.CreateConnected(analogChannels, digitalChannels);
+        agent.RegisterConnectedDevice(DeviceId, device);
+        return (agent, device);
+    }
+}

--- a/src/Daqifi.Mcp.Tests/SdToolContractTests.cs
+++ b/src/Daqifi.Mcp.Tests/SdToolContractTests.cs
@@ -1,0 +1,281 @@
+using Daqifi.Core.Device.SdCard;
+using Daqifi.Mcp.Tools;
+using ModelContextProtocol;
+
+namespace Daqifi.Mcp.Tests;
+
+/// <summary>
+/// Contract tests for the SD-card tools with a card actually attached (#465) — the half
+/// <see cref="SdCardAgentGuardTests"/> cannot reach, since those run with nothing connected.
+/// </summary>
+public class SdCardToolContractTests
+{
+    [Fact]
+    public async Task ListSdFiles_OnAnEmptyCard_ReturnsAnEmptyListRatherThanFailing()
+    {
+        // Documented contract: an empty list always means an empty card. A device that could not
+        // answer raises instead, so an agent can trust the difference.
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+
+        var listing = await agent.ListSdFilesAsync(AgentHarness.DeviceId, CancellationToken.None);
+
+        Assert.Equal(0, listing.FileCount);
+        Assert.Empty(listing.Files);
+    }
+
+    [Fact]
+    public async Task ListSdFiles_ReportsWhatTheCardStatesAndNullsWhatItDoesNot()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        var created = new DateTime(2026, 8, 13, 9, 30, 0, DateTimeKind.Utc);
+        device.SdFiles.Add(new SdCardFileInfo("log_a.bin", created, sizeInBytes: 0));
+        device.SdFiles.Add(new SdCardFileInfo("log_b.bin"));
+
+        var listing = await agent.ListSdFilesAsync(AgentHarness.DeviceId, CancellationToken.None);
+
+        Assert.Equal(2, listing.FileCount);
+
+        // A size of 0 is a real (empty) file; only an unknown size is null. Collapsing the two
+        // would have an agent skip a file that exists.
+        var a = listing.Files.Single(f => f.FileName == "log_a.bin");
+        Assert.Equal(0, a.SizeBytes);
+        Assert.Equal(created, a.CreatedDate);
+
+        var b = listing.Files.Single(f => f.FileName == "log_b.bin");
+        Assert.Null(b.SizeBytes);
+        Assert.Null(b.CreatedDate);
+    }
+
+    [Theory]
+    [InlineData("list")]
+    [InlineData("storage")]
+    public async Task ABusyCard_IsReportedAsSomethingTheAgentCanActOn(string tool)
+    {
+        // Core's message says the card is busy; only this layer knows the next step is a tool call.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.SdFailure = new SdCardBusyException(new[] { "busy" });
+
+        Task Call() => tool == "list"
+            ? agent.ListSdFilesAsync(AgentHarness.DeviceId, CancellationToken.None)
+            : agent.GetSdStorageAsync(AgentHarness.DeviceId, CancellationToken.None);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(Call);
+
+        Assert.Contains("stop_sd_logging", ex.Message);
+        // The original is kept, so the raw device response is still available for diagnosis.
+        Assert.IsType<SdCardBusyException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task AnEmptyTransfer_ExplainsTheStreamingInteractionThatCausesIt()
+    {
+        // A live stream collapses the device's SD buffer, and the symptom (an empty transfer)
+        // gives no hint of the cause — so the tool has to supply it.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.SdFailure = new SdCardEmptyTransferException("log_a.bin", listedSizeInBytes: 4096);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ListSdFilesAsync(AgentHarness.DeviceId, CancellationToken.None));
+
+        Assert.Contains("streaming", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.IsType<SdCardEmptyTransferException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task AnUnrecognizedCardFailure_IsLeftExactlyAsCoreRaisedIt()
+    {
+        // Only the two failures with an MCP-specific next step are rewritten; rewriting the rest
+        // would replace messages that are already written for a human.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.SdFailure = new TimeoutException("the device stopped answering");
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(
+            () => agent.ListSdFilesAsync(AgentHarness.DeviceId, CancellationToken.None));
+
+        Assert.Equal("the device stopped answering", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetSdStorage_ReportsUsedSpaceAndPercentFree()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.SdStorage = new SdCardStorageInfo(FreeBytes: 333, TotalBytes: 1000);
+
+        var report = await agent.GetSdStorageAsync(AgentHarness.DeviceId, CancellationToken.None);
+
+        Assert.Equal(333, report.FreeBytes);
+        Assert.Equal(667, report.UsedBytes);
+        Assert.Equal(1000, report.TotalBytes);
+        Assert.Equal(33.3, report.PercentFree);
+    }
+
+    [Fact]
+    public async Task GetSdStorage_OnACardReportingNoCapacity_ReportsZeroPercentRatherThanDividingByIt()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.SdStorage = new SdCardStorageInfo(FreeBytes: 0, TotalBytes: 0);
+
+        var report = await agent.GetSdStorageAsync(AgentHarness.DeviceId, CancellationToken.None);
+
+        Assert.Equal(0, report.PercentFree);
+    }
+
+    [Fact]
+    public async Task StartSdLogging_PassesTheFormatAndReportsTheNameTheDeviceChose()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1 });
+        await agent.SetSampleRateAsync(AgentHarness.DeviceId, 500);
+
+        var result = await agent.StartLoggingAsync(AgentHarness.DeviceId, fileName: null, "csv", CancellationToken.None);
+
+        Assert.Equal(SdCardLogFormat.Csv, device.StartedSession!.Format);
+        // Core owns the naming convention, so the tool must report what came back rather than a
+        // name it guessed — the two used to be generated independently.
+        Assert.Equal(device.StartedSession.FileName, result.FileName);
+        Assert.Equal(500, result.SampleRateHz);
+        Assert.Equal(new[] { 0, 1 }, result.EnabledAnalogChannels);
+    }
+
+    [Fact]
+    public async Task StartSdLogging_WithAnUnknownFormat_IsRejectedBeforeTheCardIsTouched()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.StartLoggingAsync(AgentHarness.DeviceId, "log.bin", "parquet", CancellationToken.None));
+
+        Assert.Contains("'protobuf', 'json', or 'csv'", ex.Message);
+        Assert.Null(device.StartedSession);
+    }
+
+    [Fact]
+    public async Task StartSdLogging_WithARateTheChannelSetCannotSustain_RefusesRatherThanRecordNothing()
+    {
+        // The firmware answers an over-cap rate by refusing and recording zero samples, silently.
+        // This is the last point before the wire where an agent can be told.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0 });
+        await agent.SetSampleRateAsync(AgentHarness.DeviceId, 20_000);
+
+        // The cap moves under the live rate without any tool call re-validating it — which is the
+        // only way an over-cap rate survives to this point, since every configure_* call enforces.
+        device.CapForEnabledAnalogCount = _ => 1_000;
+        await device.ReadCapabilityDocumentAsync();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.StartLoggingAsync(AgentHarness.DeviceId, "log.bin", "protobuf", CancellationToken.None));
+
+        Assert.Contains("set_sample_rate", ex.Message);
+        Assert.Null(device.StartedSession);
+    }
+
+    [Fact]
+    public async Task StopSdLogging_EndsTheSessionAndTheStatusSaysSo()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.StartLoggingAsync(AgentHarness.DeviceId, "log.bin", "protobuf", CancellationToken.None);
+        Assert.True(agent.GetStatus(AgentHarness.DeviceId).LoggingToSdCard);
+
+        var message = await agent.StopLoggingAsync(AgentHarness.DeviceId, CancellationToken.None);
+
+        Assert.Contains("Stopped SD-card logging", message);
+        Assert.False(agent.GetStatus(AgentHarness.DeviceId).LoggingToSdCard);
+    }
+
+    [Theory]
+    [InlineData("start")]
+    [InlineData("stop")]
+    public async Task LoggingTools_AreRefusedInReadOnlyMode(string tool)
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(readOnly: true);
+
+        Task Call() => tool == "start"
+            ? agent.StartLoggingAsync(AgentHarness.DeviceId, "log.bin", "protobuf", CancellationToken.None)
+            : agent.StopLoggingAsync(AgentHarness.DeviceId, CancellationToken.None);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(Call);
+        Assert.Contains("read-only", ex.Message);
+        Assert.Null(device.StartedSession);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_StopsALiveRecordingBeforeReleasingTheDevice()
+    {
+        // A serial port released with the card still recording leaves the device writing to a log
+        // nothing will ever close.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        await agent.StartLoggingAsync(AgentHarness.DeviceId, "log.bin", "protobuf", CancellationToken.None);
+
+        await agent.ShutdownAsync();
+
+        Assert.False(((ISdCardOperations)device).IsLoggingToSdCard);
+        Assert.Empty(agent.ListConnected());
+    }
+}
+
+/// <summary>
+/// The tool wrapper itself: <see cref="DaqifiTools"/> exists to turn the agent's exceptions into
+/// something the model can read, and that translation had no tests of its own.
+/// </summary>
+public class ToolErrorTranslationTests
+{
+    [Fact]
+    public void ASynchronousToolFailure_ReachesTheModelAsItsOwnMessage()
+    {
+        var agent = new DaqifiAgent(new ServerOptions());
+
+        var ex = Assert.Throws<McpException>(() => DaqifiTools.GetDeviceStatus(agent, "serial:NOPE"));
+
+        // Not a generic "An error occurred": the whole point is that "call connect_device first"
+        // survives the trip to the model.
+        Assert.Contains("connect_device", ex.Message);
+    }
+
+    [Fact]
+    public async Task AnAsynchronousToolFailure_ReachesTheModelAsItsOwnMessage()
+    {
+        var agent = new DaqifiAgent(new ServerOptions());
+
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => DaqifiTools.SetSampleRate(agent, "serial:NOPE", 100));
+
+        Assert.Contains("not connected", ex.Message);
+    }
+
+    [Fact]
+    public async Task ACoreArgumentFailure_IsTranslatedToo()
+    {
+        // Core's own exception types are not McpException, and an untranslated one is what the
+        // model sees as an opaque failure.
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => DaqifiTools.SetPwmOutput(agent, AgentHarness.DeviceId, channel: 1, dutyCyclePercent: 50));
+
+        Assert.Contains("does not support PWM", ex.Message);
+    }
+
+    [Fact]
+    public async Task Cancellation_IsNotDisguisedAsAToolError()
+    {
+        // A cancelled call is the host giving up, not the device failing; reporting it as an
+        // McpException would have the model retry something that was never broken.
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => DaqifiTools.StopSdLogging(agent, AgentHarness.DeviceId, cts.Token));
+    }
+
+    [Fact]
+    public async Task ASuccessfulToolCall_IsNotWrappedAtAll()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+
+        var result = await DaqifiTools.ConfigureAnalogChannels(agent, AgentHarness.DeviceId, new[] { 0, 1 });
+
+        Assert.Equal(new[] { 0, 1 }, result.EnabledAnalogChannels);
+    }
+}

--- a/src/Daqifi.Mcp.Tests/ToolContractTests.cs
+++ b/src/Daqifi.Mcp.Tests/ToolContractTests.cs
@@ -1,0 +1,657 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Mcp.Tests;
+
+/// <summary>
+/// Contract tests for the tools an agent can call once a device is connected (#465).
+/// </summary>
+/// <remarks>
+/// The tool layer's job is argument validation, ordering, and state mapping, and its failures are
+/// characteristically silent — an empty list, a rate reported as valid that the device will
+/// refuse. These drive the real <see cref="DaqifiAgent"/> against a
+/// <see cref="FakeStreamingDevice"/>, so what is asserted is what an agent would actually be
+/// told and what the device would actually be sent.
+/// </remarks>
+public class IntrospectionToolContractTests
+{
+    [Fact]
+    public void ListConnected_ReportsTheRegisteredDeviceAndItsChannelCounts()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogChannels: 4, digitalChannels: 8);
+
+        var listed = Assert.Single(agent.ListConnected());
+
+        Assert.Equal(AgentHarness.DeviceId, listed.DeviceId);
+        Assert.True(listed.Connected);
+        Assert.Equal(4, listed.AnalogChannelCount);
+        Assert.Equal(8, listed.DigitalChannelCount);
+    }
+
+    [Fact]
+    public async Task GetStatus_ReflectsTheEnabledChannelsAndRate()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 2, 0 });
+        await agent.ConfigureDigitalChannelsAsync(AgentHarness.DeviceId, new[] { 5 });
+        await agent.SetSampleRateAsync(AgentHarness.DeviceId, 300);
+
+        var status = agent.GetStatus(AgentHarness.DeviceId);
+
+        Assert.Equal(AgentHarness.DeviceId, status.DeviceId);
+        Assert.False(status.Streaming);
+        Assert.False(status.LoggingToSdCard);
+        Assert.Equal(300, status.SampleRateHz);
+        // Sorted, not in the order they were asked for: an agent diffs these between calls.
+        Assert.Equal(new[] { 0, 2 }, status.EnabledAnalogChannels);
+        Assert.Equal(new[] { 5 }, status.EnabledDigitalChannels);
+    }
+
+    [Fact]
+    public void ListChannels_ReportsEveryChannelWithItsTypeAndPwmCapability()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogChannels: 2, digitalChannels: 8);
+
+        var channels = agent.ListChannels(AgentHarness.DeviceId);
+
+        Assert.Equal(10, channels.Count);
+        Assert.Equal(2, channels.Count(c => c.Type == nameof(ChannelType.Analog)));
+
+        // PWM capability is a hardware fact the agent has no other way to learn, and getting it
+        // wrong sends an agent at a channel the firmware will half-arm and then refuse (#450).
+        var pwmCapable = channels
+            .Where(c => c.Type == nameof(ChannelType.Digital) && c.PwmCapable == true)
+            .Select(c => c.ChannelNumber)
+            .OrderBy(n => n);
+        Assert.Equal(new[] { 0, 3, 4, 5, 6, 7 }, pwmCapable);
+
+        // Analog channels carry no digital-only fields at all, rather than a misleading false.
+        Assert.All(
+            channels.Where(c => c.Type == nameof(ChannelType.Analog)),
+            c =>
+            {
+                Assert.Null(c.PwmCapable);
+                Assert.Null(c.PwmEnabled);
+                Assert.Null(c.OutputValue);
+            });
+    }
+
+    [Fact]
+    public async Task DisconnectDevice_ReleasesTheDeviceAndForgetsIt()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+
+        var message = await agent.DisconnectAsync(AgentHarness.DeviceId);
+
+        Assert.Contains("Disconnected", message);
+        Assert.False(device.IsConnected);
+        Assert.Empty(agent.ListConnected());
+
+        // And the id is genuinely gone, not just hidden from the listing.
+        var ex = Assert.Throws<InvalidOperationException>(() => agent.GetStatus(AgentHarness.DeviceId));
+        Assert.Contains("connect_device", ex.Message);
+    }
+
+    [Fact]
+    public void Tools_OnADeviceThatHasSinceDropped_SaySoAndReleaseIt()
+    {
+        // The silent version of this failure is the worst one: a handle that still answers
+        // introspection from stale in-memory state while the device is gone.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.Disconnect();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => agent.GetStatus(AgentHarness.DeviceId));
+        Assert.Contains("no longer connected", ex.Message);
+
+        // Evicted, so it does not linger in list_connected_devices as if it were usable.
+        Assert.Empty(agent.ListConnected());
+    }
+}
+
+public class AnalogConfigurationToolContractTests
+{
+    [Fact]
+    public async Task ConfigureAnalogChannels_EnablesExactlyTheRequestedSet()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogChannels: 4);
+
+        var result = await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 2 });
+
+        Assert.Equal(new[] { 0, 2 }, result.EnabledAnalogChannels);
+        // Bit 0 + bit 2 = 5. Asserted on the wire, because "enabled" that never reached the
+        // device is the shape of an MCP escape.
+        Assert.Contains(ScpiMessageProducer.EnableAdcChannels("5").Data, device.Sent);
+    }
+
+    [Fact]
+    public async Task ConfigureAnalogChannels_DisablesTheChannelsLeftOut()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogChannels: 4);
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1, 2 });
+        device.ClearSent();
+
+        var result = await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 1 });
+
+        Assert.Equal(new[] { 1 }, result.EnabledAnalogChannels);
+        Assert.Equal(ScpiMessageProducer.EnableAdcChannels("2").Data, device.Sent.Last());
+    }
+
+    [Fact]
+    public async Task ConfigureAnalogChannels_WithAnEmptyList_DisablesEverything()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogChannels: 4);
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1 });
+
+        var result = await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, Array.Empty<int>());
+
+        Assert.Empty(result.EnabledAnalogChannels);
+    }
+
+    [Fact]
+    public async Task ConfigureAnalogChannels_WithAnUnknownChannel_ChangesNothing()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogChannels: 4);
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 1 });
+        device.ClearSent();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 9 }));
+
+        // The message has to name what does exist; an agent cannot see the board.
+        Assert.Contains("9", ex.Message);
+        Assert.Contains("0, 1, 2, 3", ex.Message);
+
+        // All-or-nothing: a partly-applied selection is a configuration neither side asked for.
+        Assert.Empty(device.Sent);
+        Assert.Equal(new[] { 1 }, agent.GetStatus(AgentHarness.DeviceId).EnabledAnalogChannels);
+    }
+
+    [Fact]
+    public async Task ConfigureAnalogChannels_RefreshesTheDeviceCapBeforeReportingARate()
+    {
+        // #447: the cap is scoped to the channel set that was live when the document was read, so
+        // a configuration call that did not re-read it would validate against the previous set.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        var before = device.CapabilityReads;
+
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0 });
+
+        Assert.True(device.CapabilityReads > before);
+    }
+
+    [Fact]
+    public async Task WideningTheChannelSet_LowersALiveRateThatNoLongerFits()
+    {
+        // The #447 escape in full: 2000 Hz is legal with one channel enabled (cap 20000) and
+        // illegal with four (cap 5000). Left alone it stays live, is echoed back as valid, and
+        // cannot even be re-set, because re-requesting the same value now fails.
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogChannels: 4);
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0 });
+        await agent.SetSampleRateAsync(AgentHarness.DeviceId, 12_000);
+
+        var result = await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1, 2, 3 });
+
+        Assert.Equal(12_000, result.SampleRateAdjustedFromHz);
+        Assert.Equal(5_000, result.SampleRateHz);
+        Assert.Equal(5_000, agent.GetStatus(AgentHarness.DeviceId).SampleRateHz);
+    }
+
+    [Fact]
+    public async Task NarrowingTheChannelSet_LeavesAFittingRateAlone()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogChannels: 4);
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1, 2, 3 });
+        await agent.SetSampleRateAsync(AgentHarness.DeviceId, 1_000);
+
+        var result = await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0 });
+
+        // Null means "nothing was adjusted" — an agent keys off it, so it must not be set to the
+        // unchanged rate just because a re-validation ran.
+        Assert.Null(result.SampleRateAdjustedFromHz);
+        Assert.Equal(1_000, result.SampleRateHz);
+    }
+
+    [Fact]
+    public async Task DisablingEveryChannel_LeavesTheLiveRateAloneRatherThanZeroingIt()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0 });
+        await agent.SetSampleRateAsync(AgentHarness.DeviceId, 2_000);
+
+        var result = await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, Array.Empty<int>());
+
+        Assert.Null(result.SampleRateAdjustedFromHz);
+        Assert.Equal(2_000, result.SampleRateHz);
+    }
+}
+
+public class DigitalConfigurationToolContractTests
+{
+    [Fact]
+    public async Task ConfigureDigitalChannels_EnablesExactlyTheRequestedSet()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(digitalChannels: 8);
+
+        var result = await agent.ConfigureDigitalChannelsAsync(AgentHarness.DeviceId, new[] { 3, 1 });
+
+        Assert.Equal(new[] { 1, 3 }, result.EnabledDigitalChannels);
+    }
+
+    [Fact]
+    public async Task ConfigureDigitalChannels_DisablesTheChannelsLeftOut()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(digitalChannels: 8);
+        await agent.ConfigureDigitalChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1, 2 });
+
+        var result = await agent.ConfigureDigitalChannelsAsync(AgentHarness.DeviceId, new[] { 2 });
+
+        Assert.Equal(new[] { 2 }, result.EnabledDigitalChannels);
+    }
+
+    [Fact]
+    public async Task ConfigureDigitalChannels_WithAnUnknownChannel_ChangesNothing()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(digitalChannels: 8);
+        device.ClearSent();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ConfigureDigitalChannelsAsync(AgentHarness.DeviceId, new[] { 1, 42 }));
+
+        Assert.Contains("42", ex.Message);
+        Assert.Empty(device.Sent);
+        Assert.Empty(agent.GetStatus(AgentHarness.DeviceId).EnabledDigitalChannels);
+    }
+
+    [Fact]
+    public async Task ConfigureDigitalChannels_DoesNotDisturbTheAnalogSelection()
+    {
+        // The two tools share a channel collection; a digital call that swept analog channels up
+        // with it would silently end an acquisition.
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1 });
+
+        await agent.ConfigureDigitalChannelsAsync(AgentHarness.DeviceId, new[] { 4 });
+
+        var status = agent.GetStatus(AgentHarness.DeviceId);
+        Assert.Equal(new[] { 0, 1 }, status.EnabledAnalogChannels);
+        Assert.Equal(new[] { 4 }, status.EnabledDigitalChannels);
+    }
+}
+
+public class DigitalPinToolContractTests
+{
+    [Fact]
+    public async Task SetDigitalDirection_DrivesTheChannelItWasAskedAbout()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+
+        var result = await agent.SetDigitalDirectionAsync(AgentHarness.DeviceId, 2, "output");
+
+        Assert.Equal(2, result.Channel);
+        Assert.Equal(nameof(ChannelDirection.Output), result.Direction);
+        Assert.Contains(ScpiMessageProducer.SetDioPortDirection(2, 1).Data, device.Sent);
+    }
+
+    [Fact]
+    public async Task SetDigitalDirection_OnAnUnknownChannel_NamesTheChannelsThatExist()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(digitalChannels: 4);
+        device.ClearSent();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetDigitalDirectionAsync(AgentHarness.DeviceId, 11, "output"));
+
+        Assert.Contains("11", ex.Message);
+        Assert.Contains("0, 1, 2, 3", ex.Message);
+        Assert.Empty(device.Sent);
+    }
+
+    [Fact]
+    public async Task SetDigitalOutput_OnAnInputChannel_SwitchesDirectionBeforeDrivingIt()
+    {
+        // One tool call is documented as enough to drive a pin. The order is the contract: a
+        // value written while the pin is still an input goes nowhere.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.ClearSent();
+
+        var result = await agent.SetDigitalOutputAsync(AgentHarness.DeviceId, 1, high: true);
+
+        Assert.True(result.OutputValue);
+        Assert.Equal(nameof(ChannelDirection.Output), result.Direction);
+
+        var direction = device.Sent.ToList().IndexOf(ScpiMessageProducer.SetDioPortDirection(1, 1).Data);
+        var value = device.Sent.ToList().IndexOf(ScpiMessageProducer.SetDioPortState(1, 1).Data);
+        Assert.True(direction >= 0, "the direction command was never sent");
+        Assert.True(value >= 0, "the value command was never sent");
+        Assert.True(direction < value, "the value was driven before the pin was an output");
+    }
+
+    [Fact]
+    public async Task SetDigitalOutput_OnAChannelAlreadyAnOutput_DoesNotResendTheDirection()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        await agent.SetDigitalDirectionAsync(AgentHarness.DeviceId, 1, "output");
+        device.ClearSent();
+
+        await agent.SetDigitalOutputAsync(AgentHarness.DeviceId, 1, high: false);
+
+        Assert.DoesNotContain(ScpiMessageProducer.SetDioPortDirection(1, 1).Data, device.Sent);
+        Assert.Contains(ScpiMessageProducer.SetDioPortState(1, 0).Data, device.Sent);
+    }
+
+    [Theory]
+    [InlineData("direction")]
+    [InlineData("output")]
+    public async Task DigitalWrites_AreRefusedWhilePwmRunsOnTheChannel(string operation)
+    {
+        // #449: the firmware ignores direction/state writes while PWM is running, so a tool that
+        // forwarded them would report success for a pin that never moved.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        await agent.SetPwmOutputAsync(AgentHarness.DeviceId, 4, dutyCyclePercent: 50, frequencyHz: 1000);
+        device.ClearSent();
+
+        Task Call() => operation == "direction"
+            ? agent.SetDigitalDirectionAsync(AgentHarness.DeviceId, 4, "output")
+            : agent.SetDigitalOutputAsync(AgentHarness.DeviceId, 4, high: true);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(Call);
+
+        // Names the tool an agent actually has, and only that: Core's own guard would have said
+        // "SetPwmEnabled(channel, false)", an SDK method an MCP caller has no way to reach.
+        Assert.Contains("disable_pwm", ex.Message);
+        Assert.DoesNotContain("SetPwmEnabled", ex.Message);
+        Assert.Empty(device.Sent);
+    }
+
+    [Fact]
+    public async Task DigitalWrites_ResumeOncePwmIsDisabled()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        await agent.SetPwmOutputAsync(AgentHarness.DeviceId, 4, dutyCyclePercent: 50, frequencyHz: 1000);
+        await agent.DisablePwmAsync(AgentHarness.DeviceId, 4);
+        device.ClearSent();
+
+        var result = await agent.SetDigitalOutputAsync(AgentHarness.DeviceId, 4, high: true);
+
+        Assert.True(result.OutputValue);
+        Assert.Contains(ScpiMessageProducer.SetDioPortState(4, 1).Data, device.Sent);
+    }
+}
+
+public class PwmToolContractTests
+{
+    [Fact]
+    public async Task SetPwmOutput_SendsDutyThenFrequencyThenEnable()
+    {
+        // The firmware applies the stored duty when the frequency is programmed, so this order is
+        // what keeps a stale compare value from being latched.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.ClearSent();
+
+        var result = await agent.SetPwmOutputAsync(AgentHarness.DeviceId, 4, dutyCyclePercent: 25, frequencyHz: 2000);
+
+        var sent = device.Sent.ToList();
+        var duty = sent.IndexOf(ScpiMessageProducer.SetPwmChannelDutyCycle(4, 25).Data);
+        var frequency = sent.IndexOf(ScpiMessageProducer.SetPwmChannelFrequency(0, 2000).Data);
+        var enable = sent.IndexOf(ScpiMessageProducer.SetPwmChannelEnabled(4, true).Data);
+
+        Assert.True(duty >= 0 && frequency >= 0 && enable >= 0, $"missing command in: {string.Join(" | ", sent)}");
+        Assert.True(duty < frequency, "the frequency was programmed before the duty was stored");
+        Assert.True(frequency < enable, "the channel was enabled before the timer was programmed");
+
+        Assert.True(result.Enabled);
+        Assert.Equal(25, result.DutyCyclePercent);
+        Assert.Equal(2000, result.FrequencyHz);
+    }
+
+    [Fact]
+    public async Task SetPwmOutput_WithFrequencyZero_KeepsTheSessionFrequency()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        await agent.SetPwmOutputAsync(AgentHarness.DeviceId, 4, dutyCyclePercent: 40, frequencyHz: 7000);
+        device.ClearSent();
+
+        var result = await agent.SetPwmOutputAsync(AgentHarness.DeviceId, 5, dutyCyclePercent: 60, frequencyHz: 0);
+
+        // The frequency is one device-wide timer; asking for 0 means "leave it", not "0 Hz".
+        Assert.Equal(7000, result.FrequencyHz);
+        Assert.DoesNotContain(device.Sent, c => c.StartsWith("PWM:CHannel:FREQuency", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SetPwmOutput_OnANonCapableChannel_IsRefusedBeforeTheChannelIsArmed()
+    {
+        // The firmware flags a channel PWM-active before its own capability check fails, and never
+        // rolls that back — so an enable that reaches a non-capable channel leaves it dead to
+        // digital writes. Nothing at all may go out.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.ClearSent();
+
+        // Channel 1 is not one of the output-compare channels (0, 3, 4, 5, 6, 7).
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => agent.SetPwmOutputAsync(AgentHarness.DeviceId, 1, dutyCyclePercent: 50, frequencyHz: 1000));
+
+        Assert.Contains("0, 3, 4, 5, 6, 7", ex.Message);
+        Assert.DoesNotContain(device.Sent, c => c.StartsWith("PWM:CHannel:ENable", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DisablePwm_IsAcceptedOnANonCapableChannel()
+    {
+        // The firmware can flag a channel PWM-active before failing its own capability check, and
+        // this is the only command that clears it — so it must not be gated on capability.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.ClearSent();
+
+        var result = await agent.DisablePwmAsync(AgentHarness.DeviceId, 1);
+
+        Assert.False(result.Enabled);
+        Assert.Contains(ScpiMessageProducer.SetPwmChannelEnabled(1, false).Data, device.Sent);
+    }
+
+    [Fact]
+    public async Task DisablePwm_BeforeAnythingWasCommanded_ReportsNoDutyOrFrequency()
+    {
+        // #450: Core seeds duty and frequency with session defaults that look exactly like real
+        // device state. Reporting them would be the tool inventing a reading.
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+
+        var result = await agent.DisablePwmAsync(AgentHarness.DeviceId, 4);
+
+        Assert.Null(result.DutyCyclePercent);
+        Assert.Null(result.FrequencyHz);
+    }
+
+    [Fact]
+    public async Task DisablePwm_AfterSetPwmOutput_ReportsWhatWasCommanded()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.SetPwmOutputAsync(AgentHarness.DeviceId, 4, dutyCyclePercent: 35, frequencyHz: 900);
+
+        var result = await agent.DisablePwmAsync(AgentHarness.DeviceId, 4);
+
+        Assert.False(result.Enabled);
+        Assert.Equal(35, result.DutyCyclePercent);
+        Assert.Equal(900, result.FrequencyHz);
+    }
+
+    [Fact]
+    public async Task DisablePwm_OnOneChannel_StillReportsTheDeviceWideFrequency()
+    {
+        // The frequency was commanded for the device, not for the channel, so it stays reportable
+        // on a channel that never had a duty set of its own.
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.SetPwmOutputAsync(AgentHarness.DeviceId, 4, dutyCyclePercent: 35, frequencyHz: 900);
+
+        var result = await agent.DisablePwmAsync(AgentHarness.DeviceId, 6);
+
+        Assert.Equal(900, result.FrequencyHz);
+        Assert.Null(result.DutyCyclePercent);
+    }
+
+    [Fact]
+    public async Task PwmTools_OnAnUnknownChannel_NameTheChannelsThatExist()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(digitalChannels: 8);
+
+        var setEx = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetPwmOutputAsync(AgentHarness.DeviceId, 30, dutyCyclePercent: 50, frequencyHz: 1000));
+        Assert.Contains("Unknown digital channel 30", setEx.Message);
+
+        var disableEx = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.DisablePwmAsync(AgentHarness.DeviceId, 30));
+        Assert.Contains("Unknown digital channel 30", disableEx.Message);
+    }
+}
+
+public class SampleRateToolContractTests
+{
+    [Fact]
+    public async Task SetSampleRate_AtExactlyTheCap_IsAccepted()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1 });
+
+        var result = await agent.SetSampleRateAsync(AgentHarness.DeviceId, 10_000);
+
+        Assert.Equal(10_000, result.RequestedRateHz);
+        Assert.Equal(10_000, agent.GetStatus(AgentHarness.DeviceId).SampleRateHz);
+    }
+
+    [Fact]
+    public async Task SetSampleRate_AboveTheCap_IsRejectedAndLeavesTheLiveRateAlone()
+    {
+        // Rejected rather than silently clamped: the device answers an over-ask with SCPI -222
+        // and streams nothing, so an agent told "ok, 10000" would wait forever for samples.
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1 });
+        await agent.SetSampleRateAsync(AgentHarness.DeviceId, 400);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetSampleRateAsync(AgentHarness.DeviceId, 10_001));
+
+        Assert.Contains("10000", ex.Message);
+        Assert.Equal(400, agent.GetStatus(AgentHarness.DeviceId).SampleRateHz);
+    }
+
+    [Fact]
+    public async Task SetSampleRate_WithNothingEnabled_SaysToEnableAChannel()
+    {
+        // A cap of 0 is a real answer, and "exceeds the maximum 0 Hz" would point an agent at
+        // lowering the rate when the remedy is enabling a channel.
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, Array.Empty<int>());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetSampleRateAsync(AgentHarness.DeviceId, 100));
+
+        Assert.Contains("No channels are enabled", ex.Message);
+        Assert.Contains("configure_analog_channels", ex.Message);
+        Assert.DoesNotContain("exceeds the maximum", ex.Message);
+    }
+
+    [Fact]
+    public async Task SetSampleRate_HonoursTheServerWideClamp()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(maxSampleRateHz: 250);
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0 });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetSampleRateAsync(AgentHarness.DeviceId, 251));
+        Assert.Contains("250", ex.Message);
+
+        var ok = await agent.SetSampleRateAsync(AgentHarness.DeviceId, 250);
+        Assert.Equal(250, ok.RequestedRateHz);
+    }
+
+    [Fact]
+    public async Task ConfiguringChannels_AlsoEnforcesTheServerWideClamp()
+    {
+        // The operator's clamp has to bind on the re-validation path too, or a channel change
+        // could leave a rate above it live and reported as adjusted-and-fine.
+        var (agent, _) = AgentHarness.WithConnectedDevice(maxSampleRateHz: 300);
+        await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0 });
+        await agent.SetSampleRateAsync(AgentHarness.DeviceId, 300);
+
+        var result = await agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0, 1 });
+
+        Assert.Null(result.SampleRateAdjustedFromHz);
+        Assert.Equal(300, result.SampleRateHz);
+    }
+
+    [Fact]
+    public async Task SetSampleRate_BelowOne_IsRejectedBeforeTheDeviceIsTouched()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.ClearSent();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetSampleRateAsync(AgentHarness.DeviceId, 0));
+
+        Assert.Empty(device.Sent);
+    }
+}
+
+public class ReadOnlyModeContractTests
+{
+    /// <summary>
+    /// Every mutating tool, refused before it reaches a device that is genuinely connected. The
+    /// existing no-device tests cannot tell a real refusal from "there was nothing to do anyway".
+    /// </summary>
+    public static TheoryData<string> MutatingTools() => new()
+    {
+        "configure_analog_channels",
+        "configure_digital_channels",
+        "set_digital_direction",
+        "set_digital_output",
+        "set_pwm_output",
+        "disable_pwm",
+        "set_sample_rate",
+    };
+
+    [Theory]
+    [MemberData(nameof(MutatingTools))]
+    public async Task MutatingTools_AreRefusedAndSendNothing(string tool)
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(readOnly: true);
+        device.ClearSent();
+
+        Task Call() => tool switch
+        {
+            "configure_analog_channels" => agent.ConfigureAnalogChannelsAsync(AgentHarness.DeviceId, new[] { 0 }),
+            "configure_digital_channels" => agent.ConfigureDigitalChannelsAsync(AgentHarness.DeviceId, new[] { 0 }),
+            "set_digital_direction" => agent.SetDigitalDirectionAsync(AgentHarness.DeviceId, 0, "output"),
+            "set_digital_output" => agent.SetDigitalOutputAsync(AgentHarness.DeviceId, 0, high: true),
+            "set_pwm_output" => agent.SetPwmOutputAsync(AgentHarness.DeviceId, 4, 50, 1000),
+            "disable_pwm" => agent.DisablePwmAsync(AgentHarness.DeviceId, 4),
+            _ => agent.SetSampleRateAsync(AgentHarness.DeviceId, 100),
+        };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(Call);
+        Assert.Contains("read-only", ex.Message);
+        Assert.Empty(device.Sent);
+    }
+
+    [Theory]
+    [InlineData("status")]
+    [InlineData("channels")]
+    [InlineData("list")]
+    public void Introspection_StillWorksInReadOnlyMode(string tool)
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(readOnly: true);
+
+        switch (tool)
+        {
+            case "status":
+                Assert.Equal(AgentHarness.DeviceId, agent.GetStatus(AgentHarness.DeviceId).DeviceId);
+                break;
+            case "channels":
+                Assert.NotEmpty(agent.ListChannels(AgentHarness.DeviceId));
+                break;
+            default:
+                Assert.Single(agent.ListConnected());
+                break;
+        }
+    }
+}

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -1028,6 +1028,21 @@ public sealed class DaqifiAgent
 
     // ------------------------------------------------------------------ helpers
 
+    /// <summary>
+    /// Files an already-connected device under <paramref name="deviceId"/>, as if
+    /// <see cref="ConnectAsync"/> had produced it.
+    /// </summary>
+    /// <remarks>
+    /// Exists so the tool surface can be exercised against a device double (#465). Every tool
+    /// past <see cref="Require"/> — which is all of the configuration, digital, PWM and rate
+    /// logic — is otherwise reachable only with hardware attached, which is why the whole of
+    /// this server's test coverage used to stop at "nothing is connected". Deliberately
+    /// <c>internal</c>: the supported way in is <see cref="ConnectAsync"/>, which owns discovery
+    /// lookup and the duplicate-device policy this bypasses.
+    /// </remarks>
+    internal void RegisterConnectedDevice(string deviceId, DaqifiDevice device) =>
+        _registry.Register(device, deviceInfo: null, key: deviceId);
+
     private DaqifiDevice Require(string deviceId)
     {
         if (!_registry.TryGet(deviceId, out var registration))


### PR DESCRIPTION
## What was wrong

The MCP server is what an AI agent actually touches, and its whole test suite could only check what happens when **nothing is connected**. Every decision the tools make once a device *is* connected — which channel numbers exist, whether a sample rate still fits under the device's ceiling, what order the digital and PWM commands go out in, what a busy SD card is reported as — was reachable only with hardware plugged in, so 1,185 lines of tool layer had no coverage at all. That matters here more than usual because MCP failures are quiet: an empty list, a rate reported as valid that the firmware will silently refuse, a pin that reports "driven" and never moved.

## How it was fixed

There is now a device double — a real `DaqifiStreamingDevice` connected without a transport, capturing SCPI instead of writing it, and re-issuing its capability document the way firmware does — and 68 contract tests driving the real `DaqifiAgent` and `DaqifiTools` over it. They assert what an agent would be told *and* what the device would be sent.

The one thing a reviewer may want to push back on: this needs a way to file an already-connected device with the agent, so `DaqifiAgent` gains a single `internal` method (`RegisterConnectedDevice`) that the tests use. It is the only production change in the PR. The alternative was a hand-written `IStreamingDevice` fake, which would have let the test re-specify the bitmask arithmetic, the PWM-capable mask and the rate cap — exactly the parts worth checking.

Worth knowing about one test in particular: the PWM guard test now also asserts the message does **not** mention `SetPwmEnabled`. Core's own guard has since grown a message that names `disable_pwm` too, so without that second assertion the test passes whether the MCP-level guard is there or not.

## Verified

- 68 new tests (Mcp 86 → 154). Full suite green on net9.0 and net10.0 (Core 3135 passed / 2 skipped each), 0 warnings.
- Three deliberate mutations of the production code — dropping the rate re-validation, driving a digital value before switching the pin to output, dropping the PWM guard — each fail the test that claims to cover them.
- **Bench (real Nq1, fw 3.7.2, USB, non-destructive — no streaming, no card writes, no pins driven): 28/28.** A throwaway harness drove the same tool calls against the board to confirm the double is telling the truth: PWM-capable channels really are {0, 3, 4, 5, 6, 7}; widening 2 analog channels to 8 really does drop the ceiling (6924 → 4525 Hz) and lower the live rate, reporting what it was lowered from; disabling every channel really does leave the rate alone and answer "no channels are enabled" rather than "you asked for too much"; and the card's listing really does include a file with a size but no creation date, which is the null case one of the tests pins.

closes #465

Not merging — for review.