### PR TITLE
test: remove tautological StreamingFrequency round-trip test

### DIFF
--- a/src/Daqifi.Core.Tests/Device/BootloaderSessionDeviceTests.cs
+++ b/src/Daqifi.Core.Tests/Device/BootloaderSessionDeviceTests.cs
@@ -203,14 +203,6 @@ public class BootloaderSessionDeviceTests
         Assert.Equal(DaqifiStreamingDevice.DefaultPwmFrequencyHz, new BootloaderSessionDevice().PwmFrequencyHz);
     }
 
-    [Fact]
-    public void StreamingFrequency_RoundTrips()
-    {
-        var device = new BootloaderSessionDevice { StreamingFrequency = 42 };
-
-        Assert.Equal(42, device.StreamingFrequency);
-    }
-
     #endregion
 
     #region Cancellation


### PR DESCRIPTION
Maintenance routine: useless-test pruner. `BootloaderSessionDeviceTests.StreamingFrequency_RoundTrips()` set `BootloaderSessionDevice.StreamingFrequency` (a plain auto-property with no logic in its getter or setter) and then asserted it read back the same value — a test that cannot fail short of the C# compiler itself being broken. Same pattern already pruned from other files in #576.

Removed the one test method; nothing else touched. Safe because it deletes zero test coverage of real behavior (there was none to begin with) and no production code changed.

Verified: full `dotnet test` suite green on net9.0 and net10.0 (3726 passed, 2 skipped, 0 failed both times).

Not merging — for review.