### PR TITLE
feat(sd): understand the device's end-of-listing marker

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
@@ -24,6 +24,34 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.Equal("data.csv", result[0].FileName);
         }
 
+        [Fact]
+        public void ParseFileList_WithFileNamedLikeTheMarker_KeepsTheFile()
+        {
+            // The marker is matched as a whole token, not as a prefix: a file
+            // whose name merely starts with the marker text is still a file, and
+            // hiding it would be the same defect as inventing one.
+            // No "Daqifi/" prefix on purpose: with one, the line does not start
+            // with the marker text at all and the exactness guard is never
+            // reached -- the test would pass whether or not the guard exists.
+            var lines = new[] { "__END_OF_LIST__notes.csv 12", "__END_OF_LIST__ OK" };
+
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            Assert.Single(result);
+            Assert.Equal("__END_OF_LIST__notes.csv", result[0].FileName);
+        }
+
+        [Fact]
+        public void GetListingStatus_WithFileNamedLikeTheMarker_IsUnterminated()
+        {
+            // Same rule from the other side: a filename starting with the marker
+            // text must not be read as the listing's terminator.
+            var status = SdCardFileListParser.GetListingStatus(
+                new[] { "__END_OF_LIST__notes.csv 12" });
+
+            Assert.Equal(SdCardListingStatus.Unterminated, status);
+        }
+
         [Theory]
         [InlineData("__END_OF_LIST__ OK", SdCardListingStatus.Complete)]
         [InlineData("__END_OF_LIST__ INCOMPLETE", SdCardListingStatus.Incomplete)]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
@@ -66,6 +66,22 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public void GetListingStatus_WithContentAfterTheMarker_IsUnterminated()
+        {
+            // A marker with entries after it did not terminate THIS listing --
+            // it is left over from an earlier, timed-out exchange. Claiming
+            // Complete there would vouch for a reply we never saw the end of.
+            var status = SdCardFileListParser.GetListingStatus(new[]
+            {
+                "Daqifi/a.csv 1",
+                "__END_OF_LIST__ OK",
+                "Daqifi/b.csv 2",
+            });
+
+            Assert.Equal(SdCardListingStatus.Unterminated, status);
+        }
+
+        [Fact]
         public void GetListingStatus_WithNoMarker_IsUnterminated()
         {
             // Pre-#794 firmware, and the abort case, which deliberately sends none.

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileListParserTests.cs
@@ -7,6 +7,72 @@ namespace Daqifi.Core.Tests.Device.SdCard
 {
     public class SdCardFileListParserTests
     {
+        // ---- firmware #794: the end-of-listing marker -----------------------
+
+        [Fact]
+        public void ParseFileList_WithEndOfListMarker_DoesNotYieldAFile()
+        {
+            // Arrange -- the marker is not blank, is not an error shape, and its
+            // first token is not empty, so every existing filter passes it through.
+            var lines = new[] { "Daqifi/data.csv 1024", "__END_OF_LIST__ OK" };
+
+            // Act
+            var result = SdCardFileListParser.ParseFileList(lines);
+
+            // Assert -- one real file, and no phantom named after the marker.
+            Assert.Single(result);
+            Assert.Equal("data.csv", result[0].FileName);
+        }
+
+        [Theory]
+        [InlineData("__END_OF_LIST__ OK", SdCardListingStatus.Complete)]
+        [InlineData("__END_OF_LIST__ INCOMPLETE", SdCardListingStatus.Incomplete)]
+        [InlineData("__END_OF_LIST__ FAILED", SdCardListingStatus.Failed)]
+        [InlineData("  __END_OF_LIST__ ok  ", SdCardListingStatus.Complete)]
+        public void GetListingStatus_ReadsTheMarker(string marker, SdCardListingStatus expected)
+        {
+            var status = SdCardFileListParser.GetListingStatus(
+                new[] { "Daqifi/data.csv 1024", marker });
+
+            Assert.Equal(expected, status);
+        }
+
+        [Fact]
+        public void GetListingStatus_WithNoMarker_IsUnterminated()
+        {
+            // Pre-#794 firmware, and the abort case, which deliberately sends none.
+            var status = SdCardFileListParser.GetListingStatus(
+                new[] { "Daqifi/data.csv 1024" });
+
+            Assert.Equal(SdCardListingStatus.Unterminated, status);
+        }
+
+        [Fact]
+        public void GetListingStatus_WithUnknownStatusWord_IsNotTreatedAsComplete()
+        {
+            // A future status word this version does not know still terminated the
+            // listing, but its contents cannot be claimed complete.
+            var status = SdCardFileListParser.GetListingStatus(
+                new[] { "Daqifi/data.csv 1024", "__END_OF_LIST__ SOMETHINGNEW" });
+
+            Assert.Equal(SdCardListingStatus.Incomplete, status);
+        }
+
+        [Fact]
+        public void GetListingStatus_WithStaleMarkerAhead_TakesTheLast()
+        {
+            // A marker from a previous, timed-out exchange can lead this reply. The
+            // one that ENDS the reply describes the walk that produced it.
+            var status = SdCardFileListParser.GetListingStatus(new[]
+            {
+                "__END_OF_LIST__ FAILED",
+                "Daqifi/data.csv 1024",
+                "__END_OF_LIST__ OK",
+            });
+
+            Assert.Equal(SdCardListingStatus.Complete, status);
+        }
+
         [Fact]
         public void ParseFileList_WithValidFiles_ReturnsCorrectCount()
         {

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
@@ -661,7 +661,10 @@ public class SdCardOperationsCollaboratorTests
     public async Task DeleteSdCardFileAsync_DeletesThenRelistsInTheSameExchange()
     {
         var host = new FakeHost();
-        host.EnqueueResponse("Daqifi/keep.bin 10");
+        // The delete refresh now carries the same transport terminator the read
+        // path uses, so the canned reply must too -- it is what proves the
+        // exchange finished rather than being cut short.
+        host.EnqueueResponse("Daqifi/keep.bin 10", NoErrorTerminator);
         var ops = new SdCardOperations(host);
 
         await ops.DeleteSdCardFileAsync("gone.bin");
@@ -675,6 +678,7 @@ public class SdCardOperationsCollaboratorTests
                 "send:" + EnableSd,
                 "send:SYSTem:STORage:SD:DELete \"gone.bin\"",
                 "send:" + ListFiles,
+                "send:" + SystemError,
                 "send:" + DisableSd,
                 "send:" + EnableLan,
                 "exchange:end",
@@ -687,8 +691,8 @@ public class SdCardOperationsCollaboratorTests
     public async Task DeleteSdCardFileAsync_ScpiError_RetriesExactlyOnce()
     {
         var host = new FakeHost();
-        host.EnqueueResponse("**ERROR: -200,\"Execution error\"");
-        host.EnqueueResponse("Daqifi/keep.bin 10");
+        host.EnqueueResponse("**ERROR: -200,\"Execution error\"", NoErrorTerminator);
+        host.EnqueueResponse("Daqifi/keep.bin 10", NoErrorTerminator);
         var ops = new SdCardOperations(host);
 
         await ops.DeleteSdCardFileAsync("gone.bin");

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
@@ -688,6 +688,26 @@ public class SdCardOperationsCollaboratorTests
     }
 
     [Fact]
+    public async Task DeleteSdCardFileAsync_RelistRetryError_IsNotBlamedOnTheDelete()
+    {
+        // The delete SUCCEEDED -- its exchange came back with no error at all,
+        // just an unterminated listing. The relist-only retry then hits a
+        // transient bus error of its own. That error belongs to a LIST that
+        // never carried a DELETE, so it must not be reported as "the delete
+        // operation failed"; the honest answer is that the listing could not
+        // be confirmed.
+        var host = new FakeHost();
+        host.EnqueueResponse("Daqifi/keep.bin 10");                         // no terminator
+        host.EnqueueResponse("**ERROR: -200,\"Execution error\"", NoErrorTerminator);
+        var ops = new SdCardOperations(host);
+
+        var ex = await Assert.ThrowsAsync<SdCardListIncompleteException>(
+            () => ops.DeleteSdCardFileAsync("gone.bin"));
+
+        Assert.DoesNotContain("delete operation failed", ex.Message);
+    }
+
+    [Fact]
     public async Task DeleteSdCardFileAsync_ScpiError_RetriesExactlyOnce()
     {
         var host = new FakeHost();

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -724,13 +724,35 @@ namespace Daqifi.Core.Tests.Device.SdCard
             // The fake appends the terminator whenever the exchange asked for it,
             // which is what a healthy device does. This knob withholds it, which
             // is what a reply cut short by the completion window looks like.
-            device.UnterminatedAttempts = 1;
+            // int.MaxValue, not 1: one stall is RETRIED now, so withholding the
+            // terminator once would prove the retry works, not the throw.
+            device.UnterminatedAttempts = int.MaxValue;
             device.Connect();
 
             await Assert.ThrowsAsync<SdCardListIncompleteException>(
                 () => device.DeleteSdCardFileAsync("data.bin"));
 
             Assert.Empty(device.SdCardFiles);
+        }
+
+        [Fact]
+        public async Task DeleteSdCardFileAsync_WithOneUnterminatedListing_RetriesAndCaches()
+        {
+            // One stalled relist is a transient, and the read path has always
+            // retried it. The retry re-LISTs only -- re-sending the DELETE
+            // would ask the device to remove a file that is already gone.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "Daqifi/remaining.bin 12" };
+            device.UnterminatedAttempts = 1;
+            device.Connect();
+
+            await device.DeleteSdCardFileAsync("data.bin");
+
+            Assert.Equal("remaining.bin", Assert.Single(device.SdCardFiles).FileName);
+            var sent = device.SentMessages.Select(m => m.Data).ToList();
+            Assert.Equal(
+                1,
+                sent.Count(c => c.StartsWith("SYSTem:STORage:SD:DELete", StringComparison.Ordinal)));
         }
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -690,6 +690,46 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task DeleteSdCardFileAsync_WithIncompleteListing_ThrowsAndKeepsTheCache()
+        {
+            // The refresh after a DELETE is what a caller consults next to
+            // decide whether the file is gone, so a listing the device itself
+            // called INCOMPLETE must not become that answer -- every absence in
+            // a short list would look confirmed.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "Daqifi/remaining.bin 12",
+                "__END_OF_LIST__ INCOMPLETE",
+            };
+            device.Connect();
+
+            await Assert.ThrowsAsync<SdCardListIncompleteException>(
+                () => device.DeleteSdCardFileAsync("data.bin"));
+
+            Assert.Empty(device.SdCardFiles);
+        }
+
+        [Fact]
+        public async Task DeleteSdCardFileAsync_WithCompleteListing_UpdatesTheCache()
+        {
+            // The same path with an OK marker still refreshes, and the marker
+            // itself is not mistaken for a file.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "Daqifi/remaining.bin 12",
+                "__END_OF_LIST__ OK",
+            };
+            device.Connect();
+
+            await device.DeleteSdCardFileAsync("data.bin");
+
+            Assert.Single(device.SdCardFiles);
+            Assert.Equal("remaining.bin", device.SdCardFiles[0].FileName);
+        }
+
+        [Fact]
         public async Task DeleteSdCardFileAsync_RestoresLanInterface()
         {
             // Arrange

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -855,6 +855,48 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task DeleteSdCardFileAsync_ErrorAndFileAbsentFromUnterminatedListing_Throws()
+        {
+            // Absence is only evidence if the listing is whole. Here the reply
+            // is transport-terminated -- so the exchange finished -- but the
+            // device sent no end-of-listing marker, which is exactly the case
+            // where a walk cut short and a walk that reached the end look
+            // identical. The target is missing, and that means nothing.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "**ERROR: -200,\"Execution error\"",
+                "Daqifi/remaining.bin 12",
+            };
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<SdCardOperationException>(
+                () => device.DeleteSdCardFileAsync("data.bin"));
+
+            Assert.Contains("-200", ex.Message);
+        }
+
+        [Fact]
+        public async Task DeleteSdCardFileAsync_ErrorAndFileAbsentFromIncompleteListing_Throws()
+        {
+            // The device said outright that it did not finish the walk, so the
+            // file it never reached cannot be reported as deleted.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "**ERROR: -200,\"Execution error\"",
+                "Daqifi/remaining.bin 12",
+                "__END_OF_LIST__ INCOMPLETE",
+            };
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<SdCardOperationException>(
+                () => device.DeleteSdCardFileAsync("data.bin"));
+
+            Assert.Contains("-200", ex.Message);
+        }
+
+        [Fact]
         public async Task DeleteSdCardFileAsync_WithCompleteListing_UpdatesTheCache()
         {
             // The same path with an OK marker still refreshes, and the marker

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -832,6 +832,29 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task DeleteSdCardFileAsync_ErrorButFileGone_TreatsTheDeleteAsDone()
+        {
+            // The error line carries no origin: DELETE, LIST and SYST:ERRor?
+            // travel together, and the LIST has failure modes of its own. Here
+            // the file the caller asked to delete is ABSENT from a listing that
+            // rendered completely -- so it was deleted, whatever the error was
+            // about. Reporting failure would send the caller to delete a file
+            // that is already gone.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "**ERROR: -200,\"Execution error\"",
+                "Daqifi/remaining.bin 12",
+                "__END_OF_LIST__ OK",
+            };
+            device.Connect();
+
+            await device.DeleteSdCardFileAsync("data.bin");
+
+            Assert.Equal("remaining.bin", Assert.Single(device.SdCardFiles).FileName);
+        }
+
+        [Fact]
         public async Task DeleteSdCardFileAsync_WithCompleteListing_UpdatesTheCache()
         {
             // The same path with an OK marker still refreshes, and the marker

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -1200,6 +1200,51 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task GetSdCardFilesAsync_WhenStaleMarkerAccompaniesThisRequestsError_StillThrows()
+        {
+            // A stale end-of-listing marker, left in the buffer by an earlier timed-out
+            // exchange, arrives ahead of THIS request's own SCPI error. The marker is
+            // framing and must not vouch for the reply: if it counted as content, the
+            // error would be skipped, the status would read Unterminated rather than
+            // Failed, and the caller would be handed a confidently empty card for a
+            // listing the device never produced.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var staleMarkerThenError = new List<string>
+            {
+                "__END_OF_LIST__ OK",
+                "**ERROR: -200,\"Execution error\"",
+            };
+
+            // Both the first attempt and its retry see it, so the loop runs out of
+            // attempts holding the error rather than recovering on the second.
+            device.ResponseSequence.Enqueue(new List<string>(staleMarkerThenError));
+            device.ResponseSequence.Enqueue(new List<string>(staleMarkerThenError));
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<SdCardOperationException>(
+                () => device.GetSdCardFilesAsync());
+
+            Assert.Contains("Execution error", ex.Message);
+            Assert.Equal("**ERROR: -200,\"Execution error\"", ex.LastScpiError);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WhenMarkerIsTheOnlyLine_ReportsAnEmptyCard()
+        {
+            // The other side of the same predicate: a genuinely empty directory ends
+            // with nothing but the marker. Treating the marker as framing must not
+            // turn that into an error -- there is no SCPI error to surface, so the
+            // empty listing is the right answer.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "__END_OF_LIST__ OK" };
+            device.Connect();
+
+            var files = await device.GetSdCardFilesAsync();
+
+            Assert.Empty(files);
+        }
+
+        [Fact]
         public async Task GetSdCardFilesAsync_WhenTerminatorMissingOnFirstAttemptOnly_RetriesAndSucceeds()
         {
             // A one-off stall is retried on the same terms as a transient SCPI error, so a single

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -756,6 +756,29 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task DeleteSdCardFileAsync_WithPersistentDeviceError_ThrowsAndKeepsTheCache()
+        {
+            // A delete the device refuses on every attempt: the retry above
+            // exhausts without throwing, and the reply that reaches the cache
+            // logic carries an error line, a valid transport terminator and no
+            // device marker. Nothing in the status guards fires, ParseFileList
+            // skips the error line, and the cache would become an EMPTY list --
+            // telling the caller the delete worked and the card is empty, in
+            // the one case where the device said neither.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "**ERROR: -200,\"Execution error\"",
+            };
+            device.Connect();
+
+            await Assert.ThrowsAnyAsync<Exception>(
+                () => device.DeleteSdCardFileAsync("locked.bin"));
+
+            Assert.Empty(device.SdCardFiles);
+        }
+
+        [Fact]
         public async Task DeleteSdCardFileAsync_WithCompleteListing_UpdatesTheCache()
         {
             // The same path with an OK marker still refreshes, and the marker

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -779,6 +779,31 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task DeleteSdCardFileAsync_RefusedWithOtherFilesPresent_Throws()
+        {
+            // The realistic shape of a refused delete: the card still holds
+            // other files, so the reply carries an error line AND real entries.
+            // ThrowIfSdCardListError returns silently on that (its content
+            // escape is right for the read path), so the delete's own error is
+            // what has to be judged -- otherwise the caller is told the delete
+            // worked while the file is still listed.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "**ERROR: -200,\"Execution error\"",
+                "Daqifi/fileA.csv 100",
+                "Daqifi/fileB.csv 200",
+                "__END_OF_LIST__ OK",
+            };
+            device.Connect();
+
+            await Assert.ThrowsAsync<SdCardOperationException>(
+                () => device.DeleteSdCardFileAsync("fileA.csv"));
+
+            Assert.Empty(device.SdCardFiles);
+        }
+
+        [Fact]
         public async Task DeleteSdCardFileAsync_WithCompleteListing_UpdatesTheCache()
         {
             // The same path with an OK marker still refreshes, and the marker

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -711,6 +711,29 @@ namespace Daqifi.Core.Tests.Device.SdCard
         }
 
         [Fact]
+        public async Task DeleteSdCardFileAsync_WithNoTransportTerminator_ThrowsAndKeepsTheCache()
+        {
+            // A reply cut short by the completion window loses the device marker
+            // too, so it reads as Unterminated -- which is legitimate on
+            // pre-#796 firmware and cannot be treated as an error on its own.
+            // The transport terminator is what separates "the firmware sent no
+            // marker" from "we stopped listening": without it the exchange is
+            // not known to have finished, so nothing it contains can be cached.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string> { "Daqifi/remaining.bin 12" };
+            // The fake appends the terminator whenever the exchange asked for it,
+            // which is what a healthy device does. This knob withholds it, which
+            // is what a reply cut short by the completion window looks like.
+            device.UnterminatedAttempts = 1;
+            device.Connect();
+
+            await Assert.ThrowsAsync<SdCardListIncompleteException>(
+                () => device.DeleteSdCardFileAsync("data.bin"));
+
+            Assert.Empty(device.SdCardFiles);
+        }
+
+        [Fact]
         public async Task DeleteSdCardFileAsync_WithCompleteListing_UpdatesTheCache()
         {
             // The same path with an OK marker still refreshes, and the marker

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -772,8 +772,10 @@ namespace Daqifi.Core.Tests.Device.SdCard
             };
             device.Connect();
 
-            await Assert.ThrowsAnyAsync<Exception>(
+            var ex = await Assert.ThrowsAsync<SdCardOperationException>(
                 () => device.DeleteSdCardFileAsync("locked.bin"));
+            // The device's own words, not a generic "listing incomplete".
+            Assert.Contains("-200", ex.Message);
 
             Assert.Empty(device.SdCardFiles);
         }
@@ -800,6 +802,32 @@ namespace Daqifi.Core.Tests.Device.SdCard
             await Assert.ThrowsAsync<SdCardOperationException>(
                 () => device.DeleteSdCardFileAsync("fileA.csv"));
 
+            Assert.Empty(device.SdCardFiles);
+        }
+
+        [Fact]
+        public async Task DeleteSdCardFileAsync_RefusedAndUnterminated_ReportsTheDeviceError()
+        {
+            // Both failures at once: the device refuses the delete AND the
+            // confirmation exchange never terminates. The completeness throw
+            // used to fire first, so the caller was told "the listing did not
+            // complete -- check the connection and retry" for a delete the
+            // device had explicitly refused, with LastScpiError null. The
+            // delete's own outcome is judged first now, so the reported error
+            // is the one the device actually gave.
+            var device = new TestableSdCardStreamingDevice("TestDevice");
+            device.CannedTextResponse = new List<string>
+            {
+                "**ERROR: -200,\"Execution error\"",
+            };
+            device.UnterminatedAttempts = int.MaxValue;
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<SdCardOperationException>(
+                () => device.DeleteSdCardFileAsync("locked.bin"));
+
+            Assert.IsNotType<SdCardListIncompleteException>(ex);
+            Assert.Contains("-200", ex.Message);
             Assert.Empty(device.SdCardFiles);
         }
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -18,6 +18,13 @@ namespace Daqifi.Core.Device.SdCard
         private const string DaqifiDirectoryPrefix = "Daqifi/";
 
         /// <summary>
+        /// Marker the device appends to a directory listing so a host can tell a
+        /// finished reply from a truncated one (firmware #794). The status word
+        /// follows it: <c>OK</c>, <c>INCOMPLETE</c> or <c>FAILED</c>.
+        /// </summary>
+        internal const string ListEndMarker = "__END_OF_LIST__";
+
+        /// <summary>
         /// Parses a collection of text lines from the SD card file list response into file info objects.
         /// </summary>
         /// <param name="lines">The raw text lines from the device response.</param>
@@ -45,6 +52,15 @@ namespace Daqifi.Core.Device.SdCard
                 // in ScpiResponseClassifier so it stays consistent with
                 // DaqifiStreamingDevice.IsNonResultLine (closes #190).
                 if (ScpiResponseClassifier.IsErrorResponseLine(path))
+                {
+                    continue;
+                }
+
+                // The end-of-listing marker is framing, not a file. Without this
+                // it survives every filter below -- it is not blank, not an error
+                // shape, and its first token is not empty -- and the device would
+                // appear to be carrying a file called "__END_OF_LIST__".
+                if (path.StartsWith(ListEndMarker, StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -107,6 +123,64 @@ namespace Daqifi.Core.Device.SdCard
                        out var size)
                 ? size
                 : null;
+        }
+
+        /// <summary>
+        /// How a directory listing ended, read from the device's end-of-listing
+        /// marker (firmware #794).
+        /// </summary>
+        /// <remarks>
+        /// Before that firmware a listing simply stopped, so a complete reply and
+        /// one cut short by a timeout, a buffer boundary or a stall-abort were
+        /// byte-identical. <see cref="SdCardListingStatus.Unterminated"/> is that
+        /// case and is NOT an error: it means the device cannot say, so a caller
+        /// must not report absence as fact.
+        /// </remarks>
+        /// <param name="lines">The raw text lines from the device response.</param>
+        /// <returns>The listing's terminating status.</returns>
+        public static SdCardListingStatus GetListingStatus(IEnumerable<string> lines)
+        {
+            if (lines == null)
+            {
+                throw new ArgumentNullException(nameof(lines));
+            }
+
+            // LAST marker wins. A reply that somehow carries two is already
+            // suspect, and the one that ends the reply is the one describing the
+            // walk that produced it.
+            var status = SdCardListingStatus.Unterminated;
+            foreach (var line in lines)
+            {
+                var trimmed = (line ?? string.Empty).Trim();
+                if (!trimmed.StartsWith(ListEndMarker, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var word = trimmed.Substring(ListEndMarker.Length).Trim();
+                if (word.Equals("OK", StringComparison.OrdinalIgnoreCase))
+                {
+                    status = SdCardListingStatus.Complete;
+                }
+                else if (word.Equals("INCOMPLETE", StringComparison.OrdinalIgnoreCase))
+                {
+                    status = SdCardListingStatus.Incomplete;
+                }
+                else if (word.Equals("FAILED", StringComparison.OrdinalIgnoreCase))
+                {
+                    status = SdCardListingStatus.Failed;
+                }
+                else
+                {
+                    // A marker with a status word this version does not know is
+                    // still a terminated listing, but its contents cannot be
+                    // trusted as complete -- treat it the way an explicitly
+                    // partial one is treated rather than as success.
+                    status = SdCardListingStatus.Incomplete;
+                }
+            }
+
+            return status;
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -60,7 +60,7 @@ namespace Daqifi.Core.Device.SdCard
                 // it survives every filter below -- it is not blank, not an error
                 // shape, and its first token is not empty -- and the device would
                 // appear to be carrying a file called "__END_OF_LIST__".
-                if (path.StartsWith(ListEndMarker, StringComparison.Ordinal))
+                if (IsListEndMarker(path, out _))
                 {
                     continue;
                 }
@@ -126,6 +126,44 @@ namespace Daqifi.Core.Device.SdCard
         }
 
         /// <summary>
+        /// True when <paramref name="line"/> IS the end-of-listing marker, as
+        /// opposed to merely starting with its text.
+        /// </summary>
+        /// <remarks>
+        /// The marker is either the token alone or the token followed by
+        /// whitespace and a status word. A prefix match would swallow a file
+        /// legitimately named <c>__END_OF_LIST__notes.csv</c> -- unlikely, but the
+        /// cost of being exact is one comparison and the cost of being loose is a
+        /// file the user cannot see.
+        /// </remarks>
+        /// <param name="line">The raw line, trimmed internally.</param>
+        /// <param name="statusWord">The status word, or empty when there is none.</param>
+        /// <returns>True when the line is the marker.</returns>
+        private static bool IsListEndMarker(string line, out string statusWord)
+        {
+            statusWord = string.Empty;
+
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith(ListEndMarker, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (trimmed.Length == ListEndMarker.Length)
+            {
+                return true;
+            }
+
+            if (!char.IsWhiteSpace(trimmed[ListEndMarker.Length]))
+            {
+                return false;
+            }
+
+            statusWord = trimmed.Substring(ListEndMarker.Length).Trim();
+            return true;
+        }
+
+        /// <summary>
         /// How a directory listing ended, read from the device's end-of-listing
         /// marker (firmware #794).
         /// </summary>
@@ -151,13 +189,11 @@ namespace Daqifi.Core.Device.SdCard
             var status = SdCardListingStatus.Unterminated;
             foreach (var line in lines)
             {
-                var trimmed = (line ?? string.Empty).Trim();
-                if (!trimmed.StartsWith(ListEndMarker, StringComparison.Ordinal))
+                if (!IsListEndMarker(line ?? string.Empty, out var word))
                 {
                     continue;
                 }
 
-                var word = trimmed.Substring(ListEndMarker.Length).Trim();
                 if (word.Equals("OK", StringComparison.OrdinalIgnoreCase))
                 {
                     status = SdCardListingStatus.Complete;

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -139,7 +139,7 @@ namespace Daqifi.Core.Device.SdCard
         /// <param name="line">The raw line, trimmed internally.</param>
         /// <param name="statusWord">The status word, or empty when there is none.</param>
         /// <returns>True when the line is the marker.</returns>
-        private static bool IsListEndMarker(string line, out string statusWord)
+        internal static bool IsListEndMarker(string line, out string statusWord)
         {
             statusWord = string.Empty;
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -191,6 +191,18 @@ namespace Daqifi.Core.Device.SdCard
             {
                 if (!IsListEndMarker(line ?? string.Empty, out var word))
                 {
+                    // Content AFTER a marker means that marker did not end
+                    // this listing -- it was left in flight by an earlier,
+                    // timed-out exchange. Only a marker that is actually last
+                    // describes the walk we are holding, so anything following
+                    // one puts us back to knowing nothing. Unterminated is the
+                    // safe direction: it is not an error, it just declines to
+                    // claim the listing is whole.
+                    if (!string.IsNullOrWhiteSpace(line))
+                    {
+                        status = SdCardListingStatus.Unterminated;
+                    }
+
                     continue;
                 }
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardListingStatus.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardListingStatus.cs
@@ -1,0 +1,43 @@
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// How a <c>SYSTem:STORage:SD:LISt?</c> reply ended.
+    /// </summary>
+    /// <remarks>
+    /// The device appends an end-of-listing marker so a host can tell a finished
+    /// reply from a truncated one (firmware #794). Before that, a listing simply
+    /// stopped: a complete one and one cut short by a read timeout, a buffer
+    /// boundary or a stall-abort were byte-identical, so a client could never
+    /// prove a file was ABSENT rather than merely unreached.
+    /// </remarks>
+    public enum SdCardListingStatus
+    {
+        /// <summary>
+        /// No marker was present. Either the firmware predates #794, or the reply
+        /// was cut short — including the abort case, which deliberately sends no
+        /// marker because the peer had stopped draining. NOT an error, and NOT a
+        /// clean bill of health: the listing may be missing entries, so absence
+        /// of a file must not be reported as fact.
+        /// </summary>
+        Unterminated = 0,
+
+        /// <summary>The device walked the whole tree and emitted every entry.</summary>
+        Complete,
+
+        /// <summary>
+        /// The walk finished but skipped entries — the directory-depth cap, a
+        /// subdirectory it could not read or open, a path or entry that did not
+        /// fit. The files listed are real; the list is not all of them.
+        /// </summary>
+        Incomplete,
+
+        /// <summary>
+        /// Nothing could be listed at all — the directory would not open, or the
+        /// path was too long. An empty result here means "I could not look", not
+        /// "there is nothing there".
+        /// </summary>
+        Failed,
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -865,10 +865,33 @@ namespace Daqifi.Core.Device.SdCard
             // refused twice, returned success with fileA still in the cache.
             if (deleteExchangeError != null)
             {
-                throw new SdCardOperationException(
-                    "The SD card delete operation failed: " + deleteExchangeError,
-                    lines,
-                    deleteExchangeError);
+                // ...unless the card itself says the file is gone. An error
+                // line carries no origin: the exchange sends DELETE, LIST and
+                // SYSTem:ERRor? together, and the LIST has failure modes of
+                // its own (busy, the 10 s large-directory timeout) that have
+                // nothing to do with the delete. The retry then re-sends the
+                // DELETE for a file the first attempt already removed, the
+                // device answers "delete operation failed" because it is not
+                // there, and that second, genuine error would be reported as
+                // the delete failing.
+                //
+                // The listing in the same exchange settles it. If it rendered
+                // completely and the file is absent, the delete happened --
+                // whatever the error line was about. Verifying the outcome
+                // beats attributing the error, which the wire format does not
+                // let us do.
+                var target = System.IO.Path.GetFileName(fileName);
+                var goneFromCard = refreshComplete
+                    && !SdCardFileListParser.ParseFileList(refreshListing).Any(
+                        f => string.Equals(f.FileName, target,
+                                           StringComparison.OrdinalIgnoreCase));
+                if (!goneFromCard)
+                {
+                    throw new SdCardOperationException(
+                        "The SD card delete operation failed: " + deleteExchangeError,
+                        lines,
+                        deleteExchangeError);
+                }
             }
 
             if (!refreshComplete)

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -846,6 +846,28 @@ namespace Daqifi.Core.Device.SdCard
                 throw new SdCardListIncompleteException(lines);
             }
 
+            // The DELETE's own outcome, judged before anything about the
+            // listing. The retry loop above exits either way, so a delete the
+            // device refused on BOTH attempts arrives here with its error line
+            // intact -- and ThrowIfSdCardListError alone will not catch it: its
+            // hasContentLine escape returns silently whenever the reply carries
+            // real entries, which is the normal case (you deleted one file, the
+            // others are still there). That escape is right for the read path,
+            // where a stray error has no bearing on the listing; it is wrong
+            // here, where the error line IS the answer to "did the delete
+            // happen?". Reproduced: a card holding fileA and fileB, a DELETE
+            // refused twice, returned success with fileA still in the cache.
+            if (ScpiResponseClassifier.ContainsScpiError(lines))
+            {
+                var deleteError = lines
+                    .LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
+                throw new SdCardOperationException(
+                    "The SD card delete operation failed: "
+                        + (deleteError ?? "the device reported an error"),
+                    lines,
+                    deleteError);
+            }
+
             // And the error guard the read path has always applied to its own
             // listing. Without it a delete that FAILED on the device twice --
             // the retry above exhausts without throwing -- came back here with

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -285,8 +285,16 @@ namespace Daqifi.Core.Device.SdCard
             // to prevent, one level deeper. Unterminated is the pre-#794 firmware and
             // is not an error: the reply framing already told us the exchange
             // completed, we simply learn nothing more from the device.
-            if (SdCardFileListParser.GetListingStatus(listing) == SdCardListingStatus.Failed)
+            var listingStatus = SdCardFileListParser.GetListingStatus(listing);
+            if (listingStatus == SdCardListingStatus.Failed
+                || listingStatus == SdCardListingStatus.Incomplete)
             {
+                // INCOMPLETE throws for the same reason a missing transport
+                // terminator does, a few lines above: the caller is about to
+                // cache this list and answer "is my file on the card?" from it.
+                // A device-truncated listing and a transport-truncated one are
+                // the same class of wrong answer, so they raise the same
+                // exception -- a client that handles one already handles this.
                 throw new SdCardListIncompleteException(lines);
             }
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -745,6 +745,15 @@ namespace Daqifi.Core.Device.SdCard
                     _host.Send(ScpiMessageProducer.GetSdFileList);
                 },
                 responseTimeoutMs: 3000,
+                // Same completion window the read path uses for the same
+                // command. Without it this exchange takes the 250 ms default,
+                // and the firmware walks the directory tree between chunks --
+                // so a merely-slow listing is cut off BEFORE its terminator
+                // arrives, reads as Unterminated (which by design does not
+                // throw) and slips past the guard below to overwrite the cache
+                // with a partial list. The guard can only judge a marker it
+                // was given time to receive.
+                completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
                 cancellationToken: cancellationToken,
                 prepareAsync: PrepareSdInterfaceAndSettleAsync,
                 finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
@@ -764,6 +773,11 @@ namespace Daqifi.Core.Device.SdCard
                             _host.Send(ScpiMessageProducer.GetSdFileList);
                         },
                         responseTimeoutMs: 3000,
+                        // The retry needs the window as much as the first
+                        // attempt: it is the same listing, and a retry that
+                        // truncates hands the same partial list to the same
+                        // cache.
+                        completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
                         cancellationToken: cancellationToken,
                         prepareAsync: PrepareSdInterfaceAndSettleAsync,
                         finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -1476,8 +1476,17 @@ namespace Daqifi.Core.Device.SdCard
             // If any line looks like a real result (non-empty, not an error or
             // firmware status line), hand off to the parser. Stray interleaved
             // error lines are still parsed away by SdCardFileListParser.
+            //
+            // The end-of-listing marker is framing, not a result. Counting it as
+            // content would let a stale marker -- one left in the buffer by an
+            // earlier timed-out exchange, which is exactly what
+            // TrySplitAtSdListTerminator warns about -- vouch for a reply whose
+            // only other line is this request's SCPI error, and the caller would
+            // be handed a confidently empty card.
             var hasContentLine = lines.Any(line =>
-                !string.IsNullOrWhiteSpace(line) && !ScpiResponseClassifier.IsErrorResponseLine(line));
+                !string.IsNullOrWhiteSpace(line)
+                && !ScpiResponseClassifier.IsErrorResponseLine(line)
+                && !SdCardFileListParser.IsListEndMarker(line, out _));
             if (hasContentLine)
             {
                 return;

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -799,6 +799,17 @@ namespace Daqifi.Core.Device.SdCard
                 }
             }
 
+            // The error from an exchange that actually SENT the delete, taken
+            // before the relist retry below can reassign `lines`. Without this
+            // capture the check further down reads whichever reply came last,
+            // and a transient error from a LIST-only retry -- a bus still
+            // settling, the -200 this file documents elsewhere -- was reported
+            // as "the delete operation failed" for a delete that had already
+            // succeeded and was never re-sent.
+            var deleteExchangeError = ScpiResponseClassifier.ContainsScpiError(lines)
+                ? lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim()
+                : null;
+
             // Prove the EXCHANGE finished before judging what it contained. A
             // reply cut short by the completion window loses the device's
             // marker too, so it would otherwise read as Unterminated -- which
@@ -852,15 +863,12 @@ namespace Daqifi.Core.Device.SdCard
             // here, where the error line IS the answer to "did the delete
             // happen?". Reproduced: a card holding fileA and fileB, a DELETE
             // refused twice, returned success with fileA still in the cache.
-            if (ScpiResponseClassifier.ContainsScpiError(lines))
+            if (deleteExchangeError != null)
             {
-                var deleteError = lines
-                    .LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
                 throw new SdCardOperationException(
-                    "The SD card delete operation failed: "
-                        + (deleteError ?? "the device reported an error"),
+                    "The SD card delete operation failed: " + deleteExchangeError,
                     lines,
-                    deleteError);
+                    deleteExchangeError);
             }
 
             if (!refreshComplete)

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -805,7 +805,43 @@ namespace Daqifi.Core.Device.SdCard
             // is legitimate on pre-#796 firmware and therefore cannot be
             // treated as an error on its own. The transport terminator is what
             // separates the two, and the read path has always required it.
-            if (!TrySplitAtSdListTerminator(lines, out var refreshListing))
+            var refreshComplete = TrySplitAtSdListTerminator(lines, out var refreshListing);
+
+            if (!refreshComplete && !ScpiResponseClassifier.ContainsScpiError(lines))
+            {
+                // An unterminated reply with no error is a one-off stall, and
+                // the read path gives that a second attempt for the same
+                // reason. Re-LIST only: the DELETE was accepted -- nothing
+                // reported otherwise -- so re-sending it would ask the device
+                // to remove a file that is already gone and turn a transient
+                // stall into a hard error. That is also why this is a separate
+                // loop from the error retry above, which re-sends both
+                // deliberately because there the delete itself may not have
+                // landed.
+                for (var retry = 0; retry < SD_LIST_MAX_RETRIES && !refreshComplete; retry++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+
+                    lines = await _host.ExecuteTextCommandAsync(
+                        () =>
+                        {
+                            _host.Send(ScpiMessageProducer.GetSdFileList);
+                            _host.Send(ScpiMessageProducer.GetSystemError);
+                        },
+                        responseTimeoutMs: 3000,
+                        completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
+                        cancellationToken: cancellationToken,
+                        prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                        finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
+
+                    refreshComplete = TrySplitAtSdListTerminator(lines, out refreshListing)
+                                      && !ScpiResponseClassifier.ContainsScpiError(refreshListing);
+                }
+            }
+
+            if (!refreshComplete)
             {
                 throw new SdCardListIncompleteException(lines);
             }

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -743,6 +743,15 @@ namespace Daqifi.Core.Device.SdCard
                 {
                     _host.Send(ScpiMessageProducer.DeleteSdFile(fileName));
                     _host.Send(ScpiMessageProducer.GetSdFileList);
+
+                    // Transport terminator, exactly as the read path sends it.
+                    // Without it a reply cut short by the completion window is
+                    // indistinguishable from a complete one that carried no
+                    // device marker -- and the second of those is legitimate
+                    // (pre-#796 firmware), so the status alone cannot tell them
+                    // apart. This is what makes "the exchange finished" a fact
+                    // rather than an assumption.
+                    _host.Send(ScpiMessageProducer.GetSystemError);
                 },
                 responseTimeoutMs: 3000,
                 // Same completion window the read path uses for the same
@@ -771,6 +780,7 @@ namespace Daqifi.Core.Device.SdCard
                         {
                             _host.Send(ScpiMessageProducer.DeleteSdFile(fileName));
                             _host.Send(ScpiMessageProducer.GetSdFileList);
+                            _host.Send(ScpiMessageProducer.GetSystemError);
                         },
                         responseTimeoutMs: 3000,
                         // The retry needs the window as much as the first
@@ -789,6 +799,17 @@ namespace Daqifi.Core.Device.SdCard
                 }
             }
 
+            // Prove the EXCHANGE finished before judging what it contained. A
+            // reply cut short by the completion window loses the device's
+            // marker too, so it would otherwise read as Unterminated -- which
+            // is legitimate on pre-#796 firmware and therefore cannot be
+            // treated as an error on its own. The transport terminator is what
+            // separates the two, and the read path has always required it.
+            if (!TrySplitAtSdListTerminator(lines, out var refreshListing))
+            {
+                throw new SdCardListIncompleteException(lines);
+            }
+
             // Same guard as the read path: a listing the device itself called
             // INCOMPLETE or FAILED must not become the cached answer to "what
             // is on the card?". This refresh follows a DELETE, so the cache it
@@ -796,14 +817,14 @@ namespace Daqifi.Core.Device.SdCard
             // whether the file is gone -- and a partial list makes every
             // absence look confirmed. The cache is left untouched rather than
             // replaced with a list we know is short.
-            var refreshStatus = SdCardFileListParser.GetListingStatus(lines);
+            var refreshStatus = SdCardFileListParser.GetListingStatus(refreshListing);
             if (refreshStatus == SdCardListingStatus.Failed
                 || refreshStatus == SdCardListingStatus.Incomplete)
             {
                 throw new SdCardListIncompleteException(lines);
             }
 
-            _sdCardFiles = SdCardFileListParser.ParseFileList(lines);
+            _sdCardFiles = SdCardFileListParser.ParseFileList(refreshListing);
         }
 
         /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -846,6 +846,16 @@ namespace Daqifi.Core.Device.SdCard
                 throw new SdCardListIncompleteException(lines);
             }
 
+            // And the error guard the read path has always applied to its own
+            // listing. Without it a delete that FAILED on the device twice --
+            // the retry above exhausts without throwing -- came back here with
+            // an "**ERROR: -200" line, a valid transport terminator and no
+            // device marker, so nothing fired: ParseFileList skips the error
+            // line, the cache became an EMPTY list, and the method returned
+            // success. The caller was told the delete worked and the card is
+            // empty, in the one case where the device had said neither.
+            ThrowIfSdCardListError(refreshListing);
+
             // Same guard as the read path: a listing the device itself called
             // INCOMPLETE or FAILED must not become the cached answer to "what
             // is on the card?". This refresh follows a DELETE, so the cache it

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -880,8 +880,20 @@ namespace Daqifi.Core.Device.SdCard
                 // whatever the error line was about. Verifying the outcome
                 // beats attributing the error, which the wire format does not
                 // let us do.
+                // Absence only proves anything if the listing is WHOLE.
+                // refreshComplete says the transport delivered a terminated
+                // reply; it says nothing about whether the device's walk
+                // reached the end of the tree. A listing the device called
+                // INCOMPLETE, or an Unterminated one, can be missing the
+                // target because it stopped early -- reading that as "deleted"
+                // is the same wrong answer pointed the other way. Only the
+                // device's own Complete marker rules it out, so against
+                // firmware that sends no marker the error stands, exactly as
+                // it did before this check existed.
                 var target = System.IO.Path.GetFileName(fileName);
                 var goneFromCard = refreshComplete
+                    && SdCardFileListParser.GetListingStatus(refreshListing)
+                        == SdCardListingStatus.Complete
                     && !SdCardFileListParser.ParseFileList(refreshListing).Any(
                         f => string.Equals(f.FileName, target,
                                            StringComparison.OrdinalIgnoreCase));

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -841,11 +841,6 @@ namespace Daqifi.Core.Device.SdCard
                 }
             }
 
-            if (!refreshComplete)
-            {
-                throw new SdCardListIncompleteException(lines);
-            }
-
             // The DELETE's own outcome, judged before anything about the
             // listing. The retry loop above exits either way, so a delete the
             // device refused on BOTH attempts arrives here with its error line
@@ -867,6 +862,12 @@ namespace Daqifi.Core.Device.SdCard
                     lines,
                     deleteError);
             }
+
+            if (!refreshComplete)
+            {
+                throw new SdCardListIncompleteException(lines);
+            }
+
 
             // And the error guard the read path has always applied to its own
             // listing. Without it a delete that FAILED on the device twice --

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -278,6 +278,18 @@ namespace Daqifi.Core.Device.SdCard
 
             ThrowIfSdCardListError(listing);
 
+            // The device's own end-of-listing marker (firmware #794), when it sends
+            // one. FAILED means the walk could not open the directory at all, so an
+            // empty result would report "there is nothing there" for what was really
+            // "I could not look" -- the exact confusion the terminator above exists
+            // to prevent, one level deeper. Unterminated is the pre-#794 firmware and
+            // is not an error: the reply framing already told us the exchange
+            // completed, we simply learn nothing more from the device.
+            if (SdCardFileListParser.GetListingStatus(listing) == SdCardListingStatus.Failed)
+            {
+                throw new SdCardListIncompleteException(lines);
+            }
+
             var files = SdCardFileListParser.ParseFileList(listing);
             _sdCardFiles = files;
             return files;

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -775,6 +775,20 @@ namespace Daqifi.Core.Device.SdCard
                 }
             }
 
+            // Same guard as the read path: a listing the device itself called
+            // INCOMPLETE or FAILED must not become the cached answer to "what
+            // is on the card?". This refresh follows a DELETE, so the cache it
+            // overwrites is exactly what a caller consults next to decide
+            // whether the file is gone -- and a partial list makes every
+            // absence look confirmed. The cache is left untouched rather than
+            // replaced with a list we know is short.
+            var refreshStatus = SdCardFileListParser.GetListingStatus(lines);
+            if (refreshStatus == SdCardListingStatus.Failed
+                || refreshStatus == SdCardListingStatus.Incomplete)
+            {
+                throw new SdCardListIncompleteException(lines);
+            }
+
             _sdCardFiles = SdCardFileListParser.ParseFileList(lines);
         }
 


### PR DESCRIPTION
Client half of firmware [PR #796 — tell the host where a directory listing ended](https://github.com/daqifi/daqifi-nyquist-firmware/pull/796) (firmware issue [#794](https://github.com/daqifi/daqifi-nyquist-firmware/issues/794)). **The firmware PR does not merge until this one does** — see "Why this must land first".

## What the firmware adds

`SYSTem:STORage:SD:LISt?` now ends with one marker line:

| marker | meaning |
|---|---|
| `__END_OF_LIST__ OK` | walked the whole tree, every entry emitted |
| `__END_OF_LIST__ INCOMPLETE` | finished, but entries were skipped (depth cap, unreadable subdirectory, a path that did not fit) |
| `__END_OF_LIST__ FAILED` | nothing could be listed at all |

An **aborted** listing sends no marker at all, deliberately: the abort happens because the peer stopped draining, and each further chunk costs ~10 s of transfer retries.

## Why this must land first

`SdCardFileListParser.ParseFileList` takes the **first token** of every non-blank, non-error line and turns it into a file:

```csharp
var tokenEnd = path.IndexOfAny(new[] { ' ', '\t' });
if (tokenEnd > 0) { path = path.Substring(0, tokenEnd); }
var fileName = Path.GetFileName(path);
if (string.IsNullOrWhiteSpace(fileName)) { continue; }
files.Add(new SdCardFileInfo(fileName, createdDate));
```

`__END_OF_LIST__ OK` is not blank and is not error-shaped, so without this change the desktop app would list a **phantom file called `__END_OF_LIST__`** that the user can neither open nor delete.

## What this does

1. **Skips the marker** in `ParseFileList` — required for the above.
2. **Uses it.** New public `SdCardListingStatus` + `SdCardFileListParser.GetListingStatus(lines)`. It reads the **last** marker in the reply: one leading the response is a stale marker from a timed-out exchange, the same reasoning `TrySplitAtSdListTerminator` already applies a few lines away.
3. `GetSdCardFilesAsync` treats **FAILED** as an incomplete listing (`SdCardListIncompleteException`) instead of returning an empty list. An empty list from a walk that could not open the directory reports *"there is nothing there"* for what was really *"I could not look"* — the confusion this mechanism exists to end.

`Unterminated` is **not** an error: firmware predating #796 sends no marker, and neither does an aborted listing. Callers simply learn nothing more from the device, which is where we already are today. An **unknown** status word counts as `Incomplete`, not `Complete` — a future firmware saying something this version does not understand has still told us not to trust the list as whole.

## Note on what was already here

`TrySplitAtSdListTerminator` already gives this client a completeness signal by chasing the listing with `SYST:ERR?` and requiring its reply to arrive after the entries. That is a genuine and clever guard, and it is why "the host cannot tell" was too strong a claim in the firmware issue. What it cannot do is distinguish a walk that **skipped** part of the card from one that saw all of it, or an unopenable directory from an empty one — the device is the only thing that knows that, and now it says so.

## Test plan

- 6 new unit tests: marker not parsed as a file; each status word; no marker → `Unterminated`; unknown word → `Incomplete`; a stale leading marker loses to the trailing one.
- `dotnet test`: **43 passed, 0 failed** on net9.0 and net10.0.
- **Mutation-proved**: disabling the skip line fails exactly one test (43 → 42 passed on both frameworks), so the marker test cannot pass vacuously.
- Hardware: covered by the firmware PR's bench run and by `test_794_sd_list_terminator.py` in daqifi-python-test-suite ([#151](https://github.com/daqifi/daqifi-python-test-suite/pull/151)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)