### PR TITLE
refactor(firmware): flatten IsProtectedHexRecord nested conditional

### DIFF
--- a/src/Daqifi.Core/Firmware/IntelHexParser.cs
+++ b/src/Daqifi.Core/Firmware/IntelHexParser.cs
@@ -231,20 +231,16 @@ public class IntelHexParser
     private bool IsProtectedHexRecord(byte[] hexRecord, ushort baseAddress)
     {
         var recordType = hexRecord[3];
-
-        if (recordType == 0x00)
+        if (recordType != 0x00)
         {
-            var offsetAddressArray = hexRecord.Skip(1).Take(2).ToArray();
-            if (BitConverter.IsLittleEndian) Array.Reverse(offsetAddressArray);
-            var offsetAddress = BitConverter.ToUInt16(offsetAddressArray, 0);
-            var hexRecordAddress = ((uint)baseAddress << 16) | offsetAddress;
-
-            if (hexRecordAddress >= _beginProtectedAddress && hexRecordAddress <= _endProtectedAddress)
-            {
-                return true;
-            }
+            return false;
         }
 
-        return false;
+        var offsetAddressArray = hexRecord.Skip(1).Take(2).ToArray();
+        if (BitConverter.IsLittleEndian) Array.Reverse(offsetAddressArray);
+        var offsetAddress = BitConverter.ToUInt16(offsetAddressArray, 0);
+        var hexRecordAddress = ((uint)baseAddress << 16) | offsetAddress;
+
+        return hexRecordAddress >= _beginProtectedAddress && hexRecordAddress <= _endProtectedAddress;
     }
 }


### PR DESCRIPTION
**Maintenance routine: logic-simplifier.** Not tied to an issue — small, safe cleanup found while walking the maintenance rotation.

**What was wrong:** `IntelHexParser.IsProtectedHexRecord` nested the protected-address-range check inside the record-type check, returning `true` from inside two levels of `if` blocks and falling through to a final `return false`. Functionally fine, just harder to read than it needs to be.

**How it was fixed:** Inverted the record-type check into an early guard clause (`if (recordType != 0x00) return false;`) and replaced the inner `if (...) return true;` with a direct `return` of the boolean comparison. Behavior is identical for every input — same short-circuiting, same computation only performed when `recordType == 0x00`, same result.

Internal-only method (`private`), no public API surface touched, no behavior change.

**Verified:** `dotnet test` full suite green on net9.0 and net10.0 (3725 passed, 2 skipped — pre-existing hardware-loopback skips, unrelated). No production behavior changed, so no bench validation needed.

Not merging — for review.