### PR TITLE
fix(diagnostics): reading counters mid-stream reported a silently incomplete answer as a complete one

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -1057,10 +1057,18 @@ Notes:
   `Key=Value` lines whose membership grows between firmware versions, so every numeric pair is exposed
   through `Values` and the typed properties return `null` for fields the running firmware omits.
 - Each call runs as a text command (the protobuf consumer is paused for the exchange, like the SD and
-  LAN-chip queries). They do **not** stop streaming, so you can sample live counters — but parsing is
-  most reliable when the device is not actively streaming. Avoid issuing them concurrently.
+  LAN-chip queries). Avoid issuing them concurrently.
+- **Query while the device is not streaming.** These calls do not stop an active capture, but the
+  firmware does not stop either: pausing Core's protobuf reader leaves the device emitting frames, and
+  whatever is in flight lands on the front of the reply and destroys its first line. A mid-capture call
+  is therefore opportunistic — it may fail, and stopping the stream is the only way to be sure of a
+  clean read.
 - A `DeviceDiagnosticsException` (carrying `RawDeviceResponse`) is thrown when the device returns a
-  SCPI error or an unparseable response for the structured queries.
+  SCPI error or an unparseable response for the structured queries. Its subclass
+  `DeviceDiagnosticsCorruptedResponseException` is thrown by the four counter queries
+  (`GetStreamStatsAsync`, `GetMemoryDiagnosticsAsync`, `GetSystemErrorCountAsync`, `SetLogLevelAsync`)
+  when the reply arrived with stream frames welded into it — previously those queries silently dropped
+  the mangled line and reported the rest as a complete reading.
 - `SYSTem:OS:Stats?` (FreeRTOS task stats) is intentionally **not** wrapped: it is commented out in the
   current firmware. It can be added once the firmware re-enables it.
 

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
@@ -279,6 +279,169 @@ public class DeviceDiagnosticsTests
         await Assert.ThrowsAsync<DeviceNotConnectedException>(() => device.GetMemoryDiagnosticsAsync());
     }
 
+    // ---------------------------------------------------------------------------------------
+    // Issue #537: a diagnostics query issued while the device is streaming gets protobuf frame
+    // bytes welded onto the front of its first reply line, because pausing Core's protobuf reader
+    // does not stop the firmware. CorruptedFirstLine below is the shape captured off the bench --
+    // the key is destroyed, the value survives -- and the tolerant parser used to drop the pair
+    // and report the rest as a complete reading.
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>A first reply line as it arrives mid-stream: binary prefix, real key, real value.</summary>
+    private const string CorruptedFirstLine = "\u0008\uFFFD\\3\uFFFD\u0004\u0012\u0003\u0008\u0000TotalSamplesStreamed=203";
+
+    [Fact]
+    public async Task GetStreamStatsAsync_WhenStreamFramesCorruptTheReply_ThrowsInsteadOfLosingTheCounter()
+    {
+        // Before #537 this returned successfully with a healthy-looking Values dictionary and
+        // TotalSamplesStreamed == null: the headline counter, silently gone.
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { CorruptedFirstLine, "QueueDroppedSamples=0", "TimerISRCalls=933" },
+        };
+        device.Connect();
+
+        var ex = await Assert.ThrowsAsync<DeviceDiagnosticsCorruptedResponseException>(
+            () => device.GetStreamStatsAsync());
+
+        // The raw reply is retained so a caller can still log or salvage what arrived.
+        Assert.Equal(3, ex.RawDeviceResponse.Count);
+        Assert.Contains("TotalSamplesStreamed", ex.RawDeviceResponse[0]);
+    }
+
+    [Fact]
+    public async Task GetSystemErrorCountAsync_WhenStreamFramesCorruptTheReply_ThrowsCorruptedResponse()
+    {
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "\u00000" },
+        };
+        device.Connect();
+
+        await Assert.ThrowsAsync<DeviceDiagnosticsCorruptedResponseException>(
+            () => device.GetSystemErrorCountAsync());
+    }
+
+    [Fact]
+    public async Task GetMemoryDiagnosticsAsync_WhenStreamFramesCorruptTheReply_ThrowsCorruptedResponse()
+    {
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "\u0000HeapTotal=75000", "HeapFree=45000" },
+        };
+        device.Connect();
+
+        await Assert.ThrowsAsync<DeviceDiagnosticsCorruptedResponseException>(
+            () => device.GetMemoryDiagnosticsAsync());
+    }
+
+    [Fact]
+    public async Task SetLogLevelAsync_WhenStreamFramesCorruptTheEcho_ThrowsCorruptedResponse()
+    {
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "\u0000STREAM: 2 (ceiling 3)" },
+        };
+        device.Connect();
+
+        await Assert.ThrowsAsync<DeviceDiagnosticsCorruptedResponseException>(
+            () => device.SetLogLevelAsync("STREAM", 2));
+    }
+
+    [Fact]
+    public async Task SetLogLevelAsync_WhenTheDeviceRejectedTheRequest_ReportsTheRejectionNotTheCorruption()
+    {
+        // A device that answered "no" gave a real answer; that diagnosis outranks "your reply was
+        // mangled", so the rejection check deliberately runs first.
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "**ERROR: -224,\"Illegal parameter value\"", "\u0000noise" },
+        };
+        device.Connect();
+
+        var ex = await Assert.ThrowsAsync<DeviceDiagnosticsException>(() => device.SetLogLevelAsync("STREAM", 2));
+        Assert.IsNotType<DeviceDiagnosticsCorruptedResponseException>(ex);
+    }
+
+    [Fact]
+    public async Task GetStreamStatsAsync_WhenReplyContainsATab_IsNotTreatedAsCorrupted()
+    {
+        // Tab is real device output (it appears as a SCPI token delimiter), so it must not be
+        // mistaken for interleaved binary and fail an otherwise clean read.
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "TotalSamplesStreamed\t=\t15000" },
+        };
+        device.Connect();
+
+        var stats = await device.GetStreamStatsAsync();
+
+        Assert.Equal(15000UL, stats.TotalSamplesStreamed);
+    }
+
+    [Fact]
+    public async Task GetSystemLogAsync_WhenALineIsCorrupted_StillReturnsTheSurvivingEntries()
+    {
+        // Deliberately NOT guarded: the log read clears the buffer on the device, so the entries
+        // that did arrive are all anyone will ever get. Throwing them away would destroy more than
+        // it protects, and a missing entry is visible in the result anyway.
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "\u0000Test log message 1", "Test info message" },
+        };
+        device.Connect();
+
+        var entries = await device.GetSystemLogAsync();
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal("Test info message", entries[1].Message);
+    }
+
+    [Fact]
+    public async Task GetCommandHistoryAsync_WhenALineIsCorrupted_StillReturnsTheSurvivingCommands()
+    {
+        // Same reasoning as the system log: one lost line out of several is visible in the result.
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "\u00002: SYSTem:LOG?", "1: SYSTem:LOG:CMDHistory?" },
+        };
+        device.Connect();
+
+        var commands = await device.GetCommandHistoryAsync();
+
+        Assert.Contains("SYSTem:LOG:CMDHistory?", commands);
+    }
+
+    [Fact]
+    public async Task ClearSystemLogAsync_WhenTheAckIsCorrupted_DoesNotReportAFailure()
+    {
+        // Deliberately NOT guarded: the reply is an ack, not a result. The command ran; failing it
+        // over a mangled ack would report a failure that did not happen.
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "\u0000Log cleared" },
+        };
+        device.Connect();
+
+        await device.ClearSystemLogAsync();
+
+        Assert.Contains("SYSTem:LOG:CLEar", device.SentCommands);
+    }
+
+    [Fact]
+    public async Task TestSystemLogAsync_WhenTheAckIsCorrupted_DoesNotReportAFailure()
+    {
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "\u0000Added test log messages" },
+        };
+        device.Connect();
+
+        await device.TestSystemLogAsync();
+
+        Assert.Contains("SYSTem:LOG:TEST", device.SentCommands);
+    }
+
     /// <summary>
     /// A streaming device whose text-command exchange returns a canned response and records the
     /// SCPI commands sent during the exchange, so diagnostics methods can be tested without a

--- a/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
@@ -107,5 +107,43 @@ namespace Daqifi.Core.Tests.Device
             Assert.False(ScpiResponseClassifier.TryParseSystemErrorReplyCode(line, out var code));
             Assert.Equal(0, code);
         }
+
+        [Theory]
+        // The shape captured off the bench in #537: a partial protobuf frame welded onto the front
+        // of the first reply line, with the real key and value still attached behind it.
+        [InlineData("\u0008\uFFFD\\3\uFFFD\u0004\u0012\u0003\u0008\u0000TotalSamplesStreamed=203")]
+        [InlineData("\u0000TotalSamplesStreamed=203")]        // a lone NUL is enough
+        [InlineData("STREAM: 2 (ceiling 3)\u0007")]           // junk trailing the line, not leading it
+        [InlineData("\uFFFD3")]                               // UTF-8 could not decode the byte at all
+        [InlineData("\u007F42")]                              // DEL
+        [InlineData("\u009F42")]                              // a C1 control from a decoded 2-byte sequence
+        public void IsBinaryCorruptedLine_DetectsNonTextBytes(string line)
+        {
+            Assert.True(ScpiResponseClassifier.IsBinaryCorruptedLine(line));
+        }
+
+        [Theory]
+        [InlineData("TotalSamplesStreamed=203")]
+        [InlineData("STREAM: 2 (ceiling 3)")]
+        [InlineData("**ERROR: -200, \"Execution error\"")]
+        [InlineData("ERROR\t-200, \"Execution error\"")]      // tab is real device output, not corruption
+        [InlineData("DAQiFi/log_20260802_153435.bin 1539")]
+        [InlineData("  padded  ")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void IsBinaryCorruptedLine_PassesRealDeviceText(string? line)
+        {
+            Assert.False(ScpiResponseClassifier.IsBinaryCorruptedLine(line));
+        }
+
+        [Fact]
+        public void ContainsBinaryCorruptedLine_FindsCorruptionAnywhereInTheResponse()
+        {
+            var clean = new[] { "TotalSamplesStreamed=203", "QueueDroppedSamples=0" };
+            var corrupted = new[] { "TotalSamplesStreamed=203", "\u0000QueueDroppedSamples=0" };
+
+            Assert.False(ScpiResponseClassifier.ContainsBinaryCorruptedLine(clean));
+            Assert.True(ScpiResponseClassifier.ContainsBinaryCorruptedLine(corrupted));
+        }
     }
 }

--- a/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsCorruptedResponseException.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsCorruptedResponseException.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.Diagnostics
+{
+    /// <summary>
+    /// Thrown when a diagnostics reply arrived with non-text bytes welded into it, so the values it
+    /// carries are incomplete and must not be reported as a result (issue #537).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The cause is asking a streaming device for its counters. The diagnostics queries deliberately
+    /// do not stop the stream, but the firmware keeps emitting protobuf frames throughout the
+    /// exchange, and whatever was in flight when the reply began lands on the front of its first
+    /// line. The tolerant key/value parser then drops that line as unrecognised, which is what used
+    /// to turn a mangled reply into a healthy-looking one with a counter quietly missing.
+    /// </para>
+    /// <para>
+    /// The remedy is to stop streaming and query again — a retry while the stream is still running
+    /// hits the same interference, so Core does not attempt one on the caller's behalf.
+    /// <see cref="DeviceDiagnosticsException.RawDeviceResponse"/> carries the reply exactly as it
+    /// arrived, mangled line included, for callers that want to log or salvage it.
+    /// </para>
+    /// </remarks>
+    public sealed class DeviceDiagnosticsCorruptedResponseException : DeviceDiagnosticsException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceDiagnosticsCorruptedResponseException"/> class.
+        /// </summary>
+        public DeviceDiagnosticsCorruptedResponseException(
+            string message,
+            IReadOnlyList<string> rawDeviceResponse,
+            Exception? innerException = null)
+            : base(message, rawDeviceResponse, innerException)
+        {
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
@@ -15,12 +15,22 @@ namespace Daqifi.Core.Device.Diagnostics
     /// <see cref="DaqifiStreamingDevice"/> so the device delegates rather than hosts it.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Each method issues a single SCPI query/command as a text command (the protobuf consumer is
     /// paused for the exchange, same as the SD and LAN-chip queries) and hands the response to a
     /// tolerant parser. Unlike the SD operations these do not switch the SPI bus, so there is no
-    /// PrepareSdInterface / settle delay; and they intentionally do not stop streaming, so callers
-    /// can sample live counters — though parsing is most reliable when the device is not actively
-    /// streaming.
+    /// PrepareSdInterface / settle delay; and they deliberately do not stop streaming, so they can
+    /// be issued mid-capture.
+    /// </para>
+    /// <para>
+    /// Not stopping the stream has a cost the tolerant parsers used to hide. Pausing the protobuf
+    /// consumer does not tell the firmware to stop, so protobuf frame bytes keep arriving and land
+    /// on the front of the reply's first line; the parser drops what it cannot recognise, and the
+    /// caller gets a plausible-looking result with a counter silently missing (issue #537). The
+    /// four queries whose entire value is machine-parsed numbers therefore check for that evidence
+    /// and throw <see cref="DeviceDiagnosticsCorruptedResponseException"/> instead of reporting a
+    /// partial answer as a whole one.
+    /// </para>
     /// </remarks>
     internal sealed class DeviceDiagnosticsOperations : IDeviceDiagnostics
     {
@@ -93,6 +103,11 @@ namespace Daqifi.Core.Device.Diagnostics
                     lines);
             }
 
+            // After the rejection check: a device that answered "no" gave a real answer, and that
+            // diagnosis is more useful than "your reply was mangled". Before the parse, because a
+            // mangled echo is exactly why the parse below is about to fail.
+            ThrowIfCorruptedByStreamData(lines, $"the log-level command for module '{module}'");
+
             if (LogLevelParser.TryParseLines(lines, out var setting))
             {
                 return setting;
@@ -148,6 +163,8 @@ namespace Daqifi.Core.Device.Diagnostics
                 responseTimeoutMs: DIAGNOSTICS_RESPONSE_TIMEOUT_MS,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
+            ThrowIfCorruptedByStreamData(lines, "the error-count query");
+
             foreach (var line in lines)
             {
                 if (string.IsNullOrWhiteSpace(line))
@@ -176,6 +193,8 @@ namespace Daqifi.Core.Device.Diagnostics
                 responseTimeoutMs: DIAGNOSTICS_RESPONSE_TIMEOUT_MS,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
+            ThrowIfCorruptedByStreamData(lines, "the streaming-stats query");
+
             if (StreamStatsParser.TryParse(lines, out var stats))
             {
                 return stats;
@@ -196,6 +215,8 @@ namespace Daqifi.Core.Device.Diagnostics
                 responseTimeoutMs: DIAGNOSTICS_RESPONSE_TIMEOUT_MS,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
+            ThrowIfCorruptedByStreamData(lines, "the memory-diagnostics query");
+
             if (MemoryDiagnosticsParser.TryParse(lines, out var diagnostics))
             {
                 return diagnostics;
@@ -203,6 +224,52 @@ namespace Daqifi.Core.Device.Diagnostics
 
             throw new DeviceDiagnosticsException(
                 "The memory-diagnostics query returned an unparseable response.",
+                lines);
+        }
+
+        /// <summary>
+        /// Throws a <see cref="DeviceDiagnosticsCorruptedResponseException"/> when the device's reply
+        /// arrived with non-text bytes welded into it — the signature of protobuf frames from a
+        /// stream the firmware never stopped emitting (issue #537). Without this the tolerant
+        /// parsers below drop the mangled line and return the rest, which reads as a complete
+        /// answer with a counter missing.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Applied only to the four queries whose whole value is machine-parsed numbers, where a
+        /// dropped line is invisible data loss. Deliberately NOT applied elsewhere, and both
+        /// exclusions matter:
+        /// </para>
+        /// <para>
+        /// <see cref="GetSystemLogAsync"/> and <see cref="GetCommandHistoryAsync"/> return
+        /// firmware-authored text, one entry per line. Losing one entry out of ten is visible in the
+        /// result, and the log read is destructive on the device — the buffer is cleared by the very
+        /// query that read it — so throwing the surviving entries away would destroy more than it
+        /// protects.
+        /// </para>
+        /// <para>
+        /// <see cref="ClearSystemLogAsync"/> and <see cref="TestSystemLogAsync"/> answer with a short
+        /// ack, not a result. The command still ran; failing them over a mangled ack would report a
+        /// failure that did not happen.
+        /// </para>
+        /// <para>
+        /// Not retried either: the interference lasts as long as the stream does, so a second
+        /// attempt meets the same frames. Stopping the stream is the caller's call to make, not
+        /// Core's.
+        /// </para>
+        /// </remarks>
+        private static void ThrowIfCorruptedByStreamData(IReadOnlyList<string> lines, string operation)
+        {
+            if (!ScpiResponseClassifier.ContainsBinaryCorruptedLine(lines))
+            {
+                return;
+            }
+
+            throw new DeviceDiagnosticsCorruptedResponseException(
+                $"The reply to {operation} arrived with binary streaming data welded into it, so the "
+                + "values it carries are incomplete. This happens when the query runs while the device "
+                + "is streaming: pausing Core's protobuf reader does not stop the firmware, so its "
+                + "frames land on the front of the reply. Stop streaming and query again.",
                 lines);
         }
 

--- a/src/Daqifi.Core/Device/Diagnostics/IDeviceDiagnostics.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/IDeviceDiagnostics.cs
@@ -11,11 +11,20 @@ namespace Daqifi.Core.Device.Diagnostics
     /// levels, SCPI command history, error-queue depth, and streaming/memory performance counters.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// These values originate on the device; this interface is a typed wrapper over the corresponding
     /// SCPI queries, not a client-side instrumentation framework. All methods require an established
     /// connection and run as text commands, so avoid issuing them concurrently with each other or with
-    /// other text-mode operations on the same device. For reliable parsing, prefer querying while the
-    /// device is not actively streaming.
+    /// other text-mode operations on the same device.
+    /// </para>
+    /// <para>
+    /// <b>Query while the device is not streaming.</b> These calls do not stop an active capture, but
+    /// the firmware does not stop either: its stream frames interleave with the reply and can destroy
+    /// the front of it. The counter queries detect that and throw
+    /// <see cref="DeviceDiagnosticsCorruptedResponseException"/> rather than return a partial reading
+    /// as a complete one, so a mid-capture call is best treated as opportunistic — it may fail, and
+    /// stopping the stream is the only way to be sure of a clean read.
+    /// </para>
     /// </remarks>
     public interface IDeviceDiagnostics
     {
@@ -46,6 +55,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <exception cref="System.ArgumentException">Thrown when <paramref name="module"/> is null, empty, or contains invalid characters.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when <paramref name="level"/> is outside 0–3.</exception>
         /// <exception cref="DeviceDiagnosticsException">Thrown when the device rejected the request or returned an unparseable response.</exception>
+        /// <exception cref="DeviceDiagnosticsCorruptedResponseException">Thrown when the reply arrived corrupted by an active stream's frames; stop streaming and query again.</exception>
         Task<LogLevelSetting> SetLogLevelAsync(string module, int level, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -78,6 +88,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <returns>The current error-queue depth.</returns>
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         /// <exception cref="DeviceDiagnosticsException">Thrown when the device returned an unparseable response.</exception>
+        /// <exception cref="DeviceDiagnosticsCorruptedResponseException">Thrown when the reply arrived corrupted by an active stream's frames; stop streaming and query again.</exception>
         Task<int> GetSystemErrorCountAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -87,6 +98,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <returns>The parsed streaming statistics.</returns>
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         /// <exception cref="DeviceDiagnosticsException">Thrown when the device returned an unparseable response.</exception>
+        /// <exception cref="DeviceDiagnosticsCorruptedResponseException">Thrown when the reply arrived corrupted by an active stream's frames; stop streaming and query again.</exception>
         Task<StreamStats> GetStreamStatsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -96,6 +108,7 @@ namespace Daqifi.Core.Device.Diagnostics
         /// <returns>The parsed memory diagnostics.</returns>
         /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
         /// <exception cref="DeviceDiagnosticsException">Thrown when the device returned an unparseable response.</exception>
+        /// <exception cref="DeviceDiagnosticsCorruptedResponseException">Thrown when the reply arrived corrupted by an active stream's frames; stop streaming and query again.</exception>
         Task<MemoryDiagnostics> GetMemoryDiagnosticsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -90,6 +90,64 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
+        /// Returns true when a line carries characters a SCPI text reply cannot contain: a control
+        /// character other than tab, or the U+FFFD replacement character that UTF-8 decoding
+        /// produces for a byte sequence that is not text at all. Either one means non-text bytes
+        /// were interleaved with the reply — on this device, protobuf frames from a stream the
+        /// firmware never stopped emitting (issue #537).
+        /// </summary>
+        /// <remarks>
+        /// Tab is excluded because the firmware does use it as a delimiter — <see cref="TokenDelimiters"/>
+        /// accepts it in real device output. CR and LF are the line separators, so they are already
+        /// gone by the time a line reaches here.
+        /// <para>
+        /// This detects evidence, not state: it can only fire on a line that actually arrived
+        /// mangled, so a reply taken while the device is idle can never trip it. The converse does
+        /// not hold — non-text bytes that happen to decode to printable characters are
+        /// indistinguishable from real content and pass through, which is why callers treat a
+        /// negative answer as "no evidence of corruption" rather than "known clean".
+        /// </para>
+        /// </remarks>
+        internal static bool IsBinaryCorruptedLine(string? line)
+        {
+            if (line == null)
+            {
+                return false;
+            }
+
+            foreach (var c in line)
+            {
+                if (c == '\t')
+                {
+                    continue;
+                }
+
+                if (char.IsControl(c) || c == UnicodeReplacementChar)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true when any line in the response is binary-corrupted per
+        /// <see cref="IsBinaryCorruptedLine"/>.
+        /// </summary>
+        internal static bool ContainsBinaryCorruptedLine(IReadOnlyList<string> lines)
+        {
+            return lines.Any(IsBinaryCorruptedLine);
+        }
+
+        /// <summary>
+        /// The character <see cref="System.Text.Encoding.UTF8"/> substitutes for a byte sequence it
+        /// cannot decode. The text consumer decodes response bytes as UTF-8, so raw binary reaches
+        /// the parsers as a mix of these and control characters.
+        /// </summary>
+        private const char UnicodeReplacementChar = '\uFFFD';
+
+        /// <summary>
         /// Returns true if the line is the reply to a <c>SYSTem:ERRor?</c> query — the IEEE 488.2
         /// error-queue format <c>&lt;code&gt;,"&lt;message&gt;"</c>, e.g. <c>0,"No error"</c> or
         /// <c>-200,"Execution error"</c>. Deliberately narrow: the code must be the first thing on


### PR DESCRIPTION
## What was wrong

If you asked a DAQiFi device for its streaming counters while it was actually streaming, it told you a lie and gave you no way to know. `GetStreamStatsAsync` came back successfully, with a healthy-looking 54 fields — and `TotalSamplesStreamed`, the headline counter and almost certainly the one you asked for, was quietly `null`. Nothing distinguished that from "this firmware doesn't report that field." Two of the neighbouring calls (`GetSystemErrorCountAsync`, `SetLogLevelAsync`) failed outright with a vague "returned an unparseable response" that never mentioned the real cause.

The cause: pausing Core's protobuf reader for a text exchange doesn't tell the *firmware* to stop. It keeps streaming, and whatever frame bytes are in flight land on the front of the reply's first line. The tolerant key/value parser then does what it was designed to do — skip the line it can't recognise, keep the rest — which is exactly what turns a mangled reply into a plausible one.

## How it was fixed

The four queries whose entire value is machine-parsed numbers — `GetStreamStatsAsync`, `GetMemoryDiagnosticsAsync`, `GetSystemErrorCountAsync`, `SetLogLevelAsync` — now spot the interleaved bytes and throw the new `DeviceDiagnosticsCorruptedResponseException`, which names the cause, says to stop streaming and retry, and carries the raw reply for logging or salvage. This is the issue's option 1: it doesn't make mid-stream counters *work*, it stops them being silently wrong.

Three calls a reviewer might push back on, all deliberate:

- **Evidence-driven, not state-driven.** The check fires on a line that actually arrived mangled, never on "the device is streaming". So an idle read cannot trip it, and a mid-stream read that happens to come through clean still succeeds. It's also one-sided: bytes that happen to decode to printable characters are indistinguishable from real content and still slip through — this narrows the failure, it doesn't eliminate it.
- **Not applied to everything.** The log and command-history readers keep their old behaviour: their entries are firmware-authored text where one lost line is visible in the result, and `SYSTem:LOG?` *clears the buffer as it reads*, so discarding the survivors would destroy more than it protects. `ClearSystemLogAsync` / `TestSystemLogAsync` answer with an ack, not a result — the command ran, and failing it over a mangled ack would report a failure that didn't happen.
- **Not retried.** The interference lasts as long as the stream does, so a second attempt meets the same frames. Stopping the stream is the caller's decision, not Core's.

`IDeviceDiagnostics` used to claim callers could "sample live counters". That was never true; the docs now say so.

## Verified

**26 new tests** (classifier-level and end-to-end, including the exact byte shape captured off the bench). **Full suite green on net9 + net10: 3448 Core + 192 MCP.**

**Bench-validated on the Nq1 (fw 3.7.2), before and after, same board and same session shape** — three analog channels at 100 Hz, the issue's own five calls run idle → mid-stream → idle:

| | idle (control) | mid-stream | after stop (control) |
|---|---|---|---|
| **`origin/main`** | all 5 OK, `TotalSamplesStreamed=308` | **OK, 54 fields, `TotalSamplesStreamed=NULL`** | all 5 OK |
| **this PR** | all 5 OK, `TotalSamplesStreamed=388` | **throws, naming the cause** | all 5 OK |

The raw reply the exception carried shows the defect exactly as filed — a run of protobuf frame bytes with `TotalSamplesStreamed=193` welded onto the end, while the untouched `TotalBytesStreamed=4627` on the next line survived. Both idle controls are identical and clean before and after, which is the check that actually mattered: no false rejections. All bench work was non-destructive (connect, read counters, one short stream, stop, disconnect).

closes #537

**Not merging — opened for your review.**
