### PR TITLE
fix(channel): make ChannelScaling's overflow fallback detectable

### DIFF
--- a/src/Daqifi.Core.Tests/Channel/ChannelScalingTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/ChannelScalingTests.cs
@@ -111,6 +111,52 @@ public class ChannelScalingTests
     }
 
     [Fact]
+    public void TryApply_OnANormalResult_ReturnsTrueAndTheScaledValue()
+    {
+        var scaling = new ChannelScaling(gain: 20.0, offset: 3.0);
+
+        Assert.True(scaling.TryApply(2.5, out var scaled));
+        Assert.Equal(53.0, scaled);
+    }
+
+    [Fact]
+    public void TryApply_OnAnOverflowingResult_ReturnsFalseAndTheUnscaledValue()
+    {
+        // The signal Apply cannot give: false marks the fallback as a fallback, so a caller can
+        // tell "converted" from "the original value in the original unit, unmarked" and choose to
+        // skip it rather than mix it into an aggregate.
+        var scaling = new ChannelScaling(gain: 1e308);
+
+        Assert.False(scaling.TryApply(1e10, out var scaled));
+        Assert.Equal(1e10, scaled);
+    }
+
+    [Fact]
+    public void TryApply_OnANonFiniteInput_ReturnsFalseAndTheInput()
+    {
+        // Non-finite in, non-finite out is still "the conversion did not happen" -- it is visibly
+        // wrong rather than silently mislabelled, but it is still not a converted value.
+        var scaling = new ChannelScaling(gain: 2.0);
+
+        Assert.False(scaling.TryApply(double.NaN, out var nan));
+        Assert.True(double.IsNaN(nan));
+
+        Assert.False(scaling.TryApply(double.PositiveInfinity, out var infinity));
+        Assert.Equal(double.PositiveInfinity, infinity);
+    }
+
+    [Fact]
+    public void Apply_DelegatesToTryApply()
+    {
+        // Apply is TryApply with the bool dropped, not a second implementation to keep in sync.
+        var scaling = new ChannelScaling(gain: 1e308);
+
+        scaling.TryApply(1e10, out var expected);
+
+        Assert.Equal(expected, scaling.Apply(1e10));
+    }
+
+    [Fact]
     public void Identity_LeavesValuesAlone_AndStatesNoUnit()
     {
         Assert.Equal(4.25, ChannelScaling.Identity.Apply(4.25));

--- a/src/Daqifi.Core/Channel/ChannelScaling.cs
+++ b/src/Daqifi.Core/Channel/ChannelScaling.cs
@@ -121,10 +121,12 @@ public sealed record ChannelScaling
     /// </param>
     /// <returns>
     /// <see langword="true"/> when <paramref name="scaled"/> is <paramref name="value"/> converted
-    /// by <see cref="Gain"/> and <see cref="Offset"/>; <see langword="false"/> when the arithmetic
-    /// overflowed and <paramref name="scaled"/> is the unscaled fallback — in the original unit, not
-    /// <see cref="Unit"/>. A caller that aggregates converted readings (min, max, mean) can use this
-    /// to skip a fallback sample rather than let it silently contaminate the result.
+    /// by <see cref="Gain"/> and <see cref="Offset"/>; <see langword="false"/> when the conversion
+    /// did not happen because the computed result is non-finite — either the arithmetic overflowed,
+    /// or <paramref name="value"/> itself was already NaN or infinite — and <paramref name="scaled"/>
+    /// is the unscaled fallback — in the original unit, not <see cref="Unit"/>. A caller that
+    /// aggregates converted readings (min, max, mean) can use this to skip a fallback sample rather
+    /// than let it silently contaminate the result.
     /// </returns>
     public bool TryApply(double value, out double scaled)
     {

--- a/src/Daqifi.Core/Channel/ChannelScaling.cs
+++ b/src/Daqifi.Core/Channel/ChannelScaling.cs
@@ -98,10 +98,45 @@ public sealed record ChannelScaling
     /// overflowing coefficient, and a reading that was already non-finite is handed back as it came
     /// rather than being disguised as a real measurement.
     /// </returns>
+    /// <remarks>
+    /// The return type cannot distinguish "converted" from "fell back to the unscaled value" — a
+    /// fallback comes back in the original unit with nothing marking it as such. A caller that needs
+    /// to tell the two apart, e.g. to avoid mixing an unscaled reading into a window of converted
+    /// ones, should use <see cref="TryApply"/> instead.
+    /// </remarks>
     public double Apply(double value)
     {
-        var scaled = value * Gain + Offset;
-        return double.IsFinite(scaled) ? scaled : value;
+        TryApply(value, out var result);
+        return result;
+    }
+
+    /// <summary>
+    /// Applies the transform to <paramref name="value"/>, reporting whether the conversion actually
+    /// took place.
+    /// </summary>
+    /// <param name="value">The channel value to convert, typically volts.</param>
+    /// <param name="scaled">
+    /// The converted value, or <paramref name="value"/> unchanged when the conversion would produce
+    /// a non-finite result.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when <paramref name="scaled"/> is <paramref name="value"/> converted
+    /// by <see cref="Gain"/> and <see cref="Offset"/>; <see langword="false"/> when the arithmetic
+    /// overflowed and <paramref name="scaled"/> is the unscaled fallback — in the original unit, not
+    /// <see cref="Unit"/>. A caller that aggregates converted readings (min, max, mean) can use this
+    /// to skip a fallback sample rather than let it silently contaminate the result.
+    /// </returns>
+    public bool TryApply(double value, out double scaled)
+    {
+        var result = value * Gain + Offset;
+        if (double.IsFinite(result))
+        {
+            scaled = result;
+            return true;
+        }
+
+        scaled = value;
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## What was wrong

`ChannelScaling.Apply` deliberately falls back to the unscaled value when the `Gain`/`Offset` arithmetic overflows (an adversarial gain, not a realistic transducer config) -- so a finite reading is never turned into `NaN`/`Infinity`. But the fallback returns the original value in the original unit with no way to tell it apart from a real conversion: a bare `double` can't carry that signal.

That means `IDataSample.ScaledValue` can report a value in volts while `IDataSample.Unit` still says `"PSI"`, and nothing downstream can detect it. Worse, anything aggregating readings (min/max/mean) would silently mix an unscaled fallback sample into a window of correctly-converted ones.

## The fix

Added `ChannelScaling.TryApply(double value, out double scaled)`, which returns `false` when the overflow fallback fires (with `scaled` set to the unscaled value) and `true` on a normal conversion. `Apply` is now a thin wrapper over `TryApply` so the two implementations can't drift.

This is additive -- `Apply`'s behavior and signature are unchanged, so nothing that already calls it breaks. A caller that needs to detect and skip a fallback reading (e.g. before feeding it into an aggregate) can now do so via `TryApply`.

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)