### PR TITLE
feat(device): the analog outputs a device has are finally channels you can see and write safely

### DIFF
--- a/src/Daqifi.Core.Tests/Channel/AnalogOutputChannelTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/AnalogOutputChannelTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using Daqifi.Core.Channel;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Channel
+{
+    /// <summary>
+    /// Covers the analog-output (DAC) channel model on its own: what it accepts, what it refuses,
+    /// and the stage-then-latch bookkeeping that keeps <see cref="IAnalogOutputChannel.OutputVoltage"/>
+    /// reporting only voltages the hardware is actually driving.
+    /// </summary>
+    public class AnalogOutputChannelTests
+    {
+        [Fact]
+        public void Constructor_Defaults_DescribeAnNq3Dac()
+        {
+            var channel = new AnalogOutputChannel(0);
+
+            Assert.Equal(ChannelType.AnalogOutput, channel.Type);
+            Assert.Equal(ChannelDirection.Output, channel.Direction);
+            Assert.Equal(0, channel.ChannelNumber);
+            Assert.Equal(AnalogOutputChannel.DefaultResolutionBits, channel.ResolutionBits);
+            Assert.Equal(AnalogOutputChannel.DefaultMinimumVoltage, channel.MinimumVoltage);
+            Assert.Equal(AnalogOutputChannel.DefaultMaximumVoltage, channel.MaximumVoltage);
+            Assert.Equal("Analog Output 0", channel.Name);
+            Assert.Equal("Analog Output 0", channel.ToString());
+            Assert.Null(channel.OutputVoltage);
+            Assert.Null(channel.PendingVoltage);
+            Assert.Null(channel.ActiveSample);
+        }
+
+        [Fact]
+        public void Constructor_NegativeChannelNumber_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AnalogOutputChannel(-1));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-4)]
+        [InlineData(33)]
+        public void Constructor_ImplausibleResolution_Throws(int resolutionBits)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new AnalogOutputChannel(0, resolutionBits));
+        }
+
+        [Theory]
+        [InlineData(double.NaN)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(60.0)]
+        [InlineData(-60.0)]
+        public void Constructor_ImplausibleRangeEndpoint_Throws(double minimum)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new AnalogOutputChannel(0, 12, minimum, 100.0));
+        }
+
+        [Theory]
+        [InlineData(5.0, 5.0)]
+        [InlineData(5.0, -5.0)]
+        public void Constructor_EmptyOrInvertedRange_Throws(double minimum, double maximum)
+        {
+            Assert.Throws<ArgumentException>(
+                () => new AnalogOutputChannel(0, 12, minimum, maximum));
+        }
+
+        [Fact]
+        public void Direction_SetToOutput_IsAccepted()
+        {
+            var channel = new AnalogOutputChannel(0) { Direction = ChannelDirection.Output };
+
+            Assert.Equal(ChannelDirection.Output, channel.Direction);
+        }
+
+        [Theory]
+        [InlineData(ChannelDirection.Input)]
+        [InlineData(ChannelDirection.Unknown)]
+        public void Direction_SetToAnythingElse_Throws(ChannelDirection direction)
+        {
+            var channel = new AnalogOutputChannel(0);
+
+            Assert.Throws<ArgumentException>(() => channel.Direction = direction);
+        }
+
+        [Theory]
+        [InlineData(0.0, true)]     // the low endpoint is in range
+        [InlineData(10.0, true)]    // so is the high one
+        [InlineData(5.0, true)]
+        [InlineData(-0.1, false)]
+        [InlineData(10.1, false)]
+        [InlineData(double.NaN, false)]
+        [InlineData(double.PositiveInfinity, false)]
+        public void IsInRange_TreatsTheStatedRangeAsInclusive(double voltage, bool expected)
+        {
+            var channel = new AnalogOutputChannel(0, 12, 0.0, 10.0);
+
+            Assert.Equal(expected, channel.IsInRange(voltage));
+        }
+
+        [Fact]
+        public void Stage_RecordsPendingWithoutChangingTheDrivenValue()
+        {
+            var channel = new AnalogOutputChannel(0);
+            var samples = Subscribe(channel);
+
+            channel.Stage(3.25);
+
+            Assert.Equal(3.25, channel.PendingVoltage);
+            Assert.Null(channel.OutputVoltage);
+            Assert.Empty(samples);
+        }
+
+        [Fact]
+        public void Latch_PromotesThePendingValueAndAnnouncesIt()
+        {
+            var channel = new AnalogOutputChannel(0);
+            var samples = Subscribe(channel);
+            var at = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Local);
+
+            channel.Stage(3.25);
+            var latched = channel.Latch(at);
+
+            Assert.True(latched);
+            Assert.Equal(3.25, channel.OutputVoltage);
+            Assert.Null(channel.PendingVoltage);
+            Assert.Equal(new[] { 3.25 }, samples);
+            Assert.Equal(at, channel.ActiveSample!.Timestamp);
+        }
+
+        [Fact]
+        public void Latch_WithNothingStaged_ChangesNothing()
+        {
+            var channel = new AnalogOutputChannel(0);
+            channel.Stage(1.0);
+            channel.Latch(DateTime.Now);
+
+            var samples = Subscribe(channel);
+            var latched = channel.Latch(DateTime.Now);
+
+            Assert.False(latched);
+            Assert.Equal(1.0, channel.OutputVoltage);
+            Assert.Empty(samples);
+        }
+
+        [Fact]
+        public void Stage_Twice_LatchesOnlyTheLatestValue()
+        {
+            var channel = new AnalogOutputChannel(0);
+            var samples = Subscribe(channel);
+
+            channel.Stage(1.0);
+            channel.Stage(2.0);
+            channel.Latch(DateTime.Now);
+
+            Assert.Equal(new[] { 2.0 }, samples);
+            Assert.Equal(2.0, channel.OutputVoltage);
+        }
+
+        [Fact]
+        public void ClearPending_DropsTheStagedValueWithoutDrivingIt()
+        {
+            var channel = new AnalogOutputChannel(0);
+            var samples = Subscribe(channel);
+
+            channel.Stage(4.0);
+            channel.ClearPending();
+
+            Assert.Null(channel.PendingVoltage);
+            Assert.Null(channel.OutputVoltage);
+            Assert.False(channel.Latch(DateTime.Now));
+            Assert.Empty(samples);
+        }
+
+        [Fact]
+        public void SetOutputVoltage_RecordsTheValueWithoutStaging()
+        {
+            var channel = new AnalogOutputChannel(0);
+            var samples = Subscribe(channel);
+
+            channel.SetOutputVoltage(7.5, DateTime.Now);
+
+            Assert.Equal(7.5, channel.OutputVoltage);
+            Assert.Null(channel.PendingVoltage);
+            Assert.Equal(new[] { 7.5 }, samples);
+        }
+
+        [Fact]
+        public void UpdateFromCapabilities_ReplacesTheResolutionAndRangeInPlace()
+        {
+            var channel = new AnalogOutputChannel(0, 12, 0.0, 10.0);
+
+            channel.UpdateFromCapabilities(16, -5.0, 5.0, rangeIsAssumed: true);
+
+            Assert.Equal(16, channel.ResolutionBits);
+            Assert.Equal(-5.0, channel.MinimumVoltage);
+            Assert.Equal(5.0, channel.MaximumVoltage);
+            Assert.True(channel.RangeIsAssumed);
+            Assert.True(channel.IsInRange(-5.0));
+            Assert.False(channel.IsInRange(7.5));
+        }
+
+        [Fact]
+        public void SetActiveSample_NullSample_Throws()
+        {
+            var channel = new AnalogOutputChannel(0);
+
+            Assert.Throws<ArgumentNullException>(() => channel.SetActiveSample(null!));
+        }
+
+        /// <summary>
+        /// Collects the values announced through <see cref="IChannel.SampleReceived"/>, which is how
+        /// a consumer (a UI binding, the live sample stream) learns an output changed.
+        /// </summary>
+        private static List<double> Subscribe(AnalogOutputChannel channel)
+        {
+            var values = new List<double>();
+            channel.SampleReceived += (_, e) =>
+            {
+                Assert.Same(channel, e.Channel);
+                values.Add(e.Sample.Value);
+            };
+            return values;
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -857,6 +857,20 @@ public class ScpiMessageProducerTests
         AssertMessageFormat(message);
     }
 
+    [Fact]
+    public void GetAnalogOutputVoltage_ReturnsCorrectQuery()
+    {
+        var message = ScpiMessageProducer.GetAnalogOutputVoltage(2);
+        Assert.Equal("SOURce:VOLTage:LEVel? 2", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void GetAnalogOutputVoltage_WithNegativeChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.GetAnalogOutputVoltage(-1));
+    }
+
     // --- Logging & diagnostics ---
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAnalogOutputTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAnalogOutputTests.cs
@@ -1,0 +1,532 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Daqifi.Core.Device.Capabilities;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device
+{
+    /// <summary>
+    /// Covers the analog-output (DAC) channel model end to end on a device: where the channels come
+    /// from, that a status message cannot wipe them, the range check that runs before anything
+    /// reaches the wire, the stage/latch pair, and the readback.
+    /// </summary>
+    public class DaqifiStreamingDeviceAnalogOutputTests
+    {
+        /// <summary>
+        /// Two DAC channels shaped exactly as the firmware emits them (see
+        /// <c>EmitAoutChannelJson</c> in SCPIInterface.c), alongside one analog input so the tests
+        /// can show outputs coexisting with the acquisition channels.
+        /// </summary>
+        private const string TwoDacDocument = """
+            {"schema_version":2,"channels":[
+              {"id":0,"kind":"analog-input","signal_type":"voltage","unit":"V","resolution_bits":12,"simultaneous":false,"differential":false,"ranges":[{"min":0.000,"max":5.000}],"extensions":{}},
+              {"id":0,"kind":"analog-output","signal_type":"voltage","unit":"V","resolution_bits":12,"ranges":[{"min":0.000,"max":10.000}],"calibration":{"model":"linear","user_override_supported":true},"extensions":{}},
+              {"id":1,"kind":"analog-output","signal_type":"voltage","unit":"V","resolution_bits":12,"ranges":[{"min":-5.000,"max":5.000}],"calibration":{"model":"linear","user_override_supported":true},"extensions":{}}
+            ]}
+            """;
+
+        #region Population from the capability document
+
+        [Fact]
+        public void Sync_DocumentWithDacChannels_PutsThemInTheChannelSnapshot()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+
+            var count = device.SyncAnalogOutputChannelsFromCapabilities();
+
+            Assert.Equal(2, count);
+            var outputs = OutputChannels(device);
+            Assert.Equal(new[] { 0, 1 }, outputs.Select(c => c.ChannelNumber));
+            Assert.All(outputs, c => Assert.Equal(ChannelType.AnalogOutput, c.Type));
+            Assert.All(outputs, c => Assert.Equal(ChannelDirection.Output, c.Direction));
+            Assert.All(outputs, c => Assert.Equal(12, c.ResolutionBits));
+            Assert.All(outputs, c => Assert.False(c.RangeIsAssumed));
+            Assert.Equal(0.0, outputs[0].MinimumVoltage);
+            Assert.Equal(10.0, outputs[0].MaximumVoltage);
+            Assert.Equal(-5.0, outputs[1].MinimumVoltage);
+            Assert.Equal(5.0, outputs[1].MaximumVoltage);
+        }
+
+        [Fact]
+        public void Sync_DocumentWithoutDacChannels_AddsNothing()
+        {
+            var device = ConnectedDeviceWith("""
+                {"schema_version":2,"channels":[
+                  {"id":0,"kind":"analog-input","signal_type":"voltage","unit":"V","resolution_bits":12,"ranges":[{"min":0.000,"max":5.000}],"extensions":{}}
+                ]}
+                """);
+
+            Assert.Equal(0, device.SyncAnalogOutputChannelsFromCapabilities());
+            Assert.Empty(OutputChannels(device));
+        }
+
+        [Fact]
+        public void Sync_NoDocumentRead_AddsNothing()
+        {
+            var device = new CapturingAnalogOutputDevice();
+            device.Connect();
+
+            Assert.Equal(0, device.SyncAnalogOutputChannelsFromCapabilities());
+            Assert.Empty(OutputChannels(device));
+        }
+
+        [Fact]
+        public void Sync_Twice_KeepsTheSameChannelInstances()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            var first = OutputChannels(device);
+
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            var second = OutputChannels(device);
+
+            Assert.Equal(2, second.Count);
+            Assert.Same(first[0], second[0]);
+            Assert.Same(first[1], second[1]);
+        }
+
+        [Fact]
+        public void Sync_RangeMissingFromTheDocument_FallsBackAndSaysSo()
+        {
+            var device = ConnectedDeviceWith("""
+                {"schema_version":2,"channels":[
+                  {"id":0,"kind":"analog-output","signal_type":"voltage","unit":"V","resolution_bits":12,"extensions":{}}
+                ]}
+                """);
+
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            var output = Assert.Single(OutputChannels(device));
+            Assert.True(output.RangeIsAssumed);
+            Assert.Equal(AnalogOutputChannel.DefaultMinimumVoltage, output.MinimumVoltage);
+            Assert.Equal(AnalogOutputChannel.DefaultMaximumVoltage, output.MaximumVoltage);
+        }
+
+        [Fact]
+        public void Sync_ImplausibleResolution_FallsBackToTheNq3Default()
+        {
+            var device = ConnectedDeviceWith("""
+                {"schema_version":2,"channels":[
+                  {"id":0,"kind":"analog-output","signal_type":"voltage","unit":"V","resolution_bits":0,"ranges":[{"min":0.000,"max":10.000}],"extensions":{}}
+                ]}
+                """);
+
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            var output = Assert.Single(OutputChannels(device));
+            Assert.Equal(AnalogOutputChannel.DefaultResolutionBits, output.ResolutionBits);
+            // A bad resolution says nothing about the range, which was stated and stays stated.
+            Assert.False(output.RangeIsAssumed);
+        }
+
+        [Fact]
+        public void Sync_DuplicateChannelId_ModelsItOnce()
+        {
+            var device = ConnectedDeviceWith("""
+                {"schema_version":2,"channels":[
+                  {"id":0,"kind":"analog-output","resolution_bits":12,"ranges":[{"min":0.000,"max":10.000}],"extensions":{}},
+                  {"id":0,"kind":"analog-output","resolution_bits":12,"ranges":[{"min":-5.000,"max":5.000}],"extensions":{}}
+                ]}
+                """);
+
+            Assert.Equal(1, device.SyncAnalogOutputChannelsFromCapabilities());
+            var output = Assert.Single(OutputChannels(device));
+            Assert.Equal(10.0, output.MaximumVoltage); // the first description wins
+        }
+
+        [Fact]
+        public void PopulateChannelsFromStatus_AfterSync_KeepsTheOutputChannels()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            var beforeRepopulation = OutputChannels(device);
+
+            // A status frame describes analog inputs and DIO only; the firmware never fills in the
+            // protobuf's DAC fields, so this must not be read as "the device has no outputs".
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 2,
+                AnalogInRes = 4095,
+                DigitalPortNum = 2,
+            });
+
+            var afterRepopulation = OutputChannels(device);
+            Assert.Equal(2, afterRepopulation.Count);
+            Assert.Same(beforeRepopulation[0], afterRepopulation[0]);
+            Assert.Same(beforeRepopulation[1], afterRepopulation[1]);
+            Assert.Equal(2, device.GetChannelsSnapshot().Count(c => c.Type == ChannelType.Analog));
+            Assert.Equal(2, device.GetChannelsSnapshot().Count(c => c.Type == ChannelType.Digital));
+        }
+
+        [Fact]
+        public void Sync_AfterChannelsWerePopulated_LeavesTheInputChannelsAlone()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 2,
+                AnalogInRes = 4095,
+                DigitalPortNum = 2,
+            });
+            var inputsBefore = device.GetChannelsSnapshot()
+                .Where(c => c.Type != ChannelType.AnalogOutput)
+                .ToList();
+
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            var after = device.GetChannelsSnapshot();
+            Assert.Equal(inputsBefore.Count + 2, after.Count);
+            foreach (var input in inputsBefore)
+            {
+                Assert.Contains(input, after);
+            }
+        }
+
+        [Fact]
+        public void Sync_WhenTheOutputSetIsUnchanged_RaisesNoChannelsPopulated()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            var raised = 0;
+            device.ChannelsPopulated += (_, _) => raised++;
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            Assert.Equal(0, raised);
+        }
+
+        [Fact]
+        public void Sync_WhenOutputsAppear_RaisesChannelsPopulatedWithTheInputCounts()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 3,
+                AnalogInRes = 4095,
+                DigitalPortNum = 2,
+            });
+
+            ChannelsPopulatedEventArgs? seen = null;
+            device.ChannelsPopulated += (_, e) => seen = e;
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            Assert.NotNull(seen);
+            Assert.Equal(3, seen!.AnalogChannelCount);
+            Assert.Equal(2, seen.DigitalChannelCount);
+            Assert.Equal(7, seen.Channels.Count);
+        }
+
+        #endregion
+
+        #region Writing a voltage
+
+        [Fact]
+        public void SetAnalogOutput_InRange_StagesThenLatchesAndRecordsTheValue()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            device.SetAnalogOutput(0, 2.5);
+
+            Assert.Equal(
+                new[] { "SOURce:VOLTage:LEVel 0,2.5", "CONFigure:DAC:UPDATE" },
+                device.SentCommands);
+            var output = OutputChannels(device)[0];
+            Assert.Equal(2.5, output.OutputVoltage);
+            Assert.Null(output.PendingVoltage);
+        }
+
+        [Theory]
+        [InlineData(10.5)]
+        [InlineData(-0.5)]
+        public void SetAnalogOutput_OutOfTheStatedRange_ThrowsAndSendsNothing(double voltage)
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => device.SetAnalogOutput(0, voltage));
+            Assert.Contains("0 to 10", ex.Message);
+            Assert.Empty(device.SentCommands);
+            Assert.Null(OutputChannels(device)[0].OutputVoltage);
+        }
+
+        [Fact]
+        public void SetAnalogOutput_UsesEachChannelsOwnRange()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            // -2 V is out of channel 0's 0..10 V range but inside channel 1's -5..5 V.
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetAnalogOutput(0, -2.0));
+            device.SetAnalogOutput(1, -2.0);
+
+            Assert.Equal(-2.0, OutputChannels(device)[1].OutputVoltage);
+        }
+
+        [Fact]
+        public void SetAnalogOutput_DeviceDescribedNoDacChannels_StillWritesByNumber()
+        {
+            // The only analog-output path this library has ever had addresses the DAC by number
+            // with no channel model behind it. Firmware that does not describe its DACs must keep
+            // working rather than start being refused.
+            var device = new CapturingAnalogOutputDevice();
+            device.Connect();
+
+            device.SetAnalogOutput(3, 42.0);
+
+            Assert.Equal(
+                new[] { "SOURce:VOLTage:LEVel 3,42", "CONFigure:DAC:UPDATE" },
+                device.SentCommands);
+        }
+
+        [Fact]
+        public void SetAnalogOutput_NegativeChannel_ThrowsAndSendsNothing()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => device.SetAnalogOutput(-1, 1.0));
+            Assert.Empty(device.SentCommands);
+        }
+
+        [Fact]
+        public void SetAnalogOutput_NotConnected_ThrowsAndSendsNothing()
+        {
+            var device = new CapturingAnalogOutputDevice();
+
+            Assert.Throws<DeviceNotConnectedException>(() => device.SetAnalogOutput(0, 1.0));
+            Assert.Empty(device.SentCommands);
+        }
+
+        [Fact]
+        public void StageAnalogOutput_DoesNotDriveThePinUntilTheLatch()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            device.StageAnalogOutput(0, 1.5);
+
+            Assert.Equal(new[] { "SOURce:VOLTage:LEVel 0,1.5" }, device.SentCommands);
+            var output = OutputChannels(device)[0];
+            Assert.Equal(1.5, output.PendingVoltage);
+            Assert.Null(output.OutputVoltage);
+        }
+
+        [Fact]
+        public void LatchAnalogOutputs_AppliesEveryStagedChannelTogether()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            device.StageAnalogOutput(0, 1.5);
+            device.StageAnalogOutput(1, -1.5);
+            device.LatchAnalogOutputs();
+
+            Assert.Equal(
+                new[] { "SOURce:VOLTage:LEVel 0,1.5", "SOURce:VOLTage:LEVel 1,-1.5", "CONFigure:DAC:UPDATE" },
+                device.SentCommands);
+            var outputs = OutputChannels(device);
+            Assert.Equal(1.5, outputs[0].OutputVoltage);
+            Assert.Equal(-1.5, outputs[1].OutputVoltage);
+            Assert.All(outputs, c => Assert.Null(c.PendingVoltage));
+        }
+
+        [Fact]
+        public void LatchAnalogOutputs_WithNothingStaged_StillCommandsTheDevice()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            device.LatchAnalogOutputs();
+
+            Assert.Equal(new[] { "CONFigure:DAC:UPDATE" }, device.SentCommands);
+            Assert.All(OutputChannels(device), c => Assert.Null(c.OutputVoltage));
+        }
+
+        [Fact]
+        public void StageAnalogOutput_NotConnected_ThrowsAndStagesNothing()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            device.Disconnect();
+
+            Assert.Throws<DeviceNotConnectedException>(() => device.StageAnalogOutput(0, 1.0));
+            Assert.Null(OutputChannels(device)[0].PendingVoltage);
+            Assert.Empty(device.SentCommands);
+        }
+
+        #endregion
+
+        #region Enabling
+
+        [Fact]
+        public void EnableChannel_OnAnAnalogOutput_IsRefused()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            var output = OutputChannels(device)[0];
+
+            var ex = Assert.Throws<ArgumentException>(() => device.EnableChannel(output));
+            Assert.Contains("SetAnalogOutput", ex.Message);
+            Assert.Empty(device.SentCommands);
+        }
+
+        [Fact]
+        public void DisableAllChannels_IgnoresAnalogOutputs()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 2,
+                AnalogInRes = 4095,
+            });
+            device.SentCommands.Clear();
+
+            device.DisableAllChannels();
+
+            // Only the ADC mask is pushed; nothing addresses the DAC channels.
+            Assert.Equal(new[] { "ENAble:VOLTage:DC 0" }, device.SentCommands);
+        }
+
+        #endregion
+
+        #region Readback
+
+        [Fact]
+        public async Task GetAnalogOutputAsync_ParsesTheVoltageAndRecordsIt()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            device.CannedTextResponse.Add("2.5000");
+
+            var volts = await device.GetAnalogOutputAsync(0);
+
+            Assert.Equal(2.5, volts);
+            Assert.Equal(new[] { "SOURce:VOLTage:LEVel? 0" }, device.SentCommands);
+            Assert.Equal(2.5, OutputChannels(device)[0].OutputVoltage);
+        }
+
+        [Fact]
+        public async Task GetAnalogOutputAsync_SkipsEchoLinesBeforeTheNumber()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            device.CannedTextResponse.Add("SOURce:VOLTage:LEVel? 0");
+            device.CannedTextResponse.Add(" -1.2500 ");
+
+            Assert.Equal(-1.25, await device.GetAnalogOutputAsync(1));
+        }
+
+        [Fact]
+        public async Task GetAnalogOutputAsync_DeviceReportsAnError_Throws()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            device.CannedTextResponse.Add("**ERROR: -113, \"Undefined header\"");
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.GetAnalogOutputAsync(0));
+            Assert.Contains("rejected", ex.Message);
+        }
+
+        [Fact]
+        public async Task GetAnalogOutputAsync_UnparseableAnswer_Throws()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            device.CannedTextResponse.Add("not a voltage");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => device.GetAnalogOutputAsync(0));
+        }
+
+        [Fact]
+        public async Task GetAnalogOutputAsync_NoAnswerAtAll_Throws()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => device.GetAnalogOutputAsync(0));
+            Assert.Contains("(nothing)", ex.Message);
+        }
+
+        [Fact]
+        public async Task GetAnalogOutputAsync_NegativeChannel_Throws()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                () => device.GetAnalogOutputAsync(-1));
+        }
+
+        [Fact]
+        public async Task GetAnalogOutputAsync_NotConnected_Throws()
+        {
+            var device = new CapturingAnalogOutputDevice();
+
+            await Assert.ThrowsAsync<DeviceNotConnectedException>(
+                () => device.GetAnalogOutputAsync(0));
+        }
+
+        #endregion
+
+        private static CapturingAnalogOutputDevice ConnectedDeviceWith(string capabilityJson)
+        {
+            Assert.True(CapabilityDocumentParser.TryParse(capabilityJson, out var document));
+
+            var device = new CapturingAnalogOutputDevice();
+            device.Connect();
+            device.Metadata.ApplyCapabilityDocument(document!);
+            device.SentCommands.Clear();
+            return device;
+        }
+
+        private static List<IAnalogOutputChannel> OutputChannels(DaqifiDevice device)
+            => device.GetChannelsSnapshot()
+                .OfType<IAnalogOutputChannel>()
+                .OrderBy(c => c.ChannelNumber)
+                .ToList();
+
+        /// <summary>
+        /// A streaming device that records what it would have sent and answers text exchanges from
+        /// a canned response, so the analog-output paths can be exercised without hardware
+        /// (mirrors <c>TestableLanChipInfoDevice</c>).
+        /// </summary>
+        private sealed class CapturingAnalogOutputDevice : DaqifiStreamingDevice
+        {
+            public CapturingAnalogOutputDevice() : base("TestDevice") { }
+
+            public List<string> SentCommands { get; } = new();
+
+            public List<string> CannedTextResponse { get; } = new();
+
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                if (message is IOutboundMessage<string> stringMessage)
+                {
+                    SentCommands.Add(stringMessage.Data);
+                }
+            }
+
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+                Action setupAction,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default,
+                Func<CancellationToken, Task>? prepareAsync = null,
+                Func<Task>? finalizeAsync = null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                setupAction();
+                return Task.FromResult<IReadOnlyList<string>>(CannedTextResponse.ToList());
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAnalogOutputTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAnalogOutputTests.cs
@@ -165,6 +165,50 @@ namespace Daqifi.Core.Tests.Device
         }
 
         [Fact]
+        public void PopulateChannelsFromStatus_AfterTheDeviceMovedToAnotherBoard_DropsTheOutputChannels()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+            Assert.Equal(2, OutputChannels(device).Count);
+
+            // Reconnecting this instance to a different known board drops the capability
+            // document it read from the previous one — and the DAC channels that document
+            // described must not linger as another board's outputs.
+            device.Metadata.UpdateFromProtobuf(new DaqifiOutMessage { DevicePn = "Nq3" });
+            device.Metadata.UpdateFromProtobuf(new DaqifiOutMessage { DevicePn = "Nq1" });
+            Assert.Null(device.Metadata.CapabilityDocument);
+
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 2,
+                AnalogInRes = 4095,
+            });
+
+            Assert.Empty(OutputChannels(device));
+        }
+
+        [Fact]
+        public void PopulateChannelsFromStatus_WhenTheBoardIsUnchanged_KeepsTheOutputChannels()
+        {
+            var device = ConnectedDeviceWith(TwoDacDocument);
+            device.SyncAnalogOutputChannelsFromCapabilities();
+
+            // The same board repeating its part number is not a board change, so the document —
+            // and the channels it described — survive.
+            device.Metadata.UpdateFromProtobuf(new DaqifiOutMessage { DevicePn = "Nq3" });
+            device.Metadata.UpdateFromProtobuf(new DaqifiOutMessage { DevicePn = "Nq3" });
+            Assert.NotNull(device.Metadata.CapabilityDocument);
+
+            device.PopulateChannelsFromStatus(new DaqifiOutMessage
+            {
+                AnalogInPortNum = 2,
+                AnalogInRes = 4095,
+            });
+
+            Assert.Equal(2, OutputChannels(device).Count);
+        }
+
+        [Fact]
         public void Sync_AfterChannelsWerePopulated_LeavesTheInputChannelsAlone()
         {
             var device = ConnectedDeviceWith(TwoDacDocument);

--- a/src/Daqifi.Core/Channel/AnalogOutputChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogOutputChannel.cs
@@ -1,0 +1,325 @@
+namespace Daqifi.Core.Channel;
+
+/// <summary>
+/// An analog-output (DAC) channel on a DAQiFi device. Populated from the device's capability
+/// document, which is the only place the firmware describes its DAC channels — the protobuf status
+/// message declares the fields but never fills them in.
+/// </summary>
+/// <remarks>
+/// A write is a two-step device operation: staging a voltage records it on the device without
+/// changing the pin, and a latch applies every staged channel at once. This class models both, so
+/// <see cref="OutputVoltage"/> only ever reports a voltage the hardware is actually driving and
+/// <see cref="PendingVoltage"/> reports one that is waiting.
+/// </remarks>
+public sealed class AnalogOutputChannel : IAnalogOutputChannel
+{
+    /// <summary>
+    /// The DAC resolution assumed when the device states none: 12 bits, the DAC7718 fitted to NQ3.
+    /// </summary>
+    public const int DefaultResolutionBits = 12;
+
+    /// <summary>The lowest voltage assumed when the device states no range.</summary>
+    public const double DefaultMinimumVoltage = 0.0;
+
+    /// <summary>
+    /// The highest voltage assumed when the device states no range — 10 V, the DAC7718's hardware
+    /// full scale on NQ3.
+    /// </summary>
+    public const double DefaultMaximumVoltage = 10.0;
+
+    /// <summary>Smallest resolution accepted as physically plausible, in bits.</summary>
+    public const int MinResolutionBits = 1;
+
+    /// <summary>Largest resolution accepted as physically plausible, in bits.</summary>
+    public const int MaxResolutionBits = 32;
+
+    /// <summary>
+    /// Largest absolute voltage accepted as a range endpoint. DAQiFi analog output tops out at
+    /// 10 V; 50 leaves headroom for future hardware while still rejecting a corrupt value.
+    /// </summary>
+    public const double MaxRangeMagnitudeVolts = 50.0;
+
+    private readonly object _lock = new();
+    private IDataSample? _activeSample;
+    private string _name;
+    private bool _isEnabled;
+    private int _resolutionBits;
+    private double _minimumVoltage;
+    private double _maximumVoltage;
+    private bool _rangeIsAssumed;
+    private double? _pendingVoltage;
+
+    /// <inheritdoc />
+    public int ChannelNumber { get; }
+
+    /// <inheritdoc />
+    public string Name
+    {
+        get { lock (_lock) { return _name; } }
+        set { lock (_lock) { _name = value; } }
+    }
+
+    /// <summary>
+    /// Gets or sets whether the channel is enabled. Carried for <see cref="IChannel"/>
+    /// compatibility only — an analog output is driven by writing a voltage to it, and nothing in
+    /// the acquisition path (the ADC enable bitmask, the stream decoder, the sample-rate model)
+    /// consults this flag for an output channel.
+    /// </summary>
+    public bool IsEnabled
+    {
+        get { lock (_lock) { return _isEnabled; } }
+        set { lock (_lock) { _isEnabled = value; } }
+    }
+
+    /// <summary>Gets the channel type (always <see cref="ChannelType.AnalogOutput"/>).</summary>
+    public ChannelType Type => ChannelType.AnalogOutput;
+
+    /// <summary>
+    /// Gets the channel direction. Always <see cref="ChannelDirection.Output"/>; assigning
+    /// anything else throws, because the direction of a DAC channel is a fact about the hardware
+    /// rather than a setting.
+    /// </summary>
+    /// <exception cref="ArgumentException">A direction other than Output was assigned.</exception>
+    public ChannelDirection Direction
+    {
+        get => ChannelDirection.Output;
+        set
+        {
+            if (value != ChannelDirection.Output)
+            {
+                throw new ArgumentException(
+                    $"An analog output channel is always {nameof(ChannelDirection.Output)}; it cannot be set to {value}.",
+                    nameof(value));
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public IDataSample? ActiveSample
+    {
+        get { lock (_lock) { return _activeSample; } }
+    }
+
+    /// <inheritdoc />
+    public int ResolutionBits
+    {
+        get { lock (_lock) { return _resolutionBits; } }
+    }
+
+    /// <inheritdoc />
+    public double MinimumVoltage
+    {
+        get { lock (_lock) { return _minimumVoltage; } }
+    }
+
+    /// <inheritdoc />
+    public double MaximumVoltage
+    {
+        get { lock (_lock) { return _maximumVoltage; } }
+    }
+
+    /// <inheritdoc />
+    public bool RangeIsAssumed
+    {
+        get { lock (_lock) { return _rangeIsAssumed; } }
+    }
+
+    /// <inheritdoc />
+    public double? OutputVoltage
+    {
+        get { lock (_lock) { return _activeSample?.Value; } }
+    }
+
+    /// <inheritdoc />
+    public double? PendingVoltage
+    {
+        get { lock (_lock) { return _pendingVoltage; } }
+    }
+
+    /// <inheritdoc />
+    public event EventHandler<SampleReceivedEventArgs>? SampleReceived;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnalogOutputChannel"/> class.
+    /// </summary>
+    /// <param name="channelNumber">The device-facing channel number.</param>
+    /// <param name="resolutionBits">The DAC resolution in bits.</param>
+    /// <param name="minimumVoltage">The lowest voltage the channel accepts.</param>
+    /// <param name="maximumVoltage">The highest voltage the channel accepts.</param>
+    /// <param name="rangeIsAssumed">
+    /// Whether the range is a Core fallback rather than a device-stated one.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The channel number is negative, the resolution is outside
+    /// [<see cref="MinResolutionBits"/>, <see cref="MaxResolutionBits"/>], or a range endpoint is
+    /// non-finite or beyond <see cref="MaxRangeMagnitudeVolts"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">The range is empty or inverted.</exception>
+    public AnalogOutputChannel(
+        int channelNumber,
+        int resolutionBits = DefaultResolutionBits,
+        double minimumVoltage = DefaultMinimumVoltage,
+        double maximumVoltage = DefaultMaximumVoltage,
+        bool rangeIsAssumed = false)
+    {
+        if (channelNumber < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(channelNumber), channelNumber, "Channel number must be non-negative.");
+        }
+
+        ValidateResolutionBits(resolutionBits, nameof(resolutionBits));
+        ValidateRangeEndpoint(minimumVoltage, nameof(minimumVoltage));
+        ValidateRangeEndpoint(maximumVoltage, nameof(maximumVoltage));
+
+        if (minimumVoltage >= maximumVoltage)
+        {
+            throw new ArgumentException(
+                $"The output range is empty: minimum ({minimumVoltage}) must be below maximum ({maximumVoltage}).",
+                nameof(minimumVoltage));
+        }
+
+        ChannelNumber = channelNumber;
+        _resolutionBits = resolutionBits;
+        _minimumVoltage = minimumVoltage;
+        _maximumVoltage = maximumVoltage;
+        _rangeIsAssumed = rangeIsAssumed;
+        _name = $"Analog Output {channelNumber}";
+    }
+
+    /// <inheritdoc />
+    public bool IsInRange(double voltage)
+    {
+        if (!double.IsFinite(voltage))
+        {
+            return false;
+        }
+
+        lock (_lock)
+        {
+            return voltage >= _minimumVoltage && voltage <= _maximumVoltage;
+        }
+    }
+
+    /// <summary>
+    /// Atomically refreshes the resolution and range from a newly-read capability document, so a
+    /// consumer holding this instance keeps it across a re-read rather than losing its identity.
+    /// </summary>
+    internal void UpdateFromCapabilities(
+        int resolutionBits, double minimumVoltage, double maximumVoltage, bool rangeIsAssumed)
+    {
+        lock (_lock)
+        {
+            _resolutionBits = resolutionBits;
+            _minimumVoltage = minimumVoltage;
+            _maximumVoltage = maximumVoltage;
+            _rangeIsAssumed = rangeIsAssumed;
+        }
+    }
+
+    /// <summary>
+    /// Records a voltage as staged on the device but not yet driven on the pin.
+    /// </summary>
+    internal void Stage(double voltage)
+    {
+        lock (_lock)
+        {
+            _pendingVoltage = voltage;
+        }
+    }
+
+    /// <summary>
+    /// Promotes the staged voltage (if any) to the driven value, raising
+    /// <see cref="SampleReceived"/> so a consumer sees the change the same way it sees an input
+    /// sample. Returns whether anything was pending.
+    /// </summary>
+    internal bool Latch(DateTime timestamp)
+    {
+        double staged;
+
+        lock (_lock)
+        {
+            if (_pendingVoltage is null)
+            {
+                return false;
+            }
+
+            staged = _pendingVoltage.Value;
+            _pendingVoltage = null;
+        }
+
+        SetActiveSample(new DataSample(timestamp, staged));
+        return true;
+    }
+
+    /// <summary>
+    /// Discards a staged voltage without driving it — used when the device rejects or never
+    /// receives the latch.
+    /// </summary>
+    internal void ClearPending()
+    {
+        lock (_lock)
+        {
+            _pendingVoltage = null;
+        }
+    }
+
+    /// <summary>
+    /// Records a voltage as the value now driven on this channel, bypassing the staging step.
+    /// Used by the device readback, which reports what the hardware currently holds.
+    /// </summary>
+    internal void SetOutputVoltage(double voltage, DateTime timestamp)
+        => SetActiveSample(new DataSample(timestamp, voltage));
+
+    /// <summary>
+    /// Sets the value driven on this channel and raises <see cref="SampleReceived"/>. This is a
+    /// record of what the host commanded, not a hardware measurement; the device has no DAC
+    /// readback path.
+    /// </summary>
+    /// <param name="value">The voltage now driven on the channel.</param>
+    /// <param name="timestamp">When the value took effect.</param>
+    public void SetActiveSample(double value, DateTime timestamp)
+        => SetActiveSample(new DataSample(timestamp, value));
+
+    /// <summary>
+    /// Sets the value driven on this channel from a fully-formed sample and raises
+    /// <see cref="SampleReceived"/>.
+    /// </summary>
+    /// <param name="sample">The sample to record.</param>
+    public void SetActiveSample(IDataSample sample)
+    {
+        ArgumentNullException.ThrowIfNull(sample);
+
+        lock (_lock)
+        {
+            _activeSample = sample;
+        }
+
+        SampleReceived?.Invoke(this, new SampleReceivedEventArgs(this, sample));
+    }
+
+    /// <summary>Returns the channel name.</summary>
+    public override string ToString() => Name;
+
+    private static void ValidateResolutionBits(int resolutionBits, string parameterName)
+    {
+        if (resolutionBits is < MinResolutionBits or > MaxResolutionBits)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                resolutionBits,
+                $"DAC resolution must be between {MinResolutionBits} and {MaxResolutionBits} bits.");
+        }
+    }
+
+    private static void ValidateRangeEndpoint(double volts, string parameterName)
+    {
+        if (!double.IsFinite(volts) || Math.Abs(volts) > MaxRangeMagnitudeVolts)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                volts,
+                $"An output range endpoint must be finite and within +/-{MaxRangeMagnitudeVolts} V.");
+        }
+    }
+}

--- a/src/Daqifi.Core/Channel/ChannelType.cs
+++ b/src/Daqifi.Core/Channel/ChannelType.cs
@@ -13,5 +13,18 @@ public enum ChannelType
     /// <summary>
     /// Analog channel (continuous value).
     /// </summary>
-    Analog
+    Analog,
+
+    /// <summary>
+    /// Analog output (DAC) channel — a continuous value the host drives onto a pin rather than
+    /// one the device measures. Modelled by <see cref="AnalogOutputChannel"/> and populated from
+    /// the device's capability document; available on NQ3 hardware only.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a distinct member rather than <see cref="Analog"/> with
+    /// <see cref="ChannelDirection.Output"/>: every acquisition path in the library selects its
+    /// channels with <c>Type == Analog</c> (the ADC enable bitmask, the stream decoder, the
+    /// sample-rate model), and a DAC channel belongs in none of them.
+    /// </remarks>
+    AnalogOutput
 }

--- a/src/Daqifi.Core/Channel/IAnalogOutputChannel.cs
+++ b/src/Daqifi.Core/Channel/IAnalogOutputChannel.cs
@@ -1,0 +1,60 @@
+namespace Daqifi.Core.Channel;
+
+/// <summary>
+/// An analog-output (DAC) channel: a channel the host drives to a voltage rather than one the
+/// device measures. Available on NQ3 hardware only.
+/// </summary>
+/// <remarks>
+/// Deliberately <b>not</b> an <see cref="IAnalogChannel"/>. Every acquisition path in the library
+/// selects its channels with <c>is IAnalogChannel</c> or <c>Type == ChannelType.Analog</c> — the
+/// ADC enable bitmask, the stream decoder, the sample-rate model — and a DAC channel belongs in
+/// none of them. It shares only <see cref="IChannel"/>, which is what puts it in the device's
+/// channel collection and gives it the sample/notification plumbing used here to report the value
+/// currently driven on the pin.
+/// </remarks>
+public interface IAnalogOutputChannel : IChannel
+{
+    /// <summary>
+    /// Gets the DAC resolution in bits, as stated by the device's capability document.
+    /// </summary>
+    int ResolutionBits { get; }
+
+    /// <summary>
+    /// Gets the lowest voltage this channel accepts.
+    /// </summary>
+    double MinimumVoltage { get; }
+
+    /// <summary>
+    /// Gets the highest voltage this channel accepts.
+    /// </summary>
+    double MaximumVoltage { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="MinimumVoltage"/>/<see cref="MaximumVoltage"/>
+    /// came from the device's own self-description. When <c>false</c> the device stated no range
+    /// and the defaults are in use, so a rejected write may reflect Core's assumption rather than
+    /// the hardware's real limit.
+    /// </summary>
+    bool RangeIsAssumed { get; }
+
+    /// <summary>
+    /// Gets the voltage most recently latched onto this channel by this library, or <c>null</c> if
+    /// none has been. This is what Core commanded, not a hardware measurement — the DAC7718 has no
+    /// readback path, and the device's own <c>SOURce:VOLTage:LEVel?</c> likewise answers with the
+    /// last value it was told.
+    /// </summary>
+    double? OutputVoltage { get; }
+
+    /// <summary>
+    /// Gets the voltage staged for this channel and not yet latched, or <c>null</c> when nothing is
+    /// pending. Staged values take effect together on the next latch.
+    /// </summary>
+    double? PendingVoltage { get; }
+
+    /// <summary>
+    /// Returns whether <paramref name="voltage"/> lies within this channel's accepted range.
+    /// </summary>
+    /// <param name="voltage">The voltage to test, in volts.</param>
+    /// <returns><c>true</c> when the voltage is finite and within the range, inclusive.</returns>
+    bool IsInRange(double voltage);
+}

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -695,6 +695,29 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> UpdateDacOutputs => new ScpiMessage("CONFigure:DAC:UPDATE");
 
+    /// <summary>
+    /// Creates a query message asking the device for the voltage currently held on an analog
+    /// output (DAC) channel.
+    /// </summary>
+    /// <param name="channel">The analog output channel number.</param>
+    /// <remarks>
+    /// The DAC7718 has no hardware readback, so the device answers with the voltage it was last
+    /// told to drive, formatted to its configured voltage precision. Analog output is available on
+    /// NQ3 hardware only.
+    /// Command: SOURce:VOLTage:LEVel? channel
+    /// Example: messageProducer.Send(ScpiMessageProducer.GetAnalogOutputVoltage(0));
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="channel"/> is negative.</exception>
+    public static IOutboundMessage<string> GetAnalogOutputVoltage(int channel)
+    {
+        if (channel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+
+        return new ScpiMessage($"SOURce:VOLTage:LEVel? {channel}");
+    }
+
     // ---------------------------------------------------------------------
     // ADC calibration & voltage-precision persistence
     //

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -2675,6 +2675,10 @@ namespace Daqifi.Core.Device
 
             Metadata.ApplyCapabilityDocument(document);
 
+            // The document is also the only description of the device's DAC channels, so this is
+            // the moment they can be modelled (#499).
+            SyncAnalogOutputChannelsFromCapabilities();
+
             // The document is the only place the device says what its analog readings are measured
             // in, so this is where a channel learns its unit (#501). Never overwrites a scaling a
             // caller configured, which matters because this method is re-run on every capability
@@ -3987,6 +3991,13 @@ namespace Daqifi.Core.Device
 
                 (analogCount, digitalCount) = _channelPopulator.Populate(message, _channels, updatedChannels);
 
+                // Analog-output (DAC) channels are described only by the capability document —
+                // the protobuf declares analog_out_port_num/_res/_range but the firmware never
+                // fills them in — so a status message says nothing about them and must not be read
+                // as "this device has none". Carry the modelled ones across untouched, in the same
+                // order, so the membership comparison below still sees no change.
+                CarryForwardAnalogOutputChannels(_channels, updatedChannels);
+
                 // Only a change of *membership* needs handling here. A status that re-asserts a
                 // different enabled mask on channels the device already had has moved the version
                 // already, through those channels' own notifications — they were still subscribed
@@ -4032,6 +4043,203 @@ namespace Daqifi.Core.Device
                 Array.AsReadOnly(channelsSnapshot),
                 analogCount,
                 digitalCount));
+        }
+
+        /// <summary>
+        /// Appends the analog-output channels already modelled on this device to a freshly-built
+        /// channel list, preserving their instances and their order.
+        /// </summary>
+        private static void CarryForwardAnalogOutputChannels(
+            IReadOnlyList<IChannel> existing, List<IChannel> destination)
+        {
+            foreach (var channel in existing)
+            {
+                if (channel.Type == ChannelType.AnalogOutput)
+                {
+                    destination.Add(channel);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Brings the device's analog-output (DAC) channels into line with the capability document
+        /// the device most recently reported, so they appear in <see cref="GetChannelsSnapshot"/>
+        /// alongside the input channels.
+        /// </summary>
+        /// <remarks>
+        /// The capability document is the <b>only</b> place the firmware describes its DAC
+        /// channels: the protobuf status message declares
+        /// <c>analog_out_port_num</c>/<c>_res</c>/<c>_range</c> but never populates them, which is
+        /// why analog outputs are not built in <see cref="PopulateChannelsFromStatus"/> with
+        /// everything else. <see cref="ReadCapabilityDocumentAsync"/> calls this for you; call it
+        /// yourself only if you applied a document by hand through
+        /// <see cref="DeviceMetadata.ApplyCapabilityDocument"/>. With no document in hand, or on a
+        /// device whose document lists no analog outputs, the channel collection is left alone.
+        /// Existing instances are refreshed in place so a consumer-held reference survives a
+        /// re-read.
+        /// </remarks>
+        /// <returns>The number of analog-output channels the device now has.</returns>
+        public int SyncAnalogOutputChannelsFromCapabilities()
+        {
+            var document = Metadata.CapabilityDocument;
+            if (document is null || document.Channels.Count == 0)
+            {
+                return 0;
+            }
+
+            IChannel[]? channelsSnapshot = null;
+            var analogCount = 0;
+            var digitalCount = 0;
+            int outputCount;
+
+            lock (_channelsLock)
+            {
+                var existingOutputs = new Dictionary<int, AnalogOutputChannel>();
+                var retained = new List<IChannel>(_channels.Count);
+
+                foreach (var channel in _channels)
+                {
+                    if (channel is AnalogOutputChannel output)
+                    {
+                        existingOutputs[output.ChannelNumber] = output;
+                    }
+                    else
+                    {
+                        retained.Add(channel);
+
+                        if (channel.Type == ChannelType.Analog)
+                        {
+                            analogCount++;
+                        }
+                        else if (channel.Type == ChannelType.Digital)
+                        {
+                            digitalCount++;
+                        }
+                    }
+                }
+
+                var rebuiltOutputs = new List<IChannel>();
+                var seenNumbers = new HashSet<int>();
+
+                foreach (var descriptor in document.Channels)
+                {
+                    if (descriptor.Kind != CapabilityChannelKind.AnalogOutput)
+                    {
+                        continue;
+                    }
+
+                    if (descriptor.Id < 0)
+                    {
+                        var negativeId = descriptor.Id;
+                        SafeLog(() => _logger.LogWarning(
+                            "[SyncAnalogOutputChannels] Device '{DeviceName}' described an analog output with a negative id ({ChannelId}); ignoring it.",
+                            Name, negativeId));
+                        continue;
+                    }
+
+                    if (!seenNumbers.Add(descriptor.Id))
+                    {
+                        var duplicateId = descriptor.Id;
+                        SafeLog(() => _logger.LogWarning(
+                            "[SyncAnalogOutputChannels] Device '{DeviceName}' described analog output {ChannelId} more than once; keeping the first description.",
+                            Name, duplicateId));
+                        continue;
+                    }
+
+                    var (resolutionBits, minimumVoltage, maximumVoltage, rangeIsAssumed) =
+                        ResolveAnalogOutputDescriptor(descriptor);
+
+                    if (existingOutputs.TryGetValue(descriptor.Id, out var existing))
+                    {
+                        existing.UpdateFromCapabilities(resolutionBits, minimumVoltage, maximumVoltage, rangeIsAssumed);
+                        rebuiltOutputs.Add(existing);
+                    }
+                    else
+                    {
+                        rebuiltOutputs.Add(new AnalogOutputChannel(
+                            descriptor.Id, resolutionBits, minimumVoltage, maximumVoltage, rangeIsAssumed));
+                    }
+                }
+
+                outputCount = rebuiltOutputs.Count;
+
+                // Only disturb the collection when the set of output channels actually changed; a
+                // re-read describing the same DACs updates them in place and raises nothing.
+                var compositionChanged =
+                    outputCount != existingOutputs.Count ||
+                    !seenNumbers.SetEquals(existingOutputs.Keys);
+
+                if (compositionChanged)
+                {
+                    retained.AddRange(rebuiltOutputs);
+                    _channels.Clear();
+                    _channels.AddRange(retained);
+                    channelsSnapshot = _channels.ToArray();
+
+                    // An analog output carries no enablement notification of its own, so the set
+                    // changing is the only thing a cache keyed on the channel list can observe.
+                    Interlocked.Increment(ref _channelStateVersion);
+                }
+            }
+
+            if (channelsSnapshot is not null)
+            {
+                // Outside the lock: a handler calling back into a channel method takes the same
+                // lock. Mirrors PopulateChannelsFromStatus.
+                ChannelsPopulated?.Invoke(this, new ChannelsPopulatedEventArgs(
+                    Array.AsReadOnly(channelsSnapshot), analogCount, digitalCount));
+            }
+
+            return outputCount;
+        }
+
+        /// <summary>
+        /// Derives the resolution and voltage range to model an analog-output channel with, falling
+        /// back to <see cref="AnalogOutputChannel"/>'s NQ3 defaults for anything the document does
+        /// not state or states implausibly.
+        /// </summary>
+        private (int ResolutionBits, double MinimumVoltage, double MaximumVoltage, bool RangeIsAssumed)
+            ResolveAnalogOutputDescriptor(CapabilityChannel descriptor)
+        {
+            var resolutionBits = descriptor.ResolutionBits ?? AnalogOutputChannel.DefaultResolutionBits;
+
+            if (resolutionBits is < AnalogOutputChannel.MinResolutionBits or > AnalogOutputChannel.MaxResolutionBits)
+            {
+                var stated = resolutionBits;
+                SafeLog(() => _logger.LogWarning(
+                    "[SyncAnalogOutputChannels] Device '{DeviceName}' reported an implausible DAC resolution ({Resolution} bits) for analog output {ChannelId}; assuming {AssumedResolution}.",
+                    Name, stated, descriptor.Id, AnalogOutputChannel.DefaultResolutionBits));
+                resolutionBits = AnalogOutputChannel.DefaultResolutionBits;
+            }
+
+            var minimum = descriptor.RangeMinimum;
+            var maximum = descriptor.RangeMaximum;
+
+            var statedRangeIsUsable =
+                minimum.HasValue && maximum.HasValue &&
+                double.IsFinite(minimum.Value) && double.IsFinite(maximum.Value) &&
+                Math.Abs(minimum.Value) <= AnalogOutputChannel.MaxRangeMagnitudeVolts &&
+                Math.Abs(maximum.Value) <= AnalogOutputChannel.MaxRangeMagnitudeVolts &&
+                minimum.Value < maximum.Value;
+
+            if (statedRangeIsUsable)
+            {
+                return (resolutionBits, minimum!.Value, maximum!.Value, false);
+            }
+
+            if (minimum.HasValue || maximum.HasValue)
+            {
+                SafeLog(() => _logger.LogWarning(
+                    "[SyncAnalogOutputChannels] Device '{DeviceName}' reported an unusable output range ({Minimum} to {Maximum}) for analog output {ChannelId}; assuming {AssumedMinimum} to {AssumedMaximum} V.",
+                    Name, minimum, maximum, descriptor.Id,
+                    AnalogOutputChannel.DefaultMinimumVoltage, AnalogOutputChannel.DefaultMaximumVoltage));
+            }
+
+            return (
+                resolutionBits,
+                AnalogOutputChannel.DefaultMinimumVoltage,
+                AnalogOutputChannel.DefaultMaximumVoltage,
+                true);
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -3996,7 +3996,16 @@ namespace Daqifi.Core.Device
                 // fills them in — so a status message says nothing about them and must not be read
                 // as "this device has none". Carry the modelled ones across untouched, in the same
                 // order, so the membership comparison below still sees no change.
-                CarryForwardAnalogOutputChannels(_channels, updatedChannels);
+                //
+                // Their lifetime is the document's: metadata is updated from this same message
+                // before we get here, so a reconnect that lands this instance on a *different*
+                // known board has already dropped the document it read from the previous one, and
+                // the channels it described go with it rather than lingering as another board's
+                // DACs.
+                if (Metadata.CapabilityDocument is not null)
+                {
+                    CarryForwardAnalogOutputChannels(_channels, updatedChannels);
+                }
 
                 // Only a change of *membership* needs handling here. A status that re-asserts a
                 // different enabled mask on channels the device already had has moved the version

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -925,6 +925,61 @@ namespace Daqifi.Core.Device
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Stages an analog output (DAC) voltage without applying it. The value takes effect on the
+        /// next <see cref="LatchAnalogOutputs"/>, so several channels can be made to change together.
+        /// </summary>
+        /// <param name="channelNumber">The analog output channel number.</param>
+        /// <param name="voltage">
+        /// The output voltage, in volts. Must be finite, and within the channel's range when the
+        /// device described one.
+        /// </param>
+        /// <remarks>
+        /// This is the device's own two-step protocol made explicit:
+        /// <see cref="SetAnalogOutput"/> is exactly a stage followed by a latch. Until the latch,
+        /// <see cref="Daqifi.Core.Channel.IAnalogOutputChannel.PendingVoltage"/> reports the staged
+        /// value and <see cref="Daqifi.Core.Channel.IAnalogOutputChannel.OutputVoltage"/> still
+        /// reports what the pin is driving. Analog output is available on NQ3 hardware only.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The channel number is negative, or the voltage falls outside the channel's stated range.
+        /// </exception>
+        /// <exception cref="DeviceNotConnectedException">The device is not connected.</exception>
+        public void StageAnalogOutput(int channelNumber, double voltage)
+            => _channelControl.StageAnalogOutput(channelNumber, voltage);
+
+        /// <summary>
+        /// Applies every analog output (DAC) voltage staged since the last latch, so the staged
+        /// channels change together.
+        /// </summary>
+        /// <remarks>
+        /// Latching with nothing staged is harmless — the device re-applies what it already holds.
+        /// Analog output is available on NQ3 hardware only.
+        /// </remarks>
+        /// <exception cref="DeviceNotConnectedException">The device is not connected.</exception>
+        public void LatchAnalogOutputs() => _channelControl.LatchAnalogOutputs();
+
+        /// <summary>
+        /// Asks the device what voltage an analog output (DAC) channel is holding, and records it
+        /// on the modelled channel.
+        /// </summary>
+        /// <param name="channelNumber">The analog output channel number.</param>
+        /// <param name="cancellationToken">Cancels the exchange.</param>
+        /// <returns>The voltage the device reports, in volts.</returns>
+        /// <remarks>
+        /// The DAC has no hardware readback, so the device answers with the value it was last told
+        /// to drive. That still makes this the authoritative round-trip: it reflects what the
+        /// device actually accepted, including a write made before this session connected.
+        /// Analog output is available on NQ3 hardware only.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="channelNumber"/> is negative.</exception>
+        /// <exception cref="DeviceNotConnectedException">The device is not connected.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// The device rejected the query or answered with something that is not a voltage.
+        /// </exception>
+        public Task<double> GetAnalogOutputAsync(int channelNumber, CancellationToken cancellationToken = default)
+            => _channelControl.GetAnalogOutputAsync(channelNumber, cancellationToken);
+
         /// <inheritdoc />
         public void Reboot() => _administration.Reboot();
 

--- a/src/Daqifi.Core/Device/IStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/IStreamingDevice.cs
@@ -407,13 +407,22 @@ namespace Daqifi.Core.Device
         /// <summary>
         /// Sets the analog output (DAC) voltage of a channel and applies it immediately.
         /// </summary>
-        /// <param name="channelNumber">The analog output channel number. DAC channels are addressed by
-        /// number; they are not part of the <c>Channels</c> collection (which holds analog inputs).</param>
-        /// <param name="voltage">The output voltage, in volts. Must be a finite number.</param>
+        /// <param name="channelNumber">The analog output channel number.</param>
+        /// <param name="voltage">
+        /// The output voltage, in volts. Must be a finite number, and within the channel's stated
+        /// range when the device described one (see
+        /// <see cref="Daqifi.Core.Channel.IAnalogOutputChannel"/>).
+        /// </param>
         /// <remarks>
         /// Analog output is available on NQ3 hardware only. Each call stages the level and then latches it
-        /// immediately, so it is not suitable for synchronized multi-channel updates.
+        /// immediately, so it is not suitable for synchronized multi-channel updates — use
+        /// <see cref="DaqifiStreamingDevice.StageAnalogOutput"/> and
+        /// <see cref="DaqifiStreamingDevice.LatchAnalogOutputs"/> for that.
         /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The channel number is negative, or the voltage falls outside the range the device stated
+        /// for a channel it described.
+        /// </exception>
         void SetAnalogOutput(int channelNumber, double voltage);
 
         /// <summary>

--- a/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 #nullable enable
 
@@ -28,6 +30,12 @@ namespace Daqifi.Core.Device.Internal
         /// Shared with the device's tracking of a raw ADC-enable command, which decodes the same mask.
         /// </summary>
         internal const int MaxAdcBitmaskChannel = 31;
+
+        /// <summary>
+        /// How long to wait for the device's answer to an analog-output readback. The query reads
+        /// a value already held in RAM, so this only needs to cover the round trip.
+        /// </summary>
+        private const int AnalogOutputResponseTimeoutMs = 2000;
 
         private readonly IDeviceOperationHost _host;
 
@@ -313,19 +321,111 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="IStreamingDevice.SetAnalogOutput" />
         internal void SetAnalogOutput(int channelNumber, double voltage)
         {
+            StageAnalogOutput(channelNumber, voltage);
+            LatchAnalogOutputs();
+        }
+
+        /// <inheritdoc cref="DaqifiStreamingDevice.StageAnalogOutput" />
+        internal void StageAnalogOutput(int channelNumber, double voltage)
+        {
             if (channelNumber < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(channelNumber), channelNumber, "Channel number cannot be negative.");
             }
 
+            // Range-check against the device's own description of the channel before anything
+            // reaches the wire. A device that never described its DAC channels (no capability
+            // document, or firmware that does not report them) models none, and the command is
+            // still sent by number — refusing it would break the only analog-output path this
+            // library has ever had.
+            var channel = FindAnalogOutputChannel(channelNumber);
+
+            if (channel is not null && !channel.IsInRange(voltage))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(voltage),
+                    voltage,
+                    $"Analog output {channelNumber} accepts {channel.MinimumVoltage} to {channel.MaximumVoltage} V"
+                    + (channel.RangeIsAssumed ? " (assumed; the device stated no range)." : "."));
+            }
+
             _host.EnsureConnected();
 
-            // Analog-output (DAC) channels are addressed by number; they are not part of the
-            // populated Channels collection (PopulateChannelsFromStatus creates analog *input*
-            // channels only). Stage the level, then latch it.
             _host.Send(ScpiMessageProducer.SetAnalogOutputVoltage(channelNumber, voltage));
-            _host.Send(ScpiMessageProducer.UpdateDacOutputs);
+            channel?.Stage(voltage);
         }
+
+        /// <inheritdoc cref="DaqifiStreamingDevice.LatchAnalogOutputs" />
+        internal void LatchAnalogOutputs()
+        {
+            _host.EnsureConnected();
+
+            _host.Send(ScpiMessageProducer.UpdateDacOutputs);
+
+            // The device latches every staged channel at once, so every modelled channel with a
+            // pending value now reflects what the hardware is driving.
+            var latchedAt = DateTime.Now;
+            foreach (var channel in _host.SnapshotChannels())
+            {
+                (channel as AnalogOutputChannel)?.Latch(latchedAt);
+            }
+        }
+
+        /// <inheritdoc cref="DaqifiStreamingDevice.GetAnalogOutputAsync" />
+        internal async Task<double> GetAnalogOutputAsync(int channelNumber, CancellationToken cancellationToken = default)
+        {
+            // Build the query first so argument validation surfaces the same exception type
+            // regardless of connection state (matches SetDioDirection / the diagnostics ops).
+            var query = ScpiMessageProducer.GetAnalogOutputVoltage(channelNumber);
+
+            _host.EnsureConnected();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var lines = await _host.ExecuteTextCommandAsync(
+                () => _host.Send(query),
+                responseTimeoutMs: AnalogOutputResponseTimeoutMs,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (ScpiResponseClassifier.ContainsScpiError(lines))
+            {
+                throw new InvalidOperationException(
+                    $"The device rejected a readback of analog output {channelNumber}. It answered: {DescribeLines(lines)}");
+            }
+
+            foreach (var line in lines)
+            {
+                if (double.TryParse(line?.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var volts)
+                    && double.IsFinite(volts))
+                {
+                    FindAnalogOutputChannel(channelNumber)?.SetOutputVoltage(volts, DateTime.Now);
+                    return volts;
+                }
+            }
+
+            throw new InvalidOperationException(
+                $"The device's readback of analog output {channelNumber} was not a voltage. It answered: {DescribeLines(lines)}");
+        }
+
+        /// <summary>
+        /// Finds the modelled analog-output channel with this number, or <c>null</c> when the
+        /// device has not described one.
+        /// </summary>
+        private AnalogOutputChannel? FindAnalogOutputChannel(int channelNumber)
+        {
+            foreach (var channel in _host.SnapshotChannels())
+            {
+                if (channel is AnalogOutputChannel output && output.ChannelNumber == channelNumber)
+                {
+                    return output;
+                }
+            }
+
+            return null;
+        }
+
+        private static string DescribeLines(IReadOnlyList<string> lines)
+            => lines.Count == 0 ? "(nothing)" : string.Join(" | ", lines);
 
         /// <summary>
         /// Sets the enabled state for a set of channels, then sends one device command per affected
@@ -342,6 +442,16 @@ namespace Daqifi.Core.Device.Internal
                 if (channel is null)
                 {
                     throw new ArgumentException("The channel collection contains a null entry.", nameof(channels));
+                }
+
+                // An analog output is driven by writing a voltage to it, not by being enabled for
+                // acquisition — it appears in neither the ADC enable bitmask nor the DIO enable,
+                // so letting it through here would set a flag that no command ever acts on.
+                if (channel.Type == ChannelType.AnalogOutput)
+                {
+                    throw new ArgumentException(
+                        $"Analog output {channel.ChannelNumber} is not an acquisition channel and cannot be enabled or disabled; write to it with SetAnalogOutput instead.",
+                        nameof(channels));
                 }
 
                 EnsureChannelBelongs(channel);


### PR DESCRIPTION
### What was wrong

If your DAQiFi device has analog outputs, Core could barely talk to them. `SetAnalogOutput(channel, volts)` fired a command at a channel number and hoped: the channel appeared nowhere in `Channels`, nothing checked the voltage against what the hardware accepts, nothing recorded what you had written, and there was no way to ask the device what it was driving. Send 42 V to a 0-10 V output and the library passed it straight through for the firmware to silently clamp. Everything around this was already built — the SCPI commands, the capability parser's `analog-output` kind, `DeviceCapabilities.AnalogOutputChannels` — which is why the desktop app's four-issue analog-output epic has been stuck: the piece in the middle was missing.

### How it was fixed

Analog outputs are now real channels. `ChannelType.AnalogOutput` and an `AnalogOutputChannel` carrying resolution, voltage range, and the value being driven; they show up in `GetChannelsSnapshot()` next to the inputs. A voltage is range-checked against the device's own description before anything reaches the wire, and the device's two-step write protocol is now explicit in the API — `StageAnalogOutput` then `LatchAnalogOutputs`, so several outputs change together; `SetAnalogOutput` is exactly that pair. `GetAnalogOutputAsync` adds the `SOURce:VOLTage:LEVel?` round trip.

Two decisions worth pushing back on if you disagree. **The channels come from the capability document, not the status message** — the protobuf declares `analog_out_port_num`/`_res`/`_range` and the firmware never fills any of them in (they are commented out in `NanoPB_Encoder.c`), so a status frame says nothing about DACs and must not be read as "this device has none"; modelled outputs are carried across every repopulation untouched. And **a device that never described its DACs still writes by number exactly as before** — refusing those would break the only analog-output path the library has ever had, so the range check applies only to channels the device actually described. Enabling an output channel for acquisition now throws instead of silently doing nothing, since it belongs in neither the ADC bitmask nor the DIO enable.

`AnalogOutputChannel` deliberately does not implement `IAnalogChannel`: every acquisition path selects channels with `is IAnalogChannel` or `Type == Analog`, and a DAC belongs in none of them.

### Verification

51 new tests. Full suite green on **net9.0** (3283 Core + 192 Mcp) and **net10.0** (3283), 0 warnings. Five mutations confirm the tests bite: dropping the carry-forward across a status repopulation (1 failure), removing the range check (3), removing the enable guard (1), leaving a staged value pending after a latch (4), and rebuilding the channel collection unconditionally (1).

**Bench — Nq1 fw 3.7.2 on `/dev/cu.usbmodem1101`, serial, non-destructive** (connect, initialize, query, disconnect; no writes, no reboot/format/delete/firmware/LAN):

```
Connected: DAQiFi Device  fw=3.7.2  pn=Nq1
Capability document: schema v2, 32 channel entries
  document analog-output entries: 0
Channel snapshot: 32 total  analog-in=16  digital=16  analog-out=0
Re-sync reported 0 analog-output channel(s); snapshot now 32 total.
GetAnalogOutputAsync(0) -> InvalidOperationException: The device rejected a
  readback of analog output 0. It answered: **ERROR: -200, "Execution error"
After 1.5 s of live status frames: 32 total  analog-in=16 digital=16 analog-out=0
```

The bench unit is an NQ1 and analog output is NQ3-only, so this validates the negative and error paths against real firmware rather than the happy path: the device describes no DACs, none are modelled, the existing 32 channels are untouched through initialization and a stream of live status frames, re-sync is idempotent, and a real firmware rejection surfaces as a clear exception instead of a parse failure. **The positive path — a value round-tripping through `SOURce:VOLTage:LEVel?` — is covered by tests only; it needs NQ3 hardware to confirm.**

`closes #499`

Not merging — for review.