### PR TITLE
chore(firmware): flatten nested asset-match condition in GitHub release parsing

### DIFF
--- a/src/Daqifi.Core/Firmware/GitHubFirmwareDownloadService.cs
+++ b/src/Daqifi.Core/Firmware/GitHubFirmwareDownloadService.cs
@@ -348,13 +348,12 @@ public sealed class GitHubFirmwareDownloadService : IFirmwareDownloadService
             {
                 if (!asset.TryGetProperty("name", out var nameProp)) continue;
                 var name = nameProp.GetString();
-                if (name != null && name.EndsWith(assetExtension, StringComparison.OrdinalIgnoreCase))
-                {
-                    downloadUrl = asset.TryGetProperty("browser_download_url", out var urlProp) ? urlProp.GetString() : null;
-                    assetFileName = name;
-                    assetSize = asset.TryGetProperty("size", out var sizeProp) ? sizeProp.GetInt64() : null;
-                    break;
-                }
+                if (name == null || !name.EndsWith(assetExtension, StringComparison.OrdinalIgnoreCase)) continue;
+
+                downloadUrl = asset.TryGetProperty("browser_download_url", out var urlProp) ? urlProp.GetString() : null;
+                assetFileName = name;
+                assetSize = asset.TryGetProperty("size", out var sizeProp) ? sizeProp.GetInt64() : null;
+                break;
             }
         }
 


### PR DESCRIPTION
**Routine: logic-simplifier** (maintenance rotation, no tracking issue).

`GitHubFirmwareDownloadService.ParseReleaseElement`'s asset-matching loop nested the actual match logic three levels deep (extension check, then a `foreach`, then an `if` wrapping the assignment). This flattens the innermost `if` into a guard-clause `continue`, so the match/assign code reads at the same level as the rest of the loop body instead of inside a wrapping block.

Behavior is unchanged: same null-check-before-`EndsWith`, same `OrdinalIgnoreCase` comparison, same first-match-wins/`break` semantics — this is a straightforward De Morgan inversion (`A && B` → `if (!A || !B) continue;`), not a behavior change.

**Verified:** `dotnet test` full suite green on net9.0 and net10.0 (3726 passed, 2 skipped, 0 failed). Parser-internal change with no board-observable behavior, so no bench validation applies.

Not merging — for review.