### PR TITLE
chore(sdcard): unify duplicated configuration-override merge logic

### DIFF
--- a/src/Daqifi.Core/Device/SdCard/SdCardConfigurationMerge.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardConfigurationMerge.cs
@@ -1,0 +1,38 @@
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Merges an override <see cref="SdCardDeviceConfiguration"/> into a file-derived one.
+/// </summary>
+/// <remarks>
+/// The CSV and JSON SD card log parsers each carried an identical copy of this merge logic
+/// (the binary/protobuf parser's variant compares differently and is intentionally not folded
+/// in here); it now lives once so the two formats can't drift out of sync with each other.
+/// </remarks>
+internal static class SdCardConfigurationMerge
+{
+    /// <summary>
+    /// Merges <paramref name="overrideConfig"/> into <paramref name="parsed"/>. File-derived
+    /// values are primary; the override fills in gaps (zero or null fields).
+    /// </summary>
+    public static SdCardDeviceConfiguration Merge(
+        SdCardDeviceConfiguration parsed,
+        SdCardDeviceConfiguration? overrideConfig)
+    {
+        if (overrideConfig == null)
+        {
+            return parsed;
+        }
+
+        return new SdCardDeviceConfiguration(
+            AnalogPortCount: parsed.AnalogPortCount > 0 ? parsed.AnalogPortCount : overrideConfig.AnalogPortCount,
+            DigitalPortCount: parsed.DigitalPortCount > 0 ? parsed.DigitalPortCount : overrideConfig.DigitalPortCount,
+            TimestampFrequency: parsed.TimestampFrequency > 0 ? parsed.TimestampFrequency : overrideConfig.TimestampFrequency,
+            DeviceSerialNumber: parsed.DeviceSerialNumber ?? overrideConfig.DeviceSerialNumber,
+            DevicePartNumber: parsed.DevicePartNumber ?? overrideConfig.DevicePartNumber,
+            FirmwareRevision: parsed.FirmwareRevision ?? overrideConfig.FirmwareRevision,
+            CalibrationValues: parsed.CalibrationValues ?? overrideConfig.CalibrationValues,
+            Resolution: parsed.Resolution > 0 ? parsed.Resolution : overrideConfig.Resolution,
+            PortRange: parsed.PortRange ?? overrideConfig.PortRange,
+            InternalScaleM: parsed.InternalScaleM ?? overrideConfig.InternalScaleM);
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -133,7 +133,7 @@ public sealed class SdCardCsvFileParser
                 EmptySamples());
         }
 
-        var config = MergeConfiguration(header.Config, options.ConfigurationOverride);
+        var config = SdCardConfigurationMerge.Merge(header.Config, options.ConfigurationOverride);
 
         var (timestampFrequency, timestampSource) = SdCardTimestampFrequencyResolver.Resolve(
             header.Config.TimestampFrequency,
@@ -508,32 +508,6 @@ public sealed class SdCardCsvFileParser
         {
             return null;
         }
-    }
-
-    /// <summary>
-    /// Merges an override configuration into a parsed configuration.
-    /// File-parsed values are primary; the override fills in gaps (zero or null fields).
-    /// </summary>
-    private static SdCardDeviceConfiguration MergeConfiguration(
-        SdCardDeviceConfiguration parsed,
-        SdCardDeviceConfiguration? overrideConfig)
-    {
-        if (overrideConfig == null)
-        {
-            return parsed;
-        }
-
-        return new SdCardDeviceConfiguration(
-            AnalogPortCount: parsed.AnalogPortCount > 0 ? parsed.AnalogPortCount : overrideConfig.AnalogPortCount,
-            DigitalPortCount: parsed.DigitalPortCount > 0 ? parsed.DigitalPortCount : overrideConfig.DigitalPortCount,
-            TimestampFrequency: parsed.TimestampFrequency > 0 ? parsed.TimestampFrequency : overrideConfig.TimestampFrequency,
-            DeviceSerialNumber: parsed.DeviceSerialNumber ?? overrideConfig.DeviceSerialNumber,
-            DevicePartNumber: parsed.DevicePartNumber ?? overrideConfig.DevicePartNumber,
-            FirmwareRevision: parsed.FirmwareRevision ?? overrideConfig.FirmwareRevision,
-            CalibrationValues: parsed.CalibrationValues ?? overrideConfig.CalibrationValues,
-            Resolution: parsed.Resolution > 0 ? parsed.Resolution : overrideConfig.Resolution,
-            PortRange: parsed.PortRange ?? overrideConfig.PortRange,
-            InternalScaleM: parsed.InternalScaleM ?? overrideConfig.InternalScaleM);
     }
 
 #pragma warning disable CS1998 // Async iterator: yield break requires async; no real awaits.

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -322,33 +322,7 @@ public sealed class SdCardJsonFileParser
             FirmwareRevision: null,
             CalibrationValues: null);
 
-        return MergeConfiguration(inferred, options.ConfigurationOverride);
-    }
-
-    /// <summary>
-    /// Merges an override configuration into an inferred configuration.
-    /// Inferred (file-derived) values are primary; the override fills in gaps (zero or null fields).
-    /// </summary>
-    private static SdCardDeviceConfiguration MergeConfiguration(
-        SdCardDeviceConfiguration inferred,
-        SdCardDeviceConfiguration? overrideConfig)
-    {
-        if (overrideConfig == null)
-        {
-            return inferred;
-        }
-
-        return new SdCardDeviceConfiguration(
-            AnalogPortCount: inferred.AnalogPortCount > 0 ? inferred.AnalogPortCount : overrideConfig.AnalogPortCount,
-            DigitalPortCount: inferred.DigitalPortCount > 0 ? inferred.DigitalPortCount : overrideConfig.DigitalPortCount,
-            TimestampFrequency: inferred.TimestampFrequency > 0 ? inferred.TimestampFrequency : overrideConfig.TimestampFrequency,
-            DeviceSerialNumber: inferred.DeviceSerialNumber ?? overrideConfig.DeviceSerialNumber,
-            DevicePartNumber: inferred.DevicePartNumber ?? overrideConfig.DevicePartNumber,
-            FirmwareRevision: inferred.FirmwareRevision ?? overrideConfig.FirmwareRevision,
-            CalibrationValues: inferred.CalibrationValues ?? overrideConfig.CalibrationValues,
-            Resolution: inferred.Resolution > 0 ? inferred.Resolution : overrideConfig.Resolution,
-            PortRange: inferred.PortRange ?? overrideConfig.PortRange,
-            InternalScaleM: inferred.InternalScaleM ?? overrideConfig.InternalScaleM);
+        return SdCardConfigurationMerge.Merge(inferred, options.ConfigurationOverride);
     }
 
 #pragma warning disable CS1998 // Async iterator: yield break requires async; no real awaits.


### PR DESCRIPTION
## What was wrong
The CSV and JSON SD card log parsers each carried their own byte-for-byte copy of the logic that merges a caller-supplied override configuration into the configuration parsed/inferred from the file. Nothing was broken for users, but the two copies could silently drift apart if one were changed without the other.

## How it was fixed
Extracted the shared merge logic into a single internal `SdCardConfigurationMerge.Merge` helper and pointed both parsers at it. No behavior change — same field-by-field precedence (file-derived values win, override fills gaps) for every input. The binary/protobuf parser's own `MergeConfigurations` is a genuinely different variant (different null/zero comparisons) and was left untouched, not folded in.

**Maintenance routine: duplicate/abstraction unifier.** Internal-only change (no public API surface touched), so this is low-risk to review.

## Verification
- `dotnet test` full suite green on net9.0 and net10.0.
- No production behavior change, so no bench validation applies.

Not merging — for review.