### PR TITLE
feat(mcp): an agent can drive an analog output, not just read one

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ DAQiFi builds wireless data acquisition hardware designed to get out of the way 
 
 Prefer a ready-made GUI? Check out [DAQiFi Desktop](https://github.com/daqifi/daqifi-desktop), which is built on top of this library.
 
-Want to drive a device from an AI assistant? The repo also ships an **[MCP server](src/Daqifi.Mcp)** — point Claude, Cursor, Codex, or any MCP-aware client at it to discover, configure channels, drive digital I/O and PWM outputs, set the sample rate, and run SD-card logging — then list, download, and CSV the recorded data back — through plain conversation.
+Want to drive a device from an AI assistant? The repo also ships an **[MCP server](src/Daqifi.Mcp)** — point Claude, Cursor, Codex, or any MCP-aware client at it to discover, configure channels, drive digital I/O, PWM and analog outputs, set the sample rate, and run SD-card logging — then list, download, and CSV the recorded data back — through plain conversation.
 
 ## See it in 30 seconds
 
@@ -70,7 +70,7 @@ More examples at [daqifi.com](https://daqifi.com).
 | Hardware | Nyquist 1 / Nyquist 3 — wireless DAQ devices (and their on-device firmware) |
 | **SDK** | **DAQiFi Core — this library** |
 | App | [DAQiFi Desktop](https://github.com/daqifi/daqifi-desktop) — GUI built on this SDK |
-| Agent | [MCP server](src/Daqifi.Mcp) — drive a device from Claude / Cursor / any MCP client: discover, configure channels, DIO/PWM, SD logging, and SD data retrieval |
+| Agent | [MCP server](src/Daqifi.Mcp) — drive a device from Claude / Cursor / any MCP client: discover, configure channels, DIO/PWM/analog output, SD logging, and SD data retrieval |
 | Your code | Custom apps, dashboards, pipelines, test rigs |
 
 ## What you can do

--- a/src/Daqifi.Mcp.Tests/AnalogOutputToolContractTests.cs
+++ b/src/Daqifi.Mcp.Tests/AnalogOutputToolContractTests.cs
@@ -1,0 +1,298 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Mcp.Tests;
+
+/// <summary>
+/// Contract tests for the analog-output (DAC) tools — the MCP half of #499, whose Core half landed
+/// in #526.
+/// </summary>
+/// <remarks>
+/// The failure this suite exists to catch is a silent one. Core sends an analog-output command by
+/// channel number and never reads the device's error queue back, so a write that the firmware
+/// discarded is indistinguishable, from the agent's side, from one it applied. What is asserted
+/// here is therefore mostly about refusals: which calls never reach the wire, and whether the agent
+/// is told why.
+/// </remarks>
+public class AnalogOutputToolContractTests
+{
+    [Fact]
+    public void ListAnalogOutputs_ReportsEachChannelWithItsRangeAndResolution()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+
+        var outputs = agent.ListAnalogOutputs(AgentHarness.DeviceId);
+
+        Assert.Equal(new[] { 0, 1 }, outputs.Select(o => o.Channel));
+        Assert.All(outputs, o =>
+        {
+            Assert.Equal(0, o.MinVolts);
+            Assert.Equal(10, o.MaxVolts);
+            Assert.Equal(12, o.ResolutionBits);
+            // The device stated this range, so a refusal quotes the hardware rather than an
+            // assumption of ours — which is the difference between "your device cannot do that"
+            // and "we guessed it cannot".
+            Assert.False(o.RangeIsAssumed);
+            Assert.Null(o.Volts);
+            Assert.Null(o.PendingVolts);
+        });
+    }
+
+    [Fact]
+    public void ListAnalogOutputs_OnADeviceWithNone_IsEmptyRatherThanAnError()
+    {
+        // An agent asking what a device can drive is entitled to the answer "nothing".
+        var (agent, _) = AgentHarness.WithConnectedDevice();
+
+        Assert.Empty(agent.ListAnalogOutputs(AgentHarness.DeviceId));
+    }
+
+    [Fact]
+    public void ListConnectedDevices_CountsAnalogOutputsSeparatelyFromInputs()
+    {
+        // Outputs sit in the same channel collection as the inputs; folding them into
+        // AnalogChannelCount would report an acquisition wider than the device can actually run.
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogChannels: 4, digitalChannels: 8, analogOutputs: 2);
+
+        var listed = Assert.Single(agent.ListConnected());
+
+        Assert.Equal(4, listed.AnalogChannelCount);
+        Assert.Equal(8, listed.DigitalChannelCount);
+        Assert.Equal(2, listed.AnalogOutputChannelCount);
+    }
+
+    [Fact]
+    public async Task SetAnalogOutput_StagesAndLatchesInThatOrder()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+
+        var result = await agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 1, 2.5, latch: true);
+
+        Assert.True(result.Applied);
+        Assert.True(result.RangeChecked);
+        Assert.Equal(2.5, result.State!.Volts);
+        Assert.Null(result.State.PendingVolts);
+        Assert.Equal(
+            new[]
+            {
+                ScpiMessageProducer.SetAnalogOutputVoltage(1, 2.5).Data,
+                ScpiMessageProducer.UpdateDacOutputs.Data,
+            },
+            device.Sent);
+    }
+
+    [Fact]
+    public async Task SetAnalogOutput_WithLatchFalse_DoesNotDriveThePin()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+
+        var result = await agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 0, 4.0, latch: false);
+
+        Assert.False(result.Applied);
+        // Pending, not driven: the distinction is the whole point of the staged form, and an agent
+        // that read this as "done" would report a voltage the hardware is not carrying.
+        Assert.Equal(4.0, result.State!.PendingVolts);
+        Assert.Null(result.State.Volts);
+        Assert.Equal(new[] { ScpiMessageProducer.SetAnalogOutputVoltage(0, 4.0).Data }, device.Sent);
+    }
+
+    [Fact]
+    public async Task LatchAnalogOutputs_AppliesEveryStagedChannelTogether()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+        await agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 0, 1.5, latch: false);
+        await agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 1, 7.5, latch: false);
+        device.ClearSent();
+
+        var result = await agent.LatchAnalogOutputsAsync(AgentHarness.DeviceId);
+
+        Assert.Equal(new[] { ScpiMessageProducer.UpdateDacOutputs.Data }, device.Sent);
+        Assert.Equal(new double?[] { 1.5, 7.5 }, result.Outputs.Select(o => o.Volts));
+        Assert.All(result.Outputs, o => Assert.Null(o.PendingVolts));
+    }
+
+    [Fact]
+    public async Task LatchAnalogOutputs_WithNothingStaged_StillCommandsTheDevice()
+    {
+        // A caller that has lost track of what it staged can always land the device in a known
+        // state; the device re-applies what it already holds.
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+        device.ClearSent();
+
+        var result = await agent.LatchAnalogOutputsAsync(AgentHarness.DeviceId);
+
+        Assert.Equal(new[] { ScpiMessageProducer.UpdateDacOutputs.Data }, device.Sent);
+        Assert.All(result.Outputs, o => Assert.Null(o.Volts));
+    }
+
+    [Fact]
+    public async Task SetAnalogOutput_OutOfRange_IsRefusedBeforeAnythingIsSent()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+        device.ClearSent();
+
+        var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 0, 42, latch: true));
+
+        // The message has to carry the range: the firmware would have clamped 42 V silently, so
+        // this is the only place an agent learns what the channel actually accepts.
+        Assert.Contains("10", ex.Message);
+        Assert.Empty(device.Sent);
+        Assert.Null(agent.ListAnalogOutputs(AgentHarness.DeviceId)[0].PendingVolts);
+    }
+
+    [Fact]
+    public async Task SetAnalogOutput_OnAnUnknownChannel_NamesTheOutputsThatExist()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+        device.ClearSent();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 7, 1.0, latch: true));
+
+        Assert.Contains("7", ex.Message);
+        Assert.Contains("0, 1", ex.Message);
+        Assert.Empty(device.Sent);
+    }
+
+    [Fact]
+    public async Task SetAnalogOutput_OnABoardWithoutDacs_IsRefusedRatherThanSilentlyDiscarded()
+    {
+        // The failure this prevents: Nyquist 1 firmware rejects the DAC command internally, Core
+        // never reads the error queue back, and the agent is told the write succeeded.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.Metadata.DeviceType = DeviceType.Nyquist1;
+        device.ClearSent();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 0, 2.5, latch: true));
+
+        Assert.Contains("Nyquist 3", ex.Message);
+        Assert.Contains(nameof(DeviceType.Nyquist1), ex.Message);
+        Assert.Empty(device.Sent);
+    }
+
+    [Fact]
+    public async Task SetAnalogOutput_OnADeviceThatDescribedNoOutputs_WritesByNumberAndSaysItWasNotChecked()
+    {
+        // Nyquist 3 firmware below v3.5.0 has no capability document, and the document is the only
+        // place a device describes its DACs. Refusing here would leave those boards with no
+        // analog-output path at all — so the write goes out, flagged as unvouched-for.
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        Assert.Equal(DeviceType.Unknown, device.Metadata.DeviceType);
+        device.ClearSent();
+
+        var result = await agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 3, 42, latch: true);
+
+        Assert.False(result.RangeChecked);
+        Assert.Null(result.State);
+        Assert.True(result.Applied);
+        Assert.Equal(
+            new[]
+            {
+                ScpiMessageProducer.SetAnalogOutputVoltage(3, 42).Data,
+                ScpiMessageProducer.UpdateDacOutputs.Data,
+            },
+            device.Sent);
+    }
+
+    [Fact]
+    public async Task SetAnalogOutput_OnANegativeChannel_IsRefusedEvenWithNothingToCheckAgainst()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice();
+        device.ClearSent();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetAnalogOutputAsync(AgentHarness.DeviceId, -1, 1.0, latch: true));
+
+        Assert.Empty(device.Sent);
+    }
+
+    [Fact]
+    public async Task ReadAnalogOutput_ReturnsWhatTheDeviceAnswersAndRecordsIt()
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+        device.AnalogOutputReadbacks[1] = "3.750";
+        device.ClearSent();
+
+        var reading = await agent.ReadAnalogOutputAsync(AgentHarness.DeviceId, 1, CancellationToken.None);
+
+        Assert.Equal(3.75, reading.Volts);
+        Assert.Equal(new[] { ScpiMessageProducer.GetAnalogOutputVoltage(1).Data }, device.Sent);
+        // Recorded on the channel, so list_analog_outputs agrees with the round-trip afterwards
+        // instead of still reporting "nothing has driven this".
+        Assert.Equal(3.75, agent.ListAnalogOutputs(AgentHarness.DeviceId)[1].Volts);
+    }
+
+    [Fact]
+    public async Task ReadAnalogOutput_WhenTheDeviceAnswersNothing_Throws()
+    {
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ReadAnalogOutputAsync(AgentHarness.DeviceId, 0, CancellationToken.None));
+
+        Assert.Contains("not a voltage", ex.Message);
+    }
+
+    [Fact]
+    public async Task ReadAnalogOutput_WhileStreaming_IsRefusedWithTheReason()
+    {
+        // The reply would arrive with binary stream frames welded onto the front of it and fail as
+        // a parse error, which describes the collision without naming it.
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+        device.AnalogOutputReadbacks[0] = "1.000";
+        device.StartStreaming();
+        device.ClearSent();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ReadAnalogOutputAsync(AgentHarness.DeviceId, 0, CancellationToken.None));
+
+        Assert.Contains("streaming", ex.Message);
+        Assert.Empty(device.Sent);
+    }
+
+    [Fact]
+    public async Task ReadAnalogOutput_IsAvailableInReadOnlyMode()
+    {
+        // It changes nothing on the device, so it sits with list_sd_files rather than with the
+        // writes.
+        var (agent, device) = AgentHarness.WithConnectedDevice(readOnly: true, analogOutputs: 2);
+        device.AnalogOutputReadbacks[0] = "0.500";
+
+        var reading = await agent.ReadAnalogOutputAsync(AgentHarness.DeviceId, 0, CancellationToken.None);
+
+        Assert.Equal(0.5, reading.Volts);
+    }
+
+    [Fact]
+    public async Task AnalogOutputTools_OnADeviceThatIsNotConnected_SaySo()
+    {
+        var agent = new DaqifiAgent(new ServerOptions());
+
+        Assert.Throws<InvalidOperationException>(() => agent.ListAnalogOutputs("serial:NOPE"));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.SetAnalogOutputAsync("serial:NOPE", 0, 1.0, latch: true));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.LatchAnalogOutputsAsync("serial:NOPE"));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ReadAnalogOutputAsync("serial:NOPE", 0, CancellationToken.None));
+    }
+
+    [Fact]
+    public void AnalogOutputs_AreNotAcquisitionChannels()
+    {
+        // They share the channel collection with the inputs, so the guard that matters is that
+        // nothing treats them as something to sample.
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogChannels: 4, analogOutputs: 2);
+
+        var channels = agent.ListChannels(AgentHarness.DeviceId);
+
+        Assert.Equal(2, channels.Count(c => c.Type == nameof(ChannelType.AnalogOutput)));
+        Assert.All(
+            channels.Where(c => c.Type == nameof(ChannelType.AnalogOutput)),
+            c => Assert.False(c.Enabled));
+        Assert.Empty(agent.GetStatus(AgentHarness.DeviceId).EnabledAnalogChannels);
+    }
+}

--- a/src/Daqifi.Mcp.Tests/AnalogOutputToolContractTests.cs
+++ b/src/Daqifi.Mcp.Tests/AnalogOutputToolContractTests.cs
@@ -197,15 +197,36 @@ public class AnalogOutputToolContractTests
             device.Sent);
     }
 
-    [Fact]
-    public async Task SetAnalogOutput_OnANegativeChannel_IsRefusedEvenWithNothingToCheckAgainst()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    public async Task SetAnalogOutput_OnANegativeChannel_SaysWhatAChannelNumberMayBe(int describedOutputs)
     {
-        var (agent, device) = AgentHarness.WithConnectedDevice();
+        // The same answer whatever the device described. Folded into the modelled-channel checks
+        // this reads as "-1 is not one of 0, 1" on one device and as something else on the other —
+        // the same mistake explained two ways, neither of them saying what is actually allowed.
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: describedOutputs);
         device.ClearSent();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => agent.SetAnalogOutputAsync(AgentHarness.DeviceId, -1, 1.0, latch: true));
 
+        Assert.Contains("0 or greater", ex.Message);
+        Assert.Empty(device.Sent);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    public async Task ReadAnalogOutput_OnANegativeChannel_SaysWhatAChannelNumberMayBe(int describedOutputs)
+    {
+        var (agent, device) = AgentHarness.WithConnectedDevice(analogOutputs: describedOutputs);
+        device.ClearSent();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ReadAnalogOutputAsync(AgentHarness.DeviceId, -1, CancellationToken.None));
+
+        Assert.Contains("0 or greater", ex.Message);
         Assert.Empty(device.Sent);
     }
 

--- a/src/Daqifi.Mcp.Tests/AnalogOutputToolContractTests.cs
+++ b/src/Daqifi.Mcp.Tests/AnalogOutputToolContractTests.cs
@@ -113,6 +113,23 @@ public class AnalogOutputToolContractTests
     }
 
     [Fact]
+    public async Task SetAnalogOutput_WithLatch_AlsoAppliesAnotherChannelStagedEarlier()
+    {
+        // The latch is device-wide, not per-channel. A caller that staged channel 0 and then wrote
+        // channel 1 outright has moved both pins, and the result it gets back names only channel 1
+        // — which is why the tool description sends it to list_analog_outputs to see them all.
+        var (agent, _) = AgentHarness.WithConnectedDevice(analogOutputs: 2);
+        await agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 0, 3.0, latch: false);
+
+        var result = await agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 1, 6.0, latch: true);
+
+        Assert.Equal(6.0, result.State!.Volts);
+        var outputs = agent.ListAnalogOutputs(AgentHarness.DeviceId);
+        Assert.Equal(3.0, outputs[0].Volts);
+        Assert.Null(outputs[0].PendingVolts);
+    }
+
+    [Fact]
     public async Task LatchAnalogOutputs_WithNothingStaged_StillCommandsTheDevice()
     {
         // A caller that has lost track of what it staged can always land the device in a known

--- a/src/Daqifi.Mcp.Tests/DeviceDouble.cs
+++ b/src/Daqifi.Mcp.Tests/DeviceDouble.cs
@@ -59,11 +59,31 @@ internal sealed class FakeStreamingDevice : DaqifiStreamingDevice, ISdCardOperat
     }
 
     /// <summary>
+    /// The analog outputs this device's capability document describes, in document order. Empty by
+    /// default, which is what every board but a Nyquist 3 reports.
+    /// </summary>
+    internal List<CapabilityChannel> AnalogOutputDescriptors { get; } = new();
+
+    /// <summary>
+    /// Canned answers for <c>SOURce:VOLTage:LEVel?</c>, keyed by channel number — what the firmware
+    /// says it is holding. A channel with no entry answers nothing, which is how a device that
+    /// ignores the query behaves.
+    /// </summary>
+    internal Dictionary<int, string> AnalogOutputReadbacks { get; } = new();
+
+    /// <summary>
     /// Builds a connected device with <paramref name="analogChannels"/> analog inputs and
     /// <paramref name="digitalChannels"/> digital channels, and its capability document already
     /// read once — the state a device is in the moment <c>connect_device</c> returns.
     /// </summary>
-    internal static FakeStreamingDevice CreateConnected(int analogChannels = 4, int digitalChannels = 8)
+    /// <param name="analogOutputs">
+    /// Analog-output (DAC) channels for the capability document to describe, each 0-10 V at 12 bits.
+    /// Defaults to none, matching the Nyquist 1 the rest of these tests model; the board is left
+    /// <see cref="DeviceType.Unknown"/> either way, so the analog-output feature gate lets a write
+    /// through (an unidentified board is not a refusal — see <c>DaqifiDevice.Supports</c>).
+    /// </param>
+    internal static FakeStreamingDevice CreateConnected(
+        int analogChannels = 4, int digitalChannels = 8, int analogOutputs = 0)
     {
         var device = new FakeStreamingDevice("Fake Nq1");
         device.PopulateChannelsFromStatus(new DaqifiOutMessage
@@ -72,6 +92,20 @@ internal sealed class FakeStreamingDevice : DaqifiStreamingDevice, ISdCardOperat
             AnalogInRes = 65535,
             DigitalPortNum = (uint)digitalChannels,
         });
+
+        for (var id = 0; id < analogOutputs; id++)
+        {
+            device.AnalogOutputDescriptors.Add(new CapabilityChannel
+            {
+                Id = id,
+                Kind = CapabilityChannelKind.AnalogOutput,
+                SignalType = "voltage",
+                Unit = "V",
+                ResolutionBits = 12,
+                RangeMinimum = 0,
+                RangeMaximum = 10,
+            });
+        }
 
         device.Metadata.Capabilities.MaxSamplingRate = HardwareMaximumRateHz;
         device.Connect();
@@ -98,6 +132,35 @@ internal sealed class FakeStreamingDevice : DaqifiStreamingDevice, ISdCardOperat
     {
         CapabilityReads++;
         return Task.FromResult<CapabilityDocument?>(ApplyCapabilityDocumentForCurrentChannels());
+    }
+
+    /// <summary>
+    /// Answers a text exchange the way the firmware would: the query still goes into
+    /// <see cref="Sent"/> (so the tests can assert what reached the wire), and the reply comes from
+    /// <see cref="AnalogOutputReadbacks"/>. A channel with no canned answer replies with nothing,
+    /// which is a device that ignored the query rather than one that answered zero.
+    /// </summary>
+    protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+        Action setupAction,
+        int responseTimeoutMs = 1000,
+        int completionTimeoutMs = 250,
+        CancellationToken cancellationToken = default,
+        Func<CancellationToken, Task>? prepareAsync = null,
+        Func<Task>? finalizeAsync = null)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        setupAction();
+
+        var query = Sent.LastOrDefault() ?? string.Empty;
+        const string readbackPrefix = "SOURce:VOLTage:LEVel? ";
+        if (query.StartsWith(readbackPrefix, StringComparison.Ordinal)
+            && int.TryParse(query[readbackPrefix.Length..], out var channel)
+            && AnalogOutputReadbacks.TryGetValue(channel, out var answer))
+        {
+            return Task.FromResult<IReadOnlyList<string>>(new[] { answer });
+        }
+
+        return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
     }
 
     // --------------------------------------------------------------------- SD card
@@ -161,6 +224,7 @@ internal sealed class FakeStreamingDevice : DaqifiStreamingDevice, ISdCardOperat
         var document = new CapabilityDocument
         {
             SchemaVersion = 1,
+            Channels = AnalogOutputDescriptors.ToList(),
             Streaming = new CapabilityStreaming
             {
                 MaximumSampleRateHz = HardwareMaximumRateHz,
@@ -169,6 +233,11 @@ internal sealed class FakeStreamingDevice : DaqifiStreamingDevice, ISdCardOperat
         };
 
         Metadata.ApplyCapabilityDocument(document);
+
+        // Both halves of what the real ReadCapabilityDocumentAsync does: the document is the only
+        // place a device describes its DACs, so applying it without this sync would leave the
+        // outputs unmodelled and the analog-output tools with nothing to find.
+        SyncAnalogOutputChannelsFromCapabilities();
         return document;
     }
 }
@@ -191,7 +260,8 @@ internal static class AgentHarness
         bool readOnly = false,
         int? maxSampleRateHz = null,
         int analogChannels = 4,
-        int digitalChannels = 8)
+        int digitalChannels = 8,
+        int analogOutputs = 0)
     {
         var agent = new DaqifiAgent(new ServerOptions
         {
@@ -199,7 +269,7 @@ internal static class AgentHarness
             MaxSampleRateHz = maxSampleRateHz,
         });
 
-        var device = FakeStreamingDevice.CreateConnected(analogChannels, digitalChannels);
+        var device = FakeStreamingDevice.CreateConnected(analogChannels, digitalChannels, analogOutputs);
         agent.RegisterConnectedDevice(DeviceId, device);
         return (agent, device);
     }

--- a/src/Daqifi.Mcp.Tests/ToolContractTests.cs
+++ b/src/Daqifi.Mcp.Tests/ToolContractTests.cs
@@ -607,6 +607,8 @@ public class ReadOnlyModeContractTests
         "set_digital_output",
         "set_pwm_output",
         "disable_pwm",
+        "set_analog_output",
+        "latch_analog_outputs",
         "set_sample_rate",
     };
 
@@ -614,7 +616,7 @@ public class ReadOnlyModeContractTests
     [MemberData(nameof(MutatingTools))]
     public async Task MutatingTools_AreRefusedAndSendNothing(string tool)
     {
-        var (agent, device) = AgentHarness.WithConnectedDevice(readOnly: true);
+        var (agent, device) = AgentHarness.WithConnectedDevice(readOnly: true, analogOutputs: 2);
         device.ClearSent();
 
         Task Call() => tool switch
@@ -625,6 +627,8 @@ public class ReadOnlyModeContractTests
             "set_digital_output" => agent.SetDigitalOutputAsync(AgentHarness.DeviceId, 0, high: true),
             "set_pwm_output" => agent.SetPwmOutputAsync(AgentHarness.DeviceId, 4, 50, 1000),
             "disable_pwm" => agent.DisablePwmAsync(AgentHarness.DeviceId, 4),
+            "set_analog_output" => agent.SetAnalogOutputAsync(AgentHarness.DeviceId, 0, 2.5, latch: true),
+            "latch_analog_outputs" => agent.LatchAnalogOutputsAsync(AgentHarness.DeviceId),
             _ => agent.SetSampleRateAsync(AgentHarness.DeviceId, 100),
         };
 
@@ -636,10 +640,11 @@ public class ReadOnlyModeContractTests
     [Theory]
     [InlineData("status")]
     [InlineData("channels")]
+    [InlineData("analog_outputs")]
     [InlineData("list")]
     public void Introspection_StillWorksInReadOnlyMode(string tool)
     {
-        var (agent, _) = AgentHarness.WithConnectedDevice(readOnly: true);
+        var (agent, _) = AgentHarness.WithConnectedDevice(readOnly: true, analogOutputs: 2);
 
         switch (tool)
         {
@@ -648,6 +653,9 @@ public class ReadOnlyModeContractTests
                 break;
             case "channels":
                 Assert.NotEmpty(agent.ListChannels(AgentHarness.DeviceId));
+                break;
+            case "analog_outputs":
+                Assert.Equal(2, agent.ListAnalogOutputs(AgentHarness.DeviceId).Count);
                 break;
             default:
                 Assert.Single(agent.ListConnected());

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -1564,8 +1564,9 @@ public sealed class DaqifiAgent
         .OrderBy(c => c.ChannelNumber)
         .ToList();
 
-    private static IAnalogOutputChannel? FindAnalogOutput(DaqifiDevice device, int channelNumber) =>
-        AnalogOutputs(device).FirstOrDefault(c => c.ChannelNumber == channelNumber);
+    private static IAnalogOutputChannel? FindAnalogOutput(DaqifiDevice device, int channelNumber) => Snapshot(device)
+        .OfType<IAnalogOutputChannel>()
+        .FirstOrDefault(c => c.ChannelNumber == channelNumber);
 
     /// <summary>
     /// Resolves a device for analog output, refusing hardware that has none.

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -1613,6 +1613,16 @@ public sealed class DaqifiAgent
     /// </returns>
     private static bool RequireKnownAnalogOutput(DaqifiDevice device, string deviceId, int channelNumber)
     {
+        // Ahead of the modelled-channel checks, so a negative number is answered the same way
+        // whatever the device happens to have described. Left inside them it reads as "-1 is not
+        // one of 0, 1" on a device with outputs and as something else entirely on one without —
+        // the same mistake explained two ways, and neither says what a channel number may be.
+        if (channelNumber < 0)
+        {
+            throw new InvalidOperationException(
+                $"Analog output channel {channelNumber} is not a channel number; it must be 0 or greater.");
+        }
+
         var outputs = AnalogOutputs(device);
         if (outputs.Count == 0)
         {
@@ -1620,12 +1630,6 @@ public sealed class DaqifiAgent
             // only place a device describes its DACs. Refusing here would leave those boards with
             // no analog-output path at all, so the number is taken at face value — the caller is
             // told through AnalogOutputResult.RangeChecked that nothing vouched for it.
-            if (channelNumber < 0)
-            {
-                throw new InvalidOperationException(
-                    $"Analog output channel {channelNumber} is not a channel number; it must be 0 or greater.");
-            }
-
             return false;
         }
 

--- a/src/Daqifi.Mcp/DaqifiAgent.cs
+++ b/src/Daqifi.Mcp/DaqifiAgent.cs
@@ -516,6 +516,127 @@ public sealed class DaqifiAgent
         }).ConfigureAwait(false);
     }
 
+    // ----------------------------------------------------------- analog output
+
+    /// <summary>
+    /// Lists the device's analog-output (DAC) channels with their range, resolution, and the value
+    /// each is driving. Read-only: available even under <c>--read-only</c>, and it touches no wire.
+    /// </summary>
+    /// <remarks>
+    /// Empty on every board without DACs, and on a board with them whose capability document did
+    /// not describe them. Deliberately not an error: an agent asking what a device can drive is
+    /// entitled to the answer "nothing", and <see cref="SetAnalogOutputAsync"/> is where an attempt
+    /// to drive one anyway is explained.
+    /// </remarks>
+    public IReadOnlyList<AnalogOutputState> ListAnalogOutputs(string deviceId) =>
+        AnalogOutputs(Require(deviceId)).Select(AnalogOutputState.From).ToList();
+
+    /// <summary>
+    /// Writes a voltage to an analog-output (DAC) channel: staged, then latched immediately unless
+    /// <paramref name="latch"/> is false.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The stage-and-latch pair is the device's own protocol, and both halves run inside one
+    /// exclusive section so no concurrent tool call can latch a half-written set.
+    /// </para>
+    /// <para>
+    /// A voltage outside the channel's stated range is refused here, before anything reaches the
+    /// wire (Core's check, on the channel the device described). The exception is a device that
+    /// described no analog outputs at all: Core still addresses those by channel number — that is
+    /// the only analog-output path the SDK has ever had — so the write proceeds with
+    /// <see cref="AnalogOutputResult.RangeChecked"/> false rather than being refused. What that
+    /// case does <i>not</i> include is a board with no DACs: <see cref="RequireAnalogOutput"/>
+    /// stops those up front, so an agent cannot get a silent success out of hardware that has
+    /// nothing to drive.
+    /// </para>
+    /// </remarks>
+    public async Task<AnalogOutputResult> SetAnalogOutputAsync(string deviceId, int channel, double volts, bool latch)
+    {
+        RequireControl();
+        var (device, streaming) = RequireAnalogOutput(deviceId);
+
+        return await device.RunExclusiveAsync(_ =>
+        {
+            // Checked inside the exclusive section, with the write it guards: a capability re-read
+            // runs under this same lock and rebuilds the analog-output channels, so an outer check
+            // could vouch for a channel that no longer exists by the time the value is staged —
+            // the shape of #449.
+            var known = RequireKnownAnalogOutput(device, deviceId, channel);
+
+            streaming.StageAnalogOutput(channel, volts);
+            if (latch)
+            {
+                streaming.LatchAnalogOutputs();
+            }
+
+            return Task.FromResult(new AnalogOutputResult(
+                deviceId,
+                channel,
+                volts,
+                Applied: latch,
+                RangeChecked: known,
+                State: FindAnalogOutput(device, channel) is { } state ? AnalogOutputState.From(state) : null));
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Applies every analog-output voltage staged since the last latch, so channels staged
+    /// separately change together.
+    /// </summary>
+    /// <remarks>
+    /// Latching with nothing staged is harmless — the device re-applies what it already holds — so
+    /// this is not refused when no value is pending; a caller that has lost track of what it staged
+    /// can always land the device in a known state.
+    /// </remarks>
+    public async Task<AnalogOutputLatchResult> LatchAnalogOutputsAsync(string deviceId)
+    {
+        RequireControl();
+        var (device, streaming) = RequireAnalogOutput(deviceId);
+
+        return await device.RunExclusiveAsync(_ =>
+        {
+            streaming.LatchAnalogOutputs();
+
+            return Task.FromResult(new AnalogOutputLatchResult(
+                deviceId,
+                AnalogOutputs(device).Select(AnalogOutputState.From).ToList()));
+        }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asks the device what voltage an analog output is holding. Read-only: it changes nothing on
+    /// the device, so it stays available under <c>--read-only</c>.
+    /// </summary>
+    /// <remarks>
+    /// Refused while the device is streaming. This is a text-mode exchange, and pausing Core's
+    /// protobuf reader does not stop the firmware: its binary frames land on the front of the reply,
+    /// so the readback would fail as "not a voltage" — a parse error that describes the collision
+    /// rather than naming it.
+    /// </remarks>
+    public async Task<AnalogOutputReading> ReadAnalogOutputAsync(
+        string deviceId, int channel, CancellationToken cancellationToken)
+    {
+        var (device, streaming) = RequireAnalogOutput(deviceId);
+
+        return await device.RunExclusiveAsync(async ct =>
+        {
+            RequireKnownAnalogOutput(device, deviceId, channel);
+
+            if (streaming.IsStreaming)
+            {
+                throw new InvalidOperationException(
+                    $"Device '{deviceId}' is streaming, and the analog-output readback is a text-mode query "
+                    + "whose reply the device's binary stream would corrupt. Stop the stream (or the SD "
+                    + "log) and read again; list_analog_outputs reports the last value this server wrote "
+                    + "without touching the device.");
+            }
+
+            var volts = await streaming.GetAnalogOutputAsync(channel, ct).ConfigureAwait(false);
+            return new AnalogOutputReading(deviceId, channel, volts);
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<SampleRateResult> SetSampleRateAsync(string deviceId, int rateHz)
     {
         if (rateHz < 1)
@@ -1437,6 +1558,85 @@ public sealed class DaqifiAgent
         .Select(c => c.ChannelNumber)
         .OrderBy(n => n)
         .ToList();
+
+    private static IReadOnlyList<IAnalogOutputChannel> AnalogOutputs(DaqifiDevice device) => Snapshot(device)
+        .OfType<IAnalogOutputChannel>()
+        .OrderBy(c => c.ChannelNumber)
+        .ToList();
+
+    private static IAnalogOutputChannel? FindAnalogOutput(DaqifiDevice device, int channelNumber) =>
+        AnalogOutputs(device).FirstOrDefault(c => c.ChannelNumber == channelNumber);
+
+    /// <summary>
+    /// Resolves a device for analog output, refusing hardware that has none.
+    /// </summary>
+    /// <remarks>
+    /// The board gate is what keeps an agent honest here. Core sends an analog-output command by
+    /// channel number whether or not a channel was ever described, and never reads the device's
+    /// error queue back, so on a board without DACs the write would look like a success to the
+    /// agent while the firmware discarded it. <see cref="DaqifiDevice.Supports"/> answers <c>true</c>
+    /// for a device that has not reported its part number yet, so this refuses only boards that
+    /// have actually identified themselves as something other than a Nyquist 3.
+    /// </remarks>
+    private (DaqifiDevice device, DaqifiStreamingDevice streaming) RequireAnalogOutput(string deviceId)
+    {
+        var device = Require(deviceId);
+
+        // Narrower than RequireStreaming's IStreamingDevice: the stage/latch/readback trio lives on
+        // the concrete class, since only SetAnalogOutput is on the interface.
+        if (device is not DaqifiStreamingDevice streaming)
+        {
+            throw new InvalidOperationException(
+                $"Device '{deviceId}' does not support analog-output operations.");
+        }
+
+        if (!device.Supports(DeviceFeature.AnalogOutput))
+        {
+            throw new InvalidOperationException(
+                $"Device '{deviceId}' has no analog outputs. Analog output (DAC) is fitted to Nyquist 3 "
+                + $"hardware only, and this device reports itself as {device.Metadata.DeviceType}. Use "
+                + "set_digital_output or set_pwm_output to drive a pin on this board.");
+        }
+
+        return (device, streaming);
+    }
+
+    /// <summary>
+    /// Checks a channel number against the analog outputs the device described, and reports whether
+    /// there was anything to check it against.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the channel is one the device described (so Core will range-check the
+    /// write); <c>false</c> when the device described no analog outputs at all and the command can
+    /// only be addressed by number.
+    /// </returns>
+    private static bool RequireKnownAnalogOutput(DaqifiDevice device, string deviceId, int channelNumber)
+    {
+        var outputs = AnalogOutputs(device);
+        if (outputs.Count == 0)
+        {
+            // Nyquist 3 firmware below v3.5.0 has no capability document, and the document is the
+            // only place a device describes its DACs. Refusing here would leave those boards with
+            // no analog-output path at all, so the number is taken at face value — the caller is
+            // told through AnalogOutputResult.RangeChecked that nothing vouched for it.
+            if (channelNumber < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Analog output channel {channelNumber} is not a channel number; it must be 0 or greater.");
+            }
+
+            return false;
+        }
+
+        if (outputs.All(c => c.ChannelNumber != channelNumber))
+        {
+            throw new InvalidOperationException(
+                $"Unknown analog output channel {channelNumber} on device '{deviceId}'. This device has "
+                + $"analog outputs: {string.Join(", ", outputs.Select(c => c.ChannelNumber))}.");
+        }
+
+        return true;
+    }
 
     private static IChannel RequireDigitalChannel(DaqifiDevice device, int channelNumber)
     {

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -25,24 +25,33 @@ public sealed record DiscoveredDevice(
         info.Type.ToString());
 }
 
-/// <summary>Summary of a currently-connected device.</summary>
+/// <summary>
+/// Summary of a currently-connected device. <see cref="AnalogOutputChannelCount"/> counts DAC
+/// channels, which are reported separately from <see cref="AnalogChannelCount"/> because they are
+/// driven rather than measured — they never appear in an acquisition and are written with
+/// set_analog_output. It is 0 on every board but Nyquist 3, and also on a Nyquist 3 whose
+/// capability document did not describe them (see <see cref="AnalogOutputState"/>).
+/// </summary>
 public sealed record ConnectedDeviceInfo(
     string DeviceId,
     string Name,
     bool Connected,
     int AnalogChannelCount,
-    int DigitalChannelCount)
+    int DigitalChannelCount,
+    int AnalogOutputChannelCount)
 {
     public static ConnectedDeviceInfo From(string id, DaqifiDevice device)
     {
         var analog = 0;
         var digital = 0;
+        var analogOutput = 0;
         foreach (var ch in device.GetChannelsSnapshot())
         {
             if (ch.Type == ChannelType.Analog) analog++;
             else if (ch.Type == ChannelType.Digital) digital++;
+            else if (ch.Type == ChannelType.AnalogOutput) analogOutput++;
         }
-        return new ConnectedDeviceInfo(id, device.Name, device.IsConnected, analog, digital);
+        return new ConnectedDeviceInfo(id, device.Name, device.IsConnected, analog, digital, analogOutput);
     }
 }
 
@@ -164,6 +173,91 @@ public sealed record PwmResult(string DeviceId, int Channel, bool Enabled, int? 
             frequencyCommanded ? device.PwmFrequencyHz : null);
     }
 }
+
+/// <summary>
+/// One analog-output (DAC) channel: what it accepts and what it is driving.
+/// </summary>
+/// <param name="Channel">The channel number, as set_analog_output takes it.</param>
+/// <param name="Name">The channel's display name.</param>
+/// <param name="Volts">
+/// The voltage this channel is driving, or <c>null</c> when nothing has driven it yet. It is what
+/// this server last latched or last read back — the DAC has no hardware readback, so no value
+/// anywhere is a measurement of the pin.
+/// </param>
+/// <param name="PendingVolts">
+/// A voltage staged by set_analog_output with <c>latch=false</c> and not yet applied, or
+/// <c>null</c> when nothing is waiting. It reaches the pin on the next latch_analog_outputs.
+/// </param>
+/// <param name="MinVolts">The lowest voltage the channel accepts.</param>
+/// <param name="MaxVolts">The highest voltage the channel accepts.</param>
+/// <param name="RangeIsAssumed">
+/// Whether the range above is this library's fallback rather than the device's own statement. When
+/// <c>true</c> the device described the channel but not its range, so a rejected write may reflect
+/// an assumption rather than the hardware's real limit.
+/// </param>
+/// <param name="ResolutionBits">The DAC resolution in bits.</param>
+public sealed record AnalogOutputState(
+    int Channel,
+    string Name,
+    double? Volts,
+    double? PendingVolts,
+    double MinVolts,
+    double MaxVolts,
+    bool RangeIsAssumed,
+    int ResolutionBits)
+{
+    public static AnalogOutputState From(IAnalogOutputChannel ch) => new(
+        ch.ChannelNumber,
+        ch.Name,
+        ch.OutputVoltage,
+        ch.PendingVoltage,
+        ch.MinimumVoltage,
+        ch.MaximumVoltage,
+        ch.RangeIsAssumed,
+        ch.ResolutionBits);
+}
+
+/// <summary>
+/// Result of writing an analog-output voltage.
+/// </summary>
+/// <param name="Applied">
+/// Whether the value is now on the pin. <c>false</c> means it was staged only and is waiting for
+/// latch_analog_outputs.
+/// </param>
+/// <param name="RangeChecked">
+/// Whether the voltage was validated against a range the device stated. <c>false</c> means the
+/// device described no analog outputs at all — the command was addressed by channel number and
+/// nothing here can vouch for it (see <see cref="DaqifiAgent.SetAnalogOutputAsync"/>).
+/// </param>
+/// <param name="State">
+/// The channel afterwards, or <c>null</c> when the device described no analog outputs and there is
+/// therefore no modelled channel to report.
+/// </param>
+public sealed record AnalogOutputResult(
+    string DeviceId,
+    int Channel,
+    double RequestedVolts,
+    bool Applied,
+    bool RangeChecked,
+    AnalogOutputState? State);
+
+/// <summary>
+/// Result of latching the staged analog outputs: every modelled analog-output channel afterwards,
+/// so a caller that staged several sees them all take effect together. <see cref="Outputs"/> is
+/// empty when the device described no analog outputs — the latch command was still sent.
+/// </summary>
+public sealed record AnalogOutputLatchResult(string DeviceId, IReadOnlyList<AnalogOutputState> Outputs);
+
+/// <summary>
+/// What the device answered when asked what an analog output is holding.
+/// </summary>
+/// <param name="Volts">
+/// The voltage the device reports. Not a measurement of the pin: the DAC has no readback path, so
+/// the firmware answers with the value it was last told to drive. It is still the authoritative
+/// round-trip — it reflects what the device accepted, including a write made before this server
+/// connected.
+/// </param>
+public sealed record AnalogOutputReading(string DeviceId, int Channel, double Volts);
 
 /// <summary>
 /// Result of a sample-rate change. A request exceeding the effective ceiling (the device's cap

--- a/src/Daqifi.Mcp/README.md
+++ b/src/Daqifi.Mcp/README.md
@@ -24,6 +24,10 @@ The server speaks MCP over **stdio**, so the client launches it as a subprocess.
 | `set_digital_output` | Drive a digital channel high or low (switches it to output if needed). |
 | `set_pwm_output` | Start PWM on a capable channel: duty 1-100%, shared frequency 6-50000 Hz. |
 | `disable_pwm` | Stop PWM on a channel (pin is left high-impedance). |
+| `list_analog_outputs` | The DAC channels with the voltage range each accepts and the value it is driving. |
+| `set_analog_output` | Drive a DAC channel to a voltage (**Nyquist 3 only**); range-checked before it is sent. |
+| `latch_analog_outputs` | Apply the voltages staged with `set_analog_output latch=false`, together. |
+| `read_analog_output` | Ask the device what a DAC channel is holding. |
 | `set_sample_rate` | Set sample rate in Hz (ceiling depends on the enabled channel count; over-cap requests are rejected). |
 | `read_channel_values` | Latest value on every enabled channel, with the timestamp it was sampled at. |
 | `capture_samples` | A block of live data as rows: one row per sample tick, one column per channel. |
@@ -49,6 +53,14 @@ The server speaks MCP over **stdio**, so the client launches it as a subprocess.
 > (firmware #703), after which downloads come back empty until the device is reconnected or another
 > SD recording re-arms it. Do the SD work first on a fresh connection.
 
+> **Analog output is Nyquist 3 hardware.** On any other board `set_analog_output` is refused
+> outright, because the firmware would otherwise discard the command without saying so and the call
+> would look like a success. `set_analog_output` applies the voltage immediately unless you pass
+> `latch=false`, which stages it instead so several channels can be made to change together on one
+> `latch_analog_outputs`. Neither the staged value nor `read_analog_output` is a measurement of the
+> pin — the DAC has no readback path, so the device answers with the value it was last told to
+> drive.
+
 ## Run it
 
 ### Option A — install as a .NET global tool (recommended)
@@ -72,10 +84,11 @@ dotnet run --project src/Daqifi.Mcp
 ```
 
 `--read-only` blocks anything that changes the device or the card: channel/rate configuration,
-DIO/PWM output, start/stop logging, and `delete_sd_file`. Reading data back is still allowed —
-`list_sd_files`, `get_sd_storage` and `download_sd_file` all work, since they change nothing on the
-device (the download does write its two files into this machine's temp directory, which is the only
-way the data can reach the agent at all).
+DIO/PWM output, analog output (`set_analog_output`, `latch_analog_outputs`), start/stop logging, and
+`delete_sd_file`. Reading data back is still allowed — `list_sd_files`, `get_sd_storage`,
+`download_sd_file`, `list_analog_outputs` and `read_analog_output` all work, since they change
+nothing on the device (the download does write its two files into this machine's temp directory,
+which is the only way the data can reach the agent at all).
 
 The live tools sit on the line: reading a stream that is **already** running changes nothing and is
 allowed, but starting one is a change, so `read_channel_values` and `capture_samples` are refused

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -111,7 +111,7 @@ public static class DaqifiTools
         => GuardAsync(() => agent.DisablePwmAsync(deviceId, channel));
 
     [McpServerTool(Name = "list_analog_outputs")]
-    [Description("List the device's analog output (DAC) channels with the voltage range each accepts, its resolution, and the value it is driving. Call this before set_analog_output to learn the legal range. An empty list means this device drives no analog outputs — the hardware is Nyquist 3 only. Available in --read-only mode; costs no device round-trip.")]
+    [Description("List the device's analog output (DAC) channels with the voltage range each accepts, its resolution, and the value it is driving. Call this before set_analog_output to learn the legal range. An empty list means no DAC channel is modelled, which happens two ways: the board has none (analog output is Nyquist 3 hardware), or it has them but did not describe them in its capability document (firmware below v3.5.0). Do not read an empty list as 'writing is impossible' — in the second case set_analog_output still drives the channel by number and answers with rangeChecked false, saying that nothing validated the voltage; only in the first is it refused. Available in --read-only mode; costs no device round-trip, so `volts` is only what this server has written or read back this session — a null there means this server has not touched the channel, NOT that the pin is at 0 V. Use read_analog_output to ask the device itself.")]
     public static IReadOnlyList<AnalogOutputState> ListAnalogOutputs(
         DaqifiAgent agent,
         [Description("The device_id to inspect.")] string deviceId)

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -118,7 +118,7 @@ public static class DaqifiTools
         => Guard(() => agent.ListAnalogOutputs(deviceId));
 
     [McpServerTool(Name = "set_analog_output")]
-    [Description("Drive an analog output (DAC) channel to a voltage. Nyquist 3 hardware only; on any other board the call is refused rather than silently discarded by the firmware. A voltage outside the channel's range is rejected before anything is sent — call list_analog_outputs for the range. By default the value takes effect immediately; pass latch=false to stage it instead and apply several channels together with latch_analog_outputs.")]
+    [Description("Drive an analog output (DAC) channel to a voltage. Nyquist 3 hardware only; on any other board the call is refused rather than silently discarded by the firmware. A voltage outside the channel's range is rejected before anything is sent — call list_analog_outputs for the range. By default the value takes effect immediately; pass latch=false to stage it instead and apply several channels together with latch_analog_outputs. Note that the latch is device-wide, not per-channel: a call with latch=true also applies anything staged earlier on OTHER channels, and the result reports only the channel written — call list_analog_outputs afterwards to see them all.")]
     public static Task<AnalogOutputResult> SetAnalogOutput(
         DaqifiAgent agent,
         [Description("The device_id to control.")] string deviceId,

--- a/src/Daqifi.Mcp/Tools/DaqifiTools.cs
+++ b/src/Daqifi.Mcp/Tools/DaqifiTools.cs
@@ -110,6 +110,39 @@ public static class DaqifiTools
         [Description("The digital channel number to stop PWM on.")] int channel)
         => GuardAsync(() => agent.DisablePwmAsync(deviceId, channel));
 
+    [McpServerTool(Name = "list_analog_outputs")]
+    [Description("List the device's analog output (DAC) channels with the voltage range each accepts, its resolution, and the value it is driving. Call this before set_analog_output to learn the legal range. An empty list means this device drives no analog outputs — the hardware is Nyquist 3 only. Available in --read-only mode; costs no device round-trip.")]
+    public static IReadOnlyList<AnalogOutputState> ListAnalogOutputs(
+        DaqifiAgent agent,
+        [Description("The device_id to inspect.")] string deviceId)
+        => Guard(() => agent.ListAnalogOutputs(deviceId));
+
+    [McpServerTool(Name = "set_analog_output")]
+    [Description("Drive an analog output (DAC) channel to a voltage. Nyquist 3 hardware only; on any other board the call is refused rather than silently discarded by the firmware. A voltage outside the channel's range is rejected before anything is sent — call list_analog_outputs for the range. By default the value takes effect immediately; pass latch=false to stage it instead and apply several channels together with latch_analog_outputs.")]
+    public static Task<AnalogOutputResult> SetAnalogOutput(
+        DaqifiAgent agent,
+        [Description("The device_id to control.")] string deviceId,
+        [Description("The analog output channel number, as list_analog_outputs reports it.")] int channel,
+        [Description("The output voltage in volts. Must lie inside the channel's range (commonly 0-10 V).")] double volts,
+        [Description("Apply the value now (default). Pass false to stage it without changing the pin; it takes effect on the next latch_analog_outputs, which is how several outputs are made to change together.")] bool latch = true)
+        => GuardAsync(() => agent.SetAnalogOutputAsync(deviceId, channel, volts, latch));
+
+    [McpServerTool(Name = "latch_analog_outputs")]
+    [Description("Apply every analog output voltage staged with set_analog_output latch=false, so the staged channels change together. Returns the state of every analog output afterwards. Harmless with nothing staged — the device re-applies what it already holds.")]
+    public static Task<AnalogOutputLatchResult> LatchAnalogOutputs(
+        DaqifiAgent agent,
+        [Description("The device_id to latch.")] string deviceId)
+        => GuardAsync(() => agent.LatchAnalogOutputsAsync(deviceId));
+
+    [McpServerTool(Name = "read_analog_output")]
+    [Description("Ask the device what voltage an analog output channel is holding. This is a round-trip to the firmware, so it reflects what the device actually accepted — including a value written before this server connected — but it is not a measurement of the pin: the DAC has no readback path, so the device answers with the value it was last told to drive. Refused while the device is streaming, because the binary stream corrupts the reply. Available in --read-only mode.")]
+    public static Task<AnalogOutputReading> ReadAnalogOutput(
+        DaqifiAgent agent,
+        [Description("The device_id to query.")] string deviceId,
+        [Description("The analog output channel number.")] int channel,
+        CancellationToken cancellationToken = default)
+        => GuardAsync(() => agent.ReadAnalogOutputAsync(deviceId, channel, cancellationToken));
+
     [McpServerTool(Name = "set_sample_rate")]
     [Description("Set the device sample (streaming) rate in Hz, applied to streaming and SD-card logging. The achievable maximum depends on how many channels are currently enabled (configure channels first for an accurate ceiling) and is further capped by --max-sample-rate-hz if set; a request above the effective cap is rejected — the call throws rather than silently applying a lower rate.")]
     public static Task<SampleRateResult> SetSampleRate(


### PR DESCRIPTION
### What was wrong

[#526](https://github.com/daqifi/daqifi-core/pull/526) gave Core a real analog-output model — channels with a range, a validated write, a readback. The MCP server got none of it. An agent could call `list_channels`, see a channel typed `AnalogOutput`, and then find there was no tool that would write to it. Issue #499 called this out as item 4: *"a `set_analog_output` MCP tool becomes trivial once this lands."*

### How it was fixed

Four tools, and the DTOs to make their answers legible:

| Tool | What it does |
|---|---|
| `list_analog_outputs` | The DAC channels with the range each accepts, its resolution, and what it is driving. No device round-trip. |
| `set_analog_output` | Drive a channel to a voltage. `latch=false` stages instead, so several outputs change together. |
| `latch_analog_outputs` | Apply everything staged. |
| `read_analog_output` | Ask the device what it is holding (`SOURce:VOLTage:LEVel?`). |

`connect_device` and `list_connected_devices` now report `analogOutputChannelCount` separately from the analog inputs — outputs share the channel collection but are never sampled, so folding them into `analogChannelCount` would describe an acquisition wider than the device can run.

### Two decisions worth pushing back on

**Boards without DACs are refused, where Core lets the write through.** Core sends the DAC command by channel number whether or not a channel was ever described, and never reads the device's error queue back. On a Nyquist 1 the firmware discards the command internally and the caller is told nothing — Core keeps that path because it is the only analog-output path the SDK has ever had, and removing it would break existing consumers. MCP has no such history, so it checks `DeviceFeature.AnalogOutput` first and refuses with the board named. The alternative was letting an agent report "I set output 0 to 2.5 V" about hardware that has no output 0. Note `Supports` answers `true` for a device that has not reported its part number yet, so this refuses only boards that have actually identified themselves as something else.

**A Nyquist 3 that described no outputs still writes by number.** The capability document is the only place firmware describes its DACs, and firmware below v3.5.0 has no capability document at all. Refusing there would leave those boards with no analog-output path, so the write goes out with `rangeChecked: false` in the result — the agent is told nothing vouched for the number rather than being quietly reassured.

`read_analog_output` is refused while the device is streaming: it is a text-mode query, and the firmware's binary frames land on the front of the reply, so it would fail as an unhelpful "not a voltage" parse error. Both it and `list_analog_outputs` stay available under `--read-only`; the two writes do not.

### Verification

25 new tests. Full suite green on **net9.0** (3476 Core + 217 Mcp) and **net10.0** (3476), 0 warnings.

Six mutations confirm the tests bite — removing the board gate (1 failure), removing the streaming guard (1), making `latch=false` latch anyway (1), dropping the unknown-channel check (1), counting outputs as analog inputs (1), and moving the negative-channel guard back inside the modelled-channel branch (4).

One caveat on the test runs, in the interest of not overstating them: a single full net10.0 run failed `MessageProducerIdleWakeupTests.WakeCount_IsCumulativeAcrossRestarts`. That is a pre-existing flake, not this branch — the branch changes no file under `src/Daqifi.Core`, and the test then passed 3/3 on full-suite re-runs and 3/3 in isolation. It looks like the same family as #531.

**Bench — Nq1 fw 3.7.2 on `/dev/cu.usbmodem1101`, serial, non-destructive.** Driven through a harness that references this branch's `Daqifi.Mcp` and calls the agent methods the tools wrap (the repo's bench CLI exercises `Daqifi.Core` only, and nothing here is in Core):

```
serial:/dev/cu.usbmodem1101  Nq1  sn=9090539562006014104  fw=3.7.2  type=Nyquist1
Connected: Nq1  analogIn=16 digital=16 analogOut=0
list_channels: Analog=16, Digital=16

list_analog_outputs -> [] (device described no analog outputs)
set_analog_output(0, 2.5) -> InvalidOperationException: Device '...' has no analog outputs.
  Analog output (DAC) is fitted to Nyquist 3 hardware only, and this device reports itself as
  Nyquist1. Use set_digital_output or set_pwm_output to drive a pin on this board.
set_analog_output(0, 2.5, latch=false) -> (same refusal)
latch_analog_outputs -> (same refusal)
read_analog_output(0) -> (same refusal)

After: connected=True analogIn=16 digital=16 analogOut=0; list_channels: Analog=16, Digital=16
```

The bench unit is an NQ1, so this validates the decision the PR turns on — the board gate firing against **real** device metadata rather than a test double's — plus that nothing reached the wire and the device's 32 channels are untouched. **The positive path (a voltage staged, latched, and read back) is covered by tests only; it needs NQ3 hardware to confirm.**

### After review

Three commits followed the first review round, all in the MCP layer:

- **Both Qodo findings** (77e24fc). A negative channel number was answered two different ways depending on what the device had described — the guard now runs first, so it does not. And `list_analog_outputs`'s description claimed an empty list meant the board drives no analog outputs, when the other cause is a board that does: an NQ3 below firmware v3.5.0 has no capability document to describe its DACs, and `set_analog_output` still drives those by number. An agent reading the old text would have skipped a write that works.
- **The latch is device-wide, not per-channel** (43ccf1e), found re-reading my own diff. `set_analog_output` with the default `latch=true` also applies anything staged earlier on *other* channels — one `CONFigure:DAC:UPDATE` moves every staged pin — while the result names only the channel written. An agent could move a pin it had staged and forgotten with no sign of it in the answer. Said in the description, pinned by a test.
- **A smaller cleanup** (0c759c7): finding one output no longer sorts the whole set.

Closes #499 — its Core half shipped in #526, whose `closes` keyword was inside backticks and never linked.

Not merging — for review.

