### PR TITLE
chore: unify SD card CSV/JSON text-parser stream and file resolution

### DIFF
--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -50,31 +50,11 @@ public sealed class SdCardCsvFileParser
 
         options ??= new SdCardParseOptions();
 
-        var source = SdCardParseSource.TryCreate(fileStream);
-        if (source != null)
-        {
-            return await BuildSessionAsync(
-                token => SdCardTextLineReader.ReadLinesAsync(source, token),
-                () => source.TotalBytes,
-                fileName,
-                options,
-                ct).ConfigureAwait(false);
-        }
-
-        // A forward-only stream can only be read once, so it has to be read up front.
-        // Callers that want the streaming parse hand the parser a seekable stream or a path.
-        var lines = new List<SdCardLogLine>();
-        await foreach (var line in SdCardTextLineReader.ReadLinesAsync(fileStream, ct).ConfigureAwait(false))
-        {
-            lines.Add(line);
-        }
-
-        return await BuildSessionAsync(
-            _ => SdCardTextLineReader.ToAsyncEnumerable(lines),
-            () => lines.Count > 0 ? lines[^1].BytesRead : 0,
-            fileName,
-            options,
-            ct).ConfigureAwait(false);
+        return await SdCardTextFileSource.ParseAsync(
+            fileStream,
+            ct,
+            (openLines, totalBytes, token) => BuildSessionAsync(openLines, totalBytes, fileName, options, token))
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -97,14 +77,12 @@ public sealed class SdCardCsvFileParser
 
         options ??= new SdCardParseOptions();
 
-        var source = SdCardParseSource.ForFile(filePath, options.BufferSize);
-
-        return await BuildSessionAsync(
-            token => SdCardTextLineReader.ReadLinesAsync(source, token),
-            () => source.TotalBytes,
-            Path.GetFileName(filePath),
-            options,
-            ct).ConfigureAwait(false);
+        return await SdCardTextFileSource.ParseFileAsync(
+            filePath,
+            options.BufferSize,
+            ct,
+            (openLines, totalBytes, token) => BuildSessionAsync(openLines, totalBytes, Path.GetFileName(filePath), options, token))
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -130,7 +108,7 @@ public sealed class SdCardCsvFileParser
                 fileName,
                 fileCreatedDate,
                 null,
-                EmptySamples());
+                SdCardTextFileSource.EmptySamples());
         }
 
         var config = SdCardConfigurationMerge.Merge(header.Config, options.ConfigurationOverride);
@@ -149,7 +127,7 @@ public sealed class SdCardCsvFileParser
                 fileName,
                 fileCreatedDate,
                 config,
-                EmptySamples())
+                SdCardTextFileSource.EmptySamples())
             {
                 TimestampFrequency = timestampFrequency,
                 TimestampFrequencySource = timestampSource
@@ -510,10 +488,4 @@ public sealed class SdCardCsvFileParser
         }
     }
 
-#pragma warning disable CS1998 // Async iterator: yield break requires async; no real awaits.
-    private static async IAsyncEnumerable<SdCardLogEntry> EmptySamples()
-    {
-        yield break;
-    }
-#pragma warning restore CS1998
 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -42,31 +42,11 @@ public sealed class SdCardJsonFileParser
 
         options ??= new SdCardParseOptions();
 
-        var source = SdCardParseSource.TryCreate(fileStream);
-        if (source != null)
-        {
-            return await BuildSessionAsync(
-                token => SdCardTextLineReader.ReadLinesAsync(source, token),
-                () => source.TotalBytes,
-                fileName,
-                options,
-                ct).ConfigureAwait(false);
-        }
-
-        // A forward-only stream can only be read once, so it has to be read up front.
-        // Callers that want the streaming parse hand the parser a seekable stream or a path.
-        var lines = new List<SdCardLogLine>();
-        await foreach (var line in SdCardTextLineReader.ReadLinesAsync(fileStream, ct).ConfigureAwait(false))
-        {
-            lines.Add(line);
-        }
-
-        return await BuildSessionAsync(
-            _ => SdCardTextLineReader.ToAsyncEnumerable(lines),
-            () => lines.Count > 0 ? lines[^1].BytesRead : 0,
-            fileName,
-            options,
-            ct).ConfigureAwait(false);
+        return await SdCardTextFileSource.ParseAsync(
+            fileStream,
+            ct,
+            (openLines, totalBytes, token) => BuildSessionAsync(openLines, totalBytes, fileName, options, token))
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -89,14 +69,12 @@ public sealed class SdCardJsonFileParser
 
         options ??= new SdCardParseOptions();
 
-        var source = SdCardParseSource.ForFile(filePath, options.BufferSize);
-
-        return await BuildSessionAsync(
-            token => SdCardTextLineReader.ReadLinesAsync(source, token),
-            () => source.TotalBytes,
-            Path.GetFileName(filePath),
-            options,
-            ct).ConfigureAwait(false);
+        return await SdCardTextFileSource.ParseFileAsync(
+            filePath,
+            options.BufferSize,
+            ct,
+            (openLines, totalBytes, token) => BuildSessionAsync(openLines, totalBytes, Path.GetFileName(filePath), options, token))
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -128,7 +106,7 @@ public sealed class SdCardJsonFileParser
                 fileName,
                 fileCreatedDate,
                 null,
-                EmptySamples());
+                SdCardTextFileSource.EmptySamples());
         }
 
         var config = InferConfiguration(firstLine, options);
@@ -325,10 +303,4 @@ public sealed class SdCardJsonFileParser
         return SdCardConfigurationMerge.Merge(inferred, options.ConfigurationOverride);
     }
 
-#pragma warning disable CS1998 // Async iterator: yield break requires async; no real awaits.
-    private static async IAsyncEnumerable<SdCardLogEntry> EmptySamples()
-    {
-        yield break;
-    }
-#pragma warning restore CS1998
 }

--- a/src/Daqifi.Core/Device/SdCard/SdCardTextFileSource.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTextFileSource.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Resolves a <see cref="System.IO.Stream"/> or file path into the (line-source, total-bytes)
+/// pair that a text-based SD card log parser's session builder needs.
+/// </summary>
+/// <remarks>
+/// The CSV and JSON log parsers each read the same kind of text log and previously carried an
+/// identical copy of this stream/file resolution — including the fallback that buffers a
+/// forward-only stream up front because it can't be re-read; it now lives here once so the two
+/// formats can't drift out of sync with each other.
+/// </remarks>
+internal static class SdCardTextFileSource
+{
+    /// <summary>
+    /// Resolves <paramref name="fileStream"/> into an <c>openLines</c>/<c>totalBytes</c> pair
+    /// and hands it to <paramref name="buildSessionAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// A seekable stream is re-read from its starting position on each enumeration via
+    /// <see cref="SdCardParseSource"/>. A forward-only stream can only be read once, so its
+    /// lines are decoded up front instead.
+    /// </remarks>
+    public static async Task<T> ParseAsync<T>(
+        System.IO.Stream fileStream,
+        CancellationToken ct,
+        Func<Func<CancellationToken, IAsyncEnumerable<SdCardLogLine>>, Func<long>, CancellationToken, Task<T>> buildSessionAsync)
+    {
+        var source = SdCardParseSource.TryCreate(fileStream);
+        if (source != null)
+        {
+            return await buildSessionAsync(
+                token => SdCardTextLineReader.ReadLinesAsync(source, token),
+                () => source.TotalBytes,
+                ct).ConfigureAwait(false);
+        }
+
+        var lines = new List<SdCardLogLine>();
+        await foreach (var line in SdCardTextLineReader.ReadLinesAsync(fileStream, ct).ConfigureAwait(false))
+        {
+            lines.Add(line);
+        }
+
+        return await buildSessionAsync(
+            _ => SdCardTextLineReader.ToAsyncEnumerable(lines),
+            () => lines.Count > 0 ? lines[^1].BytesRead : 0,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Opens <paramref name="filePath"/> as a rewindable source and hands the resulting
+    /// <c>openLines</c>/<c>totalBytes</c> pair to <paramref name="buildSessionAsync"/>.
+    /// </summary>
+    public static Task<T> ParseFileAsync<T>(
+        string filePath,
+        int bufferSize,
+        CancellationToken ct,
+        Func<Func<CancellationToken, IAsyncEnumerable<SdCardLogLine>>, Func<long>, CancellationToken, Task<T>> buildSessionAsync)
+    {
+        var source = SdCardParseSource.ForFile(filePath, bufferSize);
+
+        return buildSessionAsync(
+            token => SdCardTextLineReader.ReadLinesAsync(source, token),
+            () => source.TotalBytes,
+            ct);
+    }
+
+    /// <summary>
+    /// An async iterator that yields no samples, for a log file with no data to report.
+    /// </summary>
+#pragma warning disable CS1998 // Async iterator: yield break requires async; no real awaits.
+    public static async IAsyncEnumerable<SdCardLogEntry> EmptySamples()
+    {
+        yield break;
+    }
+#pragma warning restore CS1998
+}


### PR DESCRIPTION
**What was wrong:** the CSV and JSON SD card log parsers each carried their own copy of the logic that resolves a stream or file path into a readable line source — including the fallback that has to buffer a forward-only stream up front because it can't be rewound — plus an identical private "no samples" helper. The two copies could silently drift apart if one was fixed and the other forgotten.

**How it was fixed:** extracted the shared resolution logic into a new internal `SdCardTextFileSource` helper and had both parsers delegate to it instead of carrying their own copies. Each format's own session-building logic, which is genuinely different between CSV and JSON, was left untouched. No public API changed — the new type and its members are internal.

Verified: `dotnet build` clean (0 warnings/errors); full test suite green on net9.0 and net10.0 (3726/3726 passed, 2 skipped, consistent both runs). Internal refactor only, no bench validation needed.

Maintenance routine: duplicate/abstraction-unifier (next in this loop's rotation after this fire's dead-code-remover pass found nothing).

Not merging — for review.