### PR TITLE
test(discovery): the code that decides which Linux serial ports are DAQiFi had no tests

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/LinuxUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/LinuxUsbPortDescriptorProviderTests.cs
@@ -1,0 +1,468 @@
+using Daqifi.Core.Device.Discovery;
+using System.Runtime.InteropServices;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+/// <summary>
+/// Tests for the Linux sysfs USB descriptor provider, driven against a fixture tty class tree
+/// rather than the real <c>/sys/class/tty</c> (slice 3 of #464).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This provider had no tests at all, and it is not incidental code: CI runs on
+/// <c>ubuntu-latest</c>, so it is the descriptor provider that actually executes there, and it is
+/// what pre-filters ports for every Linux consumer of <c>SerialDeviceFinder</c>. A wrong answer is
+/// not a crash — a DAQiFi board silently stops being discovered, or every unrelated COM port gets
+/// probed again.
+/// </para>
+/// <para>
+/// The fixtures reproduce the shape sysfs actually has: <c>&lt;root&gt;/&lt;tty&gt;/device</c> is a
+/// symlink into a device tree whose <c>idVendor</c>/<c>idProduct</c> files sit some levels above
+/// the interface node it points at, holding lowercase hex with a trailing newline. Where a test
+/// only needs the walk and not the symlink, <c>device</c> is a real directory — which is also the
+/// case the fallback in the provider covers.
+/// </para>
+/// </remarks>
+public class LinuxUsbPortDescriptorProviderTests : IDisposable
+{
+    /// <summary>DAQiFi's USB vendor ID as sysfs writes it: lowercase hex, newline-terminated.</summary>
+    private const string DaqifiVendorText = "04d8\n";
+
+    /// <summary>DAQiFi's CDC-mode product ID in the same form.</summary>
+    private const string DaqifiProductText = "f794\n";
+
+    /// <summary>
+    /// How many device-tree levels the provider examines, restated as a literal rather than read
+    /// from <see cref="LinuxUsbPortDescriptorProvider.MaxDeviceTreeLevels"/>. Building the fixture
+    /// from the constant would make the boundary tests move with any change to it, which is the
+    /// one thing they exist to catch.
+    /// </summary>
+    private const int ExpectedDeviceTreeLevels = 8;
+
+    private readonly string _root;
+
+    public LinuxUsbPortDescriptorProviderTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "daqifi-sysfs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    #region The happy path
+
+    [Fact]
+    public void Resolve_UsbCdcPort_ReadsVidPidFromTheUsbDeviceNodeAboveTheInterface()
+    {
+        // The real layout: the tty's device symlink points at the *interface* node (1-1.2:1.0),
+        // and only its parent — the USB device node — carries idVendor/idProduct.
+        var deviceNode = CreateDeviceTree("usb1", "1-1", "1-1.2");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        LinkTty("ttyACM0", CreateSubdirectory(deviceNode, "1-1.2:1.0"));
+
+        var descriptor = Resolve("/dev/ttyACM0");
+
+        Assert.NotNull(descriptor);
+        Assert.Equal(0x04D8, descriptor!.VendorId);
+        Assert.Equal(0xF794, descriptor.ProductId);
+    }
+
+    [Fact]
+    public void Resolve_IdsOnTheNodeItself_IsFoundWithoutWalkingUp()
+    {
+        var deviceNode = CreateDeviceTree("usb1", "1-2");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        LinkTty("ttyUSB0", deviceNode);
+
+        var descriptor = Resolve("/dev/ttyUSB0");
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), descriptor);
+    }
+
+    [Fact]
+    public void Resolve_DeviceEntryIsARealDirectoryRatherThanASymlink_StillWalksUp()
+    {
+        // Not the shape the kernel produces, but it is the branch the provider's `?? dirInfo`
+        // fallback exists for — and it is the shape every non-symlink fixture below relies on.
+        var ttyEntry = CreateSubdirectory(_root, "ttyACM1");
+        WriteIds(ttyEntry, DaqifiVendorText, DaqifiProductText);
+        Directory.CreateDirectory(Path.Combine(ttyEntry, "device"));
+
+        var descriptor = Resolve("/dev/ttyACM1");
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), descriptor);
+    }
+
+    [Fact]
+    public void Resolve_PortNameWithoutADirectory_IsTreatedAsTheBaseName()
+    {
+        // SerialPort.GetPortNames() yields full device paths on Linux, but nothing in the contract
+        // requires one — a caller passing the bare tty name must resolve the same port.
+        var deviceNode = CreateDeviceTree("usb1", "1-3");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        LinkTty("ttyACM2", deviceNode);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("ttyACM2"));
+    }
+
+    [Fact]
+    public void Resolve_TwoPortsOnOneTree_AnswerIndependently()
+    {
+        var daqifi = CreateDeviceTree("usb1", "1-1");
+        WriteIds(daqifi, DaqifiVendorText, DaqifiProductText);
+        LinkTty("ttyACM0", CreateSubdirectory(daqifi, "1-1:1.0"));
+
+        var other = CreateDeviceTree("usb1", "1-4");
+        WriteIds(other, "1a86\n", "7523\n");
+        LinkTty("ttyUSB0", CreateSubdirectory(other, "1-4:1.0"));
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+        Assert.Equal(new UsbPortDescriptor(0x1A86, 0x7523), Resolve("/dev/ttyUSB0"));
+    }
+
+    #endregion
+
+    #region Symlink resolution
+
+    [Fact]
+    public void Resolve_FollowsThePhysicalTargetRatherThanTheLogicalPath()
+    {
+        // The whole reason the provider resolves the link first. Walking the *logical* parents of
+        // <root>/ttyACM0/device climbs back through the tty class directory; walking the resolved
+        // target climbs the real device tree. Both chains are populated here with different IDs,
+        // so a provider that forgot to resolve would answer — just with the wrong device.
+        var deviceNode = CreateDeviceTree("usb1", "1-1", "1-1.2");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        var ttyEntry = CreateSubdirectory(_root, "ttyACM0");
+        WriteIds(ttyEntry, "1a86\n", "7523\n");
+
+        if (!TryLinkDeviceNode(Path.Combine(ttyEntry, "device"), deviceNode))
+        {
+            return;
+        }
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+    }
+
+    #endregion
+
+    #region Ports with no descriptor to give
+
+    [Fact]
+    public void Resolve_PortWithNoSysfsEntry_ReturnsNull()
+    {
+        Assert.Null(Resolve("/dev/ttyACM9"));
+    }
+
+    [Fact]
+    public void Resolve_TtyClassRootDoesNotExist_ReturnsNull()
+    {
+        var missing = Path.Combine(_root, "no-such-class-dir");
+
+        Assert.Null(LinuxUsbPortDescriptorProvider.Resolve("/dev/ttyACM0", missing));
+    }
+
+    [Fact]
+    public void Resolve_TtyEntryWithoutADeviceLink_ReturnsNull()
+    {
+        // A virtual tty (pty, console) has a class entry but no device node behind it.
+        CreateSubdirectory(_root, "tty0");
+
+        Assert.Null(Resolve("/dev/tty0"));
+    }
+
+    [Fact]
+    public void Resolve_NonUsbSerialPort_ReturnsNull()
+    {
+        // A device tree with no idVendor/idProduct anywhere in reach — e.g. an on-board 16550.
+        LinkTty("ttyS0", CreateDeviceTree("platform", "serial8250", "serial8250.0"));
+
+        Assert.Null(Resolve("/dev/ttyS0"));
+    }
+
+    [Fact]
+    public void Resolve_DeviceEntryIsAFileNotADirectory_ReturnsNull()
+    {
+        var ttyEntry = CreateSubdirectory(_root, "ttyACM0");
+        File.WriteAllText(Path.Combine(ttyEntry, "device"), "not a directory");
+
+        Assert.Null(Resolve("/dev/ttyACM0"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("/dev/")]
+    [InlineData("/")]
+    public void Resolve_PortNameWithNoFinalSegment_ReturnsNull(string portName)
+    {
+        Assert.Null(Resolve(portName));
+    }
+
+    [Fact]
+    public void Resolve_NullPortName_ReturnsNullRatherThanThrowing()
+    {
+        // The provider is called for every name the port enumeration hands back; a null must be
+        // an answer, not an exception that aborts the sweep.
+        Assert.Null(Resolve(null!));
+    }
+
+    #endregion
+
+    #region Reading the id files
+
+    [Fact]
+    public void Resolve_UppercaseHexValues_AreParsed()
+    {
+        var deviceNode = CreateDeviceTree("usb1", "1-1");
+        WriteIds(deviceNode, "04D8\n", "F794\n");
+        LinkTty("ttyACM0", deviceNode);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+    }
+
+    [Fact]
+    public void Resolve_ValuesWithSurroundingWhitespace_AreTrimmed()
+    {
+        var deviceNode = CreateDeviceTree("usb1", "1-1");
+        WriteIds(deviceNode, "  04d8\r\n", "\tf794  \n");
+        LinkTty("ttyACM0", deviceNode);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+    }
+
+    [Fact]
+    public void Resolve_ZeroedIds_AreAnAnswerNotAMiss()
+    {
+        // 0000/0000 is a real (if unusual) descriptor. It must not be confused with "not found",
+        // which is why the provider distinguishes null from a zero-valued descriptor.
+        var deviceNode = CreateDeviceTree("usb1", "1-1");
+        WriteIds(deviceNode, "0000\n", "0000\n");
+        LinkTty("ttyACM0", deviceNode);
+
+        Assert.Equal(new UsbPortDescriptor(0, 0), Resolve("/dev/ttyACM0"));
+    }
+
+    [Theory]
+    [InlineData("zzzz\n", "f794\n")]
+    [InlineData("04d8\n", "zzzz\n")]
+    [InlineData("\n", "f794\n")]
+    [InlineData("-1\n", "f794\n")]
+    public void Resolve_UnparseableIdValue_ReturnsNullWithoutWalkingPastTheNode(
+        string vendorText, string productText)
+    {
+        // The node that holds both files is the USB device node by definition. If its values do
+        // not parse, the answer is "unknown" — continuing up would report the *hub's* IDs as the
+        // port's, which is worse than no answer.
+        var hub = CreateDeviceTree("usb1", "1-1");
+        WriteIds(hub, "1d6b\n", "0002\n");
+        var deviceNode = CreateSubdirectory(hub, "1-1.2");
+        WriteIds(deviceNode, vendorText, productText);
+        LinkTty("ttyACM0", deviceNode);
+
+        Assert.Null(Resolve("/dev/ttyACM0"));
+    }
+
+    [Fact]
+    public void Resolve_NodeWithOnlyAVendorId_KeepsWalkingUp()
+    {
+        // Both files have to be present for a node to count. A partial node is not the USB device
+        // node, so the walk must continue rather than give up or answer from half a descriptor.
+        var deviceNode = CreateDeviceTree("usb1", "1-1");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        var partial = CreateSubdirectory(deviceNode, "1-1:1.0");
+        File.WriteAllText(Path.Combine(partial, "idVendor"), "1a86\n");
+        LinkTty("ttyACM0", partial);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+    }
+
+    [Fact]
+    public void Resolve_NodeWithOnlyAProductId_KeepsWalkingUp()
+    {
+        var deviceNode = CreateDeviceTree("usb1", "1-1");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        var partial = CreateSubdirectory(deviceNode, "1-1:1.0");
+        File.WriteAllText(Path.Combine(partial, "idProduct"), "7523\n");
+        LinkTty("ttyACM0", partial);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+    }
+
+    [Fact]
+    public void Resolve_IdEntryIsADirectory_IsNotMistakenForTheValueFile()
+    {
+        var deviceNode = CreateDeviceTree("usb1", "1-1");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        var decoy = CreateSubdirectory(deviceNode, "1-1:1.0");
+        Directory.CreateDirectory(Path.Combine(decoy, "idVendor"));
+        Directory.CreateDirectory(Path.Combine(decoy, "idProduct"));
+        LinkTty("ttyACM0", decoy);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+    }
+
+    #endregion
+
+    #region The depth bound
+
+    [Fact]
+    public void MaxDeviceTreeLevels_IsTheBoundTheseTestsAssume()
+    {
+        Assert.Equal(ExpectedDeviceTreeLevels, LinuxUsbPortDescriptorProvider.MaxDeviceTreeLevels);
+    }
+
+    [Fact]
+    public void Resolve_IdsAtTheLastExaminedLevel_AreStillFound()
+    {
+        // chain[^1] is the node the tty points at (level 0) and chain[1] is seven ancestors above
+        // it — the last level the provider looks at.
+        var chain = CreateChain(ExpectedDeviceTreeLevels);
+        WriteIds(chain[1], DaqifiVendorText, DaqifiProductText);
+
+        if (!TryLinkTty("ttyACM0", chain[^1]))
+        {
+            return;
+        }
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+    }
+
+    [Fact]
+    public void Resolve_IdsOneLevelBeyondTheBound_AreNotReached()
+    {
+        // chain[0] is one ancestor further up than the walk goes. Answering from it would mean the
+        // bound is not doing its job; answering null is the documented behavior.
+        var chain = CreateChain(ExpectedDeviceTreeLevels);
+        WriteIds(chain[0], DaqifiVendorText, DaqifiProductText);
+
+        if (!TryLinkTty("ttyACM0", chain[^1]))
+        {
+            return;
+        }
+
+        Assert.Null(Resolve("/dev/ttyACM0"));
+    }
+
+    #endregion
+
+    #region The platform gate
+
+    [Fact]
+    public void GetDescriptor_PortThatDoesNotExist_ReturnsNull()
+    {
+        var provider = new LinuxUsbPortDescriptorProvider();
+
+        Assert.Null(provider.GetDescriptor("/dev/ttyDAQIFI-" + Guid.NewGuid().ToString("N")));
+    }
+
+    [Fact]
+    public void GetDescriptor_OffLinux_AnswersNullForEveryPort()
+    {
+        // Elsewhere /sys/class/tty either does not exist or means something else, so the gate — not
+        // the filesystem — has to produce the answer. On Linux the same call is covered above.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return;
+        }
+
+        var provider = new LinuxUsbPortDescriptorProvider();
+
+        Assert.Null(provider.GetDescriptor("ttyACM0"));
+        Assert.Null(provider.GetDescriptor("/dev/cu.usbmodem101"));
+        Assert.Null(provider.GetDescriptor("COM9"));
+    }
+
+    [Fact]
+    public void DefaultTtyClassRoot_IsTheKernelsTtyClassDirectory()
+    {
+        // Pinned because it is the one input the tests above deliberately do not use.
+        Assert.Equal("/sys/class/tty", LinuxUsbPortDescriptorProvider.DefaultTtyClassRoot);
+    }
+
+    #endregion
+
+    #region Fixture helpers
+
+    private UsbPortDescriptor? Resolve(string portName)
+        => LinuxUsbPortDescriptorProvider.Resolve(portName, _root);
+
+    /// <summary>Creates a nested device-tree path under the fixture root and returns the leaf.</summary>
+    private string CreateDeviceTree(params string[] segments)
+    {
+        var path = Path.Combine(_root, "devices");
+        foreach (var segment in segments)
+        {
+            path = Path.Combine(path, segment);
+        }
+
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Creates <paramref name="levels"/> + 1 nested directories and returns them outermost-first,
+    /// so <c>[^1]</c> is the deepest node and <c>[0]</c> is <paramref name="levels"/> ancestors above it.
+    /// </summary>
+    private string[] CreateChain(int levels)
+    {
+        var paths = new string[levels + 1];
+        var path = Path.Combine(_root, "devices");
+        for (var i = 0; i <= levels; i++)
+        {
+            path = Path.Combine(path, "n" + i);
+            paths[i] = path;
+        }
+
+        Directory.CreateDirectory(path);
+        return paths;
+    }
+
+    private static string CreateSubdirectory(string parent, string name)
+    {
+        var path = Path.Combine(parent, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void WriteIds(string deviceNode, string vendorText, string productText)
+    {
+        File.WriteAllText(Path.Combine(deviceNode, "idVendor"), vendorText);
+        File.WriteAllText(Path.Combine(deviceNode, "idProduct"), productText);
+    }
+
+    /// <summary>Creates the tty class entry for <paramref name="ttyName"/> with its device symlink.</summary>
+    private void LinkTty(string ttyName, string target)
+    {
+        Assert.True(TryLinkTty(ttyName, target), "the fixture symlink could not be created");
+    }
+
+    private bool TryLinkTty(string ttyName, string target)
+        => TryLinkDeviceNode(Path.Combine(CreateSubdirectory(_root, ttyName), "device"), target);
+
+    /// <summary>
+    /// Creates the <c>device</c> symlink, reporting failure only on Windows — where an
+    /// unprivileged process cannot create one and the caller has nothing left to assert. On Linux
+    /// and macOS a failure is a broken fixture and fails the test.
+    /// </summary>
+    private static bool TryLinkDeviceNode(string linkPath, string target)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, target);
+            return true;
+        }
+        catch (Exception ex) when (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                                   && (ex is IOException or UnauthorizedAccessException))
+        {
+            return false;
+        }
+    }
+
+    #endregion
+}

--- a/src/Daqifi.Core.Tests/Device/Discovery/LinuxUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/LinuxUsbPortDescriptorProviderTests.cs
@@ -253,11 +253,13 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     public void Resolve_RealSysfsShape_ReadsIdsFromTheUsbDeviceNodeAboveTheInterface()
     {
         // What the kernel actually lays out: the tty's device symlink points at the *interface*
-        // node (1-1.2:1.0) under /sys/devices, and only its parent — the USB device node — carries
-        // idVendor/idProduct.
+        // node under /sys/devices, and only its parent — the USB device node — carries
+        // idVendor/idProduct. The kernel spells that interface node "1-1.2:1.0"; the fixture drops
+        // the colon, which is not a legal path segment character on Windows and carries no meaning
+        // for the walk, since nothing here parses the node's name.
         var deviceNode = CreateDeviceTree("usb1", "1-1", "1-1.2");
         WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
-        LinkTty("ttyACM0", CreateSubdirectory(deviceNode, "1-1.2:1.0"));
+        LinkTty("ttyACM0", CreateSubdirectory(deviceNode, "1-1.2_1.0"));
 
         var descriptor = Resolve("/dev/ttyACM0");
 

--- a/src/Daqifi.Core.Tests/Device/Discovery/LinuxUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/LinuxUsbPortDescriptorProviderTests.cs
@@ -16,11 +16,11 @@ namespace Daqifi.Core.Tests.Device.Discovery;
 /// probed again.
 /// </para>
 /// <para>
-/// The fixtures reproduce the shape sysfs actually has: <c>&lt;root&gt;/&lt;tty&gt;/device</c> is a
-/// symlink into a device tree whose <c>idVendor</c>/<c>idProduct</c> files sit some levels above
-/// the interface node it points at, holding lowercase hex with a trailing newline. Where a test
-/// only needs the walk and not the symlink, <c>device</c> is a real directory — which is also the
-/// case the fallback in the provider covers.
+/// Most fixtures build <c>&lt;root&gt;/&lt;tty&gt;/device</c> as a real directory, because what
+/// those tests are about is the walk and the parsing, and the provider treats a real directory as
+/// the plain case. The four tests that are specifically about the link — the realistic sysfs shape,
+/// the physical-vs-logical parent chain, and the two depth bounds — need a real directory symlink;
+/// they are grouped together and noted as such.
 /// </para>
 /// </remarks>
 public class LinuxUsbPortDescriptorProviderTests : IDisposable
@@ -58,45 +58,22 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     #region The happy path
 
     [Fact]
-    public void Resolve_UsbCdcPort_ReadsVidPidFromTheUsbDeviceNodeAboveTheInterface()
-    {
-        // The real layout: the tty's device symlink points at the *interface* node (1-1.2:1.0),
-        // and only its parent — the USB device node — carries idVendor/idProduct.
-        var deviceNode = CreateDeviceTree("usb1", "1-1", "1-1.2");
-        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
-        LinkTty("ttyACM0", CreateSubdirectory(deviceNode, "1-1.2:1.0"));
-
-        var descriptor = Resolve("/dev/ttyACM0");
-
-        Assert.NotNull(descriptor);
-        Assert.Equal(0x04D8, descriptor!.VendorId);
-        Assert.Equal(0xF794, descriptor.ProductId);
-    }
-
-    [Fact]
     public void Resolve_IdsOnTheNodeItself_IsFoundWithoutWalkingUp()
     {
-        var deviceNode = CreateDeviceTree("usb1", "1-2");
-        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
-        LinkTty("ttyUSB0", deviceNode);
+        WriteIds(MountTty("ttyUSB0"), DaqifiVendorText, DaqifiProductText);
 
-        var descriptor = Resolve("/dev/ttyUSB0");
-
-        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), descriptor);
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyUSB0"));
     }
 
     [Fact]
-    public void Resolve_DeviceEntryIsARealDirectoryRatherThanASymlink_StillWalksUp()
+    public void Resolve_IdsOnTheNodeAbove_AreWalkedUpTo()
     {
-        // Not the shape the kernel produces, but it is the branch the provider's `?? dirInfo`
-        // fallback exists for — and it is the shape every non-symlink fixture below relies on.
-        var ttyEntry = CreateSubdirectory(_root, "ttyACM1");
-        WriteIds(ttyEntry, DaqifiVendorText, DaqifiProductText);
-        Directory.CreateDirectory(Path.Combine(ttyEntry, "device"));
+        // The usual shape: the tty hangs off an interface node, and only the USB device node above
+        // it carries idVendor/idProduct.
+        var node = MountTty("ttyACM0");
+        WriteIds(Directory.GetParent(node)!.FullName, DaqifiVendorText, DaqifiProductText);
 
-        var descriptor = Resolve("/dev/ttyACM1");
-
-        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), descriptor);
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
     }
 
     [Fact]
@@ -104,50 +81,19 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     {
         // SerialPort.GetPortNames() yields full device paths on Linux, but nothing in the contract
         // requires one — a caller passing the bare tty name must resolve the same port.
-        var deviceNode = CreateDeviceTree("usb1", "1-3");
-        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
-        LinkTty("ttyACM2", deviceNode);
+        WriteIds(MountTty("ttyACM2"), DaqifiVendorText, DaqifiProductText);
 
         Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("ttyACM2"));
     }
 
     [Fact]
-    public void Resolve_TwoPortsOnOneTree_AnswerIndependently()
+    public void Resolve_TwoPorts_AnswerIndependently()
     {
-        var daqifi = CreateDeviceTree("usb1", "1-1");
-        WriteIds(daqifi, DaqifiVendorText, DaqifiProductText);
-        LinkTty("ttyACM0", CreateSubdirectory(daqifi, "1-1:1.0"));
-
-        var other = CreateDeviceTree("usb1", "1-4");
-        WriteIds(other, "1a86\n", "7523\n");
-        LinkTty("ttyUSB0", CreateSubdirectory(other, "1-4:1.0"));
+        WriteIds(MountTty("ttyACM0"), DaqifiVendorText, DaqifiProductText);
+        WriteIds(MountTty("ttyUSB0"), "1a86\n", "7523\n");
 
         Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
         Assert.Equal(new UsbPortDescriptor(0x1A86, 0x7523), Resolve("/dev/ttyUSB0"));
-    }
-
-    #endregion
-
-    #region Symlink resolution
-
-    [Fact]
-    public void Resolve_FollowsThePhysicalTargetRatherThanTheLogicalPath()
-    {
-        // The whole reason the provider resolves the link first. Walking the *logical* parents of
-        // <root>/ttyACM0/device climbs back through the tty class directory; walking the resolved
-        // target climbs the real device tree. Both chains are populated here with different IDs,
-        // so a provider that forgot to resolve would answer — just with the wrong device.
-        var deviceNode = CreateDeviceTree("usb1", "1-1", "1-1.2");
-        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
-        var ttyEntry = CreateSubdirectory(_root, "ttyACM0");
-        WriteIds(ttyEntry, "1a86\n", "7523\n");
-
-        if (!TryLinkDeviceNode(Path.Combine(ttyEntry, "device"), deviceNode))
-        {
-            return;
-        }
-
-        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
     }
 
     #endregion
@@ -169,7 +115,7 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     }
 
     [Fact]
-    public void Resolve_TtyEntryWithoutADeviceLink_ReturnsNull()
+    public void Resolve_TtyEntryWithoutADeviceNode_ReturnsNull()
     {
         // A virtual tty (pty, console) has a class entry but no device node behind it.
         CreateSubdirectory(_root, "tty0");
@@ -180,8 +126,8 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     [Fact]
     public void Resolve_NonUsbSerialPort_ReturnsNull()
     {
-        // A device tree with no idVendor/idProduct anywhere in reach — e.g. an on-board 16550.
-        LinkTty("ttyS0", CreateDeviceTree("platform", "serial8250", "serial8250.0"));
+        // A device node with no idVendor/idProduct anywhere in reach — e.g. an on-board 16550.
+        MountTty("ttyS0");
 
         Assert.Null(Resolve("/dev/ttyS0"));
     }
@@ -219,19 +165,15 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     [Fact]
     public void Resolve_UppercaseHexValues_AreParsed()
     {
-        var deviceNode = CreateDeviceTree("usb1", "1-1");
-        WriteIds(deviceNode, "04D8\n", "F794\n");
-        LinkTty("ttyACM0", deviceNode);
+        WriteIds(MountTty("ttyACM0"), "04D8\n", "F794\n");
 
         Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
     }
 
     [Fact]
-    public void Resolve_ValuesWithSurroundingWhitespace_AreTrimmed()
+    public void Resolve_ValuesWithSurroundingWhitespace_AreAccepted()
     {
-        var deviceNode = CreateDeviceTree("usb1", "1-1");
-        WriteIds(deviceNode, "  04d8\r\n", "\tf794  \n");
-        LinkTty("ttyACM0", deviceNode);
+        WriteIds(MountTty("ttyACM0"), "  04d8\r\n", "\tf794  \n");
 
         Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
     }
@@ -241,9 +183,7 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     {
         // 0000/0000 is a real (if unusual) descriptor. It must not be confused with "not found",
         // which is why the provider distinguishes null from a zero-valued descriptor.
-        var deviceNode = CreateDeviceTree("usb1", "1-1");
-        WriteIds(deviceNode, "0000\n", "0000\n");
-        LinkTty("ttyACM0", deviceNode);
+        WriteIds(MountTty("ttyACM0"), "0000\n", "0000\n");
 
         Assert.Equal(new UsbPortDescriptor(0, 0), Resolve("/dev/ttyACM0"));
     }
@@ -259,11 +199,9 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
         // The node that holds both files is the USB device node by definition. If its values do
         // not parse, the answer is "unknown" — continuing up would report the *hub's* IDs as the
         // port's, which is worse than no answer.
-        var hub = CreateDeviceTree("usb1", "1-1");
-        WriteIds(hub, "1d6b\n", "0002\n");
-        var deviceNode = CreateSubdirectory(hub, "1-1.2");
-        WriteIds(deviceNode, vendorText, productText);
-        LinkTty("ttyACM0", deviceNode);
+        var node = MountTty("ttyACM0");
+        WriteIds(Directory.GetParent(node)!.FullName, "1d6b\n", "0002\n");
+        WriteIds(node, vendorText, productText);
 
         Assert.Null(Resolve("/dev/ttyACM0"));
     }
@@ -273,11 +211,9 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     {
         // Both files have to be present for a node to count. A partial node is not the USB device
         // node, so the walk must continue rather than give up or answer from half a descriptor.
-        var deviceNode = CreateDeviceTree("usb1", "1-1");
-        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
-        var partial = CreateSubdirectory(deviceNode, "1-1:1.0");
-        File.WriteAllText(Path.Combine(partial, "idVendor"), "1a86\n");
-        LinkTty("ttyACM0", partial);
+        var node = MountTty("ttyACM0");
+        WriteIds(Directory.GetParent(node)!.FullName, DaqifiVendorText, DaqifiProductText);
+        File.WriteAllText(Path.Combine(node, "idVendor"), "1a86\n");
 
         Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
     }
@@ -285,11 +221,9 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     [Fact]
     public void Resolve_NodeWithOnlyAProductId_KeepsWalkingUp()
     {
-        var deviceNode = CreateDeviceTree("usb1", "1-1");
-        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
-        var partial = CreateSubdirectory(deviceNode, "1-1:1.0");
-        File.WriteAllText(Path.Combine(partial, "idProduct"), "7523\n");
-        LinkTty("ttyACM0", partial);
+        var node = MountTty("ttyACM0");
+        WriteIds(Directory.GetParent(node)!.FullName, DaqifiVendorText, DaqifiProductText);
+        File.WriteAllText(Path.Combine(node, "idProduct"), "7523\n");
 
         Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
     }
@@ -297,19 +231,56 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     [Fact]
     public void Resolve_IdEntryIsADirectory_IsNotMistakenForTheValueFile()
     {
-        var deviceNode = CreateDeviceTree("usb1", "1-1");
-        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
-        var decoy = CreateSubdirectory(deviceNode, "1-1:1.0");
-        Directory.CreateDirectory(Path.Combine(decoy, "idVendor"));
-        Directory.CreateDirectory(Path.Combine(decoy, "idProduct"));
-        LinkTty("ttyACM0", decoy);
+        var node = MountTty("ttyACM0");
+        WriteIds(Directory.GetParent(node)!.FullName, DaqifiVendorText, DaqifiProductText);
+        Directory.CreateDirectory(Path.Combine(node, "idVendor"));
+        Directory.CreateDirectory(Path.Combine(node, "idProduct"));
 
         Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
     }
 
     #endregion
 
-    #region The depth bound
+    #region What the device symlink is for
+
+    // The four tests below are the ones that are actually about the link, so they create a real
+    // directory symlink and let a failure to do so fail the test. That is unprivileged on Linux
+    // and macOS — CI runs ubuntu-latest — and needs Developer Mode or an elevated shell on
+    // Windows, which is not a platform this suite runs on. Everything else above deliberately
+    // needs no symlink at all.
+
+    [Fact]
+    public void Resolve_RealSysfsShape_ReadsIdsFromTheUsbDeviceNodeAboveTheInterface()
+    {
+        // What the kernel actually lays out: the tty's device symlink points at the *interface*
+        // node (1-1.2:1.0) under /sys/devices, and only its parent — the USB device node — carries
+        // idVendor/idProduct.
+        var deviceNode = CreateDeviceTree("usb1", "1-1", "1-1.2");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        LinkTty("ttyACM0", CreateSubdirectory(deviceNode, "1-1.2:1.0"));
+
+        var descriptor = Resolve("/dev/ttyACM0");
+
+        Assert.NotNull(descriptor);
+        Assert.Equal(0x04D8, descriptor!.VendorId);
+        Assert.Equal(0xF794, descriptor.ProductId);
+    }
+
+    [Fact]
+    public void Resolve_FollowsThePhysicalTargetRatherThanTheLogicalPath()
+    {
+        // The whole reason the provider resolves the link first. Walking the *logical* parents of
+        // <root>/ttyACM0/device climbs back through the tty class directory; walking the resolved
+        // target climbs the real device tree. Both chains are populated here with different IDs,
+        // so a provider that forgot to resolve would answer — just with the wrong device.
+        var deviceNode = CreateDeviceTree("usb1", "1-1", "1-1.2");
+        WriteIds(deviceNode, DaqifiVendorText, DaqifiProductText);
+        var ttyEntry = CreateSubdirectory(_root, "ttyACM0");
+        WriteIds(ttyEntry, "1a86\n", "7523\n");
+        Directory.CreateSymbolicLink(Path.Combine(ttyEntry, "device"), deviceNode);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
+    }
 
     [Fact]
     public void MaxDeviceTreeLevels_IsTheBoundTheseTestsAssume()
@@ -324,11 +295,7 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
         // it — the last level the provider looks at.
         var chain = CreateChain(ExpectedDeviceTreeLevels);
         WriteIds(chain[1], DaqifiVendorText, DaqifiProductText);
-
-        if (!TryLinkTty("ttyACM0", chain[^1]))
-        {
-            return;
-        }
+        LinkTty("ttyACM0", chain[^1]);
 
         Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), Resolve("/dev/ttyACM0"));
     }
@@ -340,11 +307,7 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
         // bound is not doing its job; answering null is the documented behavior.
         var chain = CreateChain(ExpectedDeviceTreeLevels);
         WriteIds(chain[0], DaqifiVendorText, DaqifiProductText);
-
-        if (!TryLinkTty("ttyACM0", chain[^1]))
-        {
-            return;
-        }
+        LinkTty("ttyACM0", chain[^1]);
 
         Assert.Null(Resolve("/dev/ttyACM0"));
     }
@@ -392,6 +355,14 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
     private UsbPortDescriptor? Resolve(string portName)
         => LinuxUsbPortDescriptorProvider.Resolve(portName, _root);
 
+    /// <summary>
+    /// Creates the tty class entry for <paramref name="ttyName"/> with a real <c>device</c>
+    /// directory, and returns that directory — the node the walk starts from. Its parent is the
+    /// tty entry, which is where a test puts the IDs it wants found one level up.
+    /// </summary>
+    private string MountTty(string ttyName)
+        => CreateSubdirectory(CreateSubdirectory(_root, ttyName), "device");
+
     /// <summary>Creates a nested device-tree path under the fixture root and returns the leaf.</summary>
     private string CreateDeviceTree(params string[] segments)
     {
@@ -436,33 +407,12 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
         File.WriteAllText(Path.Combine(deviceNode, "idProduct"), productText);
     }
 
-    /// <summary>Creates the tty class entry for <paramref name="ttyName"/> with its device symlink.</summary>
-    private void LinkTty(string ttyName, string target)
-    {
-        Assert.True(TryLinkTty(ttyName, target), "the fixture symlink could not be created");
-    }
-
-    private bool TryLinkTty(string ttyName, string target)
-        => TryLinkDeviceNode(Path.Combine(CreateSubdirectory(_root, ttyName), "device"), target);
-
     /// <summary>
-    /// Creates the <c>device</c> symlink, reporting failure only on Windows — where an
-    /// unprivileged process cannot create one and the caller has nothing left to assert. On Linux
-    /// and macOS a failure is a broken fixture and fails the test.
+    /// Creates the tty class entry for <paramref name="ttyName"/> with its <c>device</c> entry as a
+    /// symlink to <paramref name="target"/>, the way the kernel lays it out.
     /// </summary>
-    private static bool TryLinkDeviceNode(string linkPath, string target)
-    {
-        try
-        {
-            Directory.CreateSymbolicLink(linkPath, target);
-            return true;
-        }
-        catch (Exception ex) when (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                                   && (ex is IOException or UnauthorizedAccessException))
-        {
-            return false;
-        }
-    }
+    private void LinkTty(string ttyName, string target)
+        => Directory.CreateSymbolicLink(Path.Combine(CreateSubdirectory(_root, ttyName), "device"), target);
 
     #endregion
 }

--- a/src/Daqifi.Core.Tests/Device/Discovery/UsbProviderFactoryTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/UsbProviderFactoryTests.cs
@@ -1,0 +1,72 @@
+using Daqifi.Core.Device.Discovery;
+using System.Runtime.InteropServices;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+/// <summary>
+/// Tests for the two platform factories that decide which USB descriptor and location providers a
+/// discovery sweep gets (slice 3 of #464). Neither had any test.
+/// </summary>
+/// <remarks>
+/// These are short, but they are the only thing standing between a platform losing its provider and
+/// nobody noticing: the fallbacks are silent by design — a null provider answers null for every
+/// port, which discovery reads as "unknown, probe it anyway". A platform that quietly dropped to
+/// the fallback would still find devices, just slowly, which is exactly the regression #487 is
+/// about. Written in the style of <c>HidPlatformFactoryTests</c>: assert the branch for the
+/// platform the test run is actually on, so every supported OS is covered by the OS that runs it.
+/// </remarks>
+public class UsbProviderFactoryTests
+{
+    [Fact]
+    public void UsbPortDescriptorProviderFactory_ReturnsAProviderForEveryPlatform()
+    {
+        Assert.NotNull(UsbPortDescriptorProviderFactory.CreateForCurrentPlatform());
+    }
+
+    [Fact]
+    public void UsbPortDescriptorProviderFactory_SelectsTheProviderForThisOperatingSystem()
+    {
+        var provider = UsbPortDescriptorProviderFactory.CreateForCurrentPlatform();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Referenced by name so the Windows-only type is not bound on other platforms.
+            Assert.Equal("WindowsUsbPortDescriptorProvider", provider.GetType().Name);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            Assert.IsType<LinuxUsbPortDescriptorProvider>(provider);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            Assert.IsType<MacOsUsbPortDescriptorProvider>(provider);
+        }
+        else
+        {
+            Assert.Same(NullUsbPortDescriptorProvider.Instance, provider);
+        }
+    }
+
+    [Fact]
+    public void UsbLocationProviderFactory_ReturnsAProviderForEveryPlatform()
+    {
+        Assert.NotNull(UsbLocationProviderFactory.CreateForCurrentPlatform());
+    }
+
+    [Fact]
+    public void UsbLocationProviderFactory_ResolvesLocationsOnWindowsAndFallsBackElsewhere()
+    {
+        // Physical-location correlation is Windows-only in v1 — everywhere else the fallback is
+        // the answer, and consumers must see "no known location" rather than a wrong one.
+        var provider = UsbLocationProviderFactory.CreateForCurrentPlatform();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Equal("WindowsUsbLocationProvider", provider.GetType().Name);
+        }
+        else
+        {
+            Assert.Same(NullUsbLocationProvider.Instance, provider);
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/LinuxUsbPortDescriptorProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/LinuxUsbPortDescriptorProvider.cs
@@ -10,6 +10,20 @@ namespace Daqifi.Core.Device.Discovery;
 /// </summary>
 internal sealed class LinuxUsbPortDescriptorProvider : IUsbPortDescriptorProvider
 {
+    /// <summary>
+    /// The sysfs directory the kernel gives one entry per tty, each with a <c>device</c> symlink
+    /// into the physical device tree under <c>/sys/devices</c>.
+    /// </summary>
+    internal const string DefaultTtyClassRoot = "/sys/class/tty";
+
+    /// <summary>
+    /// How many levels of the device tree to examine: the tty's own device node plus its seven
+    /// nearest ancestors. The USB device node that holds <c>idVendor</c>/<c>idProduct</c> is only
+    /// a few levels up, so the bound stops an unexpected layout from walking to the filesystem
+    /// root rather than limiting any real device.
+    /// </summary>
+    internal const int MaxDeviceTreeLevels = 8;
+
     public UsbPortDescriptor? GetDescriptor(string portName)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -17,6 +31,22 @@ internal sealed class LinuxUsbPortDescriptorProvider : IUsbPortDescriptorProvide
             return null;
         }
 
+        return Resolve(portName, DefaultTtyClassRoot);
+    }
+
+    /// <summary>
+    /// Resolves the descriptor for <paramref name="portName"/> against the tty class directory
+    /// <paramref name="ttyClassRoot"/>, or returns null when the port has no sysfs entry, is not
+    /// USB-attached, or the layout holds no readable VID/PID.
+    /// </summary>
+    /// <remarks>
+    /// Split out from <see cref="GetDescriptor"/> — which adds the Linux platform gate and supplies
+    /// the real <see cref="DefaultTtyClassRoot"/> — so the walk can be unit tested against a
+    /// fixture tree on any OS, for the same reason
+    /// <see cref="MacOsUsbPortDescriptorProvider.Parse"/> is exposed.
+    /// </remarks>
+    internal static UsbPortDescriptor? Resolve(string portName, string ttyClassRoot)
+    {
         // portName is typically /dev/ttyACM0 or /dev/ttyUSB0.
         // The corresponding sysfs path is /sys/class/tty/<base>/device/...
         // We walk up the device tree looking for idVendor + idProduct,
@@ -25,7 +55,7 @@ internal sealed class LinuxUsbPortDescriptorProvider : IUsbPortDescriptorProvide
         if (string.IsNullOrEmpty(baseName))
             return null;
 
-        var sysfsRoot = $"/sys/class/tty/{baseName}/device";
+        var sysfsRoot = System.IO.Path.Combine(ttyClassRoot, baseName, "device");
         if (!System.IO.Directory.Exists(sysfsRoot))
             return null;
 
@@ -41,7 +71,7 @@ internal sealed class LinuxUsbPortDescriptorProvider : IUsbPortDescriptorProvide
             var dirInfo = new System.IO.DirectoryInfo(sysfsRoot);
             var resolved = dirInfo.ResolveLinkTarget(returnFinalTarget: true);
             var current = (resolved ?? dirInfo).FullName;
-            for (var i = 0; i < 8; i++)
+            for (var i = 0; i < MaxDeviceTreeLevels; i++)
             {
                 var vendorPath = System.IO.Path.Combine(current, "idVendor");
                 var productPath = System.IO.Path.Combine(current, "idProduct");


### PR DESCRIPTION
## What was wrong

On Linux, before Core opens a serial port to see whether a DAQiFi board is on it, it asks the kernel what USB device that port belongs to — that's how a machine full of Bluetooth radios, GPS receivers and other vendors' adapters doesn't cost a discovery sweep a probe timeout each. That lookup had **no tests at all**.

It is not incidental code. CI runs on `ubuntu-latest`, so this is the provider that actually executes there, and it is the one every Linux user's discovery goes through. When it gets an answer wrong nothing crashes — a board just quietly stops being discovered, or every unrelated port gets probed again and discovery slows to a crawl. Neither shows up as a failure anywhere.

## How it was fixed

The lookup is a walk up the sysfs device tree, and it was testable in principle — it reads real files — but it hardcoded `/sys/class/tty`, so there was no way to point it at anything but the live machine. The walk is now split from the "am I on Linux?" gate and takes the tty class directory as a parameter, which is the same seam `MacOsUsbPortDescriptorProvider.Parse` already has for the same reason. Behaviour is unchanged: for a bare port name, `Path.Combine` builds exactly the path the old string interpolation did.

On top of that seam, 35 tests drive it against a fixture tty tree with real symlinks, covering the parts that are easy to get wrong and impossible to notice: that the `device` entry is a **symlink** which has to be resolved before walking (walking the logical path climbs back into the class directory and finds nothing), that a node needs *both* `idVendor` and `idProduct` before it counts, that unparseable values mean "unknown" rather than "keep climbing and report the hub's IDs", and the exact depth the walk stops at. The two platform provider factories, which also had no tests, get four more.

One thing a reviewer may want to push back on: the fixtures create real directory symlinks. That works on Linux and macOS; on Windows, where an unprivileged process cannot create one, those specific tests return early rather than fail. Windows is not in CI, and the non-symlink tests still cover the walk itself.

## Verification

- Full suite green on **net9.0** (3320 Core + 192 Mcp) and **net10.0** (3320 Core), release build 0 warnings, two consecutive runs.
- **Mutation-tested: 10 of 12 mutants killed.** Ignoring the resolved symlink, moving the depth bound either way, accepting one id file instead of both, walking past an unparseable node, pointing at the tty entry instead of its device node, parsing the ids as decimal, dropping the empty-name guard, using the whole port path as the name, and the macOS factory branch all fail the suite. The two survivors are equivalent mutants — `NumberStyles.HexNumber` already implies `AllowLeadingWhite | AllowTrailingWhite`, so the `.Trim()` on each value is redundant for anything sysfs emits.
- **No bench run.** This path is Linux-only and the bench Mac could not exercise it with a board attached; nothing that reaches the device changed.

Part of #464 (the discovery-provider slice; the Windows half of it is PR #515, which is why this stays clear of those files).

**Not merging — for review.**