### PR TITLE
chore: unify HID string normalization

### DIFF
--- a/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidLibraryPlatform.cs
@@ -268,7 +268,7 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
     {
         try
         {
-            return NormalizeHidString(device.GetSerialNumber());
+            return HidStringNormalization.Normalize(device.GetSerialNumber());
         }
         catch
         {
@@ -280,7 +280,7 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
     {
         try
         {
-            return NormalizeHidString(device.GetProductName());
+            return HidStringNormalization.Normalize(device.GetProductName());
         }
         catch
         {
@@ -296,16 +296,6 @@ internal sealed class HidLibraryTransportDevice : IHidTransportDevice
         }
 
         return _stream;
-    }
-
-    private static string? NormalizeHidString(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        return value.Trim().TrimEnd('\0');
     }
 
     private byte[] FormatOutputReport(byte[] payload)

--- a/src/Daqifi.Core/Communication/Transport/HidStringNormalization.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidStringNormalization.cs
@@ -1,0 +1,30 @@
+namespace Daqifi.Core.Communication.Transport;
+
+/// <summary>
+/// Normalizes raw string fields read from native HID device descriptors (serial number,
+/// product name) into a usable managed string.
+/// </summary>
+/// <remarks>
+/// The Windows/Linux (HidSharp-backed <see cref="HidLibraryPlatform"/>) and macOS (IOKit-backed
+/// <see cref="MacOsHidPlatform"/>) transport platforms each read the same kind of raw HID string
+/// descriptor and previously carried an identical copy of this normalization; it now lives here
+/// once so the two platforms can't drift out of sync with each other.
+/// </remarks>
+internal static class HidStringNormalization
+{
+    /// <summary>
+    /// Trims a raw HID string field and strips trailing NUL padding, returning
+    /// <see langword="null"/> for a null, empty, or whitespace-only value.
+    /// </summary>
+    /// <param name="value">The raw string read from the native HID descriptor.</param>
+    /// <returns>The normalized string, or <see langword="null"/> if there was no usable value.</returns>
+    public static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim().TrimEnd('\0');
+    }
+}

--- a/src/Daqifi.Core/Communication/Transport/MacOsHidPlatform.cs
+++ b/src/Daqifi.Core/Communication/Transport/MacOsHidPlatform.cs
@@ -196,8 +196,8 @@ internal sealed class MacOsHidTransportDevice : IHidTransportDevice, IDisposable
             return null;
         }
 
-        var serialNumber = NormalizeHidString(GetStringProperty(deviceRef, NativeMethods.kIOHIDSerialNumberKey));
-        var productName = NormalizeHidString(GetStringProperty(deviceRef, NativeMethods.kIOHIDProductKey));
+        var serialNumber = HidStringNormalization.Normalize(GetStringProperty(deviceRef, NativeMethods.kIOHIDSerialNumberKey));
+        var productName = HidStringNormalization.Normalize(GetStringProperty(deviceRef, NativeMethods.kIOHIDProductKey));
 
         var maxInput = GetNumberProperty(deviceRef, NativeMethods.kIOHIDMaxInputReportSizeKey) ?? 0;
         var maxOutput = GetNumberProperty(deviceRef, NativeMethods.kIOHIDMaxOutputReportSizeKey) ?? 0;
@@ -632,16 +632,6 @@ internal sealed class MacOsHidTransportDevice : IHidTransportDevice, IDisposable
         {
             NativeMethods.CFRelease(cfKey);
         }
-    }
-
-    private static string? NormalizeHidString(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return null;
-        }
-
-        return value.Trim().TrimEnd('\0');
     }
 
     [SupportedOSPlatform("macos")]


### PR DESCRIPTION
## What

`HidLibraryPlatform` (Windows/Linux, HidSharp-backed) and `MacOsHidPlatform` (IOKit-backed) each defined a byte-for-byte identical private `NormalizeHidString(string?)` helper for turning a raw HID serial-number/product-name descriptor into a usable managed string: null/whitespace input returns `null`, otherwise the value is trimmed and trailing NUL padding is stripped.

Both had real call sites reading a connected device's serial number and product name.

## Why this is safe

Extracted the identical method body into a new internal `HidStringNormalization.Normalize` helper (same file location convention as the prior `SdCardTickDelta`/`KeyValueResponseParser`/`LineParsing` unifications) and pointed both call sites at it, deleting the two duplicate private methods. No public API surface changed, no logic changed - the extracted method is a verbatim copy, so every call site produces the exact same output for the exact same input as before.

## Testing

- Clean build, 0 warnings/errors, both TFMs.
- Full `dotnet test` on net9.0: 3726 passed, 2 pre-existing skipped, 0 failed.
- Full `dotnet test` on net10.0: 3726 passed, 2 pre-existing skipped, 0 failed.

Not merging - for review.