### PR TITLE
fix(device): give health telemetry a way to refresh, and stop the docs claiming it is live

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
@@ -197,6 +197,41 @@ namespace Daqifi.Core.Tests.Device
         }
 
         [Fact]
+        public async Task RefreshDeviceStatusAsync_ConcurrentCalls_AreNotCompletedByEachOthersReply()
+        {
+            // Both callers subscribe to the same multicast StatusMessageReceived event, so without
+            // serialization ONE incoming frame -- which answers only one of the two requests --
+            // completes both, and the loser returns a success not tied to its own request.
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            var first = device.RefreshDeviceStatusAsync(TimeSpan.FromSeconds(5));
+
+            // The second call must be queued behind the first, not racing it: at this point only
+            // one request can have gone out.
+            var second = device.RefreshDeviceStatusAsync(TimeSpan.FromSeconds(5));
+
+            await Task.Delay(50);
+            Assert.Single(device.SentCommands);
+            Assert.False(second.IsCompleted);
+
+            // One reply satisfies the first caller only.
+            device.InvokeStatusMessage(new DaqifiOutMessage { BattStatus = 11 });
+            await first;
+
+            await Task.Delay(50);
+            Assert.False(second.IsCompleted);
+
+            // The second caller's own request goes out once it holds the gate, and its own reply
+            // completes it.
+            Assert.Equal(2, device.SentCommands.Count);
+            device.InvokeStatusMessage(new DaqifiOutMessage { BattStatus = 22 });
+            await second;
+
+            Assert.Equal(22, device.Metadata.Health.BatteryPercent);
+        }
+
+        [Fact]
         public async Task RefreshDeviceStatusAsync_UnsubscribesAfterCompleting()
         {
             // The handler is added per call, so a caller polling in a loop would otherwise

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
@@ -197,6 +197,27 @@ namespace Daqifi.Core.Tests.Device
         }
 
         [Fact]
+        public async Task RefreshDeviceStatusAsync_IsNotBlockedByAThrowingStatusSubscriber()
+        {
+            // .NET stops invoking a multicast delegate at the first exception, and
+            // RaiseClassifiedEvent wraps the WHOLE list in one try/catch -- so a consumer that
+            // subscribed earlier and throws would have prevented the refresh from ever seeing its
+            // own reply. It would then time out while the status it asked for had already been
+            // applied to Metadata, which is the most confusing failure this API could produce.
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            device.StatusMessageReceived += _ => throw new InvalidOperationException("boom");
+
+            var refresh = device.RefreshDeviceStatusAsync(TimeSpan.FromSeconds(2));
+            device.InvokeStatusMessage(new DaqifiOutMessage { BattStatus = 55 });
+
+            await refresh;
+
+            Assert.Equal(55, device.Metadata.Health.BatteryPercent);
+        }
+
+        [Fact]
         public async Task RefreshDeviceStatusAsync_ConcurrentCalls_AreNotCompletedByEachOthersReply()
         {
             // Both callers subscribe to the same multicast StatusMessageReceived event, so without

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceTests.cs
@@ -152,10 +152,93 @@ namespace Daqifi.Core.Tests.Device
             Assert.NotNull(raised);
         }
 
+        [Fact]
+        public async Task RefreshDeviceStatusAsync_CompletesAndAppliesTheReply_WhenAStatusArrives()
+        {
+            // The point of the API: health is not live -- the device answers when asked and is
+            // otherwise silent -- so there has to be a supported way to ask (issue #535).
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            var refresh = device.RefreshDeviceStatusAsync(TimeSpan.FromSeconds(5));
+
+            // The reply, delivered the way the consumer loop delivers one.
+            device.InvokeStatusMessage(new DaqifiOutMessage { BattStatus = 42 });
+
+            await refresh;
+
+            // It must actually ask -- the whole point is that the device says nothing unprompted.
+            Assert.Contains(device.SentCommands, c => c.Contains("SYSInfoPB", StringComparison.Ordinal));
+
+            // Metadata is updated before the event is raised, so it is already applied here.
+            Assert.Equal(42, device.Metadata.Health.BatteryPercent);
+        }
+
+        [Fact]
+        public async Task RefreshDeviceStatusAsync_WhenTheDeviceStaysSilent_Throws()
+        {
+            // A silent device must surface as a timeout rather than hanging the caller. This is
+            // the realistic failure: the device sends nothing at all unless asked, so a lost
+            // request produces silence, not an error frame.
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            await Assert.ThrowsAsync<TimeoutException>(
+                () => device.RefreshDeviceStatusAsync(TimeSpan.FromMilliseconds(150)));
+        }
+
+        [Fact]
+        public async Task RefreshDeviceStatusAsync_WhenNotConnected_Throws()
+        {
+            var device = new TestableDaqifiDevice("TestDevice");
+
+            await Assert.ThrowsAsync<DeviceNotConnectedException>(
+                () => device.RefreshDeviceStatusAsync(TimeSpan.FromSeconds(1)));
+        }
+
+        [Fact]
+        public async Task RefreshDeviceStatusAsync_UnsubscribesAfterCompleting()
+        {
+            // The handler is added per call, so a caller polling in a loop would otherwise
+            // accumulate one subscription per refresh for the life of the connection.
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+
+            for (var i = 0; i < 3; i++)
+            {
+                var refresh = device.RefreshDeviceStatusAsync(TimeSpan.FromSeconds(5));
+                device.InvokeStatusMessage(new DaqifiOutMessage { BattStatus = 7 });
+                await refresh;
+            }
+
+            // A status arriving with no refresh outstanding must not fault anything, and the
+            // device must still be usable afterwards.
+            var ex = Record.Exception(() => device.InvokeStatusMessage(new DaqifiOutMessage { BattStatus = 9 }));
+
+            Assert.Null(ex);
+            Assert.Equal(9, device.Metadata.Health.BatteryPercent);
+        }
+
         private sealed class TestableDaqifiDevice : DaqifiDevice
         {
             public TestableDaqifiDevice(string name, IPAddress? ipAddress = null) : base(name, ipAddress)
             {
+            }
+
+            /// <summary>Commands the device was asked to send, in order.</summary>
+            public List<string> SentCommands { get; } = new();
+
+            /// <summary>
+            /// Captures instead of transmitting: this double has no transport, and the base
+            /// implementation throws without one. Recording the text also lets a test assert
+            /// WHICH command was sent, not merely that the call did not throw.
+            /// </summary>
+            public override void Send<T>(IOutboundMessage<T> message)
+            {
+                if (message is IOutboundMessage<string> text)
+                {
+                    SentCommands.Add(text.Data);
+                }
             }
 
             public void InvokeStatusMessage(DaqifiOutMessage message) => OnStatusMessageReceived(message);

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -3334,6 +3334,21 @@ namespace Daqifi.Core.Device
         /// contend for the operation lock against streaming and SD work, so how often "current"
         /// needs to be is a decision only the application can make.
         /// </para>
+        /// <para>
+        /// <b>Known limitation.</b> A status frame carries nothing saying which request it answers,
+        /// so if one refresh times out and its reply arrives late, the NEXT refresh can be
+        /// completed by that older frame rather than its own. The value is still a genuine device
+        /// reading — just one taken before this call, bounded by the previous refresh's timeout —
+        /// and this call's own reply lands moments later and updates
+        /// <see cref="DeviceMetadata.Health"/> again.
+        /// </para>
+        /// <para>
+        /// It is documented rather than worked around because the protocol offers no correlation
+        /// to work around it with. The obvious heuristic — skip one frame after a timeout — makes
+        /// the more common case worse: if the earlier reply never arrives at all, the next refresh
+        /// would discard its OWN reply and time out too. Concurrent refreshes, which had the same
+        /// shape for a different reason, are prevented outright by serializing them.
+        /// </para>
         /// </remarks>
         /// <param name="timeout">
         /// How long to wait, in total. Defaults to 5 seconds when omitted, so a silent device

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -511,6 +511,21 @@ namespace Daqifi.Core.Device
         private readonly SemaphoreSlim _statusRefreshGate = new(1, 1);
 
         /// <summary>
+        /// The waiter for an in-flight <see cref="RefreshDeviceStatusAsync"/>, invoked directly
+        /// rather than through the public <see cref="StatusMessageReceived"/> event.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RaiseClassifiedEvent"/> wraps the WHOLE multicast delegate in one try/catch,
+        /// which isolates the device from a throwing subscriber but not subscribers from each
+        /// other: .NET stops invoking an invocation list at the first exception, so a consumer
+        /// that subscribed earlier and throws would prevent the refresh from ever seeing its own
+        /// reply -- and it would time out while the status it asked for had already been applied.
+        /// Only one refresh runs at a time (<see cref="_statusRefreshGate"/>), so a single field
+        /// is enough.
+        /// </remarks>
+        private Action<DaqifiOutMessage>? _statusRefreshWaiter;
+
+        /// <summary>
         /// Maximum number of retry attempts for the <see cref="InitializeAsync"/> SCPI setup
         /// sequence when the device returns a transient SCPI error (e.g. -200 "Execution error").
         /// A common trigger is the firmware rejecting a command tied to a persisted prior-session
@@ -3379,7 +3394,7 @@ namespace Daqifi.Core.Device
                 //
                 // Metadata is updated by OnStatusMessageReceived BEFORE this event is raised, so by
                 // the time the wait completes the caller can read Metadata.Health and see the reply.
-                StatusMessageReceived += OnStatus;
+                _statusRefreshWaiter = OnStatus;
                 try
                 {
                     Send(ScpiMessageProducer.GetDeviceInfo);
@@ -3390,13 +3405,22 @@ namespace Daqifi.Core.Device
                     }
                     catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
                     {
+                        // A reply landing in the same instant the deadline fires can cancel the
+                        // wait even though the status DID arrive and was applied. Reporting that
+                        // as a timeout would tell the caller the refresh failed while the data
+                        // they asked for is sitting in Metadata.
+                        if (statusTcs.Task.IsCompletedSuccessfully)
+                        {
+                            return;
+                        }
+
                         throw new TimeoutException(
                             $"The device did not return a status message within {wait.TotalSeconds:0.##}s.");
                     }
                 }
                 finally
                 {
-                    StatusMessageReceived -= OnStatus;
+                    _statusRefreshWaiter = null;
                 }
             }
             finally
@@ -3515,6 +3539,23 @@ namespace Daqifi.Core.Device
 
             // Populate channels from the status message
             PopulateChannelsFromStatus(message);
+
+            // The refresh waiter runs BEFORE any consumer subscriber and outside the multicast
+            // event, so no third party can delay or prevent a caller of RefreshDeviceStatusAsync
+            // from seeing the reply it asked for. Its own faults are contained here for the same
+            // reason the classified event contains a subscriber's.
+            var waiter = _statusRefreshWaiter;
+            if (waiter != null)
+            {
+                try
+                {
+                    waiter(message);
+                }
+                catch (Exception ex)
+                {
+                    SafeLog(() => _logger.LogWarning(ex, "[RefreshDeviceStatus] waiter threw"));
+                }
+            }
 
             // Raise the classified event first so consumers that only care about status
             // messages can react before the undifferentiated MessageReceived below. A

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -503,6 +503,14 @@ namespace Daqifi.Core.Device
         private static readonly TimeSpan DefaultStatusRefreshTimeout = TimeSpan.FromSeconds(5);
 
         /// <summary>
+        /// Serializes <see cref="RefreshDeviceStatusAsync"/>. Two concurrent refreshes would both
+        /// subscribe to the same multicast <see cref="StatusMessageReceived"/> event, and a single
+        /// incoming frame -- which answers only one of the two requests -- would complete both, so
+        /// the loser would return a success not tied to its own request.
+        /// </summary>
+        private readonly SemaphoreSlim _statusRefreshGate = new(1, 1);
+
+        /// <summary>
         /// Maximum number of retry attempts for the <see cref="InitializeAsync"/> SCPI setup
         /// sequence when the device returns a transient SCPI error (e.g. -200 "Execution error").
         /// A common trigger is the firmware rejecting a command tied to a persisted prior-session
@@ -3313,8 +3321,16 @@ namespace Daqifi.Core.Device
         /// </para>
         /// </remarks>
         /// <param name="timeout">
-        /// How long to wait for the reply. Defaults to 5 seconds when omitted, so a silent device
+        /// How long to wait, in total. Defaults to 5 seconds when omitted, so a silent device
         /// surfaces as a <see cref="TimeoutException"/> rather than hanging the caller.
+        /// <para>
+        /// The deadline covers the whole operation, not just the device round-trip: waiting behind
+        /// another refresh, and waiting for the request itself to be sent. <see cref="Send"/> is
+        /// fire-and-forget and is <b>deferred</b> while an exclusive operation holds the device
+        /// (an SD download can hold it for many minutes), so a short timeout taken during one can
+        /// elapse before the device is ever asked. That is a real outcome, and the exception says
+        /// only that no status arrived — pass a timeout that suits what else the device is doing.
+        /// </para>
         /// </param>
         /// <param name="cancellationToken">A cancellation token to observe.</param>
         /// <returns>A task that completes once a status message has been received and applied.</returns>
@@ -3334,38 +3350,58 @@ namespace Daqifi.Core.Device
                     nameof(timeout), wait, "Timeout must be positive.");
             }
 
-            var statusTcs = new TaskCompletionSource<bool>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
+            // One deadline covers the whole operation: waiting for the gate, waiting for the send
+            // to leave the queue, and waiting for the reply. See the timeout parameter's note.
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(wait);
 
-            void OnStatus(DaqifiOutMessage _) => statusTcs.TrySetResult(true);
-
-            // Subscribed before the send, so a device that answers immediately cannot slip the
-            // reply through the gap between Send() and the subscription -- the same ordering
-            // WaitForChannelsPopulatedAsync relies on.
-            //
-            // Metadata is updated by OnStatusMessageReceived BEFORE this event is raised, so by
-            // the time the wait completes the caller can read Metadata.Health and see the reply.
-            StatusMessageReceived += OnStatus;
             try
             {
-                Send(ScpiMessageProducer.GetDeviceInfo);
+                await _statusRefreshGate.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {wait.TotalSeconds:0.##}s waiting for an earlier status "
+                    + "refresh on this device to finish.");
+            }
 
-                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                timeoutCts.CancelAfter(wait);
+            try
+            {
+                var statusTcs = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
 
+                void OnStatus(DaqifiOutMessage _) => statusTcs.TrySetResult(true);
+
+                // Subscribed before the send, so a device that answers immediately cannot slip the
+                // reply through the gap between Send() and the subscription -- the same ordering
+                // WaitForChannelsPopulatedAsync relies on.
+                //
+                // Metadata is updated by OnStatusMessageReceived BEFORE this event is raised, so by
+                // the time the wait completes the caller can read Metadata.Health and see the reply.
+                StatusMessageReceived += OnStatus;
                 try
                 {
-                    await statusTcs.Task.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+                    Send(ScpiMessageProducer.GetDeviceInfo);
+
+                    try
+                    {
+                        await statusTcs.Task.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                    {
+                        throw new TimeoutException(
+                            $"The device did not return a status message within {wait.TotalSeconds:0.##}s.");
+                    }
                 }
-                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                finally
                 {
-                    throw new TimeoutException(
-                        $"The device did not return a status message within {wait.TotalSeconds:0.##}s.");
+                    StatusMessageReceived -= OnStatus;
                 }
             }
             finally
             {
-                StatusMessageReceived -= OnStatus;
+                _statusRefreshGate.Release();
             }
         }
 

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -497,6 +497,12 @@ namespace Daqifi.Core.Device
         private static readonly TimeSpan ChannelPopulationPollInterval = TimeSpan.FromSeconds(1);
 
         /// <summary>
+        /// Default wait for <see cref="RefreshDeviceStatusAsync"/>. A device that is answering at
+        /// all replies in milliseconds; this is a hang detector, not a prediction.
+        /// </summary>
+        private static readonly TimeSpan DefaultStatusRefreshTimeout = TimeSpan.FromSeconds(5);
+
+        /// <summary>
         /// Maximum number of retry attempts for the <see cref="InitializeAsync"/> SCPI setup
         /// sequence when the device returns a transient SCPI error (e.g. -200 "Execution error").
         /// A common trigger is the firmware rejecting a command tied to a persisted prior-session
@@ -3284,6 +3290,82 @@ namespace Daqifi.Core.Device
                 SafeLog(() => _logger.LogDebug(
                     ex,
                     "[InitializeAsync] Reading the capability document failed; keeping board-derived capabilities."));
+            }
+        }
+
+        /// <summary>
+        /// Asks the device for a fresh status message and waits for it to arrive, updating
+        /// <see cref="Metadata"/> — including <see cref="DeviceMetadata.Health"/> — from the reply.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Health telemetry is <b>not</b> live. The device sends a status message when asked and at
+        /// no other time: a connected link carries stream frames only (the firmware builds each one
+        /// from four tags, none of them health), so without this call the values captured during
+        /// <c>InitializeAsync</c> stay frozen for the life of the connection. Measured on an Nq1
+        /// running 3.7.2: 1,587 inbound messages over 65 s, of which exactly one carried health —
+        /// the one the harness explicitly asked for (issue #535).
+        /// </para>
+        /// <para>
+        /// Cadence is deliberately the caller's, not Core's. A self-poll inside the library would
+        /// contend for the operation lock against streaming and SD work, so how often "current"
+        /// needs to be is a decision only the application can make.
+        /// </para>
+        /// </remarks>
+        /// <param name="timeout">
+        /// How long to wait for the reply. Defaults to 5 seconds when omitted, so a silent device
+        /// surfaces as a <see cref="TimeoutException"/> rather than hanging the caller.
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token to observe.</param>
+        /// <returns>A task that completes once a status message has been received and applied.</returns>
+        /// <exception cref="DeviceNotConnectedException">Thrown when the device is not connected.</exception>
+        /// <exception cref="TimeoutException">Thrown when no status message arrives in time.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        public async Task RefreshDeviceStatusAsync(
+            TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default)
+        {
+            EnsureConnected(cancellationToken);
+
+            var wait = timeout ?? DefaultStatusRefreshTimeout;
+            if (wait <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(timeout), wait, "Timeout must be positive.");
+            }
+
+            var statusTcs = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            void OnStatus(DaqifiOutMessage _) => statusTcs.TrySetResult(true);
+
+            // Subscribed before the send, so a device that answers immediately cannot slip the
+            // reply through the gap between Send() and the subscription -- the same ordering
+            // WaitForChannelsPopulatedAsync relies on.
+            //
+            // Metadata is updated by OnStatusMessageReceived BEFORE this event is raised, so by
+            // the time the wait completes the caller can read Metadata.Health and see the reply.
+            StatusMessageReceived += OnStatus;
+            try
+            {
+                Send(ScpiMessageProducer.GetDeviceInfo);
+
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(wait);
+
+                try
+                {
+                    await statusTcs.Task.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"The device did not return a status message within {wait.TotalSeconds:0.##}s.");
+                }
+            }
+            finally
+            {
+                StatusMessageReceived -= OnStatus;
             }
         }
 

--- a/src/Daqifi.Core/Device/DeviceHealth.cs
+++ b/src/Daqifi.Core/Device/DeviceHealth.cs
@@ -3,9 +3,24 @@ namespace Daqifi.Core.Device;
 /// <summary>
 /// Health/telemetry values decoded from a device status message: battery charge,
 /// board temperature, and the raw power/device status codes. These update as new
-/// status messages arrive (including the periodic ones emitted during streaming),
-/// so a snapshot reflects the most recent reading Core has seen.
+/// status messages arrive, so a snapshot reflects the most recent reading Core has seen.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Status messages are not periodic.</b> The device sends one when asked and at no other
+/// time — a connected link carries stream frames only, and the firmware builds each of those
+/// from four tags, none of them health. So these values are captured during
+/// <c>InitializeAsync</c> and then stay put until something asks again. Measured on an Nq1
+/// running 3.7.2: 1,587 inbound messages over 65 s, exactly one of which carried health, and
+/// only because it was requested (issue #535).
+/// </para>
+/// <para>
+/// Call <see cref="DaqifiDevice.RefreshDeviceStatusAsync"/> to get a current reading. An
+/// earlier revision of this summary said these values included "the periodic ones emitted
+/// during streaming"; there are none, and a consumer who believed it would display a battery
+/// percentage frozen at connect.
+/// </para>
+/// </remarks>
 /// <remarks>
 /// The underlying protobuf fields are proto3 scalars with no explicit presence, so a
 /// value of <c>0</c> is indistinguishable from "not reported". To avoid dropping a known
@@ -32,6 +47,13 @@ public class DeviceHealth
     /// the field), or <c>null</c> if the device has not reported a temperature since this instance
     /// was created.
     /// </summary>
+    /// <remarks>
+    /// <b>No shipping firmware populates this.</b> The encoder's <c>temp_status</c> case is empty,
+    /// so the field is never assigned, stays 0, and proto3 omits it — checked at v3.5.0, v3.6.0,
+    /// v3.7.0, v3.7.1 and v3.7.2, i.e. the whole range Core supports. Against real hardware this
+    /// is <c>null</c> and cannot be anything else; it is kept because the wire field exists and a
+    /// future firmware may fill it (issue #535).
+    /// </remarks>
     public int? BoardTemperatureCelsius { get; set; }
 
     /// <summary>


### PR DESCRIPTION
Fixes #535.

`device.Metadata.Health` is documented as live telemetry. It is a snapshot taken once at connect that **never changes again** for the life of the connection. Build a UI on it and it shows "Battery: 87%" an hour later on a device that has since run flat.

## Two independent causes, both confirmed on hardware

**1. Nothing ever asks again.** The only `GetDeviceInfo` sends are inside `WaitForChannelsPopulatedAsync`, which stops the moment channels populate during `InitializeAsync`. There was no public API to ask afterwards.

**2. The firmware sends no periodic status frames on a connected link.** Each stream frame is built from four tags and none of them is health, so a connected device is silent unless asked. From the issue's bench run (Nq1, fw 3.7.2):

| window | duration | stream frames | status frames |
|---|---|--:|--:|
| idle | 40 s | 0 | **0** |
| streaming @ 100 Hz | 20 s | 1,586 | **0** |
| after one explicit `GetDeviceInfo` | 2.5 s | — | 1 |

1,587 inbound messages; exactly **one** carried health, and only because it was requested.

## The fix

`RefreshDeviceStatusAsync(TimeSpan?, CancellationToken)` — sends `GetDeviceInfo`, waits for the next status message, returns once it has been applied. Additive, non-breaking.

It **subscribes before sending**, so a fast reply cannot slip through the gap between `Send()` and the subscription — the same ordering `WaitForChannelsPopulatedAsync` already relies on. It **unsubscribes in a `finally`**, so a caller polling in a loop does not accumulate one handler per call for the life of the connection. Default timeout 5 s: a device that is answering at all replies in milliseconds, so this is a hang detector, not a prediction.

**Cadence stays with the caller, deliberately.** The issue flagged this and it is right — a self-poll inside Core would contend for the operation lock against streaming and SD work, and how often "current" needs to be is a decision only the application can make.

## Docs corrected — both claims were wrong

`DeviceHealth` said its values update *"including the periodic ones emitted during streaming"*. There are none. Worth noting the original ticket #335 hedged this correctly as *"if present"*; **the hedge was dropped when the doc was written.**

`BoardTemperatureCelsius` now says what it is: **no shipping firmware populates it.** The encoder's `temp_status` case is empty, so the field is never assigned, stays 0, and proto3 omits it — checked at v3.5.0, v3.6.0, v3.7.0, v3.7.1 and v3.7.2, i.e. the entire range Core supports. Against real hardware it cannot be anything but `null`. Kept, because the wire field exists and a future firmware may fill it.

## Which option this took, and why

The issue offered docs-only or docs-plus-refresh and left it open. The **acceptance criteria settle it** — they ask for *"a supported way to refresh health telemetry"* and *"a test covering the refresh path"*, which docs-only cannot satisfy. It is also the smaller surprise: the alternative documents `Send(ScpiMessageProducer.GetDeviceInfo)` as the refresh path, which works but leaves every consumer to reinvent the wait, the timeout and the unsubscribe.

## Test plan

| test | asserts |
|---|---|
| `CompletesAndAppliesTheReply_WhenAStatusArrives` | it actually sends `SYSInfoPB`, and `Metadata.Health` carries the reply on return |
| `WhenTheDeviceStaysSilent_Throws` | `TimeoutException` rather than a hang — the realistic failure, since a lost request produces silence, not an error frame |
| `WhenNotConnected_Throws` | `DeviceNotConnectedException` |
| `UnsubscribesAfterCompleting` | three refreshes leave nothing subscribed; a later unsolicited status still applies and faults nothing |

All four fail without the new method — it does not exist to be called. The device double now captures `Send` rather than transmitting (it has no transport), which also lets the first test assert *which* command went out rather than merely that the call did not throw.

**Baseline-checked:** `main` fails 4 tests on this station before any change (`Device.Discovery.LinuxUsbPortDescriptorProviderTests`, a WSL/Windows runtime artefact). After: the **same 4**, passing 3538 → 3542.

No hardware needed; the bench evidence is recorded in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)