### PR TITLE
fix(tests): stop asserting an exact retry count in a wall-clock race

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
@@ -112,11 +112,11 @@ public class SerialProbeTeardownTests
         Assert.Null(status);
         // Deliberately a bound, not an exact count, mirroring
         // RequestDeviceStatusAsync_Cancelled_GivesUpEarlyAndStillTearsDown below. Requests go out
-        // on a RetryIntervalMs (300ms) cadence measured against wall-clock time inside a fixed
-        // ResponseTimeoutMs (1000ms) window; a scheduling gap on a loaded CI runner (e.g. a GC
-        // pause or thread-pool starvation between polls) can push the loop's next wake-up past the
-        // window before the second send's 300ms mark is reached, so only the first attempt goes
-        // out. Observed on CI: expected 2, actual 1. What is always true is that the probe sends at
+        // on a RetryIntervalMs cadence measured against wall-clock time inside a fixed
+        // ResponseTimeoutMs window; a scheduling gap on a loaded CI runner (e.g. a GC pause or
+        // thread-pool starvation between polls) can push the loop's next wake-up past the window
+        // before the second send's retry mark is reached, so only the first attempt goes out.
+        // Observed on CI: expected 2, actual 1. What is always true is that the probe sends at
         // least once and never exceeds MaxRetries — a port that answers nothing must not be probed
         // forever.
         Assert.InRange(stream.WrittenCommands.Count, 1, 2);

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
@@ -110,8 +110,16 @@ public class SerialProbeTeardownTests
         var status = await SerialDeviceFinder.RequestDeviceStatusAsync(stream, CancellationToken.None);
 
         Assert.Null(status);
-        // Two attempts, per MaxRetries — a port that answers nothing must not be probed forever.
-        Assert.Equal(2, stream.WrittenCommands.Count);
+        // Deliberately a bound, not an exact count, mirroring
+        // RequestDeviceStatusAsync_Cancelled_GivesUpEarlyAndStillTearsDown below. Requests go out
+        // on a RetryIntervalMs (300ms) cadence measured against wall-clock time inside a fixed
+        // ResponseTimeoutMs (1000ms) window; a scheduling gap on a loaded CI runner (e.g. a GC
+        // pause or thread-pool starvation between polls) can push the loop's next wake-up past the
+        // window before the second send's 300ms mark is reached, so only the first attempt goes
+        // out. Observed on CI: expected 2, actual 1. What is always true is that the probe sends at
+        // least once and never exceeds MaxRetries — a port that answers nothing must not be probed
+        // forever.
+        Assert.InRange(stream.WrittenCommands.Count, 1, 2);
         Assert.False(stream.FirstReaderThread!.IsAlive);
     }
 


### PR DESCRIPTION
This is the flaky-test-fixer routine's finding this fire — a small, low-risk test-only stabilization, not a functional change.

**What was wrong:** `RequestDeviceStatusAsync_SilentDevice_ReturnsNullAfterRetrying` failed on CI twice recently (once passing on an immediate rerun with zero intervening code change — see run 32580685415... actually see the two CI runs below), asserting `stream.WrittenCommands.Count == 2` for a silent device. A library user would never see this — it's test-only — but it was a source of CI noise on unrelated PRs.

**Root cause:** the probe's retry loop (`SerialDeviceFinder.RequestDeviceStatusAsync`) sends every `RetryIntervalMs` (300ms), measured against wall-clock time, inside a fixed `ResponseTimeoutMs` (1000ms) window. Under CI scheduling pressure (GC pause, thread-pool starvation between polls) the loop can wake up past the 1000ms window before the second send's 300ms mark is reached, so only the first attempt goes out — the exact failure observed: expected 2, actual 1.

**The fix:** loosen the assertion to `Assert.InRange(stream.WrittenCommands.Count, 1, 2)`, preserving the invariants that actually matter (probes at least once, never exceeds `MaxRetries`). This mirrors the already-accepted fix for the exact same race in the sibling test right below it, `RequestDeviceStatusAsync_Cancelled_GivesUpEarlyAndStillTearsDown`, which already documents "it failed on CI doing exactly that" for the identical timing pattern.

I looked at one other flake found in the same CI sweep — `UsbStreamInterfaceInitializerTests.CancellationBetweenAttempts_StopsBeforeTheRetry` — but its failure mode doesn't have a clear deterministic root cause (the cancel-then-retry path is fully synchronous in the test's execution model, so a second unscripted send shouldn't be reachable once the token is set; it only reproduced on net10.0). Left that one alone rather than guessing at a fix.

**Verification:** `dotnet build` clean (0 warnings/errors); full suite green on both net9.0 and net10.0 (3726/3726 passed, 2 skipped, consistent across both runs). No production code changed, so no bench validation applies.

Not merging — for review.