### PR TITLE
test: remove three tautological auto-property round-trip tests

### DIFF
--- a/src/Daqifi.Core.Tests/Channel/DataSampleTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/DataSampleTests.cs
@@ -54,19 +54,6 @@ public class DataSampleTests
     }
 
     [Fact]
-    public void Value_CanBeModified()
-    {
-        // Arrange
-        var sample = new DataSample(DateTime.UtcNow, 10.0);
-
-        // Act
-        sample.Value = 20.0;
-
-        // Assert
-        Assert.Equal(20.0, sample.Value);
-    }
-
-    [Fact]
     public void ToString_ReturnsFormattedString()
     {
         // Arrange

--- a/src/Daqifi.Core.Tests/Device/DeviceCapabilitiesTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceCapabilitiesTests.cs
@@ -64,25 +64,6 @@ public class DeviceCapabilitiesTests
     }
 
     [Fact]
-    public void Properties_CanBeSetAndRetrieved()
-    {
-        // Arrange
-        var capabilities = new DeviceCapabilities();
-
-        // Act
-        capabilities.AnalogInputChannels = 8;
-        capabilities.AnalogOutputChannels = 2;
-        capabilities.DigitalChannels = 16;
-        capabilities.MaxSamplingRate = 2000;
-
-        // Assert
-        Assert.Equal(8, capabilities.AnalogInputChannels);
-        Assert.Equal(2, capabilities.AnalogOutputChannels);
-        Assert.Equal(16, capabilities.DigitalChannels);
-        Assert.Equal(2000, capabilities.MaxSamplingRate);
-    }
-
-    [Fact]
     public void Clone_RoundTripsEveryPublicProperty()
     {
         // Arrange: set every public property to a non-default value so a dropped copy is detectable.

--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurationTests.cs
@@ -67,25 +67,6 @@ namespace Daqifi.Core.Tests.Device.Network
         }
 
         [Fact]
-        public void Properties_CanBeModified()
-        {
-            // Arrange
-            var config = new NetworkConfiguration();
-
-            // Act
-            config.Mode = WifiMode.ExistingNetwork;
-            config.SecurityType = WifiSecurityType.None;
-            config.Ssid = "NewSSID";
-            config.Password = "NewPassword";
-
-            // Assert
-            Assert.Equal(WifiMode.ExistingNetwork, config.Mode);
-            Assert.Equal(WifiSecurityType.None, config.SecurityType);
-            Assert.Equal("NewSSID", config.Ssid);
-            Assert.Equal("NewPassword", config.Password);
-        }
-
-        [Fact]
         public void StaticIPConstructor_SetsAllProperties()
         {
             // Arrange


### PR DESCRIPTION
**useless-test-pruner maintenance routine.** No tracking issue — this is a routine cleanup PR, not a feature.

## What was wrong
Three unit tests asserted something that could never fail:

- `DataSampleTests.Value_CanBeModified`
- `DeviceCapabilitiesTests.Properties_CanBeSetAndRetrieved`
- `NetworkConfigurationTests.Properties_CanBeModified`

Each set a bare `{ get; set; }` auto-property (`DataSample.Value`, `DeviceCapabilities.AnalogInputChannels`/`AnalogOutputChannels`/`DigitalChannels`/`MaxSamplingRate`, `NetworkConfiguration.Mode`/`SecurityType`/`Ssid`/`Password`) and then asserted it equal to the value that had just been assigned two lines above, with no production logic — no validation, no computation, no side effect — running in between. There is no code change these tests could catch: a regression that broke the property would break the class at compile time (the property wouldn't exist), not at the assertion. They added review/maintenance weight without adding any fault-detection coverage.

## How it was fixed
Deleted the three tests. Nothing else changed — no production code touched.

I deliberately kept `DigitalChannelTests.OutputValue_CanBeSet`, which looks superficially similar but whose setter takes a lock around a backing field (real, if minor, logic between write and read), so it stays under the same bar.

## Verification
`dotnet test` on both net9.0 and net10.0: 3685/3685 (3683 passed, 2 skipped, 0 failed) on each — exactly the prior pass count minus the three removed tests. Test-only change, so no bench/board validation applies.

Not merging — for review.