### PR TITLE
chore(device): unify the "first line wins" TryParseLines pattern across three parsers

### DIFF
--- a/src/Daqifi.Core/Device/Diagnostics/LogLevelParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/LogLevelParser.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Daqifi.Core.Device;
 
 namespace Daqifi.Core.Device.Diagnostics;
 
@@ -62,19 +63,8 @@ public static partial class LogLevelParser
     /// <param name="lines">Response lines from the device.</param>
     /// <param name="result">The parsed setting, or <see langword="null"/> if no line could be parsed.</param>
     /// <returns><see langword="true"/> if any line was successfully parsed; otherwise <see langword="false"/>.</returns>
-    public static bool TryParseLines(IEnumerable<string> lines, [NotNullWhen(true)] out LogLevelSetting? result)
-    {
-        foreach (var line in lines)
-        {
-            if (TryParse(line, out result))
-            {
-                return true;
-            }
-        }
-
-        result = null;
-        return false;
-    }
+    public static bool TryParseLines(IEnumerable<string> lines, [NotNullWhen(true)] out LogLevelSetting? result) =>
+        LineParsing.TryParseFirst(lines, TryParse, out result);
 
     [GeneratedRegex(@"^(?<module>\S+):\s*(?<level>\d+)\s*\(ceiling\s*(?<ceiling>\d+)\)",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]

--- a/src/Daqifi.Core/Device/LineParsing.cs
+++ b/src/Daqifi.Core/Device/LineParsing.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Daqifi.Core.Device;
+
+/// <summary>
+/// Tries to parse a single response line into <typeparamref name="T"/>, following the standard
+/// <c>Try*</c> pattern: returns <see langword="true"/> and a non-null <paramref name="result"/>
+/// on success, or <see langword="false"/> and a <see langword="null"/> <paramref name="result"/>
+/// otherwise.
+/// </summary>
+/// <typeparam name="T">The parsed result type.</typeparam>
+/// <param name="line">A single response line. May be <see langword="null"/> or empty.</param>
+/// <param name="result">The parsed value, or <see langword="null"/> if parsing failed.</param>
+internal delegate bool TryParseLine<T>(string? line, [NotNullWhen(true)] out T? result) where T : class;
+
+/// <summary>
+/// Shared helper for the several device/firmware response parsers whose multi-line variant tries
+/// each line in order and returns the first one that parses successfully.
+/// </summary>
+internal static class LineParsing
+{
+    /// <summary>
+    /// Tries each line in <paramref name="lines"/> in order against <paramref name="tryParse"/>,
+    /// returning the first successful parse.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the "first parseable line wins" response parsers (e.g. <c>SdCardSpaceParser</c>,
+    /// <c>LogLevelParser</c>, <c>LanChipInfoParser</c>) so each only needs to supply its own
+    /// single-line <c>TryParse</c>.
+    /// </remarks>
+    /// <typeparam name="T">The parsed result type.</typeparam>
+    /// <param name="lines">The response lines to try, in order.</param>
+    /// <param name="tryParse">The single-line parse function to apply to each line.</param>
+    /// <param name="result">The first successfully parsed value, or <see langword="null"/> if none parsed.</param>
+    /// <returns><see langword="true"/> if any line was successfully parsed; otherwise <see langword="false"/>.</returns>
+    public static bool TryParseFirst<T>(IEnumerable<string> lines, TryParseLine<T> tryParse, [NotNullWhen(true)] out T? result)
+        where T : class
+    {
+        foreach (var line in lines)
+        {
+            if (tryParse(line, out result))
+            {
+                return true;
+            }
+        }
+
+        result = null;
+        return false;
+    }
+}

--- a/src/Daqifi.Core/Device/LineParsing.cs
+++ b/src/Daqifi.Core/Device/LineParsing.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -34,13 +35,24 @@ internal static class LineParsing
     /// <param name="tryParse">The single-line parse function to apply to each line.</param>
     /// <param name="result">The first successfully parsed value, or <see langword="null"/> if none parsed.</param>
     /// <returns><see langword="true"/> if any line was successfully parsed; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="lines"/> or <paramref name="tryParse"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><paramref name="tryParse"/> returned <see langword="true"/> with a <see langword="null"/> result.</exception>
     public static bool TryParseFirst<T>(IEnumerable<string> lines, TryParseLine<T> tryParse, [NotNullWhen(true)] out T? result)
         where T : class
     {
+        ArgumentNullException.ThrowIfNull(lines);
+        ArgumentNullException.ThrowIfNull(tryParse);
+
         foreach (var line in lines)
         {
             if (tryParse(line, out result))
             {
+                if (result is null)
+                {
+                    throw new InvalidOperationException(
+                        $"{nameof(tryParse)} returned true with a null result; TryParseFirst callers rely on a non-null result when returning true.");
+                }
+
                 return true;
             }
         }

--- a/src/Daqifi.Core/Device/SdCard/SdCardSpaceParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardSpaceParser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using Daqifi.Core.Device;
 
 namespace Daqifi.Core.Device.SdCard;
 
@@ -61,17 +62,6 @@ public static class SdCardSpaceParser
     /// <param name="lines">Response lines from the device.</param>
     /// <param name="result">The parsed storage info, or <see langword="null"/> if no line could be parsed.</param>
     /// <returns><see langword="true"/> if any line was successfully parsed; otherwise <see langword="false"/>.</returns>
-    public static bool TryParseLines(IEnumerable<string> lines, [NotNullWhen(true)] out SdCardStorageInfo? result)
-    {
-        foreach (var line in lines)
-        {
-            if (TryParse(line, out result))
-            {
-                return true;
-            }
-        }
-
-        result = null;
-        return false;
-    }
+    public static bool TryParseLines(IEnumerable<string> lines, [NotNullWhen(true)] out SdCardStorageInfo? result) =>
+        LineParsing.TryParseFirst(lines, TryParse, out result);
 }

--- a/src/Daqifi.Core/Firmware/LanChipInfoParser.cs
+++ b/src/Daqifi.Core/Firmware/LanChipInfoParser.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using Daqifi.Core.Device;
 
 namespace Daqifi.Core.Firmware;
 
@@ -69,23 +71,6 @@ public static class LanChipInfoParser
     /// <param name="lines">Response lines from the device.</param>
     /// <param name="result">The parsed chip info, or <see langword="null"/> if no line could be parsed.</param>
     /// <returns><see langword="true"/> if any line was successfully parsed; otherwise <see langword="false"/>.</returns>
-    public static bool TryParseLines(IEnumerable<string> lines, [NotNullWhen(true)] out LanChipInfo? result)
-    {
-        result = null;
-
-        foreach (var line in lines)
-        {
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                continue;
-            }
-
-            if (TryParse(line, out result))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    public static bool TryParseLines(IEnumerable<string> lines, [NotNullWhen(true)] out LanChipInfo? result) =>
+        LineParsing.TryParseFirst(lines, TryParse, out result);
 }


### PR DESCRIPTION
**Maintenance routine: duplicate/abstraction unifier** — this is why the change is safe: it extracts an already-tested loop into a shared internal helper without changing any parser's public behavior.

## What was wrong

Three unrelated response parsers — `SdCardSpaceParser`, `LogLevelParser`, and `LanChipInfoParser` — each hand-rolled the exact same multi-line loop for their `TryParseLines` method: try each response line against the type's own single-line `TryParse`, and return the first one that succeeds. It worked correctly in all three, but the duplication meant a bug in that loop would need fixing in three places, and one copy (`LanChipInfoParser`) carried a redundant blank-line check that the other two didn't have.

## How it was fixed

Extracted the shared loop into a new internal `LineParsing.TryParseFirst<T>` helper (same generic-wrapper shape already established by `KeyValueResponseParser.TryParse<T>` from a previous PR, #577) and pointed all three `TryParseLines` methods at it. `LanChipInfoParser`'s extra blank-line pre-check was dropped since every one of these `TryParse` implementations already returns `false` on a blank line internally — so this is a no-op removal, not a behavior change. Internal-only; no public API touched.

## Verification

- `dotnet build` clean on net9.0 and net10.0, 0 warnings.
- `dotnet test` full suite green on net9.0 and net10.0 (3726 passed, 2 pre-existing hardware-loopback skips, 0 failed), including all 46 tests across the three affected parsers.
- Parser-internal, non-board-observable change — unit tests are the correct validation surface here, no bench pass needed.

Not merging — for review.