### PR TITLE
test(device): deflake USB stream-interface cancellation test

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Internal/UsbStreamInterfaceInitializerTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/UsbStreamInterfaceInitializerTests.cs
@@ -33,6 +33,13 @@ public class UsbStreamInterfaceInitializerTests
 
         public List<CancellationToken> ObservedTokens { get; } = new();
 
+        /// <summary>
+        /// Invoked synchronously after an attempt is recorded but before its response is returned,
+        /// so a test can react to "attempt N happened" deterministically instead of racing a
+        /// wall-clock timer against it.
+        /// </summary>
+        public Action? OnAttempt { get; set; }
+
         public ScriptedSender Answers(params string[] lines)
         {
             _responses.Enqueue(lines);
@@ -43,6 +50,7 @@ public class UsbStreamInterfaceInitializerTests
         {
             AttemptCount++;
             ObservedTokens.Add(cancellationToken);
+            OnAttempt?.Invoke();
 
             // An unscripted attempt is a test bug, not a silent success: surface it.
             Assert.True(_responses.Count > 0, "The sender was invoked more times than the test scripted.");
@@ -182,10 +190,15 @@ public class UsbStreamInterfaceInitializerTests
     public async Task CancellationBetweenAttempts_StopsBeforeTheRetry()
     {
         // The settle delay is cancellable, so a token cancelled while waiting must abandon the retry
-        // rather than send a command into a session that is being torn down.
+        // rather than send a command into a session that is being torn down. Cancel synchronously
+        // from the first attempt itself (rather than racing a wall-clock timer against the 150 ms
+        // retry delay) so the token is guaranteed to already be cancelled by the time the loop reaches
+        // the delay — a timer-based CancelAfter(10 ms) was observed to fire late under CI scheduling
+        // load, letting a second, unscripted attempt through and failing the test on that assertion
+        // instead of the intended OperationCanceledException.
         using var cts = new CancellationTokenSource();
         var sender = new ScriptedSender().Answers(ScpiError);
-        cts.CancelAfter(TimeSpan.FromMilliseconds(10));
+        sender.OnAttempt = () => cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => RouteAsync(sender, cancellationToken: cts.Token));


### PR DESCRIPTION
flaky-test-fixer maintenance routine. Scanned recent CI history (`gh run list`) for tests that failed and then passed on rerun with no intervening code change — this one recurred twice (2026-08-19 and 2026-08-22) with a clear, fixable root cause, so it's addressed directly rather than just logged.

**What was wrong:** `UsbStreamInterfaceInitializerTests.CancellationBetweenAttempts_StopsBeforeTheRetry` occasionally failed in CI with an unrelated assertion error instead of the exception it was checking for. It worked by racing a 10ms cancellation timer against the library's 150ms retry delay — normally the cancellation wins easily, but under CI scheduling load the timer sometimes fired late enough that the retry delay finished first, letting a second, unscripted call through and tripping the test's own bookkeeping assertion instead of testing what it meant to.

**How it was fixed:** replaced the wall-clock race with a deterministic trigger. The test's fake sender now cancels the token synchronously the moment the first attempt happens, via a small `OnAttempt` hook, so the cancellation is guaranteed to land before the retry delay is ever reached — no timing dependency left. No production code changed.

Verified: full `dotnet test` suite green on net9.0 and net10.0 (3688/3688 core tests passing), including the affected test file (14/14) run directly. No bench pass applies — pure test-only change.

Not merging — for review.