### PR TITLE
perf(device): three log commands stalled for 3 s waiting for a reply the device had already sent

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/LineBasedMessageParserTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/LineBasedMessageParserTests.cs
@@ -109,11 +109,130 @@ public class LineBasedMessageParserTests
         // Arrange
         var parser = new LineBasedMessageParser();
         var data = new byte[0];
-        
+
         // Act
         var messages = parser.ParseMessages(data, out var consumedBytes);
-        
+
         // Assert
+        Assert.Empty(messages);
+        Assert.Equal(0, consumedBytes);
+    }
+
+    // ── Reading both line endings off one wire, and seeing blank lines (#538). The DAQiFi
+    // firmware answers most commands with CRLF but a few with a bare LF, and terminates its
+    // SYSTem:LOG? dump with a blank line. The SCPI text exchange has to recognise all three. ──
+
+    [Fact]
+    public void LineBasedMessageParser_WithLineFeedEnding_ReadsCarriageReturnLineFeedDataUnchanged()
+    {
+        // The property the text exchange relies on: splitting on "\n" is not a choice between the
+        // two endings, it reads both. The carriage return lands at the end of the line's slice and
+        // is trimmed off with the rest of the trailing whitespace.
+        var parser = new LineBasedMessageParser("\n");
+        var data = Encoding.UTF8.GetBytes("Line 1\r\nLine 2\r\n");
+
+        var messages = parser.ParseMessages(data, out var consumedBytes);
+
+        Assert.Equal(2, messages.Count());
+        Assert.Equal("Line 1", messages.ElementAt(0).Data);
+        Assert.Equal("Line 2", messages.ElementAt(1).Data);
+        Assert.Equal(data.Length, consumedBytes);
+    }
+
+    [Fact]
+    public void LineBasedMessageParser_WithLineFeedEnding_ReadsBothEndingsInOneResponse()
+    {
+        // Exactly what the firmware sends: "Log cleared\n" is a bare-LF ack, the counter query
+        // answers CRLF. A CRLF-only parser never sees the first one at all.
+        var parser = new LineBasedMessageParser("\n");
+        var data = Encoding.UTF8.GetBytes("Log cleared\n0\r\nAdded test log messages\n");
+
+        var messages = parser.ParseMessages(data, out _);
+
+        Assert.Equal(
+            new[] { "Log cleared", "0", "Added test log messages" },
+            messages.Select(m => m.Data));
+    }
+
+    [Fact]
+    public void LineBasedMessageParser_WithLineFeedEnding_WhenTheCarriageReturnArrivesInAnEarlierRead_DoesNotSplitTheLine()
+    {
+        // A CRLF straddling two stream reads must still produce one line, not a line plus a blank
+        // one: the CR is never a terminator by itself, so the first read consumes nothing.
+        var parser = new LineBasedMessageParser("\n");
+
+        var firstMessages = parser.ParseMessages(Encoding.UTF8.GetBytes("Line 1\r"), out var firstConsumed);
+        Assert.Empty(firstMessages);
+        Assert.Equal(0, firstConsumed);
+
+        var messages = parser.ParseMessages(Encoding.UTF8.GetBytes("Line 1\r\n"), out var consumedBytes);
+
+        Assert.Single(messages);
+        Assert.Equal("Line 1", messages.First().Data);
+        Assert.Equal(8, consumedBytes);
+    }
+
+    [Fact]
+    public void LineBasedMessageParser_ByDefault_StillDropsBlankLines()
+    {
+        // The new behaviour is opt-in: anyone already using this parser keeps the old result.
+        var parser = new LineBasedMessageParser("\n");
+        var data = Encoding.UTF8.GetBytes("\r\n");
+
+        var messages = parser.ParseMessages(data, out var consumedBytes);
+
+        Assert.Empty(messages);
+        Assert.Equal(data.Length, consumedBytes);
+    }
+
+    [Fact]
+    public void LineBasedMessageParser_WhenEmittingEmptyLines_ReportsABlankLineAsAnEmptyMessage()
+    {
+        // The lone CRLF an empty SYSTem:LOG? answers with. It carries no content, but it is proof
+        // that the device answered — which is the whole reason the exchange asks for it (#538).
+        var parser = new LineBasedMessageParser("\n") { EmitEmptyLines = true };
+        var data = Encoding.UTF8.GetBytes("\r\n");
+
+        var messages = parser.ParseMessages(data, out var consumedBytes);
+
+        Assert.Single(messages);
+        Assert.Equal(string.Empty, messages.First().Data);
+        Assert.Equal(data.Length, consumedBytes);
+    }
+
+    [Fact]
+    public void LineBasedMessageParser_WhenEmittingEmptyLines_ReportsAWhitespaceOnlyLineAsAnEmptyMessage()
+    {
+        // Whitespace-only and empty are the same thing to a caller that only reads content, so
+        // they arrive the same way rather than as two cases every consumer has to handle.
+        var parser = new LineBasedMessageParser("\n") { EmitEmptyLines = true };
+
+        var messages = parser.ParseMessages(Encoding.UTF8.GetBytes("   \t \r\n"), out _);
+
+        Assert.Single(messages);
+        Assert.Equal(string.Empty, messages.First().Data);
+    }
+
+    [Fact]
+    public void LineBasedMessageParser_WhenEmittingEmptyLines_KeepsContentLinesUntouched()
+    {
+        // The populated log dump: entries, then the terminating blank line.
+        var parser = new LineBasedMessageParser("\n") { EmitEmptyLines = true };
+
+        var messages = parser.ParseMessages(Encoding.UTF8.GetBytes("Test error message\r\n\r\n"), out _);
+
+        Assert.Equal(new[] { "Test error message", string.Empty }, messages.Select(m => m.Data));
+    }
+
+    [Fact]
+    public void LineBasedMessageParser_WhenEmittingEmptyLines_StillLeavesAnIncompleteLineInTheBuffer()
+    {
+        // Emitting blank lines must not turn "no terminator yet" into "an empty line arrived":
+        // a partial line is still not a line.
+        var parser = new LineBasedMessageParser("\n") { EmitEmptyLines = true };
+
+        var messages = parser.ParseMessages(Encoding.UTF8.GetBytes("Incomplete"), out var consumedBytes);
+
         Assert.Empty(messages);
         Assert.Equal(0, consumedBytes);
     }

--- a/src/Daqifi.Core.Tests/Device/TextExchangeLineFramingTests.cs
+++ b/src/Daqifi.Core.Tests/Device/TextExchangeLineFramingTests.cs
@@ -1,0 +1,288 @@
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device;
+using System.Diagnostics;
+using System.Text;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Coverage for how the SCPI text exchange frames the device's reply (issue #538).
+/// </summary>
+/// <remarks>
+/// The exchange decides that the device has answered by counting the lines its parser produces, so
+/// a reply the parser cannot turn into a line is a reply the exchange cannot see: it waits out its
+/// whole first-response timeout for an answer that is already in the buffer, holding the device
+/// operation lock the entire time. The DAQiFi firmware sends two such shapes — a bare-LF reply
+/// (<c>SYSTem:LOG:CLEar</c>, <c>SYSTem:LOG:TEST</c>) and a blank line (the terminator of a
+/// <c>SYSTem:LOG?</c> dump, which is the whole reply when the log is empty). Measured on a bench
+/// Nq1 running firmware 3.7.2: both cost 1.5-2.0 s on top of the ~1.05 s a CRLF reply takes.
+/// </remarks>
+public class TextExchangeLineFramingTests
+{
+    /// <summary>
+    /// First-response timeout used by the timing assertions. Large enough that "recognised the
+    /// reply" and "waited the timeout out" are far apart even on a loaded CI machine.
+    /// </summary>
+    private const int ResponseTimeoutMs = 3000;
+
+    private const int CompletionTimeoutMs = 150;
+
+    [Fact]
+    public async Task ExecuteTextCommand_WhenTheDeviceAnswersWithABareLineFeed_ReturnsTheLine()
+    {
+        // The firmware's ack for SYSTem:LOG:CLEar, byte for byte. A CRLF-only parser never finds a
+        // terminator, so before the fix this line was not merely late — it was lost entirely, and
+        // the caller got an empty response after the full timeout.
+        using var transport = new ScriptedReplyTransport("Log cleared\n");
+        using var device = new LineFramingTestableDevice("Bare LF Device", transport);
+
+        device.Connect();
+
+        var lines = await device.CallAsync(() => transport.Release());
+
+        Assert.Equal(new[] { "Log cleared" }, lines);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_WhenTheDeviceAnswersWithABareLineFeed_DoesNotWaitOutTheTimeout()
+    {
+        // The half of #538 that is about time rather than content: the reply arrives immediately,
+        // so the exchange must finish in roughly the completion timeout, not the response timeout.
+        using var transport = new ScriptedReplyTransport("Added test log messages\n");
+        using var device = new LineFramingTestableDevice("Prompt Ack Device", transport);
+
+        device.Connect();
+
+        var stopwatch = Stopwatch.StartNew();
+        var lines = await device.CallAsync(() => transport.Release());
+        stopwatch.Stop();
+
+        Assert.Equal(new[] { "Added test log messages" }, lines);
+        AssertAnsweredPromptly(stopwatch);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_WhenTheDeviceAnswersWithOnlyABlankLine_DoesNotWaitOutTheTimeout()
+    {
+        // An empty SYSTem:LOG? answers with a lone CRLF and nothing else — measured on the bench,
+        // three trials, every one 2 bytes in 6 ms. It carries no content, but it is proof that the
+        // device answered, and treating it as silence cost the caller the full 2 s response
+        // timeout on what is the normal case for a healthy device.
+        using var transport = new ScriptedReplyTransport("\r\n");
+        using var device = new LineFramingTestableDevice("Empty Log Device", transport);
+
+        device.Connect();
+
+        var stopwatch = Stopwatch.StartNew();
+        var lines = await device.CallAsync(() => transport.Release());
+        stopwatch.Stop();
+
+        AssertAnsweredPromptly(stopwatch);
+
+        // ...and the blank line stays out of the caller's result. It is evidence for the wait
+        // loop, not content: every caller of this seam parses lines, and none of them ever saw a
+        // blank one before.
+        Assert.Empty(lines);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_WhenTheDeviceSaysNothingAtAll_StillWaitsForTheFullTimeout()
+    {
+        // The control that keeps the fix honest. Counting blank lines as an answer must not turn
+        // an unresponsive device into one that answered quickly — a silent link is still a silent
+        // link, and the caller is entitled to the full first-response window before it gives up.
+        using var transport = new ScriptedReplyTransport("\r\n");
+        using var device = new LineFramingTestableDevice("Silent Device", transport);
+
+        device.Connect();
+
+        var stopwatch = Stopwatch.StartNew();
+        var lines = await device.CallAsync(() => { /* never released: nothing reaches the stream */ });
+        stopwatch.Stop();
+
+        Assert.Empty(lines);
+        Assert.True(
+            stopwatch.ElapsedMilliseconds >= ResponseTimeoutMs - 500,
+            $"A silent device should have used the whole {ResponseTimeoutMs}ms response window, "
+            + $"but the exchange gave up after {stopwatch.ElapsedMilliseconds}ms.");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_WhenTheDeviceAnswersWithCarriageReturnLineFeed_IsUnchanged()
+    {
+        // The shape almost every reply uses. This is the check that actually matters, because the
+        // risk of splitting on LF instead of CRLF is that the carriage return leaks into the line.
+        using var transport = new ScriptedReplyTransport("0,\"No error\"\r\n");
+        using var device = new LineFramingTestableDevice("CRLF Device", transport);
+
+        device.Connect();
+
+        var lines = await device.CallAsync(() => transport.Release());
+
+        Assert.Equal(new[] { "0,\"No error\"" }, lines);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_WhenTheReplyMixesBothLineEndings_ReturnsEveryLineInOrder()
+    {
+        // A multi-line dump terminated by the firmware's trailing blank line, with a bare-LF ack
+        // in the middle for good measure. The blank is consumed by the exchange; everything else
+        // reaches the caller in the order the device sent it.
+        using var transport = new ScriptedReplyTransport(
+            "Sample queue resize skipped\r\nLog cleared\ndiag: mask=0x0001\r\n\r\n");
+        using var device = new LineFramingTestableDevice("Mixed Device", transport);
+
+        device.Connect();
+
+        var lines = await device.CallAsync(() => transport.Release());
+
+        Assert.Equal(
+            new[] { "Sample queue resize skipped", "Log cleared", "diag: mask=0x0001" },
+            lines);
+
+        device.Disconnect();
+    }
+
+    private static void AssertAnsweredPromptly(Stopwatch stopwatch)
+    {
+        // Generously bounded: a recognised reply finishes in about the completion timeout, and an
+        // unrecognised one takes at least ResponseTimeoutMs. Anything below this bound can only be
+        // the former, with room to spare for a slow build agent.
+        Assert.True(
+            stopwatch.ElapsedMilliseconds < ResponseTimeoutMs - 1000,
+            $"The exchange took {stopwatch.ElapsedMilliseconds}ms, which means it waited out its "
+            + $"{ResponseTimeoutMs}ms response timeout instead of recognising the reply.");
+    }
+
+    /// <summary>Exposes the protected text-exchange entry point with the timeouts these tests need.</summary>
+    private sealed class LineFramingTestableDevice : DaqifiDevice
+    {
+        public LineFramingTestableDevice(string name, IStreamTransport transport)
+            : base(name, transport)
+        {
+        }
+
+        public Task<IReadOnlyList<string>> CallAsync(Action setupAction)
+        {
+            return ExecuteTextCommandAsync(
+                setupAction,
+                responseTimeoutMs: ResponseTimeoutMs,
+                completionTimeoutMs: CompletionTimeoutMs);
+        }
+    }
+
+    /// <summary>
+    /// Transport whose stream withholds one canned reply — raw bytes, so the line endings under
+    /// test survive — until the setup action releases it.
+    /// </summary>
+    private sealed class ScriptedReplyTransport : IStreamTransport
+    {
+        private readonly ScriptedReplyStream _stream;
+        private bool _isConnected;
+        private bool _disposed;
+
+        public ScriptedReplyTransport(string reply)
+        {
+            _stream = new ScriptedReplyStream(reply);
+        }
+
+        public Stream Stream => _disposed
+            ? throw new ObjectDisposedException(nameof(ScriptedReplyTransport))
+            : _stream;
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "Scripted: Connected" : "Scripted: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        /// <summary>Lets the canned reply reach the stream, as a device answering would.</summary>
+        public void Release() => _stream.Release();
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(ScriptedReplyTransport));
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().Wait();
+
+        public void Disconnect() => DisconnectAsync().Wait();
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _isConnected = false;
+            _disposed = true;
+        }
+
+        private sealed class ScriptedReplyStream : Stream
+        {
+            private readonly byte[] _reply;
+            private readonly object _gate = new();
+            private bool _released;
+            private int _position;
+
+            public ScriptedReplyStream(string reply) => _reply = Encoding.ASCII.GetBytes(reply);
+
+            public void Release()
+            {
+                lock (_gate)
+                {
+                    _released = true;
+                }
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                lock (_gate)
+                {
+                    if (_released && _position < _reply.Length)
+                    {
+                        var toCopy = Math.Min(count, _reply.Length - _position);
+                        Array.Copy(_reply, _position, buffer, offset, toCopy);
+                        _position += toCopy;
+                        return toCopy;
+                    }
+                }
+
+                // Idle link: nothing to hand over, and no busy-spin in the reader thread.
+                Thread.Sleep(10);
+                return 0;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) { }
+        }
+    }
+}

--- a/src/Daqifi.Core/Communication/Consumers/LineBasedMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/LineBasedMessageParser.cs
@@ -15,7 +15,12 @@ public class LineBasedMessageParser : IMessageParser<string>
     /// <summary>
     /// Initializes a new instance of the LineBasedMessageParser class.
     /// </summary>
-    /// <param name="lineEnding">The line ending to split messages on. Defaults to CRLF. Must encode to at least one byte.</param>
+    /// <param name="lineEnding">
+    /// The line ending to split messages on. Defaults to CRLF. Must encode to at least one byte.
+    /// Passing a bare <c>"\n"</c> reads LF-terminated and CRLF-terminated data alike, because the
+    /// carriage return is left at the end of the line and trimmed off with the rest of the trailing
+    /// whitespace — which is what a protocol with both kinds of reply on the same wire needs.
+    /// </param>
     /// <param name="encoding">The text encoding to use. Defaults to UTF-8.</param>
     /// <exception cref="ArgumentNullException"><paramref name="lineEnding"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentException"><paramref name="lineEnding"/> encodes to zero bytes (an empty line ending would prevent the parser from making progress).</exception>
@@ -32,6 +37,21 @@ public class LineBasedMessageParser : IMessageParser<string>
                 "Line ending must encode to at least one byte; an empty line ending would prevent the parser from making progress.",
                 nameof(lineEnding));
     }
+
+    /// <summary>
+    /// Whether a complete line whose content is empty (or entirely whitespace) is emitted as a
+    /// message with empty <see cref="IInboundMessage{T}.Data"/>, instead of being dropped.
+    /// Defaults to <c>false</c>, which is the historical behaviour.
+    /// </summary>
+    /// <remarks>
+    /// Internal because it exists for one caller: the SCPI text exchange, which decides that the
+    /// device has answered by counting the messages this parser produces. A blank line is still an
+    /// answer — the DAQiFi firmware terminates its <c>SYSTem:LOG?</c> dump with one, so an empty log
+    /// arrives as a lone CRLF and nothing else. Dropping it here made the exchange conclude that
+    /// nothing had arrived and wait out its full first-response timeout (issue #538). The exchange
+    /// filters the blanks back out of the result, so its callers see the same lines as before.
+    /// </remarks>
+    internal bool EmitEmptyLines { get; init; }
 
     /// <summary>
     /// Parses raw data into line-based text messages.
@@ -73,15 +93,17 @@ public class LineBasedMessageParser : IMessageParser<string>
                 break;
             }
 
-            // Extract the line (excluding line ending)
+            // Extract the line (excluding line ending). Trimming here is what lets a parser
+            // configured with a bare "\n" read CRLF data unchanged: the CR lands at the end of the
+            // slice and comes straight back off. Do not remove it without replacing it.
             var lineLength = lineEndIndex - searchStart;
-            if (lineLength > 0)
+            var messageText = lineLength > 0
+                ? _encoding.GetString(data.Slice(searchStart, lineLength)).Trim()
+                : string.Empty;
+
+            if (messageText.Length > 0 || EmitEmptyLines)
             {
-                var messageText = _encoding.GetString(data.Slice(searchStart, lineLength));
-                if (!string.IsNullOrWhiteSpace(messageText))
-                {
-                    messages.Add(new TextInboundMessage(messageText.Trim()));
-                }
+                messages.Add(new TextInboundMessage(messageText));
             }
 
             // Move past this line and its ending

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -369,10 +369,28 @@ namespace Daqifi.Core.Device.Internal
 
                     Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Protobuf consumer stopped at {ElapsedMs}ms", sw.ElapsedMilliseconds));
 
-                    // Create a temporary text consumer on the same stream
+                    // Create a temporary text consumer on the same stream.
+                    //
+                    // Both parser settings exist because this loop decides that the device has
+                    // answered by counting the lines the parser produces, so any reply the parser
+                    // does not turn into a line is a reply this exchange cannot see — and it then
+                    // waits out its whole first-response timeout for an answer already sitting in
+                    // the buffer (issue #538). The firmware sends two shapes that used to vanish:
+                    //
+                    //  * a bare-LF reply. Most replies are CRLF, but SYSTem:LOG:CLEar and
+                    //    SYSTem:LOG:TEST answer "Log cleared\n" / "Added test log messages\n".
+                    //    Splitting on "\n" reads those AND the CRLF ones — the CR ends up at the
+                    //    end of the line and is trimmed off with the surrounding whitespace.
+                    //  * a blank line. SYSTem:LOG? terminates its dump with one, so an empty log
+                    //    arrives as a lone CRLF and nothing else.
+                    //
+                    // The blanks are filtered out of the result below, so callers see the same
+                    // lines they always did; only this loop's "did anything arrive?" question sees
+                    // them. Splitting on LF also means an embedded bare LF now ends a line rather
+                    // than sitting inside one, which is what a line-based text protocol means by it.
                     using var textConsumer = new StreamMessageConsumer<string>(
                         transport.Stream,
-                        new LineBasedMessageParser(),
+                        new LineBasedMessageParser(lineEnding: "\n") { EmitEmptyLines = true },
                         healthSink: transport as ITransportHealthSink);
 
                     // MessageParsed rather than MessageReceived: only the parsed line matters here,
@@ -496,9 +514,16 @@ namespace Daqifi.Core.Device.Internal
 
                 // The text consumer is stopped by this point, so the list is no longer being
                 // appended to concurrently and can be re-projected safely.
-                var result = staleLineCount > 0
-                    ? collectedLines.Skip(staleLineCount).ToList()
-                    : collectedLines;
+                //
+                // The blank lines the parser was asked to emit are dropped here. They are evidence
+                // for the wait loop above and nothing more: every caller of this seam parses
+                // content, and none of them ever saw a blank line before (#538). The stale skip
+                // runs first, so a blank line that arrived before this exchange sent anything is
+                // discarded as stale rather than counted as content — same rule as any other line.
+                var result = collectedLines
+                    .Skip(staleLineCount)
+                    .Where(line => line.Length > 0)
+                    .ToList();
 
                 completedNormally = true;
                 return result;

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -339,6 +339,24 @@ namespace Daqifi.Core.Device.Internal
                 await _host.DrainOutboundQueueAsync(cancellationToken).ConfigureAwait(false);
 
                 var collectedLines = new List<string>();
+
+                // The list is appended to from the text consumer's reader thread and read from
+                // this one, so every touch of it goes through this gate. Stopping the consumer is
+                // not enough on its own: StopSafely and Dispose are both time-bounded and can
+                // return with the reader still parked in an un-returning read, which the remarks
+                // on RestartMessageConsumerAfterSwap already say out loud. Without the gate, a
+                // line arriving in that window while the result is being projected throws
+                // "collection was modified" out of an exchange that had otherwise succeeded.
+                var collectedLinesGate = new object();
+
+                int CollectedLineCount()
+                {
+                    lock (collectedLinesGate)
+                    {
+                        return collectedLines.Count;
+                    }
+                }
+
                 var stream = transport.Stream;
                 int? originalReadTimeout = null;
 
@@ -398,7 +416,10 @@ namespace Daqifi.Core.Device.Internal
                     // nothing would read (issue #490).
                     textConsumer.MessageParsed += parsed =>
                     {
-                        collectedLines.Add(parsed.Data);
+                        lock (collectedLinesGate)
+                        {
+                            collectedLines.Add(parsed.Data);
+                        }
                     };
 
                     // The protobuf consumer is stopped for the duration of this exchange, so
@@ -431,7 +452,7 @@ namespace Daqifi.Core.Device.Internal
                     // e.g. the SD listing's end-of-listing terminator (#396) — would otherwise accept
                     // a stale line as proof that the device answered a query it never even received,
                     // and report a complete listing for a device that has gone silent.
-                    staleLineCount = collectedLines.Count;
+                    staleLineCount = CollectedLineCount();
                     if (staleLineCount > 0)
                     {
                         Log(logger => logger.LogDebug(
@@ -455,9 +476,9 @@ namespace Daqifi.Core.Device.Internal
 
                     while (DateTime.UtcNow - startTime < maxWait)
                     {
-                        var previousCount = collectedLines.Count;
+                        var previousCount = CollectedLineCount();
                         await Task.Delay(50, cancellationToken).ConfigureAwait(false);
-                        if (collectedLines.Count > previousCount)
+                        if (CollectedLineCount() > previousCount)
                         {
                             lastMessageTime = DateTime.UtcNow;
                             if (!hasReceivedAny)
@@ -487,7 +508,8 @@ namespace Daqifi.Core.Device.Internal
                         }
                     }
 
-                    Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Collection complete at {ElapsedMs}ms, {LineCount} lines", sw.ElapsedMilliseconds, collectedLines.Count));
+                    var collectedLineCount = CollectedLineCount();
+                    Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Collection complete at {ElapsedMs}ms, {LineCount} lines", sw.ElapsedMilliseconds, collectedLineCount));
 
                     // Stop the text consumer
                     textConsumer.StopSafely();
@@ -512,18 +534,23 @@ namespace Daqifi.Core.Device.Internal
                     Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Total elapsed: {ElapsedMs}ms", sw.ElapsedMilliseconds));
                 }
 
-                // The text consumer is stopped by this point, so the list is no longer being
-                // appended to concurrently and can be re-projected safely.
+                // The text consumer has been stopped and disposed by this point, but both are
+                // time-bounded, so the projection takes the gate rather than trusting that the
+                // reader thread is really gone — see the note where the gate is declared.
                 //
                 // The blank lines the parser was asked to emit are dropped here. They are evidence
                 // for the wait loop above and nothing more: every caller of this seam parses
                 // content, and none of them ever saw a blank line before (#538). The stale skip
                 // runs first, so a blank line that arrived before this exchange sent anything is
                 // discarded as stale rather than counted as content — same rule as any other line.
-                var result = collectedLines
-                    .Skip(staleLineCount)
-                    .Where(line => line.Length > 0)
-                    .ToList();
+                List<string> result;
+                lock (collectedLinesGate)
+                {
+                    result = collectedLines
+                        .Skip(staleLineCount)
+                        .Where(line => line.Length > 0)
+                        .ToList();
+                }
 
                 completedNormally = true;
                 return result;


### PR DESCRIPTION
### What was wrong

Three diagnostics calls — `ClearSystemLogAsync`, `TestSystemLogAsync`, and reading the system log on a device whose log is empty — took **2.5–3.1 seconds** instead of the ~1.05 s every other diagnostics call takes, and they held the device operation lock for the whole time, so streaming control, SD work and every other text command queued up behind them. Polling a quiet device's log cost three seconds a go.

The device was not the slow party. It answered all three immediately; Core simply could not see the answer. The SCPI text exchange decides that the device has replied by counting the lines its parser produces, so a reply the parser cannot frame is a reply the exchange never notices — and it then waits out its entire first-response timeout for something already sitting in the buffer. Two shapes the firmware actually sends were being thrown away: a **bare-LF** reply (`SYSTem:LOG:CLEar` and `SYSTem:LOG:TEST` answer `Log cleared\n` and `Added test log messages\n`, while everything else is CRLF — so that line was lost outright, not merely delayed), and a **blank line** (`SYSTem:LOG?` terminates its dump with one, so an empty log arrives as a lone CRLF and nothing else, which the parser dropped as whitespace).

### How it was fixed

The exchange now splits lines on LF, which reads bare-LF and CRLF replies alike — the carriage return lands at the end of the line and is trimmed off with the rest of the trailing whitespace — and it asks its parser to report blank lines, so it can tell "the device answered with nothing" apart from "the device said nothing". The blank lines are filtered back out before the result is returned, so every caller sees exactly the lines it saw before, and `LineBasedMessageParser`'s public default behaviour is unchanged (the new setting is internal and opt-in).

Two things a reviewer may want to push back on, both deliberate:

- **The issue's diagnosis of the empty-log case was wrong, and this PR is based on the corrected one.** #538 says an empty `SYSTem:LOG?` "produces no bytes at all". It does not — a raw probe of the bench board answers `\r\n` in 6 ms, three trials out of three. That is why this is a framing fix rather than a shorter timeout or an appended `SYSTem:ERRor?` terminator: nothing about the protocol needs to change, and no error-queue entry gets popped as a side effect.
- **Splitting on LF also means an embedded bare LF now ends a line** rather than sitting inside one. That is what a line-based text protocol means by a line, and the firmware's log entries are free-form text where the split is the more faithful reading.

The empty-vs-silent distinction the issue floats as "the more valuable half" is deliberately **not** built here — that would change what `GetSystemLogAsync` throws, which is a public behaviour decision rather than a framing bug. It is now cheap to do, though: the trailing blank line turns out to be a reliable end-of-dump terminator. Filed separately as #543.

### How it was verified

**Bench Nq1, firmware 3.7.2, USB serial.** The same harness was built twice — once against this branch, once against a throwaway detached worktree at `origin/main` — and run in the same session shape, with the empty and populated log reads interleaved so they cannot drift apart.

| call | `origin/main` `a554430` | this PR |
|---|---|---|
| `ClearSystemLogAsync` | 2560–3064 ms | **1057–1059 ms** |
| `GetSystemLogAsync` (empty log) | 3063–3064 ms | **1056–1058 ms** |
| `TestSystemLogAsync` | 2562–3062 ms | **1055–1058 ms** |
| `GetSystemLogAsync` (populated) | 1055–1057 ms | 1056–1063 ms |
| the four CRLF-answering calls | 1053–1065 ms | 1054–1064 ms |

The controls are the check that actually mattered, since the risk of this change is mangling the replies that already worked: the four CRLF calls, the populated-log read and `SetLogLevelAsync` are identical before and after, content included (`HeapFree=7544`, `TotalSamplesStreamed=308`, 10 history entries, `Level=1 Ceiling=3`).

**Tests:** 15 new (9 parser-level, 6 end-to-end). The end-to-end ones were confirmed to be real regression detectors by reverting the wiring and re-running: 4 of the 6 fail, and the two that pass are exactly the two controls — a CRLF reply, and a device that says nothing still using its full response window. Full suite green on net9 + net10: **3437 Core + 192 MCP**.

Bench work was non-destructive throughout: no SD operation, no firmware operation, no reboot, no power-state change. The volatile system-log ring buffer was cleared and re-populated, which is the subject of the issue; the device was left with a cleared log, a drained error queue and `*IDN?` answering normally.

closes #538

**Not merging — for review.**
