### PR TITLE
fix(sdcard): a short SD download is a failed download, not a successful one

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileReceiverTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -335,6 +336,99 @@ public class SdCardFileReceiverTests
 
         Assert.Equal(fileData.Length, bytesReceived);
         Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_ScpiErrorLineInsteadOfFile_ThrowsSdCardTruncatedTransferException()
+    {
+        // The exact shape the bench Nq1 emits for a file its SD buffer can no longer serve: a
+        // SCPI error line, then the end-of-file marker. Nothing on the wire distinguishes that
+        // from a finished download, so before #539 this returned 34 "successful" bytes and the
+        // caller wrote the error text to disk as the log file.
+        var errorLine = Encoding.ASCII.GetBytes("**ERROR: -200, \"Execution error\"\r\n");
+        using var sourceStream = new MemoryStream(Combine(errorLine, EofMarker));
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        var ex = await Assert.ThrowsAsync<SdCardTruncatedTransferException>(
+            () => receiver.ReceiveAsync(destinationStream, "log.bin", listedFileSizeBytes: 6159));
+
+        Assert.Equal("log.bin", ex.FileName);
+        Assert.Equal(6159, ex.ListedSizeInBytes);
+        Assert.Equal(errorLine.Length, ex.BytesReceived);
+        Assert.Contains("6159", ex.Message);
+        Assert.Contains(errorLine.Length.ToString(CultureInfo.InvariantCulture), ex.Message);
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_ShortTransferSpanningChunks_ThrowsWithTheTotalItActuallyReceived()
+    {
+        // A short transfer that arrives in several reads exercises the trailing-window accounting:
+        // the reported byte count has to be the whole transfer, not just the final chunk.
+        var partial = new byte[100];
+        new Random(539).NextBytes(partial);
+        using var sourceStream = new ChunkedMemoryStream(Combine(partial, EofMarker), chunkSize: 16);
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream, bufferSize: 16);
+
+        var ex = await Assert.ThrowsAsync<SdCardTruncatedTransferException>(
+            () => receiver.ReceiveAsync(destinationStream, "partial.bin", listedFileSizeBytes: 20118));
+
+        Assert.Equal(100, ex.BytesReceived);
+        Assert.Equal(20118, ex.ListedSizeInBytes);
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_TransferMatchingListedSize_Succeeds()
+    {
+        // The ordinary case, and the one the bench confirms byte-exact for every file the device
+        // can actually serve: received == listed is a completed download and must not throw.
+        var fileData = new byte[1539];
+        new Random(1539).NextBytes(fileData);
+        using var sourceStream = new MemoryStream(Combine(fileData, EofMarker));
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        var bytesReceived = await receiver.ReceiveAsync(
+            destinationStream, "log.bin", listedFileSizeBytes: 1539);
+
+        Assert.Equal(1539, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_TransferLongerThanListedSize_StillSucceeds()
+    {
+        // The size check is deliberately one-sided. A listing goes stale the moment an active
+        // logging session appends to the file, and the extra bytes are real content — rejecting
+        // them would turn a good download into a failure.
+        var fileData = Encoding.ASCII.GetBytes("this file grew after it was listed");
+        using var sourceStream = new MemoryStream(Combine(fileData, EofMarker));
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        var bytesReceived = await receiver.ReceiveAsync(
+            destinationStream, "growing.bin", listedFileSizeBytes: 10);
+
+        Assert.Equal(fileData.Length, bytesReceived);
+        Assert.Equal(fileData, destinationStream.ToArray());
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_ShortTransferWithUnknownListedSize_CannotBeDetected()
+    {
+        // Documents the limit of the guard: with no listing there is nothing to compare against,
+        // so a short transfer is indistinguishable from a small file and still returns. Fetching
+        // a listing before downloading is what buys the check.
+        var partial = Encoding.ASCII.GetBytes("**ERROR: -200, \"Execution error\"\r\n");
+        using var sourceStream = new MemoryStream(Combine(partial, EofMarker));
+        using var destinationStream = new MemoryStream();
+        var receiver = new SdCardFileReceiver(sourceStream);
+
+        var bytesReceived = await receiver.ReceiveAsync(
+            destinationStream, "unlisted.bin", listedFileSizeBytes: null);
+
+        Assert.Equal(partial.Length, bytesReceived);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -2114,6 +2114,55 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task DownloadSdCardFileAsync_ShortTransferForListedFile_ThrowsInsteadOfReportingSuccess()
+        {
+            // Arrange — the listing says 6159 bytes and the device answers the GET with a SCPI
+            // error line followed by the end-of-file marker, which is what the bench Nq1 actually
+            // does for a file its SD buffer can no longer serve. That used to come back as a
+            // successful 34-byte download with the error text standing in for the log (#539).
+            var errorLine = Encoding.ASCII.GetBytes("**ERROR: -200, \"Execution error\"\r\n");
+            var device = new TestableRetryDownloadDevice(errorLine, errorLine);
+            device.ListingLines.Add("Daqifi/data.bin 6159");
+            device.Connect();
+            await device.GetSdCardFilesAsync();
+            device.SentMessages.Clear();
+
+            using var destinationStream = new MemoryStream();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<SdCardTruncatedTransferException>(
+                () => device.DownloadSdCardFileAsync("data.bin", destinationStream));
+            Assert.Equal("data.bin", ex.FileName);
+            Assert.Equal(6159, ex.ListedSizeInBytes);
+            Assert.Equal(errorLine.Length, ex.BytesReceived);
+
+            // A single GET: unlike the marker-only case this is NOT retried, because the partial
+            // bytes are already in the caller's stream and a second attempt would append to them.
+            var getCommands = device.SentMessages.Select(m => m.Data).Count(c => c.Contains("SD:GET"));
+            Assert.Equal(1, getCommands);
+        }
+
+        [Fact]
+        public async Task DownloadSdCardFileAsync_TransferMatchingListedSize_Succeeds()
+        {
+            // The companion to the case above: a device that serves the whole file still reports a
+            // plain success, so the guard cannot be rejecting good downloads.
+            var fileData = new byte[512];
+            new Random(539).NextBytes(fileData);
+            var device = new TestableRetryDownloadDevice(fileData);
+            device.ListingLines.Add("Daqifi/data.bin 512");
+            device.Connect();
+            await device.GetSdCardFilesAsync();
+
+            using var destinationStream = new MemoryStream();
+
+            var result = await device.DownloadSdCardFileAsync("data.bin", destinationStream);
+
+            Assert.Equal(512, result.FileSize);
+            Assert.Equal(fileData, destinationStream.ToArray());
+        }
+
+        [Fact]
         public async Task DownloadSdCardFileAsync_AmbiguousListedName_FallsBackToConservativeBehavior()
         {
             // Arrange — the listing keeps only leaf names, so the same name can appear twice from

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperations.cs
@@ -194,6 +194,14 @@ namespace Daqifi.Core.Device.SdCard
         /// listing reported as non-empty (or whose listed size is unknown). A file the listing
         /// reports as 0 bytes downloads successfully as a legitimate empty file.
         /// </exception>
+        /// <exception cref="SdCardTruncatedTransferException">
+        /// Thrown when the transfer ends at the end-of-file marker with fewer bytes than the last
+        /// listing reported for the file — the device served a short reply, such as a SCPI error
+        /// line, in place of the file. Anything already written to
+        /// <paramref name="destinationStream"/> is not the file and must be discarded. The check
+        /// needs a size to compare against, so call <see cref="GetSdCardFilesAsync"/> before
+        /// downloading; with no listing the download cannot tell a short reply from a small file.
+        /// </exception>
         /// <exception cref="SdCardTransferStalledException">
         /// Thrown when the transfer stops making progress before the end-of-file marker arrives;
         /// <see cref="SdCardTransferStalledException.Reason"/> distinguishes a stalled read from a

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileReceiver.cs
@@ -148,12 +148,15 @@ public sealed class SdCardFileReceiver
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="listedFileSizeBytes">
-    /// The size the device's directory listing reported for this file, when known. It is the only
-    /// thing that separates a wedged SD subsystem from a genuinely 0-byte file, so a marker-only
-    /// transfer raises <see cref="SdCardEmptyTransferException"/> only when this says the file is
-    /// non-empty. Pass <c>0</c> for a listed empty file to have it return 0 bytes as a legitimate
-    /// empty download. When <c>null</c> (no listing available) the conservative behavior is kept
-    /// and a marker-only transfer throws.
+    /// The size the device's directory listing reported for this file, when known. It is what the
+    /// completed transfer is judged against, because the EOF marker is the firmware's only
+    /// completion signal and says nothing about whether the whole file arrived: a transfer shorter
+    /// than this raises <see cref="SdCardTruncatedTransferException"/>, and one with no content
+    /// bytes at all raises <see cref="SdCardEmptyTransferException"/>. It is also the only thing
+    /// that separates a wedged SD subsystem from a genuinely 0-byte file, so pass <c>0</c> for a
+    /// listed empty file to have it return 0 bytes as a legitimate empty download. When
+    /// <c>null</c> (no listing available) there is nothing to judge the size against, so a short
+    /// transfer cannot be detected and only the conservative marker-only behavior applies.
     /// </param>
     /// <returns>The total number of file bytes written (excluding the EOF marker).</returns>
     /// <exception cref="SdCardTransferStalledException">
@@ -166,6 +169,13 @@ public sealed class SdCardFileReceiver
     /// Thrown when the EOF marker arrives with zero preceding file bytes for a file that
     /// <paramref name="listedFileSizeBytes"/> reports as non-empty (or whose listed size is
     /// unknown), meaning the device opened the file but sent no content before closing it.
+    /// </exception>
+    /// <exception cref="SdCardTruncatedTransferException">
+    /// Thrown when the EOF marker arrives after fewer content bytes than
+    /// <paramref name="listedFileSizeBytes"/> reports for the file, meaning the device served a
+    /// short reply — an error line, or a partial file — rather than the file itself. Whatever
+    /// arrived has already been written to <paramref name="destinationStream"/> and must be
+    /// discarded.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="listedFileSizeBytes"/> is negative.
@@ -331,6 +341,26 @@ public sealed class SdCardFileReceiver
                         // legitimate empty download. With no listed size we keep the conservative
                         // #264 behavior so a wedged subsystem is still caught (#398 gap 2).
                         throw new SdCardEmptyTransferException(fileName, listedFileSizeBytes);
+                    }
+
+                    if (listedFileSizeBytes is > 0 && totalBytesReceived < listedFileSizeBytes)
+                    {
+                        // The marker arrived, but with less content than the listing says the file
+                        // holds. The marker is the firmware's ONLY completion signal, so without
+                        // this check a short reply is indistinguishable from a finished download:
+                        // a device that answers SD:GET with `**ERROR: -200, "Execution error"` and
+                        // then the marker hands the caller a 34-byte "log file" and no error at
+                        // all — its error queue reads clean afterwards too (#539). The listed size
+                        // is the only evidence available, and it is already in hand for the
+                        // marker-only case above, so let it settle the short case as well.
+                        //
+                        // Deliberately one-sided: a transfer LONGER than the listed size is left
+                        // alone, because a listing goes stale the moment an active logging session
+                        // appends to the file, and those extra bytes are real content.
+                        throw new SdCardTruncatedTransferException(
+                            fileName,
+                            listedFileSizeBytes.Value,
+                            totalBytesReceived);
                     }
 
                     progress?.Report(new SdCardTransferProgress(totalBytesReceived, fileName));

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -805,6 +805,12 @@ namespace Daqifi.Core.Device.SdCard
         /// whose listed size is unknown), indicating its SD subsystem is not ready. A file the
         /// listing reports as 0 bytes downloads successfully as a legitimate empty file.
         /// </exception>
+        /// <exception cref="SdCardTruncatedTransferException">
+        /// Thrown when the transfer ends at the end-of-file marker with fewer bytes than the last
+        /// <see cref="GetSdCardFilesAsync"/> listing reported for the file — the device served a
+        /// short reply, such as a SCPI error line, in place of the file. Anything already written
+        /// to <paramref name="destinationStream"/> is not the file and must be discarded.
+        /// </exception>
         /// <exception cref="SdCardTransferStalledException">
         /// Thrown when the transfer stops making progress before the end-of-file marker arrives:
         /// the transport returned an empty read, closed, or — the only signal a socket gives —
@@ -952,6 +958,14 @@ namespace Daqifi.Core.Device.SdCard
                                     listedFileSizeBytes: listedFileSizeBytes).ConfigureAwait(false);
                                 break;
                             }
+                            // Only the marker-only case is retried. A SHORT transfer
+                            // (SdCardTruncatedTransferException, #539) is not, even though it is
+                            // the same kind of transient device condition: by then those bytes
+                            // have already been written to the caller's destinationStream, which
+                            // this method cannot rewind, so a second attempt would append to the
+                            // garbage rather than replace it and could land on the listed size by
+                            // sheer accumulation. Letting it out is the honest answer — the caller
+                            // discards the stream and retries the download.
                             catch (SdCardEmptyTransferException) when (attempt < SD_LIST_MAX_RETRIES)
                             {
                                 attempt++;

--- a/src/Daqifi.Core/Device/SdCard/SdCardTruncatedTransferException.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTruncatedTransferException.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Globalization;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// Thrown when an SD card file download ends at the <c>__END_OF_FILE__</c> marker having
+    /// received fewer bytes than the directory listing reports for the file. The transfer looks
+    /// complete on the wire — the marker is the only completion signal the firmware sends — but
+    /// the content is short, so what reached the destination is a partial file or not the file
+    /// at all.
+    /// </summary>
+    /// <remarks>
+    /// The observed shape on real hardware is a device that answers <c>SD:GET</c> with a SCPI
+    /// error line and then the end-of-file marker: a 34-byte "download" of the text
+    /// <c>**ERROR: -200, "Execution error"</c> standing in for a multi-kilobyte log. Nothing in
+    /// the transfer itself distinguishes that from file content, and the device's error queue
+    /// reads clean afterwards, so the listed size is the only evidence available — which is why
+    /// this is raised on the size comparison rather than by inspecting the payload.
+    /// <para>
+    /// Whatever was received has already been written to the caller's destination stream by the
+    /// time this is thrown. It is not a usable file and must be discarded; the download is not
+    /// retried automatically, because a retry would append to that same stream rather than
+    /// replace it.
+    /// </para>
+    /// <para>
+    /// A transfer that is <em>longer</em> than the listed size does not raise this. A listing can
+    /// legitimately be stale — a file being appended to by an active logging session grows after
+    /// it was listed — and in that case the extra bytes are real content, not evidence of a
+    /// failure.
+    /// </para>
+    /// </remarks>
+    public class SdCardTruncatedTransferException : SdCardOperationException
+    {
+        /// <summary>
+        /// Gets the name of the file whose transfer came up short.
+        /// </summary>
+        public string FileName { get; }
+
+        /// <summary>
+        /// Gets the size the directory listing reported for the file. Always greater than
+        /// <see cref="BytesReceived"/>.
+        /// </summary>
+        public long ListedSizeInBytes { get; }
+
+        /// <summary>
+        /// Gets the number of file bytes actually received before the end-of-file marker. Always
+        /// greater than zero: a transfer with no content bytes at all is reported as
+        /// <see cref="SdCardEmptyTransferException"/> instead.
+        /// </summary>
+        public long BytesReceived { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SdCardTruncatedTransferException"/> class.
+        /// </summary>
+        /// <param name="fileName">The name of the file whose transfer came up short.</param>
+        /// <param name="listedSizeInBytes">The size the directory listing reported for the file.</param>
+        /// <param name="bytesReceived">The number of file bytes actually received.</param>
+        public SdCardTruncatedTransferException(
+            string fileName,
+            long listedSizeInBytes,
+            long bytesReceived)
+            : base(
+                BuildMessage(fileName, listedSizeInBytes, bytesReceived),
+                Array.Empty<string>())
+        {
+            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            ListedSizeInBytes = listedSizeInBytes;
+            BytesReceived = bytesReceived;
+        }
+
+        private static string BuildMessage(string fileName, long listedSizeInBytes, long bytesReceived)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "SD card file '{0}' ended at the end-of-file marker after only {1} of the {2} bytes " +
+                "the directory listing reports, so the download is incomplete. The device served a " +
+                "short reply — commonly a SCPI error line in place of the file — and what was " +
+                "written is not the file; discard it and retry the download.",
+                fileName,
+                bytesReceived,
+                listedSizeInBytes);
+        }
+    }
+}


### PR DESCRIPTION
## What was wrong

If the device served a short or garbage reply to an SD card download, Core reported it as a **success**. A caller asking for a 6 KB log could be handed a 34-byte file whose entire contents were the text `**ERROR: -200, "Execution error"` — no exception, no warning, nothing in the API to say the download hadn't happened. They just got a corrupt log, and whatever came next (parsing it, archiving it, uploading it) ran on bad data.

The `__END_OF_FILE__` marker is the firmware's only completion signal, and it says nothing about how much of the file actually arrived. The receiver accepted any non-zero byte count as a finished download, so a device that sent an error line and then the marker was indistinguishable from one that sent the whole file.

## How it was fixed

The receiver already had the size the directory listing reported — it just wasn't using it except to tell a genuinely 0-byte file from a wedged SD subsystem. Now a transfer that ends short of that size raises a new `SdCardTruncatedTransferException` carrying expected vs. received, instead of returning.

Two judgement calls a reviewer may want to push back on:

- **The check is one-sided.** A transfer *longer* than the listed size still succeeds. A listing goes stale the moment an active logging session appends to the file, and those extra bytes are real content — rejecting them would turn a good download into a failure.
- **A short transfer is not retried**, even though the marker-only case next to it is. By the time it's detected, the partial bytes are already in the caller's destination stream, which Core can't rewind; a second attempt would append to the garbage rather than replace it. The caller discards the stream and retries the download.

The guard needs a listing to compare against, so `GetSdCardFilesAsync` before downloading is what buys it — documented on the interface.

## How it was verified

Full suite green on net9 and net10 (3395 core + 192 MCP tests). Nine new tests: the exact hardware shape (error line + marker against a 6159-byte listing), a short transfer spanning chunks, the one-sided over-run case, exact-size success, unknown-listed-size, and two end-to-end through `DownloadSdCardFileAsync` — including one asserting a single `SD:GET`, i.e. that the truncated case is *not* retried.

Bench-validated on the Nq1 (fw 3.7.2, USB), non-destructive throughout:

- **Healthy downloads are unaffected** — the important check, since the risk of this change is rejecting good files. Two files came back byte-exact against their listed sizes (1539 and 285 bytes) and reported plain success.
- **The other failure paths are unchanged** — marker-only still raises `SdCardEmptyTransferException`; a device that stops without the marker still stalls.
- **The dangerous wire shape was reproduced at the raw-serial level**: with the device's error queue drained clean beforehand, `SD:GET` on a file listed at 14318 bytes answered with the 34-byte error line *followed by* the end-of-file marker — the exact input the new guard rejects. Through Core's own download path today's failures come back marker-only, so that shape is covered by the tests rather than by a live Core run.

The underlying device behaviour is firmware #703 (the SD circular buffer collapsing after a non-SD stream), already fixed but unreleased; this PR is only about Core no longer calling such a transfer a success.

closes #539

Not merging — this is for your review.
