### PR TITLE
test: prune tautological DeviceInfo property round-trip tests

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/DeviceInfoTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/DeviceInfoTests.cs
@@ -87,42 +87,6 @@ public class DeviceInfoTests
     }
 
     [Fact]
-    public void DeviceInfo_LocationKey_CanBeSetAndRetrieved()
-    {
-        // Arrange
-        var deviceInfo = new DeviceInfo
-        {
-            Name = "DAQiFi",
-            SerialNumber = "67890",
-            PortName = "COM3",
-            ConnectionType = ConnectionType.Serial,
-            LocationKey = "Port_#0001.Hub_#0001"
-        };
-
-        // Act & Assert
-        Assert.Equal("Port_#0001.Hub_#0001", deviceInfo.LocationKey);
-    }
-
-    [Fact]
-    public void DeviceInfo_LocalInterfaceAddress_CanBeSetAndRetrieved()
-    {
-        // Arrange
-        var localAddress = IPAddress.Parse("192.168.1.50");
-        var deviceInfo = new DeviceInfo
-        {
-            Name = "NYQUIST",
-            SerialNumber = "12345",
-            IPAddress = IPAddress.Parse("192.168.1.100"),
-            Port = 9760,
-            LocalInterfaceAddress = localAddress,
-            ConnectionType = ConnectionType.WiFi
-        };
-
-        // Act & Assert
-        Assert.Equal(localAddress, deviceInfo.LocalInterfaceAddress);
-    }
-
-    [Fact]
     public void DeviceInfo_WiFiDevice_WithLocalInterfaceAddress_StoresCorrectly()
     {
         // Arrange - Simulates a device discovered via WiFi on a multi-NIC system


### PR DESCRIPTION
This is the useless-test-pruner routine: two `DeviceInfoTests` methods looked like coverage but structurally could not fail, so they added no regression protection.

**What was wrong**: `DeviceInfo_LocationKey_CanBeSetAndRetrieved` and `DeviceInfo_LocalInterfaceAddress_CanBeSetAndRetrieved` each set a property via an object initializer and then immediately asserted the same value came back. Both `DeviceInfo.LocationKey` and `DeviceInfo.LocalInterfaceAddress` are bare `{ get; set; }` auto-properties with no validation, transformation, or side effects — the assertions are guaranteed by C# language semantics alone, not by any production behavior. This is the same pattern already pruned in #576 and #581.

**How it was fixed**: removed both test methods. Nothing else touched. Other `DeviceInfoTests` tests that exercise real logic (`ToString()` formatting, default-value checks, cross-field distinctness in `DeviceInfo_WiFiDevice_WithLocalInterfaceAddress_StoresCorrectly`) were left in place.

**Verification**: full `dotnet test` suite green on net9.0 and net10.0 (3724 passed, 2 pre-existing hardware-loopback skips, 0 failed on Daqifi.Core.Tests; 217 passed on Daqifi.Mcp.Tests net9.0). Test-only change, no bench validation applicable.

Not merging — for review.