### PR TITLE
chore(discovery): remove unused DefaultTimeoutSeconds constant

### DIFF
--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -24,7 +24,6 @@ public class WiFiDeviceFinder : DeviceFinderBase
     private const string NativeFinderQuery = "Discovery: Who is out there?\r\n";
     private const string PowerEvent = "Power event occurred";
     private const int DefaultDiscoveryPort = 30303;
-    private const int DefaultTimeoutSeconds = 5;
 
     #endregion
 


### PR DESCRIPTION
## What was wrong

Maintenance routine: dead-code remover. `WiFiDeviceFinder` declared a private `DefaultTimeoutSeconds` constant that was never referenced anywhere — not in this class, not elsewhere in the repo. Discovery timeouts are actually driven by the caller-supplied `CancellationToken`, so this looks like leftover scaffolding from an earlier implementation.

## How it was fixed

Deleted the unused constant. Nothing else changes: it's `private`, so this can't affect any downstream consumer (not API surface), and it carried no behavior since nothing read it.

Verified with an `AnalysisMode=AllEnabledByDefault` build (flags it as `CA1823: Unused field`) plus a full-repo grep confirming zero other references, including tests.

## Verification

`dotnet build` clean, `dotnet test` full suite green on net9.0 and net10.0 (3725 passed, 2 skipped, 0 failed both times). No production behavior changed, so no bench validation needed.

Routine PR (dead-code remover) — no `closes #N`. Not merging — for review.