### PR TITLE
docs(device): a comment about the firmware's malformed first frame described a shape the device does not send

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -172,6 +172,96 @@ public class StreamFrameDecoderTests
         Assert.Equal(3, reported.EnabledAnalogChannelCount);
     }
 
+    [Theory]
+    // The widths a bench Nq1 running firmware 3.7.2 actually emitted (#544). The enabled *mask*
+    // sets the width, not the channel count — {0,1,2} led with 1 value and {0,1,10} with 2, both
+    // three channels — so every row here is a real observation rather than a permutation. Before
+    // this test every discard-asserting test in the suite used a one-value frame, which meant
+    // narrowing the guard to `analogValueCount == 1` passed the whole suite while silently letting
+    // a wide capture's leading frame through (issue #351 again, at a plausible-looking width).
+    [InlineData(3, 1)]
+    [InlineData(3, 2)]
+    [InlineData(8, 2)]
+    [InlineData(8, 5)]
+    [InlineData(16, 7)]
+    public void ShortLeadingFrame_IsDiscarded_AtEveryWidthTheFirmwareEmits(
+        int enabledChannelCount, int leadingValueCount)
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var channels = new List<AnalogChannel>();
+        for (var i = 0; i < enabledChannelCount; i++)
+        {
+            channels.Add(host.AddAnalog(i, enabled: true));
+        }
+
+        StreamFrameDiscardedEventArgs? reported = null;
+        host.OnDiscard = e => reported = e;
+
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, streamingFrequencyHz: 1);
+
+        var frame = new DaqifiOutMessage { MsgTimeStamp = 1000 };
+        for (var i = 0; i < leadingValueCount; i++)
+        {
+            frame.AnalogInDataFloat.Add(i + 1f);
+        }
+        decoder.ProcessFrame(frame);
+
+        // Withheld from raw consumers too — they read AnalogInData straight off the frame, so a
+        // 7-of-16 payload is exactly as unusable to them as a 1-of-3 one.
+        Assert.Equal(new[] { "discard" }, host.Calls);
+        Assert.Equal(1, decoder.DiscardedStreamFrameCount);
+
+        Assert.NotNull(reported);
+        Assert.Equal(StreamFrameDiscardReason.PartialAnalogFrame, reported!.Reason);
+        Assert.Equal(leadingValueCount, reported.AnalogValueCount);
+        Assert.Equal(enabledChannelCount, reported.EnabledAnalogChannelCount);
+
+        // No channel may take a sample from a short frame — not even the leading ones the payload
+        // does cover, since the values are not guaranteed to belong to them.
+        Assert.All(channels, channel => Assert.Null(channel.ActiveSample));
+    }
+
+    [Fact]
+    public void AfterAWideShortLeadingFrame_TheFirstFullWidthFrameIsDeliveredIntact()
+    {
+        // The bench counterpart to the theory above: on hardware the frame after the malformed one
+        // was full width in every session, so the guard has to disarm and hand the whole payload
+        // over. Run at sixteen channels because that is where a mis-mapped value is invisible —
+        // the analog payload is matched to channels in ascending channel-number order, and only a
+        // per-channel assertion at full width proves the wide case still lands on the right ones.
+        var host = new FakeHost { IsStreaming = true };
+        var channels = new List<AnalogChannel>();
+        for (var i = 0; i < 16; i++)
+        {
+            channels.Add(host.AddAnalog(i, enabled: true));
+        }
+
+        var decoder = new StreamFrameDecoder(host);
+        decoder.BeginSession(TicksPerSecond, streamingFrequencyHz: 1);
+
+        var partial = new DaqifiOutMessage { MsgTimeStamp = 1000 };
+        for (var i = 0; i < 7; i++)
+        {
+            partial.AnalogInDataFloat.Add(99f);
+        }
+        decoder.ProcessFrame(partial);
+
+        var full = new DaqifiOutMessage { MsgTimeStamp = 2000 };
+        for (var i = 0; i < 16; i++)
+        {
+            full.AnalogInDataFloat.Add(i * 0.5f);
+        }
+        decoder.ProcessFrame(full);
+
+        Assert.Equal(new[] { "discard", "raw" }, host.Calls);
+        Assert.Equal(1, decoder.DiscardedStreamFrameCount);
+        for (var i = 0; i < 16; i++)
+        {
+            Assert.Equal(i * 0.5, channels[i].ActiveSample!.Value);
+        }
+    }
+
     #endregion
 
     #region Decode-failure isolation

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -173,26 +173,22 @@ public class StreamFrameDecoderTests
     }
 
     [Theory]
-    // The widths a bench Nq1 running firmware 3.7.2 actually emitted (#544). The enabled *mask*
-    // sets the width, not the channel count — {0,1,2} led with 1 value and {0,1,10} with 2, both
-    // three channels — so every row here is a real observation rather than a permutation. Before
-    // this test every discard-asserting test in the suite used a one-value frame, which meant
-    // narrowing the guard to `analogValueCount == 1` passed the whole suite while silently letting
-    // a wide capture's leading frame through (issue #351 again, at a plausible-looking width).
-    [InlineData(3, 1)]
-    [InlineData(3, 2)]
-    [InlineData(8, 2)]
-    [InlineData(8, 5)]
-    [InlineData(16, 7)]
-    public void ShortLeadingFrame_IsDiscarded_AtEveryWidthTheFirmwareEmits(
-        int enabledChannelCount, int leadingValueCount)
+    // The masks and widths a bench Nq1 running firmware 3.7.2 actually emitted (#544). The channel
+    // numbers are part of the observation, not filler: the enabled *mask* sets the width, not the
+    // channel count, which is why {0,1,2} leads with 1 value and {0,1,10} with 2 despite both
+    // being three channels. Before this test every discard-asserting test in the suite used a
+    // one-value frame, which meant narrowing the guard to `analogValueCount == 1` passed the whole
+    // suite while silently letting a wide capture's leading frame through (issue #351 again, at a
+    // plausible-looking width).
+    [InlineData(new[] { 0, 1, 2 }, 1)]
+    [InlineData(new[] { 0, 1, 10 }, 2)]
+    [InlineData(new[] { 0, 1, 2, 3, 4, 5, 6, 7 }, 2)]
+    [InlineData(new[] { 8, 9, 10, 11, 12, 13, 14, 15 }, 5)]
+    [InlineData(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, 7)]
+    public void ShortLeadingFrame_IsDiscarded_AtEveryMaskTheFirmwareBreaksOn(
+        int[] enabledChannelNumbers, int leadingValueCount)
     {
-        var host = new FakeHost { IsStreaming = true };
-        var channels = new List<AnalogChannel>();
-        for (var i = 0; i < enabledChannelCount; i++)
-        {
-            channels.Add(host.AddAnalog(i, enabled: true));
-        }
+        var (host, channels) = MaskedAnalogHost(enabledChannelNumbers);
 
         StreamFrameDiscardedEventArgs? reported = null;
         host.OnDiscard = e => reported = e;
@@ -215,40 +211,37 @@ public class StreamFrameDecoderTests
         Assert.NotNull(reported);
         Assert.Equal(StreamFrameDiscardReason.PartialAnalogFrame, reported!.Reason);
         Assert.Equal(leadingValueCount, reported.AnalogValueCount);
-        Assert.Equal(enabledChannelCount, reported.EnabledAnalogChannelCount);
+        Assert.Equal(enabledChannelNumbers.Length, reported.EnabledAnalogChannelCount);
 
         // No channel may take a sample from a short frame — not even the leading ones the payload
         // does cover, since the values are not guaranteed to belong to them.
         Assert.All(channels, channel => Assert.Null(channel.ActiveSample));
     }
 
-    [Fact]
-    public void AfterAWideShortLeadingFrame_TheFirstFullWidthFrameIsDeliveredIntact()
+    [Theory]
+    // The bench counterpart to the theory above: on hardware the frame after the malformed one was
+    // full width in every session, so the guard has to disarm and hand the whole payload over.
+    // {8..15} is here because a mask that does not start at channel 0 is the only way to tell
+    // "mapped in ascending channel-number order" apart from "mapped by array index" — under the
+    // latter the first value would land on AI0, which is not even enabled.
+    [InlineData(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, 7)]
+    [InlineData(new[] { 8, 9, 10, 11, 12, 13, 14, 15 }, 5)]
+    public void AfterAShortLeadingFrame_TheFirstFullWidthFrameLandsOnTheRightChannels(
+        int[] enabledChannelNumbers, int leadingValueCount)
     {
-        // The bench counterpart to the theory above: on hardware the frame after the malformed one
-        // was full width in every session, so the guard has to disarm and hand the whole payload
-        // over. Run at sixteen channels because that is where a mis-mapped value is invisible —
-        // the analog payload is matched to channels in ascending channel-number order, and only a
-        // per-channel assertion at full width proves the wide case still lands on the right ones.
-        var host = new FakeHost { IsStreaming = true };
-        var channels = new List<AnalogChannel>();
-        for (var i = 0; i < 16; i++)
-        {
-            channels.Add(host.AddAnalog(i, enabled: true));
-        }
-
+        var (host, channels) = MaskedAnalogHost(enabledChannelNumbers);
         var decoder = new StreamFrameDecoder(host);
         decoder.BeginSession(TicksPerSecond, streamingFrequencyHz: 1);
 
         var partial = new DaqifiOutMessage { MsgTimeStamp = 1000 };
-        for (var i = 0; i < 7; i++)
+        for (var i = 0; i < leadingValueCount; i++)
         {
             partial.AnalogInDataFloat.Add(99f);
         }
         decoder.ProcessFrame(partial);
 
         var full = new DaqifiOutMessage { MsgTimeStamp = 2000 };
-        for (var i = 0; i < 16; i++)
+        for (var i = 0; i < enabledChannelNumbers.Length; i++)
         {
             full.AnalogInDataFloat.Add(i * 0.5f);
         }
@@ -256,9 +249,20 @@ public class StreamFrameDecoderTests
 
         Assert.Equal(new[] { "discard", "raw" }, host.Calls);
         Assert.Equal(1, decoder.DiscardedStreamFrameCount);
-        for (var i = 0; i < 16; i++)
+
+        // The rows list their channel numbers in ascending order, which is the order the device
+        // streams values in, so the payload's i-th value belongs to the i-th listed channel.
+        for (var i = 0; i < enabledChannelNumbers.Length; i++)
         {
-            Assert.Equal(i * 0.5, channels[i].ActiveSample!.Value);
+            Assert.Equal(i * 0.5, channels[enabledChannelNumbers[i]].ActiveSample!.Value);
+        }
+
+        foreach (var channel in channels)
+        {
+            if (!channel.IsEnabled)
+            {
+                Assert.Null(channel.ActiveSample);
+            }
         }
     }
 
@@ -748,6 +752,28 @@ public class StreamFrameDecoderTests
             }
         };
         return thrower;
+    }
+
+    /// <summary>
+    /// A full sixteen-channel analog device with only <paramref name="enabledChannelNumbers"/>
+    /// enabled — the shape the bench observations in #544 were taken against.
+    /// </summary>
+    /// <remarks>
+    /// The disabled channels are the point. Adding only the enabled ones would make every mask
+    /// contiguous from zero, which cannot distinguish "the decoder counted and ordered the enabled
+    /// channels" from "the decoder used the array index as the channel number" — the two agree for
+    /// {0..N-1} and disagree for every real mask that skips a channel.
+    /// </remarks>
+    private static (FakeHost Host, AnalogChannel[] Channels) MaskedAnalogHost(int[] enabledChannelNumbers)
+    {
+        var host = new FakeHost { IsStreaming = true };
+        var enabled = new HashSet<int>(enabledChannelNumbers);
+        var channels = new AnalogChannel[16];
+        for (var i = 0; i < channels.Length; i++)
+        {
+            channels[i] = host.AddAnalog(i, enabled: enabled.Contains(i));
+        }
+        return (host, channels);
     }
 
     private static DaqifiOutMessage AnalogFrame(uint timestamp, float value)

--- a/src/Daqifi.Core/Device/Internal/StreamFrameDecoder.cs
+++ b/src/Daqifi.Core/Device/Internal/StreamFrameDecoder.cs
@@ -310,6 +310,14 @@ namespace Daqifi.Core.Device.Internal
         /// guard on the first analog-bearing frame that is not short, or once
         /// <see cref="MaxSuppressedWarmupFrames"/> have been suppressed.
         /// </summary>
+        /// <remarks>
+        /// The comparison below has to stay a "fewer than" rather than an equality against one. The
+        /// malformed frame's width follows the enabled channel mask instead of a fixed shape — on a
+        /// bench Nq1 at 3.7.2 it ran from 1 value up to 7 for a sixteen-channel capture (see
+        /// <see cref="StreamFrameDiscardReason.PartialAnalogFrame"/> and issue #544). Narrowing this
+        /// to <c>analogValueCount == 1</c> would pass a 7-value leading frame straight through on a
+        /// wide capture, reintroducing issue #351 at a width plausible enough to go unnoticed.
+        /// </remarks>
         /// <param name="message">The frame about to be delivered.</param>
         /// <param name="analogValueCount">The number of analog values the frame carried.</param>
         /// <param name="enabledAnalogChannelCount">

--- a/src/Daqifi.Core/Device/StreamFrameDiscardReason.cs
+++ b/src/Daqifi.Core/Device/StreamFrameDiscardReason.cs
@@ -15,12 +15,24 @@ namespace Daqifi.Core.Device
         /// The frame carried fewer analog values than the number of enabled analog channels.
         /// </summary>
         /// <remarks>
-        /// Firmware up to and including 3.7.2 emits a leading frame at stream start whose analog
-        /// payload holds a single value regardless of the enabled channel mask (daqifi-core #351,
-        /// daqifi-nyquist-firmware #707). Consumers that infer channel width from the first sample
-        /// would silently truncate the whole capture, so the malformed analog payload is withheld.
-        /// Any digital payload in the same frame is still delivered, and the frame's timestamp still
-        /// anchors the session clock.
+        /// <para>
+        /// Firmware up to and including 3.7.2 can emit a leading frame at stream start whose analog
+        /// payload is short (daqifi-core #351, daqifi-nyquist-firmware #707). Consumers that infer
+        /// channel width from the first sample would silently truncate the whole capture, so the
+        /// malformed analog payload is withheld. Any digital payload in the same frame is still
+        /// delivered, and the frame's timestamp still anchors the session clock.
+        /// </para>
+        /// <para>
+        /// How short it is depends on the enabled channel <em>mask</em>, not on how many channels
+        /// are enabled, so there is no fixed shape to match against. Measured on a bench Nq1 running
+        /// 3.7.2 (daqifi-core #544), the leading frame carried 1 value for mask <c>{0,1,2}</c> but 2
+        /// for <c>{0,1,10}</c> — same channel count, different width — 2 for <c>{0..7}</c>, 5 for
+        /// <c>{8..15}</c>, and 7 for all sixteen channels, while masks <c>{15}</c> and
+        /// <c>{14,15}</c> produced no malformed frame at all. The width is deterministic per mask
+        /// and independent of sample rate. A one-value frame is therefore the common case rather
+        /// than the shape of the defect, and "carried fewer values than there are enabled channels"
+        /// is the only test that holds across masks.
+        /// </para>
         /// </remarks>
         PartialAnalogFrame,
 


### PR DESCRIPTION
## What was wrong

Core guards against a firmware defect: on 3.7.2 and earlier, the very first frame of a stream can arrive with fewer analog values than you have channels enabled. Core withholds that frame, because a consumer that infers channel width from the first sample would silently truncate the entire capture (#351).

The guard works. What was wrong is the comment explaining it, which told the next reader that the malformed frame "holds a single value regardless of the enabled channel mask". On a real Nq1 both halves of that are false — the frame is short by an amount that depends on the *mask*, not the channel count, and some masks produce no malformed frame at all:

| enabled mask | channels | values in the leading frame |
|---|---|---|
| `{0,1,2}` | 3 | 1 |
| `{0,1,10}` | 3 | **2** |
| `{0..7}` | 8 | 2 |
| `{8..15}` | 8 | **5** |
| `{0..15}` | 16 | **7** |
| `{15}`, `{14,15}` | 1, 2 | **none emitted** |

Two rows with the same channel count and different widths is the whole point: there is no fixed shape to match against.

That mattered because the tests agreed with the comment rather than with the device — every discard-asserting test in the suite built a **one-value** frame. So a reasonable future cleanup, narrowing the check from "fewer values than channels" to "exactly one value", would have **passed the entire test suite** while quietly letting a 16-channel capture's 7-value first frame through to consumers. That is #351 again, at a width plausible enough that nobody would notice.

## How it was fixed

The comment now says what the device actually does, and five tests pin the multi-value shapes so the comparison can't be narrowed. No production behaviour changes — the guard's logic is untouched, because it was already right.

The one thing worth pushing back on is the docs quoting specific bench numbers, which are firmware-version-specific by nature. They're kept because the numbers are the argument: without them "don't narrow this check" reads like superstition.

## Verification

- Full suite green on net9 + net10: 3461 Core + 192 MCP.
- **The new tests were confirmed to be real regression detectors.** Narrowing the guard to `analogValueCount == 1` fails exactly the 5 new multi-value cases and passes all 3456 others — the blind spot, demonstrated rather than asserted. The one theory row that keeps passing is the 1-value case, which is the control.
- **Bench-validated on the Nq1 (3.7.2), non-destructive** — channel enable/disable and stream start/stop only, no SD op, no firmware, no reboot. 14 streaming sessions re-derived every number in the table above through Core's public `StreamFrameDiscarded` API, each mask repeated. Also re-confirmed: exactly one discard per session, and the first *delivered* frame full width in 14/14. Device left with 0 channels enabled and not streaming.

closes #544

Not merging — for review.