### PR TITLE
feat(diagnostics): expose the heap-fragmentation and pool fields as properties

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Diagnostics/MemoryDiagnosticsParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/MemoryDiagnosticsParserTests.cs
@@ -40,6 +40,78 @@ public class MemoryDiagnosticsParserTests
         Assert.Equal(11, mem.Values.Count);
     }
 
+    // The full 17-field answer a real Nq1 on firmware 3.7.2 gives, values as measured on the
+    // bench (issue #536). The device was nearly out of heap, which is what makes it a useful
+    // fixture: HeapFree looks merely tight until you see that the whole of it is one block.
+    private static readonly string[] BenchResponse =
+    {
+        "HeapTotal=75000",
+        "HeapFree=7544",
+        "HeapUsed=67456",
+        "HeapMinEverFree=7544",
+        "LargestFreeBlock=7544",
+        "SmallestFreeBlock=7544",
+        "HeapFreeBlocks=1",
+        "CoherentPoolTotal=32768",
+        "CoherentPoolFree=16384",
+        "SdCircularSize=512",
+        "SamplePoolCount=1100",
+        "SamplePoolInUse=4",
+        "SamplePoolMaxUsed=12",
+        "SamplePoolBytes=22000",
+        "SampleNextFreeBytes=2200",
+        "SampleQueueBytes=4480",
+        "SampleElementBytes=20",
+    };
+
+    [Fact]
+    public void TryParse_ExposesTheFragmentationAndPoolFieldsAsProperties()
+    {
+        // These eight parsed correctly all along -- they landed in Values with the right numbers.
+        // What was missing was any way to reach them except by magic string, on the one question
+        // a consumer actually asks this API: how close to the edge is the device?
+        var ok = MemoryDiagnosticsParser.TryParse(BenchResponse, out var mem);
+
+        Assert.True(ok);
+        Assert.NotNull(mem);
+
+        Assert.Equal(7544UL, mem!.LargestFreeBlock);
+        Assert.Equal(7544UL, mem.SmallestFreeBlock);
+        Assert.Equal(1UL, mem.HeapFreeBlocks);
+        Assert.Equal(512UL, mem.SdCircularSize);
+        Assert.Equal(22000UL, mem.SamplePoolBytes);
+        Assert.Equal(2200UL, mem.SampleNextFreeBytes);
+        Assert.Equal(4480UL, mem.SampleQueueBytes);
+        Assert.Equal(20UL, mem.SampleElementBytes);
+
+        // The reading the fields exist to make possible: the largest allocation still serviceable
+        // is the entire free heap, because it is one unbroken run. Unfragmented -- and nearly out.
+        Assert.Equal(mem.HeapFree, mem.LargestFreeBlock);
+        Assert.Equal(17, mem.Values.Count);
+    }
+
+    [Fact]
+    public void TryParse_WhenFirmwareOmitsTheNewFields_TheyReadNull()
+    {
+        // The field set varies by firmware version, which the type already documents. An older
+        // device that does not send these must give null rather than zero -- zero would read as
+        // "no free block at all", the alarming opposite of "did not say".
+        var ok = MemoryDiagnosticsParser.TryParse(SampleResponse, out var mem);
+
+        Assert.True(ok);
+        Assert.NotNull(mem);
+        Assert.Null(mem!.LargestFreeBlock);
+        Assert.Null(mem.SmallestFreeBlock);
+        Assert.Null(mem.HeapFreeBlocks);
+        Assert.Null(mem.SamplePoolBytes);
+        Assert.Null(mem.SampleNextFreeBytes);
+        Assert.Null(mem.SampleQueueBytes);
+
+        // Present in the older fixture, so these two must still resolve.
+        Assert.Equal(8192UL, mem.SdCircularSize);
+        Assert.Equal(32UL, mem.SampleElementBytes);
+    }
+
     [Fact]
     public void TryParse_MissingFieldsReturnNull()
     {

--- a/src/Daqifi.Core/Device/Diagnostics/MemoryDiagnostics.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/MemoryDiagnostics.cs
@@ -63,6 +63,63 @@ public sealed record MemoryDiagnostics
     /// </summary>
     public ulong? SamplePoolMaxUsed => GetValue("SamplePoolMaxUsed");
 
+    /// <summary>
+    /// Gets the size in bytes of the largest single free heap block, or <see langword="null"/> if
+    /// absent.
+    /// </summary>
+    /// <remarks>
+    /// This, not <see cref="HeapFree"/>, is the largest allocation the device can still service.
+    /// A device reporting 7.5 KB free across twenty blocks and one reporting 7.5 KB free in a
+    /// single block have the same <see cref="HeapFree"/> and completely different prospects.
+    /// </remarks>
+    public ulong? LargestFreeBlock => GetValue("LargestFreeBlock");
+
+    /// <summary>
+    /// Gets the size in bytes of the smallest single free heap block, or <see langword="null"/> if
+    /// absent.
+    /// </summary>
+    public ulong? SmallestFreeBlock => GetValue("SmallestFreeBlock");
+
+    /// <summary>
+    /// Gets how many separate blocks the free heap is divided into, or <see langword="null"/> if
+    /// absent.
+    /// </summary>
+    /// <remarks>
+    /// A HIGH count means fragmentation: the free bytes exist but are scattered, so a large
+    /// allocation can fail while <see cref="HeapFree"/> still looks comfortable. A count of
+    /// <c>1</c> is the opposite — the free heap is one contiguous run, the least fragmented state
+    /// there is. A device can therefore be unfragmented and nearly exhausted at the same time,
+    /// which is what <see cref="LargestFreeBlock"/> equalling <see cref="HeapFree"/> means.
+    /// </remarks>
+    public ulong? HeapFreeBlocks => GetValue("HeapFreeBlocks");
+
+    /// <summary>
+    /// Gets the size in bytes of the SD circular buffer, or <see langword="null"/> if absent.
+    /// </summary>
+    public ulong? SdCircularSize => GetValue("SdCircularSize");
+
+    /// <summary>
+    /// Gets the total bytes of sample-pool data memory, or <see langword="null"/> if absent.
+    /// </summary>
+    public ulong? SamplePoolBytes => GetValue("SamplePoolBytes");
+
+    /// <summary>
+    /// Gets the bytes occupied by the sample pool's free-list array, or <see langword="null"/> if
+    /// absent.
+    /// </summary>
+    public ulong? SampleNextFreeBytes => GetValue("SampleNextFreeBytes");
+
+    /// <summary>
+    /// Gets the estimated bytes of FreeRTOS queue overhead for samples, or <see langword="null"/>
+    /// if absent.
+    /// </summary>
+    public ulong? SampleQueueBytes => GetValue("SampleQueueBytes");
+
+    /// <summary>
+    /// Gets the size in bytes of one sample-pool element, or <see langword="null"/> if absent.
+    /// </summary>
+    public ulong? SampleElementBytes => GetValue("SampleElementBytes");
+
     private ulong? GetValue(string key) =>
         Values.TryGetValue(key, out var value) ? value : null;
 }


### PR DESCRIPTION
Fixes #536.

`GetMemoryDiagnosticsAsync` is how an application asks a device how much memory it has left — and the sharpest thing the firmware tells you, **how the free heap is broken up**, had no property. A consumer could only reach it through the untyped bag with a magic string:

```csharp
var largest = m.Values["LargestFreeBlock"];   // no property, no discoverability, no IntelliSense
```

The firmware sends **17** fields; `MemoryDiagnostics` declared **9** accessors. The missing eight now have them:

`LargestFreeBlock` · `SmallestFreeBlock` · `HeapFreeBlocks` · `SdCircularSize` · `SamplePoolBytes` · `SampleNextFreeBytes` · `SampleQueueBytes` · `SampleElementBytes`

Purely additive — same `ulong?` / `GetValue` shape as the existing nine, still `null` when the firmware of the day omits a field, so the *"field set varies by firmware version"* contract the type already documents is unchanged. **Parsing was never wrong**: all 17 already landed in `Values` with the right numbers. This was a gap in the typed surface only.

`LargestFreeBlock` is the one that earns its place: it, not `HeapFree`, is the largest allocation the device can still service. 7.5 KB free across twenty blocks and 7.5 KB free in one block report the same `HeapFree` and have completely different prospects.

## One correction to the issue

The issue offered an optional helper, `IsHeapFragmented`, defined as `LargestFreeBlock == HeapFree && HeapFreeBlocks == 1`.

**That predicate is backwards.** One free block that *is* the entire free heap is the **least** fragmented state possible — a single unbroken run. What the bench device was showing is not fragmentation but **near-exhaustion without fragmentation**, which is a different diagnosis with a different remedy: fragmentation says "the bytes are there but scattered, compact or restart", while this says "the bytes are simply gone".

So I have shipped the accessors and left the helper out — which the issue explicitly allowed for (*"Happy to leave that out if it feels like over-reach; the accessors are the part that matters"*) — and put the distinction in the doc comment on `HeapFreeBlocks` instead:

> A **high** count means fragmentation … A count of `1` is the opposite — the free heap is one contiguous run, the least fragmented state there is. A device can therefore be unfragmented and nearly exhausted at the same time.

A helper that named that state "fragmented" would send someone looking for the wrong problem, which is worse than making them read two numbers.

## Test plan

Two tests, using the **real 17-field response** measured on an Nq1 running 3.7.2 (from the issue), so the fixture is what a device actually says rather than one I invented:

| test | asserts |
|---|---|
| `ExposesTheFragmentationAndPoolFieldsAsProperties` | all eight resolve; `HeapFree == LargestFreeBlock`, the reading the fields exist to make possible |
| `WhenFirmwareOmitsTheNewFields_TheyReadNull` | an older device gives `null`, not `0` |

The second is **mutation-proved**: making an accessor return `0` instead of `null` fails it. That matters more than it looks — zero would read as *"no free block at all"*, the alarming opposite of *"did not say"*.

The first cannot compile without the accessors, so it is discriminating by construction.

**Baseline-checked:** `main` fails 4 tests on this station before any change (`Device.Discovery.LinuxUsbPortDescriptorProviderTests`, a WSL/Windows runtime artefact). After: the **same 4**, passing 3532 → 3534.

No hardware needed; the bench measurement is already recorded in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)