### PR TITLE
test(core): warm the decode-allocation probe over the count it measures

### DIFF
--- a/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
@@ -614,10 +614,23 @@ namespace Daqifi.Core.Tests.Device
                 }
             }
 
-            Push(200, 50_000u); // warm up the JIT, the decoder's channel cache and the accumulators
+            // Warm up over the SAME count as the measurement, not a token 200.
+            //
+            // This is #531's cause again, in the sibling test (#559). Tiered compilation promotes
+            // a hot method to tier 1 partway through a long loop and the rejit allocates, so a
+            // short warmup leaves the promotion to land INSIDE the measured window. It shows up as
+            // a full-run-only failure -- in isolation the method is cold and the promotion falls
+            // in the warmup; in a full run earlier tests have already made it partly hot, so the
+            // threshold is crossed later, during the measurement. Nothing about run ORDER is
+            // load-bearing, which is why the issue title's "passes in isolation" is a symptom
+            // rather than the mechanism.
+            //
+            // The measurement base tick starts beyond the warmup's last one so timestamps stay
+            // monotonic: the warmup ends at 50_000 + (frames-1) * 50_000.
+            Push(frames, 50_000u);
 
             var before = GC.GetAllocatedBytesForCurrentThread();
-            Push(frames, 50_000_000u);
+            Push(frames, 200_000_000u);
             return GC.GetAllocatedBytesForCurrentThread() - before;
 
             static void Inert(object? sender, SampleReceivedEventArgs e)


### PR DESCRIPTION
Fixes #559. Same cause as #531, in the sibling test.

## The mechanism (and why the issue titles mislead)

`AttachedToDevice_CostsTheDecodePathNoMoreThanAnEmptySubscriber` warmed with **200** frames and then measured **2,000**.

Tiered compilation promotes a hot method to tier 1 partway through a long loop, and **the rejit allocates**. A short warmup leaves that promotion to land *inside* the measured window.

That produces exactly the reported signature — *fails on a full run, passes in isolation* — but **run order is not the mechanism**. In isolation the method is cold and the promotion falls inside the warmup; in a full run earlier tests have already made it partly hot, so the threshold is crossed later, during the measurement. Both issues are titled around "passes in isolation" because that is what was *observed*; anything that changes how hot the method already is, or how large it is, moves the promotion. (#534's scaling comparison made `RecordCore` bigger, which is why #531 surfaced when it did.)

**#531's own numbers were the tell**, and are worth keeping on the record: 7,128 bytes across 10,000 calls is **0.71 bytes per call** — not a per-call allocation at all. The smallest object on this runtime is 24 bytes, so a real one would be ≥ 240 KB. A sub-byte "per-call allocation" is a fixed one-off cost divided by the loop count.

## The fix

Warm over the same count that is measured, and start the measurement's base tick beyond the warmup's last one so timestamps stay monotonic (the warmup ends at `50_000 + (frames-1) * 50_000`).

This mirrors what #531's fix already did for `Record_AfterTheFirstSamplePerChannel_AllocatesNothing`; that test has not flaked since.

## Evidence, stated honestly

This failed in a **full run earlier today** while verifying an unrelated PR — which is how it was caught, and it is a third sighting of the same pattern in the same file.

Three consecutive full runs after the change are clean: **3577 passed**, with only the four pre-existing `LinuxUsbPortDescriptorProviderTests` failures that `main` already has.

**Three runs is not proof for an intermittent.** The load-bearing argument is the mechanism above; the runs are corroboration. I would rather say that than present 3/3 as if it settled the matter.

The assertion keeps its teeth either way — a genuine per-frame allocation is orders of magnitude above the noise this removes, and the threshold is unchanged.

## Scope

Test-only; no production code touched. `#531` stays open — its own test was already fixed, and this closes the sibling it pointed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
