### PR TITLE
chore: unify duplicated MemoryDiagnosticsParser/StreamStatsParser TryParse bodies

### DIFF
--- a/src/Daqifi.Core/Device/Diagnostics/KeyValueResponseParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/KeyValueResponseParser.cs
@@ -88,6 +88,7 @@ internal static class KeyValueResponseParser
     /// </param>
     /// <param name="result">The built result, or <see langword="null"/> if no field could be parsed.</param>
     /// <returns><see langword="true"/> if at least one field was parsed; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="factory"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException"><paramref name="factory"/> returned <see langword="null"/>.</exception>
     public static bool TryParse<T>(
         IEnumerable<string> lines,

--- a/src/Daqifi.Core/Device/Diagnostics/KeyValueResponseParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/KeyValueResponseParser.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Daqifi.Core.Device.Diagnostics;
@@ -68,5 +70,34 @@ internal static class KeyValueResponseParser
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Parses response lines and, if at least one field was recognized, builds the typed result
+    /// via <paramref name="factory"/>.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the <c>Key=Value</c> diagnostics wrappers (<see cref="MemoryDiagnosticsParser"/>,
+    /// <see cref="StreamStatsParser"/>) so each only needs to supply its own result type.
+    /// </remarks>
+    /// <param name="lines">The raw response lines from the device.</param>
+    /// <param name="factory">Builds the typed result from the parsed key/value pairs.</param>
+    /// <param name="result">The built result, or <see langword="null"/> if no field could be parsed.</param>
+    /// <returns><see langword="true"/> if at least one field was parsed; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse<T>(
+        IEnumerable<string> lines,
+        Func<IReadOnlyDictionary<string, ulong>, T> factory,
+        [NotNullWhen(true)] out T? result)
+        where T : class
+    {
+        var values = Parse(lines);
+        if (values.Count == 0)
+        {
+            result = null;
+            return false;
+        }
+
+        result = factory(values);
+        return true;
     }
 }

--- a/src/Daqifi.Core/Device/Diagnostics/KeyValueResponseParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/KeyValueResponseParser.cs
@@ -81,15 +81,22 @@ internal static class KeyValueResponseParser
     /// <see cref="StreamStatsParser"/>) so each only needs to supply its own result type.
     /// </remarks>
     /// <param name="lines">The raw response lines from the device.</param>
-    /// <param name="factory">Builds the typed result from the parsed key/value pairs.</param>
+    /// <param name="factory">
+    /// Builds the typed result from the parsed key/value pairs. Must not return
+    /// <see langword="null"/>; callers rely on <c>TryParse</c> returning a non-null
+    /// <paramref name="result"/> whenever it returns <see langword="true"/>.
+    /// </param>
     /// <param name="result">The built result, or <see langword="null"/> if no field could be parsed.</param>
     /// <returns><see langword="true"/> if at least one field was parsed; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="factory"/> returned <see langword="null"/>.</exception>
     public static bool TryParse<T>(
         IEnumerable<string> lines,
         Func<IReadOnlyDictionary<string, ulong>, T> factory,
         [NotNullWhen(true)] out T? result)
         where T : class
     {
+        ArgumentNullException.ThrowIfNull(factory);
+
         var values = Parse(lines);
         if (values.Count == 0)
         {
@@ -97,7 +104,8 @@ internal static class KeyValueResponseParser
             return false;
         }
 
-        result = factory(values);
+        result = factory(values) ?? throw new InvalidOperationException(
+            $"{nameof(factory)} returned null; TryParse callers rely on a non-null result when returning true.");
         return true;
     }
 }

--- a/src/Daqifi.Core/Device/Diagnostics/MemoryDiagnosticsParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/MemoryDiagnosticsParser.cs
@@ -18,16 +18,6 @@ public static class MemoryDiagnosticsParser
     /// <param name="lines">Response lines from the device.</param>
     /// <param name="result">The parsed diagnostics, or <see langword="null"/> if no field could be parsed.</param>
     /// <returns><see langword="true"/> if at least one field was parsed; otherwise <see langword="false"/>.</returns>
-    public static bool TryParse(IEnumerable<string> lines, [NotNullWhen(true)] out MemoryDiagnostics? result)
-    {
-        var values = KeyValueResponseParser.Parse(lines);
-        if (values.Count == 0)
-        {
-            result = null;
-            return false;
-        }
-
-        result = new MemoryDiagnostics { Values = values };
-        return true;
-    }
+    public static bool TryParse(IEnumerable<string> lines, [NotNullWhen(true)] out MemoryDiagnostics? result) =>
+        KeyValueResponseParser.TryParse(lines, values => new MemoryDiagnostics { Values = values }, out result);
 }

--- a/src/Daqifi.Core/Device/Diagnostics/StreamStatsParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/StreamStatsParser.cs
@@ -18,16 +18,6 @@ public static class StreamStatsParser
     /// <param name="lines">Response lines from the device.</param>
     /// <param name="result">The parsed stats, or <see langword="null"/> if no counter could be parsed.</param>
     /// <returns><see langword="true"/> if at least one counter was parsed; otherwise <see langword="false"/>.</returns>
-    public static bool TryParse(IEnumerable<string> lines, [NotNullWhen(true)] out StreamStats? result)
-    {
-        var values = KeyValueResponseParser.Parse(lines);
-        if (values.Count == 0)
-        {
-            result = null;
-            return false;
-        }
-
-        result = new StreamStats { Values = values };
-        return true;
-    }
+    public static bool TryParse(IEnumerable<string> lines, [NotNullWhen(true)] out StreamStats? result) =>
+        KeyValueResponseParser.TryParse(lines, values => new StreamStats { Values = values }, out result);
 }


### PR DESCRIPTION
## What was wrong

`MemoryDiagnosticsParser.TryParse` and `StreamStatsParser.TryParse` were byte-for-byte identical implementations — parse the `Key=Value` response lines, fail if nothing was recognized, otherwise wrap the result — differing only in which record type each one built. A change to that logic (an edge case, a new guard) would need to be made twice and could drift.

## How it was fixed

Added a generic `KeyValueResponseParser.TryParse<T>(lines, factory, out result)` that both wrappers now delegate to, passing only their own record-construction factory. No behavior change and no public API touched — `MemoryDiagnosticsParser` and `StreamStatsParser` keep their existing public signatures.

## Verification

Full `dotnet test` suite green on net9.0 and net10.0 (3725 passed, 2 skipped, 0 failed both times). Internal-only refactor, no device-facing behavior changed, so no bench validation needed.

Maintenance routine: duplicate/abstraction unifier.

Not merging — for review.