### PR TITLE
fix(diagnostics): tell an empty system log apart from a device that never answered

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Capabilities/DaqifiDeviceCapabilityDocumentTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Capabilities/DaqifiDeviceCapabilityDocumentTests.cs
@@ -306,7 +306,8 @@ public class DaqifiDeviceCapabilityDocumentTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null)
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false)
         {
             try
             {

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceDrainErrorQueueTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceDrainErrorQueueTests.cs
@@ -209,7 +209,8 @@ namespace Daqifi.Core.Tests.Device
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -539,7 +539,8 @@ namespace Daqifi.Core.Tests.Device
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {
@@ -654,7 +655,8 @@ namespace Daqifi.Core.Tests.Device
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {
@@ -763,7 +765,8 @@ namespace Daqifi.Core.Tests.Device
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {
@@ -852,7 +855,8 @@ namespace Daqifi.Core.Tests.Device
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -365,7 +365,8 @@ public class DaqifiDeviceStaleTextLineTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null)
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false)
         {
             try
             {

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAnalogOutputTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceAnalogOutputTests.cs
@@ -565,7 +565,8 @@ namespace Daqifi.Core.Tests.Device
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 setupAction();

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
@@ -70,22 +70,6 @@ public class DeviceDiagnosticsTests
     }
 
     [Fact]
-    public async Task GetSystemLogAsync_WhenBufferHasEntries_IgnoresTheTerminator()
-    {
-        // A populated dump is its entries FOLLOWED BY the same blank terminator, so the
-        // terminator must not leak into the parsed entries as a phantom log line.
-        var device = new TestableDiagnosticsDevice("TestDevice")
-        {
-            CannedTextResponse = { "Test log message 1", "" }
-        };
-        device.Connect();
-
-        var entries = await device.GetSystemLogAsync();
-        Assert.Single(entries);
-        Assert.Equal("Test log message 1", entries[0].Message);
-    }
-
-    [Fact]
     public async Task GetSystemLogAsync_WhenErrorOnlyResponse_Throws()
     {
         // An error-only response must not masquerade as an empty log.

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
@@ -39,11 +39,50 @@ public class DeviceDiagnosticsTests
     [Fact]
     public async Task GetSystemLogAsync_WhenBufferEmpty_ReturnsEmpty()
     {
-        // No lines = genuinely empty buffer (firmware writes nothing); must not throw.
-        var device = new TestableDiagnosticsDevice("TestDevice");
+        // An empty log is a BLANK LINE, not silence. The firmware terminates every
+        // SYSTem:LOG? dump with one whether or not it had anything to say -- measured
+        // on a bench Nq1 running 3.7.2 with a raw pyserial probe: an empty log answers
+        // b'\r\n' in 6 ms (issue #543).
+        //
+        // This test previously canned NOTHING and asserted no-throw, with the comment
+        // "firmware writes nothing". That premise was wrong, and it is what made an
+        // empty log indistinguishable from a dead link: both arrived as zero lines and
+        // both were reported as "your log is empty".
+        var device = new TestableDiagnosticsDevice("TestDevice") { CannedTextResponse = { "" } };
         device.Connect();
 
         Assert.Empty(await device.GetSystemLogAsync());
+    }
+
+    [Fact]
+    public async Task GetSystemLogAsync_WhenDeviceAnswersNothingAtAll_Throws()
+    {
+        // Zero lines -- not even the terminator -- is a silent or unresponsive device.
+        // Returning an empty list here is the failure #543 exists to remove: it reports
+        // a dead link as a clean bill of health, on the one call an operator reaches for
+        // when they suspect the device is unwell.
+        var device = new TestableDiagnosticsDevice("TestDevice");
+        device.Connect();
+
+        var ex = await Assert.ThrowsAsync<DeviceDiagnosticsException>(
+            () => device.GetSystemLogAsync());
+        Assert.Contains("did not answer", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetSystemLogAsync_WhenBufferHasEntries_IgnoresTheTerminator()
+    {
+        // A populated dump is its entries FOLLOWED BY the same blank terminator, so the
+        // terminator must not leak into the parsed entries as a phantom log line.
+        var device = new TestableDiagnosticsDevice("TestDevice")
+        {
+            CannedTextResponse = { "Test log message 1", "" }
+        };
+        device.Connect();
+
+        var entries = await device.GetSystemLogAsync();
+        Assert.Single(entries);
+        Assert.Equal("Test log message 1", entries[0].Message);
     }
 
     [Fact]
@@ -471,7 +510,8 @@ public class DeviceDiagnosticsTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null)
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false)
         {
             try
             {

--- a/src/Daqifi.Core.Tests/Device/GetLanChipInfoAsyncTests.cs
+++ b/src/Daqifi.Core.Tests/Device/GetLanChipInfoAsyncTests.cs
@@ -96,7 +96,8 @@ public class GetLanChipInfoAsyncTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null)
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false)
         {
             try
             {

--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -151,7 +151,8 @@ public class ConnectionGuardTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null) => throw new NotSupportedException();
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false) => throw new NotSupportedException();
         public Task<IReadOnlyList<string>> DrainErrorQueueAsync(
             int maxIterations = 256,
             CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -619,7 +619,8 @@ public class DeviceAdministrationOperationsTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null)
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false)
         {
             Assert.Null(prepareAsync);
             Assert.Null(finalizeAsync);

--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -506,7 +506,8 @@ public class LiveSampleStreamTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null) => throw new NotSupportedException();
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false) => throw new NotSupportedException();
         public Task<IReadOnlyList<string>> DrainErrorQueueAsync(
             int maxIterations = 256,
             CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -906,7 +906,8 @@ public class StreamFrameDecoderTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null) => throw new NotSupportedException();
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false) => throw new NotSupportedException();
         public Task<IReadOnlyList<string>> DrainErrorQueueAsync(
             int maxIterations = 256,
             CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
@@ -1187,7 +1187,8 @@ public class SdCardOperationsCollaboratorTests
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null)
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false)
         {
             var index = ++ExchangeCount;
             ResponseTimeouts.Add(responseTimeoutMs);

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -2938,7 +2938,8 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {
@@ -3079,7 +3080,8 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {
@@ -3145,7 +3147,8 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 if (finalizeAsync != null)
                 {
@@ -3199,7 +3202,8 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {
@@ -3375,7 +3379,8 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {
@@ -3677,7 +3682,8 @@ namespace Daqifi.Core.Tests.Device.SdCard
                 int completionTimeoutMs = 250,
                 CancellationToken cancellationToken = default,
                 Func<CancellationToken, Task>? prepareAsync = null,
-                Func<Task>? finalizeAsync = null)
+                Func<Task>? finalizeAsync = null,
+                bool keepBlankLines = false)
             {
                 try
                 {

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1256,7 +1256,7 @@ namespace Daqifi.Core.Device
         /// <remarks>
         /// Waits up to 10 seconds to acquire the device operation lock before
         /// tearing down the consumer / producer / transport. This prevents
-        /// a race where an in-flight <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
+        /// a race where an in-flight <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task}, bool)"/>
         /// is mid-swap (text consumer running on the stream, protobuf
         /// consumer not yet restarted) and Disconnect rips the transport
         /// out from under it. If the wait times out, Disconnect proceeds
@@ -1777,6 +1777,13 @@ namespace Daqifi.Core.Device
         /// <exception cref="InvalidOperationException">Thrown when the device has no transport-based connection.</exception>
         /// <exception cref="TransportNotConnectedException">Thrown when the underlying transport has dropped.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        /// <param name="keepBlankLines">
+        /// When <c>true</c>, blank lines are returned instead of filtered out. Only the system-log
+        /// read wants this: <c>SYSTem:LOG?</c> terminates its dump with a blank line
+        /// unconditionally, so seeing it is what separates "the device answered and its log is
+        /// empty" from "the device never answered" (issue #543). Every other caller parses content
+        /// and has never seen a blank line, so the default is <c>false</c>.
+        /// </param>
         // prepareAsync and finalizeAsync are added AFTER cancellationToken (technically violating
         // CA1068 "CancellationToken should be last") to keep existing positional callers working,
         // matching the convention established in IFirmwareUpdateService for the same reason. They
@@ -1792,7 +1799,8 @@ namespace Daqifi.Core.Device
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null)
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false)
         {
             return ExecuteTextCommandCoreAsync(
                 prepareAsync,
@@ -1800,12 +1808,13 @@ namespace Daqifi.Core.Device
                 _ => { setupAction(); return Task.CompletedTask; },
                 responseTimeoutMs,
                 completionTimeoutMs,
-                cancellationToken);
+                cancellationToken,
+                keepBlankLines);
         }
 #pragma warning restore CA1068
 
         /// <summary>
-        /// Async overload of <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
+        /// Async overload of <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task}, bool)"/>
         /// that accepts an async setup action so callers can <c>await</c> cancellable operations
         /// (e.g. <see cref="Task.Delay(int, CancellationToken)"/>) between SCPI commands without
         /// blocking the thread-pool thread.
@@ -1844,7 +1853,8 @@ namespace Daqifi.Core.Device
             Func<CancellationToken, Task> setupActionAsync,
             int responseTimeoutMs,
             int completionTimeoutMs,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            bool keepBlankLines = false)
         {
             return _textExchange.ExecuteAsync(
                 prepareAsync,
@@ -1852,7 +1862,8 @@ namespace Daqifi.Core.Device
                 setupActionAsync,
                 responseTimeoutMs,
                 completionTimeoutMs,
-                cancellationToken);
+                cancellationToken,
+                keepBlankLines);
         }
 
         /// <summary>
@@ -1966,7 +1977,7 @@ namespace Daqifi.Core.Device
         /// on hardware faults, or discard them if known-stale.
         /// </para>
         /// <para>
-        /// Each iteration uses <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>, which
+        /// Each iteration uses <see cref="ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task}, bool)"/>, which
         /// pauses the protobuf consumer for the duration of the text exchange.
         /// Avoid calling this during active streaming or concurrently with
         /// other text commands.

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1312,9 +1312,11 @@ namespace Daqifi.Core.Device
             int completionTimeoutMs,
             CancellationToken cancellationToken,
             Func<CancellationToken, Task>? prepareAsync,
-            Func<Task>? finalizeAsync)
+            Func<Task>? finalizeAsync,
+            bool keepBlankLines)
             => ExecuteTextCommandAsync(
-                setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken, prepareAsync, finalizeAsync);
+                setupAction, responseTimeoutMs, completionTimeoutMs, cancellationToken, prepareAsync,
+                finalizeAsync, keepBlankLines);
 #pragma warning restore CA1068
 
         Task<IReadOnlyList<string>> IDeviceOperationHost.DrainErrorQueueAsync(

--- a/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -50,10 +51,34 @@ namespace Daqifi.Core.Device.Diagnostics
         {
             _host.EnsureConnected(cancellationToken);
 
-            var lines = await _host.ExecuteTextCommandAsync(
+            // keepBlankLines is what makes "the log is empty" distinguishable from
+            // "the device never answered" (issue #543). Both used to arrive here as an
+            // empty list, so a silent link, a wedged text exchange, or an unsupported
+            // header all reported as "your log is empty" -- the least useful answer a
+            // DIAGNOSTICS call can give, because it is indistinguishable from health.
+            //
+            // The firmware ends every SYSTem:LOG? dump with a blank line, empty or not
+            // (measured on a bench Nq1 running 3.7.2 with a raw pyserial probe, three
+            // trials of three: an empty log answers b'\r\n' in 6 ms; a populated one
+            // answers its entries followed by the same trailing b'\r\n'). So ANY line
+            // reaching us -- blank or not -- means the device answered.
+            var raw = await _host.ExecuteTextCommandAsync(
                 () => _host.Send(ScpiMessageProducer.GetSystemLog),
                 responseTimeoutMs: DIAGNOSTICS_RESPONSE_TIMEOUT_MS,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                cancellationToken: cancellationToken,
+                keepBlankLines: true).ConfigureAwait(false);
+
+            if (raw.Count == 0)
+            {
+                throw new DeviceDiagnosticsException(
+                    "The device did not answer SYSTem:LOG? - not even the blank line that "
+                    + "terminates every log dump. This is a silent or unresponsive device, "
+                    + "not an empty log.",
+                    raw);
+            }
+
+            // Everything downstream expects content lines, exactly as before.
+            var lines = raw.Where(line => line.Length > 0).ToList();
 
             var entries = SystemLogParser.Parse(lines);
 

--- a/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
@@ -77,7 +77,13 @@ namespace Daqifi.Core.Device.Diagnostics
                     raw);
             }
 
-            // Everything downstream expects content lines, exactly as before.
+            // Belt and braces, not load-bearing: SystemLogParser.Parse and
+            // ScpiResponseClassifier.IsErrorOnlyResponse both skip blank lines already
+            // (the latter explicitly, via IsNullOrWhiteSpace), so keeping the terminator
+            // would change neither. Mutation-tested: removing this line breaks nothing.
+            // It stays so the contract of this seam -- everything downstream sees the
+            // same content lines it saw before keepBlankLines existed -- holds by
+            // construction rather than by depending on two other components' internals.
             var lines = raw.Where(line => line.Length > 0).ToList();
 
             var entries = SystemLogParser.Parse(lines);

--- a/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
+++ b/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
@@ -86,7 +86,7 @@ namespace Daqifi.Core.Device.Internal
         /// </summary>
         void WithChannelsLock(Action action);
 
-        /// <inheritdoc cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
+        /// <inheritdoc cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task}, bool)"/>
 #pragma warning disable CA1068 // Matches the seam it forwards to, which orders these for source compatibility.
         Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
             Action setupAction,
@@ -94,7 +94,8 @@ namespace Daqifi.Core.Device.Internal
             int completionTimeoutMs = 250,
             CancellationToken cancellationToken = default,
             Func<CancellationToken, Task>? prepareAsync = null,
-            Func<Task>? finalizeAsync = null);
+            Func<Task>? finalizeAsync = null,
+            bool keepBlankLines = false);
 #pragma warning restore CA1068
 
         /// <inheritdoc cref="DaqifiDevice.DrainErrorQueueAsync"/>

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -203,7 +203,7 @@ namespace Daqifi.Core.Device.Internal
         /// </summary>
         /// <remarks>
         /// The parameter contract — including what the prepare and finalize phases guarantee — is
-        /// documented on <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>,
+        /// documented on <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task}, bool)"/>,
         /// the seam callers actually use.
         /// </remarks>
         internal async Task<IReadOnlyList<string>> ExecuteAsync(
@@ -212,7 +212,8 @@ namespace Daqifi.Core.Device.Internal
             Func<CancellationToken, Task> setupActionAsync,
             int responseTimeoutMs,
             int completionTimeoutMs,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            bool keepBlankLines = false)
         {
             if (responseTimeoutMs <= 0)
                 throw new ArgumentOutOfRangeException(nameof(responseTimeoutMs), responseTimeoutMs, "Timeout must be positive.");
@@ -546,9 +547,17 @@ namespace Daqifi.Core.Device.Internal
                 List<string> result;
                 lock (collectedLinesGate)
                 {
-                    result = collectedLines
-                        .Skip(staleLineCount)
-                        .Where(line => line.Length > 0)
+                    var afterStale = collectedLines.Skip(staleLineCount);
+                    // keepBlankLines is how a caller asks to see the firmware's
+                    // end-of-dump blank line. SYSTem:LOG? terminates its dump with
+                    // one unconditionally, so its presence is the difference between
+                    // "the device answered and its log is empty" and "the device did
+                    // not answer at all" -- two states that are otherwise identical
+                    // from here (issue #543). Default stays false: every other caller
+                    // parses content and has never seen a blank line (#538).
+                    result = (keepBlankLines
+                                ? afterStale
+                                : afterStale.Where(line => line.Length > 0))
                         .ToList();
                 }
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -309,7 +309,7 @@ namespace Daqifi.Core.Device.SdCard
         /// </summary>
         /// <remarks>
         /// Passed as the <c>prepareAsync</c> phase of
-        /// <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
+        /// <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task}, bool)"/>
         /// rather than run
         /// inline, so it executes inside the text-exchange lock — a competing exchange restoring the
         /// LAN interface between the switch and the commands that depend on it would leave them
@@ -331,7 +331,7 @@ namespace Daqifi.Core.Device.SdCard
         /// </summary>
         /// <remarks>
         /// Passed as the <c>finalizeAsync</c> phase of
-        /// <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task})"/>
+        /// <see cref="DaqifiDevice.ExecuteTextCommandAsync(Action, int, int, CancellationToken, Func{CancellationToken, Task}, Func{Task}, bool)"/>
         /// rather than run from the caller's own <c>finally</c>, so it holds the same lock
         /// acquisition the matching prepare phase does. Restoring from outside the lock leaves a
         /// window in which a competing exchange runs between this operation's commands and its

--- a/src/Daqifi.Mcp.Tests/DeviceDouble.cs
+++ b/src/Daqifi.Mcp.Tests/DeviceDouble.cs
@@ -146,7 +146,8 @@ internal sealed class FakeStreamingDevice : DaqifiStreamingDevice, ISdCardOperat
         int completionTimeoutMs = 250,
         CancellationToken cancellationToken = default,
         Func<CancellationToken, Task>? prepareAsync = null,
-        Func<Task>? finalizeAsync = null)
+        Func<Task>? finalizeAsync = null,
+        bool keepBlankLines = false)
     {
         cancellationToken.ThrowIfCancellationRequested();
         setupAction();


### PR DESCRIPTION
Fixes #543.

## The defect

`GetSystemLogAsync` returned an empty list for two unrelated situations:

- the device answered, and its log buffer is genuinely empty;
- the device **did not answer at all**.

A caller could not tell which. So a silent link, a wedged text exchange, or an unsupported header on below-floor firmware all presented as *"your log is empty"* — the least useful answer a **diagnostics** call can give, because it is indistinguishable from a clean bill of health, on the one call an operator reaches for when they suspect the device is unwell.

## The signal was already there

The firmware terminates **every** `SYSTem:LOG?` dump with a blank line, whether or not it had anything to say. From #543's bench work (Nq1 on firmware 3.7.2, raw pyserial probe, no Core in the path, three trials of three):

```
SYSTem:LOG?  (empty)      ->  b'\r\n'                        6 ms
SYSTem:LOG?  (populated)  ->  b'Test error message\r\n\r\n'
```

Since #538 the exchange already parses that blank line internally — it just filtered it out before any caller saw it. So **any** line reaching the diagnostics layer means the device answered, and **zero** lines means it did not.

No extra command, and specifically **no `SYSTem:ERRor?` pairing**, which would pop an entry off the device's error queue as a side effect of a read — a poor thing for a diagnostics call to do when `GetSystemErrorCountAsync` sits on the same interface.

## Why a parameter and not a new method

`keepBlankLines` is threaded through the existing `ExecuteTextCommandAsync` rather than added as a parallel method — the convention this seam already documents:

> *"a parallel method would be bypassed silently by any subclass that overrides only this one … Overriders must widen their signature — a compile error, which is the point."*

**That is most of this diff: 22 test doubles gain one parameter.** It is also load-bearing rather than incidental — the diagnostics tests inject their canned responses by overriding that virtual, so a new seam would bypass their injection and the behaviour could not be unit-tested at all. I checked `ExecuteRawCaptureAsync` as an alternative first; using it would mean reimplementing line reading, timeouts and consumer swapping in the diagnostics op, which is worse.

Only the `Action` overload is widened — the 8 overrides of the async overload are untouched.

## A test that encoded the wrong belief

`GetSystemLogAsync_WhenBufferEmpty_ReturnsEmpty` canned **nothing** and asserted no-throw, commented *"No lines = genuinely empty buffer (firmware writes nothing)"*.

That premise is false, and it is precisely what made the two states indistinguishable — the test asserted the ambiguity as correct. It now cans a **blank line**, which is what the device actually sends, and two cases join it:

| test | asserts |
|---|---|
| `WhenBufferEmpty_ReturnsEmpty` | a blank line → empty list, **no throw** |
| `WhenDeviceAnswersNothingAtAll_Throws` | zero lines → `DeviceDiagnosticsException` naming the condition |
| `WhenBufferHasEntries_IgnoresTheTerminator` | a populated dump does not leak its terminator as a phantom log entry |

## Behaviour change — worth a release note

A caller polling the log on a flaky link previously got an empty list and now gets a throw. That is the point of the issue, but it is visible. The exception is a `DeviceDiagnosticsException` (not a new type), so `catch` blocks that already handle diagnostics failures keep working.

## Test plan

- **Baseline-checked, not assumed.** `main` fails **4** tests on this station before any change — all `Device.Discovery.LinuxUsbPortDescriptorProviderTests`, a WSL/Windows runtime artefact, not related to this work.
- **After this change: the same 4**, with passing tests up from **3531 → 3533** (the two new cases) and total 3537 → 3539.
- `Daqifi.Mcp.Tests` builds clean (its `DeviceDouble` is one of the widened doubles).
- No hardware needed — the mechanism is pinned by unit tests against the real response shapes.

The issue's open questions, answered: it is scoped to `SYSTem:LOG?` only. `GetCommandHistoryAsync` is untouched — it has a *"No command history"* marker and is already distinguishable, exactly as the issue suspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)