### PR TITLE
test: add direct unit tests for WindowsUsbPortDescriptorProvider

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/WindowsUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WindowsUsbPortDescriptorProviderTests.cs
@@ -1,0 +1,95 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+/// <summary>
+/// Covers <see cref="WindowsUsbPortDescriptorProvider.Resolve"/> — the lookup that
+/// <see cref="WindowsUsbPortDescriptorProvider.GetDescriptor"/> delegates to once past the Windows
+/// platform gate. <see cref="WindowsPnpPortMap"/> takes its rows from an injected query, so this is
+/// exercised against a fake map on any platform, without WMI.
+/// </summary>
+/// <remarks>
+/// <see cref="WindowsUsbPortDescriptorProvider"/> carries <c>[SupportedOSPlatform("windows")]</c>
+/// because its production path (<see cref="WindowsPnpPortMap.Shared"/>) ultimately reaches WMI, but
+/// <see cref="WindowsUsbPortDescriptorProvider.Resolve"/> itself never touches
+/// <c>System.Management</c> — it only reads from whatever <see cref="WindowsPnpPortMap"/> it is
+/// given, which is not itself platform-gated. CA1416 is suppressed the same way
+/// <see cref="UsbPortDescriptorProviderFactory"/> already suppresses it to construct this type: the
+/// call sites here never reach the Windows-only branch.
+/// </remarks>
+#pragma warning disable CA1416
+public class WindowsUsbPortDescriptorProviderTests
+{
+    private static PnpPortEntity Usb(string port, string vidPid = "VID_04D8&PID_F794") =>
+        new($@"USB\{vidPid}\SERIAL{port}", $"USB Serial Device ({port})");
+
+    private static WindowsPnpPortMap MapOf(params PnpPortEntity[] entities) =>
+        new(() => entities);
+
+    [Fact]
+    public void Resolve_PortWithUsbEntity_ReturnsItsVidPid()
+    {
+        var map = MapOf(Usb("COM9"));
+
+        var descriptor = WindowsUsbPortDescriptorProvider.Resolve("COM9", map);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), descriptor);
+    }
+
+    [Fact]
+    public void Resolve_PortTheMapDoesNotList_ReturnsNull()
+    {
+        var map = MapOf(Usb("COM9"));
+
+        Assert.Null(WindowsUsbPortDescriptorProvider.Resolve("COM4", map));
+    }
+
+    [Fact]
+    public void Resolve_PortClaimedOnlyByANonUsbEntity_ReturnsNull()
+    {
+        // A motherboard COM port's PnP entity has no VID/PID at all.
+        var map = MapOf(new PnpPortEntity(@"ACPI\PNP0501\1", "Communications Port (COM1)"));
+
+        Assert.Null(WindowsUsbPortDescriptorProvider.Resolve("COM1", map));
+    }
+
+    [Fact]
+    public void Resolve_PortClaimedByBothANonUsbAndAUsbEntity_SkipsToTheUsbOne()
+    {
+        // Mirrors WindowsPnpPortMapTests' "two entities claim one port" case: both are kept, in
+        // enumeration order, and this is the caller that wants the first one carrying a VID/PID.
+        var map = MapOf(new PnpPortEntity(@"ACPI\PNP0501\1", "Legacy bridge (COM9)"), Usb("COM9"));
+
+        var descriptor = WindowsUsbPortDescriptorProvider.Resolve("COM9", map);
+
+        Assert.Equal(new UsbPortDescriptor(0x04D8, 0xF794), descriptor);
+    }
+
+    [Fact]
+    public void Resolve_MapRebuildThrows_ReturnsNullInsteadOfPropagating()
+    {
+        // A WMI error surfaces from WindowsPnpPortMap.GetDeviceIds as a thrown exception (see
+        // WindowsPnpPortMapTests.AFailedRebuild_LeavesTheLastGoodMapInPlace); the descriptor
+        // provider must behave like the no-op provider for this port rather than propagate it, so
+        // the caller falls through to legacy probe behavior.
+        var map = new WindowsPnpPortMap(() => throw new InvalidOperationException("WMI unavailable"));
+
+        Assert.Null(WindowsUsbPortDescriptorProvider.Resolve("COM9", map));
+    }
+
+    [Fact]
+    public void GetDescriptor_OffWindows_ReturnsNullWithoutTouchingTheMap()
+    {
+        var provider = new WindowsUsbPortDescriptorProvider();
+
+        // This assembly's tests run on macOS/Linux CI as well as Windows; off Windows the platform
+        // gate must short-circuit before WindowsPnpPortMap.Shared (which would otherwise attempt a
+        // WMI query) is ever reached.
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                System.Runtime.InteropServices.OSPlatform.Windows))
+        {
+            Assert.Null(provider.GetDescriptor("COM9"));
+        }
+    }
+}
+#pragma warning restore CA1416

--- a/src/Daqifi.Core.Tests/Device/Discovery/WindowsUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WindowsUsbPortDescriptorProviderTests.cs
@@ -80,28 +80,15 @@ public class WindowsUsbPortDescriptorProviderTests
     }
 
     // ---- the platform gate ------------------------------------------------
-    // Written in the style of LinuxUsbPortDescriptorProviderTests.GetDescriptor_OffLinux: an
-    // unconditional call whose answer is the same either side of the gate, plus one guarded to the
-    // platform where the gate is actually exercised, so neither ever passes without asserting.
-
-    [Fact]
-    public void GetDescriptor_PortNoEntityClaims_ReturnsNull()
-    {
-        // On Windows this reaches WindowsPnpPortMap.Shared and finds nothing for a port name no
-        // real device uses. Off Windows the platform gate answers directly. Either way the port is
-        // unclassified.
-        var provider = new WindowsUsbPortDescriptorProvider();
-
-#pragma warning disable CA1416 // GetDescriptor is Windows-gated at runtime, not by this call site.
-        Assert.Null(provider.GetDescriptor("COM_DAQIFI_TEST_" + Guid.NewGuid().ToString("N")));
-#pragma warning restore CA1416
-    }
 
     [Fact]
     public void GetDescriptor_OffWindows_ReturnsNullWithoutTouchingTheMap()
     {
-        // On Windows the same call is covered above; here the assertion only adds value where the
-        // gate itself is what has to produce the answer.
+        // Unlike LinuxUsbPortDescriptorProviderTests.GetDescriptor_OffLinux, there is no
+        // unconditional twin of this test that also exercises GetDescriptor on Windows: doing so
+        // would reach WindowsPnpPortMap.Shared, whose first lookup can rebuild the map and run a
+        // real WMI query — slow and flaky in a unit-test run. The Windows-side lookup logic is
+        // fully covered above through the injectable Resolve seam instead.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return;

--- a/src/Daqifi.Core.Tests/Device/Discovery/WindowsUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WindowsUsbPortDescriptorProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Daqifi.Core.Device.Discovery;
 
 namespace Daqifi.Core.Tests.Device.Discovery;
@@ -6,18 +7,10 @@ namespace Daqifi.Core.Tests.Device.Discovery;
 /// Covers <see cref="WindowsUsbPortDescriptorProvider.Resolve"/> — the lookup that
 /// <see cref="WindowsUsbPortDescriptorProvider.GetDescriptor"/> delegates to once past the Windows
 /// platform gate. <see cref="WindowsPnpPortMap"/> takes its rows from an injected query, so this is
-/// exercised against a fake map on any platform, without WMI.
+/// exercised against a fake map on any platform, without WMI. <c>Resolve</c> itself never touches
+/// <c>System.Management</c>, so it carries no platform attribute and needs no CA1416 suppression to
+/// call from here; only <see cref="GetDescriptor"/> does, once below.
 /// </summary>
-/// <remarks>
-/// <see cref="WindowsUsbPortDescriptorProvider"/> carries <c>[SupportedOSPlatform("windows")]</c>
-/// because its production path (<see cref="WindowsPnpPortMap.Shared"/>) ultimately reaches WMI, but
-/// <see cref="WindowsUsbPortDescriptorProvider.Resolve"/> itself never touches
-/// <c>System.Management</c> — it only reads from whatever <see cref="WindowsPnpPortMap"/> it is
-/// given, which is not itself platform-gated. CA1416 is suppressed the same way
-/// <see cref="UsbPortDescriptorProviderFactory"/> already suppresses it to construct this type: the
-/// call sites here never reach the Windows-only branch.
-/// </remarks>
-#pragma warning disable CA1416
 public class WindowsUsbPortDescriptorProviderTests
 {
     private static PnpPortEntity Usb(string port, string vidPid = "VID_04D8&PID_F794") =>
@@ -78,18 +71,46 @@ public class WindowsUsbPortDescriptorProviderTests
     }
 
     [Fact]
-    public void GetDescriptor_OffWindows_ReturnsNullWithoutTouchingTheMap()
+    public void Resolve_NullMap_ThrowsInsteadOfBeingSwallowed()
     {
+        // The catch below exists to turn a map-rebuild failure into "unclassified", not to hide a
+        // caller passing no map at all — that is a programmer error and must fail loudly rather
+        // than read as an indistinguishable "no USB entity".
+        Assert.Throws<ArgumentNullException>(() => WindowsUsbPortDescriptorProvider.Resolve("COM9", null!));
+    }
+
+    // ---- the platform gate ------------------------------------------------
+    // Written in the style of LinuxUsbPortDescriptorProviderTests.GetDescriptor_OffLinux: an
+    // unconditional call whose answer is the same either side of the gate, plus one guarded to the
+    // platform where the gate is actually exercised, so neither ever passes without asserting.
+
+    [Fact]
+    public void GetDescriptor_PortNoEntityClaims_ReturnsNull()
+    {
+        // On Windows this reaches WindowsPnpPortMap.Shared and finds nothing for a port name no
+        // real device uses. Off Windows the platform gate answers directly. Either way the port is
+        // unclassified.
         var provider = new WindowsUsbPortDescriptorProvider();
 
-        // This assembly's tests run on macOS/Linux CI as well as Windows; off Windows the platform
-        // gate must short-circuit before WindowsPnpPortMap.Shared (which would otherwise attempt a
-        // WMI query) is ever reached.
-        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                System.Runtime.InteropServices.OSPlatform.Windows))
+#pragma warning disable CA1416 // GetDescriptor is Windows-gated at runtime, not by this call site.
+        Assert.Null(provider.GetDescriptor("COM_DAQIFI_TEST_" + Guid.NewGuid().ToString("N")));
+#pragma warning restore CA1416
+    }
+
+    [Fact]
+    public void GetDescriptor_OffWindows_ReturnsNullWithoutTouchingTheMap()
+    {
+        // On Windows the same call is covered above; here the assertion only adds value where the
+        // gate itself is what has to produce the answer.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Assert.Null(provider.GetDescriptor("COM9"));
+            return;
         }
+
+        var provider = new WindowsUsbPortDescriptorProvider();
+
+#pragma warning disable CA1416 // GetDescriptor is Windows-gated at runtime, not by this call site.
+        Assert.Null(provider.GetDescriptor("COM9"));
+#pragma warning restore CA1416
     }
 }
-#pragma warning restore CA1416

--- a/src/Daqifi.Core/Device/Discovery/UsbPortDescriptorProviderFactory.cs
+++ b/src/Daqifi.Core/Device/Discovery/UsbPortDescriptorProviderFactory.cs
@@ -12,12 +12,10 @@ internal static class UsbPortDescriptorProviderFactory
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            // The WindowsUsbPortDescriptorProvider type is annotated
-            // [SupportedOSPlatform("windows")]; constructor only runs after
-            // the runtime check above, so the analyzer warning is suppressed.
-#pragma warning disable CA1416
+            // Only WindowsUsbPortDescriptorProvider.GetDescriptor carries
+            // [SupportedOSPlatform("windows")] — the constructor itself is
+            // unannotated, so no CA1416 suppression is needed here.
             return new WindowsUsbPortDescriptorProvider();
-#pragma warning restore CA1416
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/src/Daqifi.Core/Device/Discovery/WindowsUsbPortDescriptorProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsUsbPortDescriptorProvider.cs
@@ -8,9 +8,9 @@ namespace Daqifi.Core.Device.Discovery;
 /// built from a single WMI <c>Win32_PnPEntity</c> query per discovery pass. Returns null on
 /// non-Windows platforms so callers can fall back to a probe-everything strategy.
 /// </summary>
-[SupportedOSPlatform("windows")]
 internal sealed class WindowsUsbPortDescriptorProvider : IUsbPortDescriptorProvider
 {
+    [SupportedOSPlatform("windows")]
     public UsbPortDescriptor? GetDescriptor(string portName)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -27,10 +27,13 @@ internal sealed class WindowsUsbPortDescriptorProvider : IUsbPortDescriptorProvi
     /// <see cref="GetDescriptor"/> — which adds the Windows platform gate and supplies the real
     /// <see cref="WindowsPnpPortMap.Shared"/> — so the lookup can be unit tested against a fake map
     /// on any OS, for the same reason <see cref="LinuxUsbPortDescriptorProvider.Resolve"/> is
-    /// exposed.
+    /// exposed. Unlike <see cref="GetDescriptor"/>, this never touches WMI, so it carries no
+    /// platform attribute of its own.
     /// </summary>
     internal static UsbPortDescriptor? Resolve(string portName, WindowsPnpPortMap map)
     {
+        ArgumentNullException.ThrowIfNull(map);
+
         try
         {
             // A port the map doesn't list is left unclassified rather than refreshed: the caller

--- a/src/Daqifi.Core/Device/Discovery/WindowsUsbPortDescriptorProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsUsbPortDescriptorProvider.cs
@@ -27,8 +27,10 @@ internal sealed class WindowsUsbPortDescriptorProvider : IUsbPortDescriptorProvi
     /// <see cref="GetDescriptor"/> — which adds the Windows platform gate and supplies the real
     /// <see cref="WindowsPnpPortMap.Shared"/> — so the lookup can be unit tested against a fake map
     /// on any OS, for the same reason <see cref="LinuxUsbPortDescriptorProvider.Resolve"/> is
-    /// exposed. Unlike <see cref="GetDescriptor"/>, this never touches WMI, so it carries no
-    /// platform attribute of its own.
+    /// exposed. Unlike <see cref="GetDescriptor"/>, this never calls into <c>System.Management</c>
+    /// directly and carries no platform attribute of its own — whether the call reaches WMI depends
+    /// entirely on the <see cref="WindowsPnpPortMap"/> passed in, which is what lets a fake one keep
+    /// this path off WMI in tests.
     /// </summary>
     internal static UsbPortDescriptor? Resolve(string portName, WindowsPnpPortMap map)
     {

--- a/src/Daqifi.Core/Device/Discovery/WindowsUsbPortDescriptorProvider.cs
+++ b/src/Daqifi.Core/Device/Discovery/WindowsUsbPortDescriptorProvider.cs
@@ -18,12 +18,25 @@ internal sealed class WindowsUsbPortDescriptorProvider : IUsbPortDescriptorProvi
             return null;
         }
 
+        return Resolve(portName, WindowsPnpPortMap.Shared);
+    }
+
+    /// <summary>
+    /// Resolves the descriptor for <paramref name="portName"/> against <paramref name="map"/>, or
+    /// null if the map lists no USB-attached entity for it. Split out from
+    /// <see cref="GetDescriptor"/> — which adds the Windows platform gate and supplies the real
+    /// <see cref="WindowsPnpPortMap.Shared"/> — so the lookup can be unit tested against a fake map
+    /// on any OS, for the same reason <see cref="LinuxUsbPortDescriptorProvider.Resolve"/> is
+    /// exposed.
+    /// </summary>
+    internal static UsbPortDescriptor? Resolve(string portName, WindowsPnpPortMap map)
+    {
         try
         {
             // A port the map doesn't list is left unclassified rather than refreshed: the caller
             // probes anything it can't classify, so a miss costs one probe, while refreshing for
             // every miss would put a WMI query back on the per-port path this exists to remove.
-            return PnpDeviceIdParser.SelectUsbDescriptor(WindowsPnpPortMap.Shared.GetDeviceIds(portName));
+            return PnpDeviceIdParser.SelectUsbDescriptor(map.GetDeviceIds(portName));
         }
         catch
         {


### PR DESCRIPTION
## What was wrong

`WindowsUsbPortDescriptorProvider` — the collaborator that resolves a serial port's USB vendor/product ID on Windows via the shared PnP entity map — had no tests, unlike its Linux and macOS siblings. It read directly from the `WindowsPnpPortMap.Shared` singleton with no seam to inject a fake, so its lookup logic (which entity wins when a port is claimed by more than one, what happens on a WMI failure) was only reachable through the platform factory or real WMI.

## How it was fixed

Pulled the lookup out into an internal static `Resolve(string, WindowsPnpPortMap)`, the same shape `LinuxUsbPortDescriptorProvider.Resolve` and `MacOsUsbPortDescriptorProvider.Parse` already use. `WindowsPnpPortMap` already takes an injected query function, so `Resolve` can be driven against a fake map on any OS. `GetDescriptor` is now just the Windows platform gate plus the real shared map.

Added `WindowsUsbPortDescriptorProviderTests` covering: a port with a USB entity, a port the map doesn't list, a port claimed only by a non-USB entity, a port claimed by both a non-USB and a USB entity (picks the USB one), and a WMI failure surfacing from the map (returns null rather than propagating).

## Verification

`dotnet test` full suite green on net9.0 and net10.0 (3713 passed, 2 skipped, 0 failed both times). Test-only change plus an internal refactor (no public API surface touched) — no bench validation needed.

Part of #464 (slice 3: discovery descriptor providers). Not merging — for review.