### PR TITLE
test: deflake stale-reader grace test (release on dedicated thread, not ThreadPool timer)

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -45,14 +45,12 @@ public class StreamMessageConsumerStallingReaderTests
             Name = "TestReleaser"
         };
         releaser.Start();
-        try
-        {
-            consumer.Start();
-        }
-        finally
-        {
-            releaser.Join(TimeSpan.FromSeconds(2));
-        }
+        consumer.Start();
+
+        // Join before the test's `using` disposals run: a still-alive releaser calling
+        // stream.Release() after the stream is disposed would throw ObjectDisposedException on a
+        // background thread, which is process-terminating rather than a clean test failure.
+        Assert.True(releaser.Join(TimeSpan.FromSeconds(2)), "releaser thread did not finish in time");
 
         Assert.True(consumer.IsRunning);
         Assert.True(consumer.StopSafely(timeoutMs: 2000));

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -29,9 +29,29 @@ public class StreamMessageConsumerStallingReaderTests
         Assert.True(stream.WaitForReadEntered(TimeSpan.FromSeconds(2)));
         Assert.False(consumer.StopSafely(timeoutMs: 200));
 
-        using (var releaser = new Timer(_ => stream.Release(), null, 200, Timeout.Infinite))
+        // A dedicated thread, not a System.Threading.Timer callback, releases the stale reader
+        // while Start() is parked in its grace-period join below. A Timer callback is queued onto
+        // the shared ThreadPool, which under CI load (many test classes running in parallel) can
+        // be starved well past its 200ms due time — long enough to blow the join's 1000ms grace
+        // and turn this into a flaky ConsumerThreadNotExitedException. A dedicated background
+        // thread's Sleep is not subject to that queuing delay.
+        var releaser = new Thread(() =>
+        {
+            Thread.Sleep(200);
+            stream.Release();
+        })
+        {
+            IsBackground = true,
+            Name = "TestReleaser"
+        };
+        releaser.Start();
+        try
         {
             consumer.Start();
+        }
+        finally
+        {
+            releaser.Join(TimeSpan.FromSeconds(2));
         }
 
         Assert.True(consumer.IsRunning);

--- a/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/StreamMessageConsumerStallingReaderTests.cs
@@ -45,13 +45,24 @@ public class StreamMessageConsumerStallingReaderTests
             Name = "TestReleaser"
         };
         releaser.Start();
-        consumer.Start();
 
-        // Join before the test's `using` disposals run: a still-alive releaser calling
-        // stream.Release() after the stream is disposed would throw ObjectDisposedException on a
-        // background thread, which is process-terminating rather than a clean test failure.
-        Assert.True(releaser.Join(TimeSpan.FromSeconds(2)), "releaser thread did not finish in time");
+        // Join in `finally` — including when consumer.Start() itself throws — before the test's
+        // `using` disposals run: a still-alive releaser calling stream.Release() after the stream
+        // is disposed would throw ObjectDisposedException on a background thread, which is
+        // process-terminating rather than a clean test failure. The join result is checked
+        // afterward (rather than asserted inside `finally`) so it never masks a genuine exception
+        // from consumer.Start().
+        bool releaserJoined;
+        try
+        {
+            consumer.Start();
+        }
+        finally
+        {
+            releaserJoined = releaser.Join(TimeSpan.FromSeconds(2));
+        }
 
+        Assert.True(releaserJoined, "releaser thread did not finish in time");
         Assert.True(consumer.IsRunning);
         Assert.True(consumer.StopSafely(timeoutMs: 2000));
     }


### PR DESCRIPTION
Flaky-test-fixer routine: CI history (`gh run list`) showed `StreamMessageConsumerStallingReaderTests.Start_WhenStoppedReaderExitsWithinGrace_WaitsAndRestartsSameInstance` fail on net9.0 with `ConsumerThreadNotExitedException`, then pass on the next run with only an unrelated commit (a different test file) in between — a genuine flake, not a real regression.

**What was wrong:** the test scheduled the stream release via a `System.Threading.Timer` callback due 200ms after `Start()` begins its 1000ms grace-period wait. `Timer` callbacks run on the shared .NET ThreadPool, and under CI load — many test classes executing in parallel — that queue can occasionally be starved well past the 200ms due time, blowing the 1000ms grace window and failing the test even though the production `Start()`/grace-join logic was working correctly. This was a test-timing issue, not a bug in `StreamMessageConsumer`.

**How it was fixed:** the release now runs on its own dedicated background `Thread` with `Thread.Sleep(200)` instead of a `ThreadPool`-queued `Timer`, so it isn't subject to pool contention from other running tests.

This is a test-only change — no production code touched, so it's safe by construction (same assertions, same timing budget, just a more reliable trigger for the release).

Verified: the affected test run 5x back-to-back (all green), full `dotnet test` suite green on net9.0 and net10.0 (3729 total, 0 failed, 2 skipped, both TFMs). No bench validation needed (test-only change).

Not merging — for review.