### PR TITLE
feat(sd): tell "that directory is not there" apart from a broken filesystem

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -1047,6 +1047,77 @@ namespace Daqifi.Core.Tests.Device.SdCard
             Assert.NotEmpty(ex.RawDeviceResponse);
         }
 
+        [Theory]
+        [InlineData(4)]   // SYS_FS_ERROR_NO_FILE
+        [InlineData(5)]   // SYS_FS_ERROR_NO_PATH
+        public async Task GetSdCardFilesAsync_WhenTheDirectoryIsNotOnTheCard_ThrowsDirectoryNotFound(int fsError)
+        {
+            // Firmware #798: a listing no longer creates the directory it was asked to
+            // read, so "that directory is not there" became observable. It is a normal
+            // state -- a freshly formatted card has no log directory until the first
+            // capture writes one -- and a caller that renders it like a corrupt
+            // filesystem shows a scary message for "you have not logged anything yet".
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var response = new List<string>
+            {
+                $"[Error:{fsError}]Failed to open directory [DAQiFi]",
+                "__END_OF_LIST__ FAILED",
+            };
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<SdCardDirectoryNotFoundException>(
+                () => device.GetSdCardFilesAsync());
+
+            Assert.Equal("DAQiFi", ex.DirectoryPath);
+            // Still an SdCardFilesystemException, so every existing catch site and the
+            // desktop classifier keep working unchanged.
+            Assert.IsAssignableFrom<SdCardFilesystemException>(ex);
+        }
+
+        [Theory]
+        [InlineData(1)]   // SYS_FS_ERROR_DISK_ERR
+        [InlineData(3)]   // SYS_FS_ERROR_NOT_READY
+        [InlineData(13)]  // SYS_FS_ERROR_NO_FILESYSTEM territory -- anything unfamiliar
+        public async Task GetSdCardFilesAsync_WhenTheDirectoryFailsForAnotherReason_StaysAFilesystemError(int fsError)
+        {
+            // The other side of the same predicate. A disk error, an unready card or a
+            // code this client has never seen must NOT be narrowed to "not found" --
+            // that would tell a user with a dying card that they simply have no files.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var response = new List<string>
+            {
+                $"[Error:{fsError}]Failed to open directory [DAQiFi]",
+            };
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<SdCardFilesystemException>(
+                () => device.GetSdCardFilesAsync());
+
+            Assert.IsNotType<SdCardDirectoryNotFoundException>(ex);
+        }
+
+        [Fact]
+        public async Task GetSdCardFilesAsync_WhenTheNotFoundLineHasNoBracketedPath_StillThrowsWithANullPath()
+        {
+            // The pre-#798 firmware phrasing has no bracketed path. The code still
+            // classifies, and DirectoryPath is honestly null rather than a fragment of
+            // the message.
+            var device = new RetryableSdCardStreamingDevice("TestDevice");
+            var response = new List<string> { "[Error:5]Failed to open directory /Daqifi" };
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.ResponseSequence.Enqueue(new List<string>(response));
+            device.Connect();
+
+            var ex = await Assert.ThrowsAsync<SdCardDirectoryNotFoundException>(
+                () => device.GetSdCardFilesAsync());
+
+            Assert.Null(ex.DirectoryPath);
+        }
+
         [Fact]
         public async Task GetSdCardFilesAsync_WithFilesystemError_ThrowsSdCardFilesystemException()
         {

--- a/src/Daqifi.Core/Device/SdCard/SdCardDirectoryNotFoundException.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardDirectoryNotFoundException.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// Thrown when the device could not open the requested SD directory because it
+    /// is not on the card — as opposed to a corrupt filesystem or an I/O fault,
+    /// which surface as the plain <see cref="SdCardFilesystemException"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is a normal state, not a fault. A freshly formatted card has no log
+    /// directory until the first capture writes one, so a client that renders every
+    /// filesystem error the same way shows the user a scary message for "you have
+    /// not logged anything yet". Callers that want that distinction catch this
+    /// type; callers that do not still catch
+    /// <see cref="SdCardFilesystemException"/> and behave exactly as before.
+    /// </para>
+    /// <para>
+    /// Detected from the numeric code in the firmware's
+    /// <c>"[Error:N]Failed to open directory [path]"</c> line. <c>N</c> is a
+    /// Harmony <c>SYS_FS_ERROR</c>, whose "the path is not there" members are
+    /// <c>SYS_FS_ERROR_NO_FILE = 4</c> and <c>SYS_FS_ERROR_NO_PATH = 5</c>
+    /// (sequential from <c>SYS_FS_ERROR_OK = 0</c>; see the firmware's
+    /// <c>config/default/system/fs/sys_fs.h</c>). Coupling to an enum's ordinals is
+    /// not lovely, but the alternative is guessing from prose, and the failure mode
+    /// if Harmony ever renumbers is a slightly less specific exception type rather
+    /// than a wrong answer: an unrecognised code still throws
+    /// <see cref="SdCardFilesystemException"/>.
+    /// </para>
+    /// <para>
+    /// Reachable only on firmware carrying daqifi-nyquist-firmware#798. Before it,
+    /// listing a directory that did not exist <em>created</em> it and reported it
+    /// empty, so this condition could not be observed at all.
+    /// </para>
+    /// </remarks>
+    public class SdCardDirectoryNotFoundException : SdCardFilesystemException
+    {
+        /// <summary>
+        /// The directory the device could not find, as it appeared in the device's
+        /// message, or <c>null</c> when the message carried no bracketed path.
+        /// </summary>
+        public string? DirectoryPath { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="SdCardDirectoryNotFoundException"/> class.
+        /// </summary>
+        public SdCardDirectoryNotFoundException(
+            IReadOnlyList<string> rawDeviceResponse,
+            string? lastScpiError,
+            string deviceMessage,
+            string? directoryPath)
+            : base(rawDeviceResponse, lastScpiError, deviceMessage)
+        {
+            DirectoryPath = directoryPath;
+        }
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -1455,6 +1455,69 @@ namespace Daqifi.Core.Device.SdCard
 
 
         /// <summary>
+        /// Harmony <c>SYS_FS_ERROR</c> codes meaning "that path is not on the card":
+        /// <c>SYS_FS_ERROR_NO_FILE = 4</c> and <c>SYS_FS_ERROR_NO_PATH = 5</c>. The
+        /// enum runs sequentially from <c>SYS_FS_ERROR_OK = 0</c> — see the
+        /// firmware's <c>config/default/system/fs/sys_fs.h</c>.
+        /// </summary>
+        private static readonly int[] DirectoryNotFoundFsErrors = { 4, 5 };
+
+        /// <summary>
+        /// Reads the <c>N</c> out of a <c>"[Error:N]Failed to open directory [path]"</c>
+        /// line and reports whether it is a not-found code. An unparsable or
+        /// unrecognised code answers false, so anything unfamiliar keeps the broader
+        /// <see cref="SdCardFilesystemException"/> rather than being narrowed on a guess.
+        /// </summary>
+        private static bool IsDirectoryNotFound(string deviceMessage)
+        {
+            var match = System.Text.RegularExpressions.Regex.Match(
+                deviceMessage, @"^\[Error:(\d+)\]");
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            return int.TryParse(match.Groups[1].Value, out var code)
+                && System.Array.IndexOf(DirectoryNotFoundFsErrors, code) >= 0;
+        }
+
+        /// <summary>
+        /// Pulls the path out of the trailing <c>[path]</c> of a firmware directory
+        /// error line, or null when there is none.
+        /// </summary>
+        /// <remarks>
+        /// Searches only AFTER the leading <c>[Error:N]</c>. Taking the last bracket
+        /// pair in the whole line looks equivalent and is not: on the older phrasing
+        /// <c>"[Error:5]Failed to open directory /Daqifi"</c>, which has no bracketed
+        /// path at all, the last pair IS the error prefix and the path comes back as
+        /// <c>"Error:5"</c>. Caught by the test that pins that phrasing.
+        /// </remarks>
+        private static string? ExtractBracketedPath(string deviceMessage)
+        {
+            var prefixEnd = deviceMessage.IndexOf(']');
+            var searchFrom = prefixEnd >= 0 ? prefixEnd + 1 : 0;
+            if (searchFrom >= deviceMessage.Length)
+            {
+                return null;
+            }
+
+            var close = deviceMessage.LastIndexOf(']');
+            if (close < searchFrom)
+            {
+                return null;
+            }
+
+            var open = deviceMessage.LastIndexOf('[', close - 1);
+            if (open < searchFrom)
+            {
+                return null;
+            }
+
+            var path = deviceMessage.Substring(open + 1, close - open - 1).Trim();
+            return path.Length == 0 ? null : path;
+        }
+
+        /// <summary>
         /// Inspects the final response from a <c>SYSTem:STORage:SD:LISt?</c> exchange
         /// and throws a typed <see cref="SdCardOperationException"/> when the device
         /// reported a real failure (no SD card, filesystem error, generic SCPI error).
@@ -1482,7 +1545,22 @@ namespace Daqifi.Core.Device.SdCard
                 l.IndexOf("Failed to open directory", StringComparison.OrdinalIgnoreCase) >= 0);
             if (filesystemErrorLine != null)
             {
-                throw new SdCardFilesystemException(lines, lastScpiError, filesystemErrorLine.Trim());
+                var trimmed = filesystemErrorLine.Trim();
+
+                // "The directory is not there" is a normal state, not a fault, and
+                // it is worth telling apart: a freshly formatted card has no log
+                // directory until the first capture writes one, so a caller that
+                // renders every filesystem error identically shows a scary message
+                // for "you have not logged anything yet". Firmware #798 is what
+                // makes this observable at all -- before it, listing a directory
+                // that did not exist created it and reported it empty.
+                if (IsDirectoryNotFound(trimmed))
+                {
+                    throw new SdCardDirectoryNotFoundException(
+                        lines, lastScpiError, trimmed, ExtractBracketedPath(trimmed));
+                }
+
+                throw new SdCardFilesystemException(lines, lastScpiError, trimmed);
             }
 
             // If any line looks like a real result (non-empty, not an error or


### PR DESCRIPTION
Client half of [daqifi-nyquist-firmware#798](https://github.com/daqifi/daqifi-nyquist-firmware/pull/798) (issue [#797](https://github.com/daqifi/daqifi-nyquist-firmware/issues/797)). **This should merge before that firmware ships**, for the same reason [#550](https://github.com/daqifi/daqifi-core/pull/550) had to precede #796: firmware truth that arrives before the client understands it is a regression for users.

## What changes on the wire

Firmware #798 stops a read-only `SYST:STOR:SD:LISt?` from **creating** the directory it was asked to read. That makes "that directory is not on the card" observable for the first time — before it, the listing made the directory and truthfully reported it empty.

It arrives as the same line every filesystem fault uses:

```
[Error:5]Failed to open directory [DAQiFi]
__END_OF_LIST__ FAILED
```

And it is **not** a fault. A freshly formatted card has no log directory until the first capture writes one.

## Why this is not hypothetical

`daqifi-desktop` maps `SdCardFilesystemException` to `SdCardState.Error` with the raw device line as the user-facing message — `SdCardFailureClassifier.cs:189`, pinned by `DeviceLogsViewModelTests.RefreshFiles_SdCardFilesystemException_SetsSdCardStateError`:

```csharp
SdCardFilesystemException filesystem => new SdCardFailure(
    State: SdCardState.Error,
    StatusMessage: filesystem.DeviceMessage ?? filesystem.Message,
    Guidance: GENERIC_CARD_GUIDANCE,
    ...
```

So without this change, a user who formats a card and opens the SD panel sees **`[Error:5]Failed to open directory [DAQiFi]`** plus generic card-trouble guidance, where they previously saw an empty list. I checked that rather than assuming it.

## The change

`SdCardDirectoryNotFoundException`, thrown when the device says it could not open the directory *and the reason is that the path is not there*.

It **derives from `SdCardFilesystemException`**, so every existing catch site — including the desktop classifier above — keeps working exactly as today. Callers that want the distinction ask for it; nobody is forced to care. The desktop app can then render it as "no files yet" in its own PR, which is a UX decision that belongs there rather than here.

**Detection** is the numeric `SYS_FS_ERROR` already in the line: `NO_FILE = 4`, `NO_PATH = 5`, sequential from `SYS_FS_ERROR_OK = 0` in the firmware's `config/default/system/fs/sys_fs.h`. Coupling to an enum's ordinals is not lovely — the alternative was guessing from prose, or a firmware wire change that would itself have needed a client change to land first — and the failure mode is bounded: an unrecognised code still throws the broader `SdCardFilesystemException`, so a future renumber costs specificity, not correctness.

Every other code stays a filesystem error, including ones this client has never seen. Telling a user with a dying card that they simply have no files is the worse direction, so the narrowing is opt-in by code rather than by default.

## Test plan

- **New tests**, all in `SdCardOperationsTests`:
  - `[Theory]` over codes 4 and 5 — throws `SdCardDirectoryNotFoundException`, `DirectoryPath == "DAQiFi"`, and asserts it is still assignable to `SdCardFilesystemException` so the compatibility claim is pinned rather than asserted in prose.
  - `[Theory]` over 1, 3 and 13 — stays a plain `SdCardFilesystemException`, explicitly `IsNotType<SdCardDirectoryNotFoundException>`.
  - The older phrasing with no bracketed path — still classifies, and `DirectoryPath` is honestly `null`.
- **523 SD tests pass** on net10.0.
- **Mutation-proved**: 523 → 520 with the classification disabled, and the three failures are exactly the new not-found cases.
- **One of these tests earned its keep while being written**: the no-bracketed-path case failed on the first run because `ExtractBracketedPath` took the *last* bracket pair in the line, which on `[Error:5]Failed to open directory /Daqifi` is the error prefix — it returned `"Error:5"` as the directory. It now searches only after the prefix, and the comment says why the obvious reading is wrong.

No hardware needed for this half. The firmware side is blocked on a bench SD card (daqifi-python-test-suite#158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
