### PR TITLE
chore(sdcard): switch-expression the listing-status word mapping

### DIFF
--- a/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileListParser.cs
@@ -206,26 +206,18 @@ namespace Daqifi.Core.Device.SdCard
                     continue;
                 }
 
-                if (word.Equals("OK", StringComparison.OrdinalIgnoreCase))
+                // A marker with a status word this version does not know is
+                // still a terminated listing, but its contents cannot be
+                // trusted as complete -- treat it the way an explicitly
+                // partial one is treated rather than as success (the default
+                // arm below).
+                status = word.ToUpperInvariant() switch
                 {
-                    status = SdCardListingStatus.Complete;
-                }
-                else if (word.Equals("INCOMPLETE", StringComparison.OrdinalIgnoreCase))
-                {
-                    status = SdCardListingStatus.Incomplete;
-                }
-                else if (word.Equals("FAILED", StringComparison.OrdinalIgnoreCase))
-                {
-                    status = SdCardListingStatus.Failed;
-                }
-                else
-                {
-                    // A marker with a status word this version does not know is
-                    // still a terminated listing, but its contents cannot be
-                    // trusted as complete -- treat it the way an explicitly
-                    // partial one is treated rather than as success.
-                    status = SdCardListingStatus.Incomplete;
-                }
+                    "OK" => SdCardListingStatus.Complete,
+                    "INCOMPLETE" => SdCardListingStatus.Incomplete,
+                    "FAILED" => SdCardListingStatus.Failed,
+                    _ => SdCardListingStatus.Incomplete,
+                };
             }
 
             return status;


### PR DESCRIPTION
**Maintenance routine: logic-simplifier** — this is why the change is safe: it touches only the shape of a value-mapping expression, not the values or conditions themselves.

## What was wrong

`SdCardFileListParser.GetListingStatus` mapped the SD card listing terminator word ("OK" / "INCOMPLETE" / "FAILED" / anything else) to a status enum through a four-way `if`/`else if`/`else` chain. It worked correctly, but the chain form obscures that this is a straightforward one-to-one lookup with a single default.

## How it was fixed

Replaced the chain with an equivalent `switch` expression over the uppercased word. Same four mutually exclusive cases, same default (an unrecognized status word is still treated as `Incomplete`, per the existing comment, now attached to the default arm). `OrdinalIgnoreCase` equality against these ASCII tokens is equivalent to uppercase-then-ordinal-equal, so behavior is unchanged.

## Verification

- `dotnet test` full suite green on net9.0 and net10.0 (3727 tests, 2 pre-existing hardware-loopback skips), including the 46 `SdCardFileListParser` tests specifically.
- Parsing-only change with existing test coverage on all four branches; no bench validation needed.

Not merging — for review.