### PR TITLE
fix(sdcard): resume a live stream an SD operation defensively stopped

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -141,6 +141,7 @@ public class ConnectionGuardTests
         public DeviceMetadata Metadata => throw new NotSupportedException();
         public long ChannelStateVersion => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
+        public void StartStreaming() => throw new NotSupportedException();
         public void Send<T>(IOutboundMessage<T> message) => throw new NotSupportedException();
         public void Disconnect() => throw new NotSupportedException();
         public IReadOnlyList<IChannel> SnapshotChannels() => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -605,6 +605,7 @@ public class DeviceAdministrationOperationsTests
         public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
         public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
+        public void StartStreaming() => throw new NotSupportedException();
         public IReadOnlyList<IChannel> SnapshotChannels() => throw new NotSupportedException();
         public long ChannelStateVersion => throw new NotSupportedException();
         public void WithChannelsLock(Action action) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -497,6 +497,7 @@ public class LiveSampleStreamTests
         public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
         public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
+        public void StartStreaming() => throw new NotSupportedException();
         public void Send<T>(IOutboundMessage<T> message) => throw new NotSupportedException();
         public void Disconnect() => throw new NotSupportedException();
         public void WithChannelsLock(Action action) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -897,6 +897,7 @@ public class StreamFrameDecoderTests
         public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
         public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
+        public void StartStreaming() => throw new NotSupportedException();
         public void Disconnect() => throw new NotSupportedException();
         public void Send<T>(IOutboundMessage<T> message) => throw new NotSupportedException();
         public void WithChannelsLock(Action action) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
@@ -388,6 +388,84 @@ public class SdCardOperationsCollaboratorTests
         Assert.DoesNotContain(host.Calls, c => c.StartsWith("ensure:", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task GetSdCardFilesAsync_WasStreaming_ResumesStreamingAfterTheLanRestore()
+    {
+        // #533: a live StreamSamplesAsync consumer must not go silent forever just because
+        // something else asked the device to list its SD card.
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse(NoErrorTerminator);
+        var ops = new SdCardOperations(host);
+
+        await ops.GetSdCardFilesAsync();
+
+        Assert.True(host.IsStreaming);
+        Assert.Equal(1, host.StartStreamingCallCount);
+        // Restored after the exchange (and its finalize-phase LAN restore) has fully closed —
+        // not from inside it — the same way this whole method's try/finally sits outside the
+        // exchange it wraps.
+        Assert.Equal("send:SYSTem:StartStreamData 100", host.Calls[^1]);
+    }
+
+    [Fact]
+    public async Task GetSdCardFilesAsync_WasNotStreaming_LeavesStreamingOff()
+    {
+        var host = new FakeHost { IsStreaming = false };
+        host.EnqueueResponse(NoErrorTerminator);
+        var ops = new SdCardOperations(host);
+
+        await ops.GetSdCardFilesAsync();
+
+        Assert.False(host.IsStreaming);
+        Assert.Equal(0, host.StartStreamingCallCount);
+    }
+
+    [Fact]
+    public async Task GetSdCardFilesAsync_WasStreaming_RestoresEvenWhenTheListingIsIncomplete()
+    {
+        // The stream must come back whether the SD operation it interrupted succeeded or not —
+        // the live consumer has no idea the SD operation happened at all, let alone how it ended.
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse("Daqifi/a.bin 10");
+        host.EnqueueResponse("Daqifi/a.bin 10");
+        var ops = new SdCardOperations(host);
+
+        await Assert.ThrowsAsync<SdCardListIncompleteException>(() => ops.GetSdCardFilesAsync());
+
+        Assert.Equal(1, host.StartStreamingCallCount);
+        Assert.True(host.IsStreaming);
+    }
+
+    [Fact]
+    public async Task GetSdCardFilesAsync_WasStreaming_RestoresOnceEvenAcrossARetry()
+    {
+        // The restore is a property of the whole operation, not of each attempt inside it — firing
+        // it per-attempt would flip streaming on and off mid-retry.
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse("Daqifi/a.bin 10");
+        host.EnqueueResponse("Daqifi/a.bin 10", NoErrorTerminator);
+        var ops = new SdCardOperations(host);
+
+        await ops.GetSdCardFilesAsync();
+
+        Assert.Equal(2, host.ExchangeCount);
+        Assert.Equal(1, host.StartStreamingCallCount);
+    }
+
+    [Fact]
+    public async Task GetSdCardFilesAsync_WasStreamingButDeviceDropsMidExchange_SkipsTheStreamingRestoreToo()
+    {
+        // Same reasoning as the LAN restore this mirrors: nothing to resume once the link is gone.
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse("Daqifi/a.bin 10", NoErrorTerminator);
+        host.AfterExchangeSetup = _ => host.IsConnected = false;
+        var ops = new SdCardOperations(host);
+
+        await ops.GetSdCardFilesAsync();
+
+        Assert.Equal(0, host.StartStreamingCallCount);
+    }
+
     #endregion
 
     #region GetSdCardStorageAsync
@@ -474,6 +552,60 @@ public class SdCardOperationsCollaboratorTests
 
         await Assert.ThrowsAsync<SdCardBusyException>(() => ops.GetSdCardStorageAsync());
         Assert.Equal(0, host.ExchangeCount);
+    }
+
+    [Fact]
+    public async Task GetSdCardStorageAsync_WasStreaming_ResumesStreamingAfterTheLanRestore()
+    {
+        // #533: the storage query is one of the bench-reproduced culprits — it must not leave a
+        // concurrent live capture stalled.
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse("1000,2000");
+        var ops = new SdCardOperations(host);
+
+        await ops.GetSdCardStorageAsync();
+
+        Assert.True(host.IsStreaming);
+        Assert.Equal(1, host.StartStreamingCallCount);
+    }
+
+    [Fact]
+    public async Task GetSdCardStorageAsync_WasNotStreaming_LeavesStreamingOff()
+    {
+        var host = new FakeHost { IsStreaming = false };
+        host.EnqueueResponse("1000,2000");
+        var ops = new SdCardOperations(host);
+
+        await ops.GetSdCardStorageAsync();
+
+        Assert.False(host.IsStreaming);
+        Assert.Equal(0, host.StartStreamingCallCount);
+    }
+
+    [Fact]
+    public async Task GetSdCardStorageAsync_WasStreaming_RestoresOnceEvenAcrossARetry()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse("**ERROR: -200,\"Execution error\"");
+        host.EnqueueResponse("1000,2000");
+        var ops = new SdCardOperations(host);
+
+        await ops.GetSdCardStorageAsync();
+
+        Assert.Equal(2, host.ExchangeCount);
+        Assert.Equal(1, host.StartStreamingCallCount);
+    }
+
+    [Fact]
+    public async Task GetSdCardStorageAsync_WasStreaming_RestoresEvenWhenTheResponseIsUnparseable()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse("not a space report");
+        var ops = new SdCardOperations(host);
+
+        await Assert.ThrowsAsync<SdCardOperationException>(() => ops.GetSdCardStorageAsync());
+
+        Assert.Equal(1, host.StartStreamingCallCount);
     }
 
     #endregion
@@ -743,6 +875,46 @@ public class SdCardOperationsCollaboratorTests
         Assert.Equal(0, host.ExchangeCount);
     }
 
+    [Fact]
+    public async Task DeleteSdCardFileAsync_WasStreaming_ResumesStreamingAfterTheLanRestore()
+    {
+        // #533
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse("Daqifi/keep.bin 10", NoErrorTerminator);
+        var ops = new SdCardOperations(host);
+
+        await ops.DeleteSdCardFileAsync("gone.bin");
+
+        Assert.True(host.IsStreaming);
+        Assert.Equal(1, host.StartStreamingCallCount);
+    }
+
+    [Fact]
+    public async Task DeleteSdCardFileAsync_WasNotStreaming_LeavesStreamingOff()
+    {
+        var host = new FakeHost { IsStreaming = false };
+        host.EnqueueResponse("Daqifi/keep.bin 10", NoErrorTerminator);
+        var ops = new SdCardOperations(host);
+
+        await ops.DeleteSdCardFileAsync("gone.bin");
+
+        Assert.False(host.IsStreaming);
+        Assert.Equal(0, host.StartStreamingCallCount);
+    }
+
+    [Fact]
+    public async Task DeleteSdCardFileAsync_WasStreaming_RestoresEvenWhenTheDeleteFails()
+    {
+        var host = new FakeHost { IsStreaming = true };
+        host.EnqueueResponse("**ERROR: -200,\"Execution error\"", NoErrorTerminator);
+        host.EnqueueResponse("**ERROR: -200,\"Execution error\"", NoErrorTerminator);
+        var ops = new SdCardOperations(host);
+
+        await Assert.ThrowsAsync<SdCardOperationException>(() => ops.DeleteSdCardFileAsync("gone.bin"));
+
+        Assert.Equal(1, host.StartStreamingCallCount);
+    }
+
     #endregion
 
     #region FormatSdCardAsync
@@ -761,6 +933,40 @@ public class SdCardOperationsCollaboratorTests
             new[] { "send:" + StopStreaming, "send:" + EnableSd, "send:SYSTem:STORage:SD:FORmat" },
             host.Calls);
         Assert.Equal(0, host.ExchangeCount);
+    }
+
+    [Fact]
+    public async Task FormatSdCardAsync_WasStreaming_ResumesStreamingAfterward()
+    {
+        // #533
+        var host = new FakeHost { IsStreaming = true };
+        var ops = new SdCardOperations(host);
+
+        await ops.FormatSdCardAsync();
+
+        Assert.True(host.IsStreaming);
+        Assert.Equal(1, host.StartStreamingCallCount);
+        Assert.Equal(
+            new[]
+            {
+                "send:" + StopStreaming,
+                "send:" + EnableSd,
+                "send:SYSTem:STORage:SD:FORmat",
+                "send:SYSTem:StartStreamData 100",
+            },
+            host.Calls);
+    }
+
+    [Fact]
+    public async Task FormatSdCardAsync_WasNotStreaming_LeavesStreamingOff()
+    {
+        var host = new FakeHost { IsStreaming = false };
+        var ops = new SdCardOperations(host);
+
+        await ops.FormatSdCardAsync();
+
+        Assert.False(host.IsStreaming);
+        Assert.Equal(0, host.StartStreamingCallCount);
     }
 
     #endregion
@@ -782,6 +988,44 @@ public class SdCardOperationsCollaboratorTests
         Assert.Contains("send:SYSTem:STORage:SD:GET \"data.bin\"", host.Calls);
         Assert.Contains("send:" + DisableSd, host.Calls);
         Assert.Contains("send:" + EnableLan, host.Calls);
+    }
+
+    [Fact]
+    public async Task DownloadSdCardFileAsync_WasStreaming_ResumesStreamingAfterTheLanRestore()
+    {
+        // #533
+        var payload = new byte[] { 1, 2, 3 };
+        var host = new FakeHost
+        {
+            IsStreaming = true,
+            RawCaptureStreamFactory = () => ScriptedStream.Of(Concat(payload, EofMarker)),
+        };
+        var ops = new SdCardOperations(host);
+        using var destination = new MemoryStream();
+
+        await ops.DownloadSdCardFileAsync("data.bin", destination);
+
+        Assert.True(host.IsStreaming);
+        Assert.Equal(1, host.StartStreamingCallCount);
+        Assert.Equal("send:SYSTem:StartStreamData 100", host.Calls[^1]);
+    }
+
+    [Fact]
+    public async Task DownloadSdCardFileAsync_WasNotStreaming_LeavesStreamingOff()
+    {
+        var payload = new byte[] { 1, 2, 3 };
+        var host = new FakeHost
+        {
+            IsStreaming = false,
+            RawCaptureStreamFactory = () => ScriptedStream.Of(Concat(payload, EofMarker)),
+        };
+        var ops = new SdCardOperations(host);
+        using var destination = new MemoryStream();
+
+        await ops.DownloadSdCardFileAsync("data.bin", destination);
+
+        Assert.False(host.IsStreaming);
+        Assert.Equal(0, host.StartStreamingCallCount);
     }
 
     [Fact]
@@ -887,6 +1131,7 @@ public class SdCardOperationsCollaboratorTests
         var entered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var host = new FakeHost
         {
+            IsStreaming = true,
             // 200ms budget → a ~300ms hard deadline (the grace is clamped to a 100ms floor).
             SdCardDownloadTimeout = TimeSpan.FromMilliseconds(200),
             RawCaptureStreamFactory = () => new ParkedStream(entered, release.Task),
@@ -914,6 +1159,10 @@ public class SdCardOperationsCollaboratorTests
             Assert.Contains("send:SYSTem:STORage:SD:GET \"data.bin\"", host.Calls);
             Assert.DoesNotContain("send:" + DisableSd, host.Calls);
             Assert.DoesNotContain("send:" + EnableLan, host.Calls);
+            // #533: the same reasoning that skips the LAN restore applies here — the abandoned
+            // worker still owns the transport, so a StartStreamData write would be a second writer
+            // on a stream a transfer is still reading.
+            Assert.Equal(0, host.StartStreamingCallCount);
         }
         finally
         {
@@ -1125,8 +1374,12 @@ public class SdCardOperationsCollaboratorTests
 
         public bool IsConnected { get; set; } = true;
         public bool IsUsbConnection { get; set; } = true;
-        public bool IsStreaming { get; set; } = true;
+        public bool IsStreaming { get; set; }
         public int StreamingFrequency { get; set; } = 100;
+
+        /// <summary>Number of times <see cref="StartStreaming"/> was called, for tests that only
+        /// care that a restore happened without pinning the exact position in <see cref="Calls"/>.</summary>
+        public int StartStreamingCallCount { get; private set; }
 
         public TimeSpan SdCardDownloadTimeout { get; set; } = TimeSpan.FromMinutes(30);
         public TimeSpan SdCardTransferIdleTimeout { get; set; } = TimeSpan.FromSeconds(20);
@@ -1236,6 +1489,13 @@ public class SdCardOperationsCollaboratorTests
         public DeviceMetadata Metadata => throw new NotSupportedException();
         public long ChannelStateVersion => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
+
+        public void StartStreaming()
+        {
+            StartStreamingCallCount++;
+            Record("send:SYSTem:StartStreamData " + StreamingFrequency);
+            IsStreaming = true;
+        }
         public void Disconnect() => throw new NotSupportedException();
         public IReadOnlyList<IChannel> SnapshotChannels() => throw new NotSupportedException();
         public void WithChannelsLock(Action action) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
@@ -466,6 +466,37 @@ public class SdCardOperationsCollaboratorTests
         Assert.Equal(0, host.StartStreamingCallCount);
     }
 
+    [Fact]
+    public async Task GetSdCardFilesAsync_ResumeFailure_DoesNotMaskTheListingResult()
+    {
+        // Qodo review (#566): the resume runs in a finally, so a device that drops between the
+        // IsConnected check and the resume send must not turn a listing that already succeeded
+        // into a failure the caller never asked about.
+        var host = new FakeHost { IsStreaming = true, ThrowOnStartStreaming = true };
+        host.EnqueueResponse("Daqifi/a.bin 10", NoErrorTerminator);
+        var ops = new SdCardOperations(host);
+
+        var files = await ops.GetSdCardFilesAsync();
+
+        Assert.Equal("a.bin", Assert.Single(files).FileName);
+        Assert.Equal(1, host.StartStreamingCallCount);
+        Assert.False(host.IsStreaming);
+    }
+
+    [Fact]
+    public async Task GetSdCardFilesAsync_ResumeFailure_DoesNotMaskTheOriginalException()
+    {
+        var host = new FakeHost { IsStreaming = true, ThrowOnStartStreaming = true };
+        host.EnqueueResponse("Daqifi/a.bin 10");
+        host.EnqueueResponse("Daqifi/a.bin 10");
+        var ops = new SdCardOperations(host);
+
+        var ex = await Assert.ThrowsAsync<SdCardListIncompleteException>(() => ops.GetSdCardFilesAsync());
+
+        Assert.Contains("Daqifi/a.bin 10", ex.RawDeviceResponse);
+        Assert.Equal(1, host.StartStreamingCallCount);
+    }
+
     #endregion
 
     #region GetSdCardStorageAsync
@@ -969,6 +1000,24 @@ public class SdCardOperationsCollaboratorTests
         Assert.Equal(0, host.StartStreamingCallCount);
     }
 
+    [Fact]
+    public async Task FormatSdCardAsync_WasStreaming_RestoresEvenWhenTheFormatCommandThrows()
+    {
+        // Qodo review (#566): the restore must not be reachable only from the success path — a
+        // device that drops between EnableStorageSd and FormatSdCard must not leave a live stream
+        // that was active before this call silenced for good.
+        var host = new FakeHost
+        {
+            IsStreaming = true,
+            ThrowOnSend = ("SYSTem:STORage:SD:FORmat", new DeviceNotConnectedException()),
+        };
+        var ops = new SdCardOperations(host);
+
+        await Assert.ThrowsAsync<DeviceNotConnectedException>(() => ops.FormatSdCardAsync());
+
+        Assert.Equal(1, host.StartStreamingCallCount);
+    }
+
     #endregion
 
     #region DownloadSdCardFileAsync
@@ -1404,6 +1453,16 @@ public class SdCardOperationsCollaboratorTests
         /// <summary>Supplies the stream a raw capture reads from. Defaults to an immediately-closed stream.</summary>
         public Func<Stream>? RawCaptureStreamFactory { get; set; }
 
+        /// <summary>When set, <see cref="Send{T}"/> throws this the first time it is called with a
+        /// message whose data equals this value — simulating a command that fails outright rather
+        /// than one that gets a reply, e.g. a device that drops mid-command.</summary>
+        public (string Data, Exception Exception)? ThrowOnSend { get; set; }
+
+        /// <summary>When true, <see cref="StartStreaming"/> throws instead of recording a call —
+        /// simulating a resume attempt that fails, e.g. the device dropped after the
+        /// <see cref="IsConnected"/> check that gates it.</summary>
+        public bool ThrowOnStartStreaming { get; set; }
+
         public void EnqueueResponse(params string[] lines)
         {
             lock (_responses) { _responses.Enqueue(lines); }
@@ -1414,7 +1473,16 @@ public class SdCardOperationsCollaboratorTests
             lock (_calls) { _calls.Add(call); }
         }
 
-        public void Send<T>(IOutboundMessage<T> message) => Record("send:" + message.Data);
+        public void Send<T>(IOutboundMessage<T> message)
+        {
+            if (ThrowOnSend is { } throwOn && Equals(message.Data, throwOn.Data))
+            {
+                ThrowOnSend = null;
+                throw throwOn.Exception;
+            }
+
+            Record("send:" + message.Data);
+        }
 
         public void EnsureSupported(DeviceFeature feature)
         {
@@ -1493,6 +1561,12 @@ public class SdCardOperationsCollaboratorTests
         public void StartStreaming()
         {
             StartStreamingCallCount++;
+
+            if (ThrowOnStartStreaming)
+            {
+                throw new InvalidOperationException("Simulated StartStreaming failure.");
+            }
+
             Record("send:SYSTem:StartStreamData " + StreamingFrequency);
             IsStreaming = true;
         }

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
@@ -471,7 +471,9 @@ public class SdCardOperationsCollaboratorTests
     {
         // Qodo review (#566): the resume runs in a finally, so a device that drops between the
         // IsConnected check and the resume send must not turn a listing that already succeeded
-        // into a failure the caller never asked about.
+        // into a failure the caller never asked about. And DaqifiStreamingDevice.StartStreaming
+        // sets IsStreaming = true before it sends, so a failed resume must not leave that flag
+        // true for a stream that never actually came back — the fake reproduces that ordering.
         var host = new FakeHost { IsStreaming = true, ThrowOnStartStreaming = true };
         host.EnqueueResponse("Daqifi/a.bin 10", NoErrorTerminator);
         var ops = new SdCardOperations(host);
@@ -1564,6 +1566,11 @@ public class SdCardOperationsCollaboratorTests
 
             if (ThrowOnStartStreaming)
             {
+                // Mirrors DaqifiStreamingDevice.StartStreaming, which sets IsStreaming = true
+                // BEFORE sending the SCPI command — so a Send failure there leaves the flag true
+                // for a stream that never actually resumed, exactly what a caller of this fake
+                // needs to be able to reproduce.
+                IsStreaming = true;
                 throw new InvalidOperationException("Simulated StartStreaming failure.");
             }
 

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1292,6 +1292,8 @@ namespace Daqifi.Core.Device
 
         void IDeviceOperationHost.StopStreaming() => StopStreaming();
 
+        void IDeviceOperationHost.StartStreaming() => StartStreaming();
+
         void IDeviceOperationHost.Send<T>(IOutboundMessage<T> message) => Send(message);
 
         DeviceMetadata IDeviceOperationHost.Metadata => Metadata;

--- a/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
+++ b/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
@@ -53,6 +53,15 @@ namespace Daqifi.Core.Device.Internal
         /// <inheritdoc cref="DaqifiStreamingDevice.StopStreaming"/>
         void StopStreaming();
 
+        /// <inheritdoc cref="DaqifiStreamingDevice.StartStreaming"/>
+        /// <remarks>
+        /// Used by the SD operations to resume a live stream their own defensive stop suspended, so
+        /// the resume runs through the device's own session bookkeeping
+        /// (<see cref="DaqifiStreamingDevice.StartStreaming"/> resets the frame decoder's session)
+        /// rather than a raw <see cref="Send{T}"/> that would skip it.
+        /// </remarks>
+        void StartStreaming();
+
         /// <inheritdoc cref="DaqifiDevice.Send{T}"/>
         void Send<T>(IOutboundMessage<T> message);
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -385,9 +385,22 @@ namespace Daqifi.Core.Device.SdCard
         /// </remarks>
         private void RestoreStreamingIfNeeded(bool wasStreaming)
         {
-            if (wasStreaming && _host.IsConnected)
+            if (!wasStreaming || !_host.IsConnected)
+            {
+                return;
+            }
+
+            try
             {
                 _host.StartStreaming();
+            }
+            catch
+            {
+                // Best-effort, the same as the LAN restore this mirrors (RestoreLanInterfaceAsync,
+                // DownloadSdCardFileAsync's finally): called from a finally block, so letting a
+                // failure here escape would replace whatever the SD operation itself threw — or
+                // turn a clean success into a failure — over a device that may simply have dropped
+                // between the IsConnected check above and this call.
             }
         }
 
@@ -1023,10 +1036,19 @@ namespace Daqifi.Core.Device.SdCard
             _host.Send(ScpiMessageProducer.StopStreaming);
             _host.IsStreaming = false;
 
-            _host.Send(ScpiMessageProducer.EnableStorageSd);
-            _host.Send(ScpiMessageProducer.FormatSdCard);
-
-            RestoreStreamingIfNeeded(wasStreaming);
+            try
+            {
+                _host.Send(ScpiMessageProducer.EnableStorageSd);
+                _host.Send(ScpiMessageProducer.FormatSdCard);
+            }
+            finally
+            {
+                // In a finally, not only on the path where both sends succeed: a stream that was
+                // silenced by the stop above must come back even if EnableStorageSd or FormatSdCard
+                // itself throws (e.g. the device dropped mid-command), the same as every other SD
+                // operation in this file now guarantees.
+                RestoreStreamingIfNeeded(wasStreaming);
+            }
 
             return Task.CompletedTask;
         }

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -216,91 +216,102 @@ namespace Daqifi.Core.Device.SdCard
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Captured before the defensive stop below so the finally can tell "this operation
+            // silenced a live stream" apart from "nothing was streaming to begin with" (#533).
+            var wasStreaming = _host.IsStreaming;
+
             // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
             _host.Send(ScpiMessageProducer.StopStreaming);
             _host.IsStreaming = false;
 
-            IReadOnlyList<string> lines = Array.Empty<string>();
-            IReadOnlyList<string> listing = Array.Empty<string>();
-            var isComplete = false;
-
-            // Attempt 0 plus SD_LIST_MAX_RETRIES retries. A SCPI error here is often a transient
-            // timing issue, and an unterminated response can be a one-off stall, so both are
-            // retried once after an additional settle delay before being surfaced.
-            for (var attempt = 0; attempt <= SD_LIST_MAX_RETRIES; attempt++)
+            try
             {
-                if (attempt > 0)
+                IReadOnlyList<string> lines = Array.Empty<string>();
+                IReadOnlyList<string> listing = Array.Empty<string>();
+                var isComplete = false;
+
+                // Attempt 0 plus SD_LIST_MAX_RETRIES retries. A SCPI error here is often a transient
+                // timing issue, and an unterminated response can be a one-off stall, so both are
+                // retried once after an additional settle delay before being surfaced.
+                for (var attempt = 0; attempt <= SD_LIST_MAX_RETRIES; attempt++)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
-                }
-
-                // The SPI bus switch and its settle wait run as the exchange's prepare phase, and
-                // the restore as its finalize phase: both inside the exchange lock, so a competing
-                // text exchange can neither restore the LAN interface between the switch and the
-                // LIST nor slip in between the LIST and the restore. The prepare also sits ahead of
-                // the stale-line boundary, so its settle wait does not become a window in which a
-                // late reply to an earlier command could pass for this listing's terminator.
-                // Querying the card too soon after the switch makes the device answer -200
-                // (Execution error), so the wait itself is not optional.
-                //
-                // Each attempt therefore leaves the bus back on LAN, including across the retry
-                // delay above — the pairing is per exchange rather than per call so that gap, which
-                // is outside the lock, is not one in which the device sits switched to the card.
-                lines = await _host.ExecuteTextCommandAsync(
-                    () =>
+                    if (attempt > 0)
                     {
-                        _host.Send(ScpiMessageProducer.GetSdFileList);
+                        cancellationToken.ThrowIfCancellationRequested();
 
-                        // End-of-listing terminator — see this method's remarks. Sent inside
-                        // the same text exchange so the ordering guarantee holds.
-                        _host.Send(ScpiMessageProducer.GetSystemError);
-                    },
-                    responseTimeoutMs: 3000,
-                    completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
-                    cancellationToken: cancellationToken,
-                    prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                    finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+                    }
 
-                isComplete = TrySplitAtSdListTerminator(lines, out listing);
+                    // The SPI bus switch and its settle wait run as the exchange's prepare phase, and
+                    // the restore as its finalize phase: both inside the exchange lock, so a competing
+                    // text exchange can neither restore the LAN interface between the switch and the
+                    // LIST nor slip in between the LIST and the restore. The prepare also sits ahead of
+                    // the stale-line boundary, so its settle wait does not become a window in which a
+                    // late reply to an earlier command could pass for this listing's terminator.
+                    // Querying the card too soon after the switch makes the device answer -200
+                    // (Execution error), so the wait itself is not optional.
+                    //
+                    // Each attempt therefore leaves the bus back on LAN, including across the retry
+                    // delay above — the pairing is per exchange rather than per call so that gap, which
+                    // is outside the lock, is not one in which the device sits switched to the card.
+                    lines = await _host.ExecuteTextCommandAsync(
+                        () =>
+                        {
+                            _host.Send(ScpiMessageProducer.GetSdFileList);
 
-                if (isComplete && !ScpiResponseClassifier.ContainsScpiError(listing))
-                {
-                    break;
+                            // End-of-listing terminator — see this method's remarks. Sent inside
+                            // the same text exchange so the ordering guarantee holds.
+                            _host.Send(ScpiMessageProducer.GetSystemError);
+                        },
+                        responseTimeoutMs: 3000,
+                        completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
+                        cancellationToken: cancellationToken,
+                        prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                        finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
+
+                    isComplete = TrySplitAtSdListTerminator(lines, out listing);
+
+                    if (isComplete && !ScpiResponseClassifier.ContainsScpiError(listing))
+                    {
+                        break;
+                    }
                 }
-            }
 
-            if (!isComplete)
+                if (!isComplete)
+                {
+                    throw new SdCardListIncompleteException(lines);
+                }
+
+                ThrowIfSdCardListError(listing);
+
+                // The device's own end-of-listing marker (firmware #794), when it sends
+                // one. FAILED means the walk could not open the directory at all, so an
+                // empty result would report "there is nothing there" for what was really
+                // "I could not look" -- the exact confusion the terminator above exists
+                // to prevent, one level deeper. Unterminated is the pre-#794 firmware and
+                // is not an error: the reply framing already told us the exchange
+                // completed, we simply learn nothing more from the device.
+                var listingStatus = SdCardFileListParser.GetListingStatus(listing);
+                if (listingStatus == SdCardListingStatus.Failed
+                    || listingStatus == SdCardListingStatus.Incomplete)
+                {
+                    // INCOMPLETE throws for the same reason a missing transport
+                    // terminator does, a few lines above: the caller is about to
+                    // cache this list and answer "is my file on the card?" from it.
+                    // A device-truncated listing and a transport-truncated one are
+                    // the same class of wrong answer, so they raise the same
+                    // exception -- a client that handles one already handles this.
+                    throw new SdCardListIncompleteException(lines);
+                }
+
+                var files = SdCardFileListParser.ParseFileList(listing);
+                _sdCardFiles = files;
+                return files;
+            }
+            finally
             {
-                throw new SdCardListIncompleteException(lines);
+                RestoreStreamingIfNeeded(wasStreaming);
             }
-
-            ThrowIfSdCardListError(listing);
-
-            // The device's own end-of-listing marker (firmware #794), when it sends
-            // one. FAILED means the walk could not open the directory at all, so an
-            // empty result would report "there is nothing there" for what was really
-            // "I could not look" -- the exact confusion the terminator above exists
-            // to prevent, one level deeper. Unterminated is the pre-#794 firmware and
-            // is not an error: the reply framing already told us the exchange
-            // completed, we simply learn nothing more from the device.
-            var listingStatus = SdCardFileListParser.GetListingStatus(listing);
-            if (listingStatus == SdCardListingStatus.Failed
-                || listingStatus == SdCardListingStatus.Incomplete)
-            {
-                // INCOMPLETE throws for the same reason a missing transport
-                // terminator does, a few lines above: the caller is about to
-                // cache this list and answer "is my file on the card?" from it.
-                // A device-truncated listing and a transport-truncated one are
-                // the same class of wrong answer, so they raise the same
-                // exception -- a client that handles one already handles this.
-                throw new SdCardListIncompleteException(lines);
-            }
-
-            var files = SdCardFileListParser.ParseFileList(listing);
-            _sdCardFiles = files;
-            return files;
         }
 
         /// <summary>
@@ -350,6 +361,34 @@ namespace Daqifi.Core.Device.SdCard
             }
 
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Resumes streaming after an SD-card operation's defensive stop, if a live stream was
+        /// actually running when the operation started (#533). Every SD operation stops streaming
+        /// unconditionally before it touches the card, whether or not anyone was consuming it; left
+        /// unrestored, a caller reading <see cref="DaqifiStreamingDevice.StreamSamplesAsync"/>
+        /// concurrently goes silent for the rest of the read with no error, because the device is
+        /// still connected — only no longer streaming.
+        /// </summary>
+        /// <param name="wasStreaming">
+        /// Whether <see cref="IDeviceOperationHost.IsStreaming"/> was <c>true</c> immediately before
+        /// this operation's defensive stop. Restoring unconditionally would start streaming on a
+        /// device nothing had asked to stream from.
+        /// </param>
+        /// <remarks>
+        /// Goes through <see cref="IDeviceOperationHost.StartStreaming"/> rather than a raw
+        /// <c>Send(ScpiMessageProducer.StartStreaming(...))</c>, so the resumed stream gets the same
+        /// per-session frame-decoder reset (timestamp anchor, gap detector) any other
+        /// <see cref="DaqifiStreamingDevice.StartStreaming"/> call gets, instead of reusing the
+        /// session that was running before the SD operation.
+        /// </remarks>
+        private void RestoreStreamingIfNeeded(bool wasStreaming)
+        {
+            if (wasStreaming && _host.IsConnected)
+            {
+                _host.StartStreaming();
+            }
         }
 
         /// <summary>
@@ -442,78 +481,88 @@ namespace Daqifi.Core.Device.SdCard
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
+            var wasStreaming = _host.IsStreaming;
+
             // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
             _host.Send(ScpiMessageProducer.StopStreaming);
             _host.IsStreaming = false;
 
-            // Same prepare/finalize pairing as GetSdCardFilesAsync: the SPI bus switch and its
-            // settle wait are the exchange's prepare phase and the LAN restore is its finalize
-            // phase, so both halves are held by the one lock acquisition rather than only the
-            // switch (#407). The settle wait also moves ahead of the exchange's stale-line
-            // boundary instead of blocking a thread inside it.
-            var lines = await _host.ExecuteTextCommandAsync(
-                () => _host.Send(ScpiMessageProducer.GetSdSpace),
-                responseTimeoutMs: 3000,
-                cancellationToken: cancellationToken,
-                prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
-
-            // Only retry transient SCPI errors. A "No SD Card Detected" line
-            // is non-transient — retrying just delays the typed exception and
-            // risks misclassification if the marker isn't repeated on retry.
-            if (ScpiResponseClassifier.ContainsScpiError(lines) && !ContainsNoSdCardMarker(lines))
+            try
             {
-                for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
+                // Same prepare/finalize pairing as GetSdCardFilesAsync: the SPI bus switch and its
+                // settle wait are the exchange's prepare phase and the LAN restore is its finalize
+                // phase, so both halves are held by the one lock acquisition rather than only the
+                // switch (#407). The settle wait also moves ahead of the exchange's stale-line
+                // boundary instead of blocking a thread inside it.
+                var lines = await _host.ExecuteTextCommandAsync(
+                    () => _host.Send(ScpiMessageProducer.GetSdSpace),
+                    responseTimeoutMs: 3000,
+                    cancellationToken: cancellationToken,
+                    prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                    finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
+
+                // Only retry transient SCPI errors. A "No SD Card Detected" line
+                // is non-transient — retrying just delays the typed exception and
+                // risks misclassification if the marker isn't repeated on retry.
+                if (ScpiResponseClassifier.ContainsScpiError(lines) && !ContainsNoSdCardMarker(lines))
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
-
-                    lines = await _host.ExecuteTextCommandAsync(
-                        () => _host.Send(ScpiMessageProducer.GetSdSpace),
-                        responseTimeoutMs: 3000,
-                        cancellationToken: cancellationToken,
-                        prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                        finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
-
-                    if (!ScpiResponseClassifier.ContainsScpiError(lines) || ContainsNoSdCardMarker(lines))
+                    for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
                     {
-                        break;
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+
+                        lines = await _host.ExecuteTextCommandAsync(
+                            () => _host.Send(ScpiMessageProducer.GetSdSpace),
+                            responseTimeoutMs: 3000,
+                            cancellationToken: cancellationToken,
+                            prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                            finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
+
+                        if (!ScpiResponseClassifier.ContainsScpiError(lines) || ContainsNoSdCardMarker(lines))
+                        {
+                            break;
+                        }
                     }
                 }
-            }
 
-            if (SdCardSpaceParser.TryParseLines(lines, out var storage))
+                if (SdCardSpaceParser.TryParseLines(lines, out var storage))
+                {
+                    return storage;
+                }
+
+                // Parser failed — translate the firmware response into a typed exception.
+                var lastScpiError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
+
+                if (ContainsNoSdCardMarker(lines))
+                {
+                    throw new SdCardNotPresentException(lines, lastScpiError);
+                }
+
+                // A -113 "Undefined header" reply means the firmware doesn't recognize the storage
+                // query at all — typically because it predates the version that introduced it — so
+                // it gets the typed feature-gating exception instead of a generic operation error.
+                // The device's answer is authoritative here, so this throws on the wire response
+                // rather than on Supports(); the seam only supplies the required version and board.
+                if (lastScpiError != null
+                    && ScpiResponseClassifier.TryExtractErrorCode(lastScpiError, out var scpiErrorCode)
+                    && scpiErrorCode == ScpiErrorCodeUndefinedHeader)
+                {
+                    throw _host.CreateFeatureNotSupportedException(DeviceFeature.SdStorageQuery);
+                }
+
+                throw new SdCardOperationException(
+                    lastScpiError != null
+                        ? "The SD card storage query failed: " + lastScpiError
+                        : "The SD card storage query returned an unparseable response.",
+                    lines,
+                    lastScpiError);
+            }
+            finally
             {
-                return storage;
+                RestoreStreamingIfNeeded(wasStreaming);
             }
-
-            // Parser failed — translate the firmware response into a typed exception.
-            var lastScpiError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
-
-            if (ContainsNoSdCardMarker(lines))
-            {
-                throw new SdCardNotPresentException(lines, lastScpiError);
-            }
-
-            // A -113 "Undefined header" reply means the firmware doesn't recognize the storage
-            // query at all — typically because it predates the version that introduced it — so
-            // it gets the typed feature-gating exception instead of a generic operation error.
-            // The device's answer is authoritative here, so this throws on the wire response
-            // rather than on Supports(); the seam only supplies the required version and board.
-            if (lastScpiError != null
-                && ScpiResponseClassifier.TryExtractErrorCode(lastScpiError, out var scpiErrorCode)
-                && scpiErrorCode == ScpiErrorCodeUndefinedHeader)
-            {
-                throw _host.CreateFeatureNotSupportedException(DeviceFeature.SdStorageQuery);
-            }
-
-            throw new SdCardOperationException(
-                lastScpiError != null
-                    ? "The SD card storage query failed: " + lastScpiError
-                    : "The SD card storage query returned an unparseable response.",
-                lines,
-                lastScpiError);
         }
 
         private static bool ContainsNoSdCardMarker(IReadOnlyList<string> lines)
@@ -727,216 +776,225 @@ namespace Daqifi.Core.Device.SdCard
 
             ValidateSdCardFileName(fileName);
 
+            // Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
+            var wasStreaming = _host.IsStreaming;
+
             // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
             _host.Send(ScpiMessageProducer.StopStreaming);
             _host.IsStreaming = false;
-
-            // Same prepare/finalize treatment as GetSdCardFilesAsync, for the same reasons — the
-            // SPI switch stays serialized against competing text exchanges, its settle wait stays
-            // outside the stale-line boundary, and the restore stays under the same lock as the
-            // switch instead of running from a finally after the lock has been dropped. The
-            // consequence of a stale line is milder here (delete keys off ContainsScpiError, so it
-            // would mean a pointless delete-and-relist retry rather than a bad listing) but it is
-            // the same defect.
-            var lines = await _host.ExecuteTextCommandAsync(
-                () =>
-                {
-                    _host.Send(ScpiMessageProducer.DeleteSdFile(fileName));
-                    _host.Send(ScpiMessageProducer.GetSdFileList);
-
-                    // Transport terminator, exactly as the read path sends it.
-                    // Without it a reply cut short by the completion window is
-                    // indistinguishable from a complete one that carried no
-                    // device marker -- and the second of those is legitimate
-                    // (pre-#796 firmware), so the status alone cannot tell them
-                    // apart. This is what makes "the exchange finished" a fact
-                    // rather than an assumption.
-                    _host.Send(ScpiMessageProducer.GetSystemError);
-                },
-                responseTimeoutMs: 3000,
-                // Same completion window the read path uses for the same
-                // command. Without it this exchange takes the 250 ms default,
-                // and the firmware walks the directory tree between chunks --
-                // so a merely-slow listing is cut off BEFORE its terminator
-                // arrives, reads as Unterminated (which by design does not
-                // throw) and slips past the guard below to overwrite the cache
-                // with a partial list. The guard can only judge a marker it
-                // was given time to receive.
-                completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
-                cancellationToken: cancellationToken,
-                prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
-
-            if (ScpiResponseClassifier.ContainsScpiError(lines))
+            try
             {
-                for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
-
-                    lines = await _host.ExecuteTextCommandAsync(
-                        () =>
-                        {
-                            _host.Send(ScpiMessageProducer.DeleteSdFile(fileName));
-                            _host.Send(ScpiMessageProducer.GetSdFileList);
-                            _host.Send(ScpiMessageProducer.GetSystemError);
-                        },
-                        responseTimeoutMs: 3000,
-                        // The retry needs the window as much as the first
-                        // attempt: it is the same listing, and a retry that
-                        // truncates hands the same partial list to the same
-                        // cache.
-                        completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
-                        cancellationToken: cancellationToken,
-                        prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                        finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
-
-                    if (!ScpiResponseClassifier.ContainsScpiError(lines))
+                // Same prepare/finalize treatment as GetSdCardFilesAsync, for the same reasons — the
+                // SPI switch stays serialized against competing text exchanges, its settle wait stays
+                // outside the stale-line boundary, and the restore stays under the same lock as the
+                // switch instead of running from a finally after the lock has been dropped. The
+                // consequence of a stale line is milder here (delete keys off ContainsScpiError, so it
+                // would mean a pointless delete-and-relist retry rather than a bad listing) but it is
+                // the same defect.
+                var lines = await _host.ExecuteTextCommandAsync(
+                    () =>
                     {
-                        break;
+                        _host.Send(ScpiMessageProducer.DeleteSdFile(fileName));
+                        _host.Send(ScpiMessageProducer.GetSdFileList);
+
+                        // Transport terminator, exactly as the read path sends it.
+                        // Without it a reply cut short by the completion window is
+                        // indistinguishable from a complete one that carried no
+                        // device marker -- and the second of those is legitimate
+                        // (pre-#796 firmware), so the status alone cannot tell them
+                        // apart. This is what makes "the exchange finished" a fact
+                        // rather than an assumption.
+                        _host.Send(ScpiMessageProducer.GetSystemError);
+                    },
+                    responseTimeoutMs: 3000,
+                    // Same completion window the read path uses for the same
+                    // command. Without it this exchange takes the 250 ms default,
+                    // and the firmware walks the directory tree between chunks --
+                    // so a merely-slow listing is cut off BEFORE its terminator
+                    // arrives, reads as Unterminated (which by design does not
+                    // throw) and slips past the guard below to overwrite the cache
+                    // with a partial list. The guard can only judge a marker it
+                    // was given time to receive.
+                    completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
+                    cancellationToken: cancellationToken,
+                    prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                    finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
+
+                if (ScpiResponseClassifier.ContainsScpiError(lines))
+                {
+                    for (var retry = 0; retry < SD_LIST_MAX_RETRIES; retry++)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+
+                        lines = await _host.ExecuteTextCommandAsync(
+                            () =>
+                            {
+                                _host.Send(ScpiMessageProducer.DeleteSdFile(fileName));
+                                _host.Send(ScpiMessageProducer.GetSdFileList);
+                                _host.Send(ScpiMessageProducer.GetSystemError);
+                            },
+                            responseTimeoutMs: 3000,
+                            // The retry needs the window as much as the first
+                            // attempt: it is the same listing, and a retry that
+                            // truncates hands the same partial list to the same
+                            // cache.
+                            completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
+                            cancellationToken: cancellationToken,
+                            prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                            finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
+
+                        if (!ScpiResponseClassifier.ContainsScpiError(lines))
+                        {
+                            break;
+                        }
                     }
                 }
-            }
 
-            // The error from an exchange that actually SENT the delete, taken
-            // before the relist retry below can reassign `lines`. Without this
-            // capture the check further down reads whichever reply came last,
-            // and a transient error from a LIST-only retry -- a bus still
-            // settling, the -200 this file documents elsewhere -- was reported
-            // as "the delete operation failed" for a delete that had already
-            // succeeded and was never re-sent.
-            var deleteExchangeError = ScpiResponseClassifier.ContainsScpiError(lines)
-                ? lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim()
-                : null;
+                // The error from an exchange that actually SENT the delete, taken
+                // before the relist retry below can reassign `lines`. Without this
+                // capture the check further down reads whichever reply came last,
+                // and a transient error from a LIST-only retry -- a bus still
+                // settling, the -200 this file documents elsewhere -- was reported
+                // as "the delete operation failed" for a delete that had already
+                // succeeded and was never re-sent.
+                var deleteExchangeError = ScpiResponseClassifier.ContainsScpiError(lines)
+                    ? lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim()
+                    : null;
 
-            // Prove the EXCHANGE finished before judging what it contained. A
-            // reply cut short by the completion window loses the device's
-            // marker too, so it would otherwise read as Unterminated -- which
-            // is legitimate on pre-#796 firmware and therefore cannot be
-            // treated as an error on its own. The transport terminator is what
-            // separates the two, and the read path has always required it.
-            var refreshComplete = TrySplitAtSdListTerminator(lines, out var refreshListing);
+                // Prove the EXCHANGE finished before judging what it contained. A
+                // reply cut short by the completion window loses the device's
+                // marker too, so it would otherwise read as Unterminated -- which
+                // is legitimate on pre-#796 firmware and therefore cannot be
+                // treated as an error on its own. The transport terminator is what
+                // separates the two, and the read path has always required it.
+                var refreshComplete = TrySplitAtSdListTerminator(lines, out var refreshListing);
 
-            if (!refreshComplete && !ScpiResponseClassifier.ContainsScpiError(lines))
-            {
-                // An unterminated reply with no error is a one-off stall, and
-                // the read path gives that a second attempt for the same
-                // reason. Re-LIST only: the DELETE was accepted -- nothing
-                // reported otherwise -- so re-sending it would ask the device
-                // to remove a file that is already gone and turn a transient
-                // stall into a hard error. That is also why this is a separate
-                // loop from the error retry above, which re-sends both
-                // deliberately because there the delete itself may not have
-                // landed.
-                for (var retry = 0; retry < SD_LIST_MAX_RETRIES && !refreshComplete; retry++)
+                if (!refreshComplete && !ScpiResponseClassifier.ContainsScpiError(lines))
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
+                    // An unterminated reply with no error is a one-off stall, and
+                    // the read path gives that a second attempt for the same
+                    // reason. Re-LIST only: the DELETE was accepted -- nothing
+                    // reported otherwise -- so re-sending it would ask the device
+                    // to remove a file that is already gone and turn a transient
+                    // stall into a hard error. That is also why this is a separate
+                    // loop from the error retry above, which re-sends both
+                    // deliberately because there the delete itself may not have
+                    // landed.
+                    for (var retry = 0; retry < SD_LIST_MAX_RETRIES && !refreshComplete; retry++)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
 
-                    await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
+                        await Task.Delay(SD_INTERFACE_SETTLE_DELAY_MS, cancellationToken).ConfigureAwait(false);
 
-                    lines = await _host.ExecuteTextCommandAsync(
-                        () =>
-                        {
-                            _host.Send(ScpiMessageProducer.GetSdFileList);
-                            _host.Send(ScpiMessageProducer.GetSystemError);
-                        },
-                        responseTimeoutMs: 3000,
-                        completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
-                        cancellationToken: cancellationToken,
-                        prepareAsync: PrepareSdInterfaceAndSettleAsync,
-                        finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
+                        lines = await _host.ExecuteTextCommandAsync(
+                            () =>
+                            {
+                                _host.Send(ScpiMessageProducer.GetSdFileList);
+                                _host.Send(ScpiMessageProducer.GetSystemError);
+                            },
+                            responseTimeoutMs: 3000,
+                            completionTimeoutMs: SD_LIST_COMPLETION_TIMEOUT_MS,
+                            cancellationToken: cancellationToken,
+                            prepareAsync: PrepareSdInterfaceAndSettleAsync,
+                            finalizeAsync: RestoreLanInterfaceAsync).ConfigureAwait(false);
 
-                    refreshComplete = TrySplitAtSdListTerminator(lines, out refreshListing)
-                                      && !ScpiResponseClassifier.ContainsScpiError(refreshListing);
+                        refreshComplete = TrySplitAtSdListTerminator(lines, out refreshListing)
+                                          && !ScpiResponseClassifier.ContainsScpiError(refreshListing);
+                    }
                 }
-            }
 
-            // The DELETE's own outcome, judged before anything about the
-            // listing. The retry loop above exits either way, so a delete the
-            // device refused on BOTH attempts arrives here with its error line
-            // intact -- and ThrowIfSdCardListError alone will not catch it: its
-            // hasContentLine escape returns silently whenever the reply carries
-            // real entries, which is the normal case (you deleted one file, the
-            // others are still there). That escape is right for the read path,
-            // where a stray error has no bearing on the listing; it is wrong
-            // here, where the error line IS the answer to "did the delete
-            // happen?". Reproduced: a card holding fileA and fileB, a DELETE
-            // refused twice, returned success with fileA still in the cache.
-            if (deleteExchangeError != null)
-            {
-                // ...unless the card itself says the file is gone. An error
-                // line carries no origin: the exchange sends DELETE, LIST and
-                // SYSTem:ERRor? together, and the LIST has failure modes of
-                // its own (busy, the 10 s large-directory timeout) that have
-                // nothing to do with the delete. The retry then re-sends the
-                // DELETE for a file the first attempt already removed, the
-                // device answers "delete operation failed" because it is not
-                // there, and that second, genuine error would be reported as
-                // the delete failing.
-                //
-                // The listing in the same exchange settles it. If it rendered
-                // completely and the file is absent, the delete happened --
-                // whatever the error line was about. Verifying the outcome
-                // beats attributing the error, which the wire format does not
-                // let us do.
-                // Absence only proves anything if the listing is WHOLE.
-                // refreshComplete says the transport delivered a terminated
-                // reply; it says nothing about whether the device's walk
-                // reached the end of the tree. A listing the device called
-                // INCOMPLETE, or an Unterminated one, can be missing the
-                // target because it stopped early -- reading that as "deleted"
-                // is the same wrong answer pointed the other way. Only the
-                // device's own Complete marker rules it out, so against
-                // firmware that sends no marker the error stands, exactly as
-                // it did before this check existed.
-                var target = System.IO.Path.GetFileName(fileName);
-                var goneFromCard = refreshComplete
-                    && SdCardFileListParser.GetListingStatus(refreshListing)
-                        == SdCardListingStatus.Complete
-                    && !SdCardFileListParser.ParseFileList(refreshListing).Any(
-                        f => string.Equals(f.FileName, target,
-                                           StringComparison.OrdinalIgnoreCase));
-                if (!goneFromCard)
+                // The DELETE's own outcome, judged before anything about the
+                // listing. The retry loop above exits either way, so a delete the
+                // device refused on BOTH attempts arrives here with its error line
+                // intact -- and ThrowIfSdCardListError alone will not catch it: its
+                // hasContentLine escape returns silently whenever the reply carries
+                // real entries, which is the normal case (you deleted one file, the
+                // others are still there). That escape is right for the read path,
+                // where a stray error has no bearing on the listing; it is wrong
+                // here, where the error line IS the answer to "did the delete
+                // happen?". Reproduced: a card holding fileA and fileB, a DELETE
+                // refused twice, returned success with fileA still in the cache.
+                if (deleteExchangeError != null)
                 {
-                    throw new SdCardOperationException(
-                        "The SD card delete operation failed: " + deleteExchangeError,
-                        lines,
-                        deleteExchangeError);
+                    // ...unless the card itself says the file is gone. An error
+                    // line carries no origin: the exchange sends DELETE, LIST and
+                    // SYSTem:ERRor? together, and the LIST has failure modes of
+                    // its own (busy, the 10 s large-directory timeout) that have
+                    // nothing to do with the delete. The retry then re-sends the
+                    // DELETE for a file the first attempt already removed, the
+                    // device answers "delete operation failed" because it is not
+                    // there, and that second, genuine error would be reported as
+                    // the delete failing.
+                    //
+                    // The listing in the same exchange settles it. If it rendered
+                    // completely and the file is absent, the delete happened --
+                    // whatever the error line was about. Verifying the outcome
+                    // beats attributing the error, which the wire format does not
+                    // let us do.
+                    // Absence only proves anything if the listing is WHOLE.
+                    // refreshComplete says the transport delivered a terminated
+                    // reply; it says nothing about whether the device's walk
+                    // reached the end of the tree. A listing the device called
+                    // INCOMPLETE, or an Unterminated one, can be missing the
+                    // target because it stopped early -- reading that as "deleted"
+                    // is the same wrong answer pointed the other way. Only the
+                    // device's own Complete marker rules it out, so against
+                    // firmware that sends no marker the error stands, exactly as
+                    // it did before this check existed.
+                    var target = System.IO.Path.GetFileName(fileName);
+                    var goneFromCard = refreshComplete
+                        && SdCardFileListParser.GetListingStatus(refreshListing)
+                            == SdCardListingStatus.Complete
+                        && !SdCardFileListParser.ParseFileList(refreshListing).Any(
+                            f => string.Equals(f.FileName, target,
+                                               StringComparison.OrdinalIgnoreCase));
+                    if (!goneFromCard)
+                    {
+                        throw new SdCardOperationException(
+                            "The SD card delete operation failed: " + deleteExchangeError,
+                            lines,
+                            deleteExchangeError);
+                    }
                 }
-            }
 
-            if (!refreshComplete)
+                if (!refreshComplete)
+                {
+                    throw new SdCardListIncompleteException(lines);
+                }
+
+
+                // And the error guard the read path has always applied to its own
+                // listing. Without it a delete that FAILED on the device twice --
+                // the retry above exhausts without throwing -- came back here with
+                // an "**ERROR: -200" line, a valid transport terminator and no
+                // device marker, so nothing fired: ParseFileList skips the error
+                // line, the cache became an EMPTY list, and the method returned
+                // success. The caller was told the delete worked and the card is
+                // empty, in the one case where the device had said neither.
+                ThrowIfSdCardListError(refreshListing);
+
+                // Same guard as the read path: a listing the device itself called
+                // INCOMPLETE or FAILED must not become the cached answer to "what
+                // is on the card?". This refresh follows a DELETE, so the cache it
+                // overwrites is exactly what a caller consults next to decide
+                // whether the file is gone -- and a partial list makes every
+                // absence look confirmed. The cache is left untouched rather than
+                // replaced with a list we know is short.
+                var refreshStatus = SdCardFileListParser.GetListingStatus(refreshListing);
+                if (refreshStatus == SdCardListingStatus.Failed
+                    || refreshStatus == SdCardListingStatus.Incomplete)
+                {
+                    throw new SdCardListIncompleteException(lines);
+                }
+
+                _sdCardFiles = SdCardFileListParser.ParseFileList(refreshListing);
+            }
+            finally
             {
-                throw new SdCardListIncompleteException(lines);
+                RestoreStreamingIfNeeded(wasStreaming);
             }
-
-
-            // And the error guard the read path has always applied to its own
-            // listing. Without it a delete that FAILED on the device twice --
-            // the retry above exhausts without throwing -- came back here with
-            // an "**ERROR: -200" line, a valid transport terminator and no
-            // device marker, so nothing fired: ParseFileList skips the error
-            // line, the cache became an EMPTY list, and the method returned
-            // success. The caller was told the delete worked and the card is
-            // empty, in the one case where the device had said neither.
-            ThrowIfSdCardListError(refreshListing);
-
-            // Same guard as the read path: a listing the device itself called
-            // INCOMPLETE or FAILED must not become the cached answer to "what
-            // is on the card?". This refresh follows a DELETE, so the cache it
-            // overwrites is exactly what a caller consults next to decide
-            // whether the file is gone -- and a partial list makes every
-            // absence look confirmed. The cache is left untouched rather than
-            // replaced with a list we know is short.
-            var refreshStatus = SdCardFileListParser.GetListingStatus(refreshListing);
-            if (refreshStatus == SdCardListingStatus.Failed
-                || refreshStatus == SdCardListingStatus.Incomplete)
-            {
-                throw new SdCardListIncompleteException(lines);
-            }
-
-            _sdCardFiles = SdCardFileListParser.ParseFileList(refreshListing);
         }
 
         /// <summary>
@@ -958,12 +1016,17 @@ namespace Daqifi.Core.Device.SdCard
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
+            var wasStreaming = _host.IsStreaming;
+
             // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
             _host.Send(ScpiMessageProducer.StopStreaming);
             _host.IsStreaming = false;
 
             _host.Send(ScpiMessageProducer.EnableStorageSd);
             _host.Send(ScpiMessageProducer.FormatSdCard);
+
+            RestoreStreamingIfNeeded(wasStreaming);
 
             return Task.CompletedTask;
         }
@@ -1071,6 +1134,9 @@ namespace Daqifi.Core.Device.SdCard
             {
                 throw new SdCardBusyException(Array.Empty<string>());
             }
+
+            // Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
+            var wasStreaming = _host.IsStreaming;
 
             // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
             _host.Send(ScpiMessageProducer.StopStreaming);
@@ -1181,6 +1247,11 @@ namespace Daqifi.Core.Device.SdCard
                     {
                         // Best-effort restoration; the device may have disconnected
                     }
+
+                    // Same "still owns the transport" reasoning as the LAN restore above applies to
+                    // resuming a live stream (#533): an abandoned worker can still be reading the
+                    // transport, and StartStreaming's Send would be a second writer on it.
+                    RestoreStreamingIfNeeded(wasStreaming);
                 }
             }
 

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -401,6 +401,14 @@ namespace Daqifi.Core.Device.SdCard
                 // failure here escape would replace whatever the SD operation itself threw — or
                 // turn a clean success into a failure — over a device that may simply have dropped
                 // between the IsConnected check above and this call.
+                //
+                // DaqifiStreamingDevice.StartStreaming sets IsStreaming = true BEFORE it sends the
+                // SCPI command, so a Send failure here can leave the flag true for a stream that
+                // never actually resumed. Left alone, that is exactly the "flag says streaming, the
+                // device isn't" staleness #533 exists to fix — just relocated to this catch instead
+                // of fixed by it. Correcting it here is safe: this catch is the only code that knows
+                // the resume attempt failed.
+                _host.IsStreaming = false;
             }
         }
 


### PR DESCRIPTION
## Summary
- Fixes #533: an SD listing (`GetSdCardFilesAsync`), storage query (`GetSdCardStorageAsync`), delete (`DeleteSdCardFileAsync`), format (`FormatSdCardAsync`), or download (`DownloadSdCardFileAsync`) unconditionally stopped device streaming before touching the card (issue #118's defensive stop) but never restarted it — so a concurrent `StreamSamplesAsync` consumer went permanently silent with no error, exactly as reproduced in #533's bench data.
- Each of those five operations now captures whether streaming was active immediately before its defensive stop, and — once the whole operation (including its retries) has finished — resumes it through a new `IDeviceOperationHost.StartStreaming()`, which routes through `DaqifiStreamingDevice.StartStreaming()` so the frame decoder's session (timestamp anchor, gap detector) resets correctly rather than reusing stale session state.
- `DownloadSdCardFileAsync` skips the resume when its transfer was abandoned (timeout, #399/#401) — same reasoning as the existing LAN-interface restore skip: an abandoned worker still owns the transport, and writing to it would be a second writer on a stream a transfer is still reading.
- `StopSdCardLoggingAsync` is deliberately untouched: it stops streaming as part of ending a session Core itself started for SD logging, not as an incidental defensive measure, so its existing "leaves streaming off" behavior is correct.

## Test plan
- [x] `dotnet build` — whole solution builds clean
- [x] `dotnet test src/Daqifi.Core.Tests -f net9.0` — 3610 passed, 2 skipped (hardware-only), 0 failed
- [x] New collaborator tests added in `SdCardOperationsCollaboratorTests.cs` covering: restore fires once after the exchange for each of the five operations, restore is skipped when nothing was streaming, restore happens even when the operation throws, restore fires once (not per attempt) across a retry, restore is skipped when the device drops mid-exchange, and restore is skipped for an abandoned download transfer

🤖 Generated with [Claude Code](https://claude.com/claude-code)