### PR TITLE
fix(test): stabilize a flaky LiveSampleStream concurrency test

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -416,7 +416,16 @@ public class LiveSampleStreamTests
 
     private sealed class FakeChannel : IChannel
     {
+        // LiveSampleStream deliberately ends concurrent enumerations' buffers with
+        // AllowSynchronousContinuations = false, so two enumerations can unsubscribe from this same
+        // event on two different thread-pool threads at once (see
+        // LiveSampleStreamTests.ConcurrentEnumerations_AllEndOnTheSameDrop). A plain `+=`/`-=` and a
+        // plain `SubscriberCount++`/`--` are not atomic, so that race could lose an update and leave
+        // this fake reporting a stale subscriber count. A lock keeps both in sync regardless of which
+        // thread reaches them first.
+        private readonly object _subscriptionLock = new();
         private EventHandler<SampleReceivedEventArgs>? _sampleReceived;
+        private int _subscriberCount;
 
         public FakeChannel(int channelNumber)
         {
@@ -424,12 +433,15 @@ public class LiveSampleStreamTests
             Name = "ch" + channelNumber;
         }
 
-        public int SubscriberCount { get; private set; }
+        public int SubscriberCount
+        {
+            get { lock (_subscriptionLock) { return _subscriberCount; } }
+        }
 
         public event EventHandler<SampleReceivedEventArgs>? SampleReceived
         {
-            add { _sampleReceived += value; SubscriberCount++; }
-            remove { _sampleReceived -= value; SubscriberCount--; }
+            add { lock (_subscriptionLock) { _sampleReceived += value; _subscriberCount++; } }
+            remove { lock (_subscriptionLock) { _sampleReceived -= value; _subscriberCount--; } }
         }
 
         public void RaiseSample(double value)

--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -448,7 +448,17 @@ public class LiveSampleStreamTests
         {
             var sample = new DataSample(DateTime.UtcNow, value);
             ActiveSample = sample;
-            _sampleReceived?.Invoke(this, new SampleReceivedEventArgs(this, sample));
+
+            // Snapshot the delegate under the same lock the add/remove accessors use, so this read
+            // can't race a concurrent subscribe/unsubscribe; invoke outside the lock to avoid holding
+            // it across a callback into the (single-threaded, non-reentrant) enumeration under test.
+            EventHandler<SampleReceivedEventArgs>? handler;
+            lock (_subscriptionLock)
+            {
+                handler = _sampleReceived;
+            }
+
+            handler?.Invoke(this, new SampleReceivedEventArgs(this, sample));
         }
 
         public int ChannelNumber { get; }


### PR DESCRIPTION
## What was wrong
CI occasionally failed `LiveSampleStreamTests.ConcurrentEnumerations_AllEndOnTheSameDrop` with no code change involved — a rerun of the same commit passed. Two instances were found in recent CI history (run 32343537179 on `fix/532-locked-port-not-lost`, `Assert.Equal() Failure: Expected: 0 Actual: 1`), both on otherwise-green commits.

## How it was fixed
The test's `FakeChannel` tracked `SubscriberCount` with a plain `++`/`--` in its event add/remove accessors. `LiveSampleStream` deliberately completes each enumeration's buffer off-thread (`AllowSynchronousContinuations = false`), so this test — which ends two concurrent enumerations at once on purpose — can have both unsubscribe from the same fake channel on two different thread-pool threads simultaneously. The unsynchronized increment/decrement could race and drop an update, leaving the final count off by one. A lock around the fake's event accessors and counter read makes the bookkeeping atomic. This is a test-double fix only; no production code changed.

## Verified
- Full `dotnet test` green on net9.0/net10.0 (3724 passed, 2 skipped, 0 failed both TFMs).
- The affected test run 20x in a tight loop on net9.0 with no failures (previously observed to fail intermittently under CI's parallel load).
- Test-only change — no bench validation applicable.

Routine: flaky-test-fixer (maintenance rotation). Not tied to a specific issue.

Not merging — for review.