### PR TITLE
chore(sdcard): unify duplicated tick-delta-with-rollover math

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardTickDeltaTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardTickDeltaTests.cs
@@ -48,11 +48,10 @@ public class SdCardTickDeltaTests
     }
 
     [Fact]
-    public void Compute_WithPreviousAtZeroAndRollover_ReturnsCurrentPlusOne()
+    public void Compute_WithPreviousAtMaxValueAndCurrentAtZero_ReturnsOne()
     {
-        // previous == 0 is not "at max", so current < previous never happens here except when
-        // current itself wrapped past zero — covered by the general rollover case above. This
-        // instead exercises the boundary where previous is the last possible value before max.
+        // previous is exactly uint.MaxValue and current has wrapped to 0 — the tightest
+        // possible rollover boundary (one tick past the wrap).
         var delta = SdCardTickDelta.Compute(previous: uint.MaxValue, current: 0u);
 
         Assert.Equal(1L, delta);

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardTickDeltaTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardTickDeltaTests.cs
@@ -1,0 +1,60 @@
+using Daqifi.Core.Device.SdCard;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+/// <summary>
+/// Direct unit tests for <see cref="SdCardTickDelta"/> — the tick-delta-with-rollover
+/// calculation previously duplicated identically across the CSV, JSON, and binary/protobuf
+/// SD card log parsers.
+/// </summary>
+public class SdCardTickDeltaTests
+{
+    [Fact]
+    public void Compute_WithNoRollover_ReturnsSimpleDifference()
+    {
+        var delta = SdCardTickDelta.Compute(previous: 100u, current: 150u);
+
+        Assert.Equal(50L, delta);
+    }
+
+    [Fact]
+    public void Compute_WithEqualTicks_ReturnsZero()
+    {
+        var delta = SdCardTickDelta.Compute(previous: 42u, current: 42u);
+
+        Assert.Equal(0L, delta);
+    }
+
+    [Fact]
+    public void Compute_WithSingleRollover_ReturnsWrappedDistance()
+    {
+        // previous is 10 ticks from uint.MaxValue; current is 5 ticks past the wrap.
+        var previous = uint.MaxValue - 10;
+        var current = 5u;
+
+        var delta = SdCardTickDelta.Compute(previous, current);
+
+        // 10 ticks remaining to the wrap + 1 (the wrap itself) + 5 ticks past it.
+        Assert.Equal(16L, delta);
+    }
+
+    [Fact]
+    public void Compute_WithCurrentAtMaxValue_ReturnsDistanceToMax()
+    {
+        var delta = SdCardTickDelta.Compute(previous: uint.MaxValue - 3, current: uint.MaxValue);
+
+        Assert.Equal(3L, delta);
+    }
+
+    [Fact]
+    public void Compute_WithPreviousAtZeroAndRollover_ReturnsCurrentPlusOne()
+    {
+        // previous == 0 is not "at max", so current < previous never happens here except when
+        // current itself wrapped past zero — covered by the general rollover case above. This
+        // instead exercises the boundary where previous is the last possible value before max.
+        var delta = SdCardTickDelta.Compute(previous: uint.MaxValue, current: 0u);
+
+        Assert.Equal(1L, delta);
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -408,7 +408,7 @@ public sealed class SdCardCsvFileParser
                 }
                 else
                 {
-                    var delta = ComputeTickDelta(previousTimestamp.Value, rowTimestamp);
+                    var delta = SdCardTickDelta.Compute(previousTimestamp.Value, rowTimestamp);
                     elapsedSeconds += delta * tickPeriod;
                     previousTimestamp = rowTimestamp;
                 }
@@ -534,20 +534,6 @@ public sealed class SdCardCsvFileParser
             Resolution: parsed.Resolution > 0 ? parsed.Resolution : overrideConfig.Resolution,
             PortRange: parsed.PortRange ?? overrideConfig.PortRange,
             InternalScaleM: parsed.InternalScaleM ?? overrideConfig.InternalScaleM);
-    }
-
-    /// <summary>
-    /// Computes the tick delta between two uint32 timestamps, handling rollover.
-    /// </summary>
-    private static long ComputeTickDelta(uint previous, uint current)
-    {
-        if (current >= previous)
-        {
-            return current - previous;
-        }
-
-        // Rollover: ticks remaining to max + current
-        return (long)(uint.MaxValue - previous) + current + 1;
     }
 
 #pragma warning disable CS1998 // Async iterator: yield break requires async; no real awaits.

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -382,7 +382,7 @@ public sealed class SdCardFileParser
                     }
                     else
                     {
-                        var delta = ComputeTickDelta(previousTimestamp.Value, msg.MsgTimeStamp);
+                        var delta = SdCardTickDelta.Compute(previousTimestamp.Value, msg.MsgTimeStamp);
                         elapsedSeconds += delta * tickPeriod;
                         previousTimestamp = msg.MsgTimeStamp;
                     }
@@ -437,19 +437,6 @@ public sealed class SdCardFileParser
         }
     }
 
-    /// <summary>
-    /// Computes the tick delta between two uint32 timestamps, handling rollover.
-    /// </summary>
-    private static long ComputeTickDelta(uint previous, uint current)
-    {
-        if (current >= previous)
-        {
-            return current - previous;
-        }
-
-        // Rollover: ticks remaining to max + current
-        return (long)(uint.MaxValue - previous) + current + 1;
-    }
 
     /// <summary>
     /// Determines whether a message contains stream sample payload fields.

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -209,7 +209,7 @@ public sealed class SdCardJsonFileParser
                 }
                 else
                 {
-                    var delta = ComputeTickDelta(previousTimestamp.Value, timestamp);
+                    var delta = SdCardTickDelta.Compute(previousTimestamp.Value, timestamp);
                     elapsedSeconds += delta * tickPeriod;
                     previousTimestamp = timestamp;
                 }
@@ -349,20 +349,6 @@ public sealed class SdCardJsonFileParser
             Resolution: inferred.Resolution > 0 ? inferred.Resolution : overrideConfig.Resolution,
             PortRange: inferred.PortRange ?? overrideConfig.PortRange,
             InternalScaleM: inferred.InternalScaleM ?? overrideConfig.InternalScaleM);
-    }
-
-    /// <summary>
-    /// Computes the tick delta between two uint32 timestamps, handling rollover.
-    /// </summary>
-    private static long ComputeTickDelta(uint previous, uint current)
-    {
-        if (current >= previous)
-        {
-            return current - previous;
-        }
-
-        // Rollover: ticks remaining to max + current
-        return (long)(uint.MaxValue - previous) + current + 1;
     }
 
 #pragma warning disable CS1998 // Async iterator: yield break requires async; no real awaits.

--- a/src/Daqifi.Core/Device/SdCard/SdCardTickDelta.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTickDelta.cs
@@ -1,0 +1,33 @@
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Computes the elapsed device-clock ticks between two consecutive samples' raw timestamps,
+/// accounting for the tick counter wrapping around at <see cref="uint.MaxValue"/>.
+/// </summary>
+/// <remarks>
+/// The CSV, JSON, and binary/protobuf SD card log parsers each read the same device tick
+/// counter and previously carried an identical copy of this calculation; it now lives here
+/// once so the three formats can't drift out of sync with each other.
+/// </remarks>
+internal static class SdCardTickDelta
+{
+    /// <summary>
+    /// Returns the number of ticks elapsed from <paramref name="previous"/> to
+    /// <paramref name="current"/>, treating a <paramref name="current"/> smaller than
+    /// <paramref name="previous"/> as a single wraparound of the 32-bit counter rather than
+    /// time moving backwards.
+    /// </summary>
+    /// <param name="previous">The previous sample's raw tick count.</param>
+    /// <param name="current">The current sample's raw tick count.</param>
+    /// <returns>The elapsed ticks, always non-negative.</returns>
+    public static long Compute(uint previous, uint current)
+    {
+        if (current >= previous)
+        {
+            return current - previous;
+        }
+
+        // Rollover: ticks remaining to max + current
+        return (long)(uint.MaxValue - previous) + current + 1;
+    }
+}


### PR DESCRIPTION
duplicate/abstraction-unifier maintenance routine. Safe because the extracted method's body is verbatim-identical across all three call sites (confirmed by diff) and is a pure, stateless calculation with no external state — this is a mechanical move, not a rewrite.

**What was wrong:** the CSV, JSON, and binary/protobuf SD card log parsers each carried their own private copy of the same tick-counter rollover calculation, used to reconstruct each sample's timestamp from the device's 32-bit tick counter. Three identical copies meant a future bug fix or edge-case tweak to that math could easily land in one or two parsers and be missed in the third, silently producing wrong timestamps for whichever format got skipped.

**How it was fixed:** moved the method, unchanged, into a new internal `SdCardTickDelta.Compute` helper shared by all three parsers, and deleted the three private copies. No behavior change — same math, same call sites, just one source of truth now.

Verified: full `dotnet test` suite green on net9.0 and net10.0 (3730/3730 core tests passing, including 5 new direct unit tests for the extracted helper covering the no-rollover, exact-equal-ticks, and rollover-boundary cases). This is offline log-parsing logic with no board-observable behavior, so no bench validation applies.

Not merging — for review.