### PR TITLE
fix(device): reject a stale blank line in a text exchange's capture-to-send window

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -55,6 +55,54 @@ public class DaqifiDeviceStaleTextLineTests
         device.Disconnect();
     }
 
+    // ── The capture-to-send window (#553) — the gap between the stale-line boundary capture
+    // and the setup action actually finishing, which the access-counted mock above cannot
+    // target: both existing Stream accesses land before the boundary is even captured. These
+    // use a dedicated hook fired at the boundary itself, and a setup action slow enough that a
+    // line released there is guaranteed to have arrived before the boundary closes. ───────────
+
+    [Fact]
+    public async Task ExecuteTextCommand_DropsABlankThatArrivesWhileTheCommandIsStillBeingSent()
+    {
+        // The blank is released the instant the boundary is captured — squarely inside the
+        // window a stale reply to an earlier command can land in, and before this exchange has
+        // actually gotten its command onto the wire. Without the fix this leaks through as
+        // "the device answered and its response was empty", which is the exact SYSTem:LOG?
+        // misattribution the issue describes.
+        using var transport = new ReleaseOnStreamAccessMockTransport("\r\n");
+        using var device = new StaleBoundaryHookTestableDevice(
+            "Slow-Sending Device", transport, onStaleLineBoundaryCaptured: () => transport.Release());
+
+        device.Connect();
+
+        var lines = await device.CallExecuteTextCommandAsync(
+            () => Thread.Sleep(100),
+            keepBlankLines: true);
+
+        Assert.Empty(lines);
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_KeepsAContentLineThatArrivesWhileTheCommandIsStillBeingSent()
+    {
+        // The complement, and the reason the fix only narrows the boundary for blanks: a content
+        // line released in the same window is left alone, matching the deliberate decision
+        // recorded in #553 not to risk discarding a genuinely fast reply.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleBoundaryHookTestableDevice(
+            "Fast-Replying Device", transport, onStaleLineBoundaryCaptured: () => transport.Release());
+
+        device.Connect();
+
+        var lines = await device.CallExecuteTextCommandAsync(() => Thread.Sleep(100));
+
+        Assert.Contains(lines, l => l.Contains("No error"));
+
+        device.Disconnect();
+    }
+
     [Fact]
     public async Task ExecuteTextCommandWithPrepare_RunsPrepareBeforeTheSetupAction()
     {
@@ -344,6 +392,35 @@ public class DaqifiDeviceStaleTextLineTests
                 () => { finalized = true; return Task.CompletedTask; }));
 
         Assert.False(finalized, "The finalize phase ran for an exchange that never started.");
+    }
+
+    /// <summary>
+    /// Exposes <see cref="DaqifiDevice.OnStaleLineBoundaryCaptured"/> so a test can release a line
+    /// into the transport at the exact instant the exchange's stale-line boundary is captured —
+    /// the capture-to-send window from issue #553.
+    /// </summary>
+    private sealed class StaleBoundaryHookTestableDevice : DaqifiDevice
+    {
+        private readonly Action _onStaleLineBoundaryCaptured;
+
+        public StaleBoundaryHookTestableDevice(
+            string name, IStreamTransport transport, Action onStaleLineBoundaryCaptured)
+            : base(name, transport)
+        {
+            _onStaleLineBoundaryCaptured = onStaleLineBoundaryCaptured;
+        }
+
+        internal override void OnStaleLineBoundaryCaptured() => _onStaleLineBoundaryCaptured();
+
+        public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(
+            Action setupAction, bool keepBlankLines = false)
+        {
+            return ExecuteTextCommandAsync(
+                setupAction,
+                responseTimeoutMs: 500,
+                completionTimeoutMs: 150,
+                keepBlankLines: keepBlankLines);
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -191,5 +191,6 @@ public class ConnectionGuardTests
         public void ExitOperationLockOwnership() => throw new NotSupportedException();
         public Task DrainOutboundQueueAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
         public IDisposable SubscribeConsumerErrors(IMessageConsumer<string> consumer) => throw new NotSupportedException();
+        public void OnStaleLineBoundaryCaptured() => throw new NotSupportedException();
     }
 }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1989,6 +1989,17 @@ namespace Daqifi.Core.Device
         /// <inheritdoc />
         ILogger ITextExchangeHost.Logger => _logger;
 
+        /// <inheritdoc />
+        void ITextExchangeHost.OnStaleLineBoundaryCaptured() => OnStaleLineBoundaryCaptured();
+
+        /// <summary>
+        /// A no-op on the real device. Overridable for tests, mirroring <see cref="MaxDeferredSends"/> —
+        /// see <see cref="ITextExchangeHost.OnStaleLineBoundaryCaptured"/> for why this seam exists.
+        /// </summary>
+        internal virtual void OnStaleLineBoundaryCaptured()
+        {
+        }
+
         #endregion
 
         #region IOperationSerializationHost — the serializer's view of this device

--- a/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
+++ b/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
@@ -139,5 +139,14 @@ namespace Daqifi.Core.Device.Internal
         /// down an exchange.
         /// </summary>
         ILogger Logger { get; }
+
+        /// <summary>
+        /// Called the instant the exchange has captured its stale-line boundary, before
+        /// <c>setupActionAsync</c> runs. A no-op on the real device; it exists so a test double can
+        /// release a line into the transport at precisely this point — the capture-to-send window
+        /// described in issue #553, which no delay-based or access-counted seam can reliably target
+        /// because it is normally sub-millisecond.
+        /// </summary>
+        void OnStaleLineBoundaryCaptured();
     }
 }

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -365,6 +365,10 @@ namespace Daqifi.Core.Device.Internal
                 // note at the point it is captured, below.
                 var staleLineCount = 0;
 
+                // Number of lines collected by the time the setup action finished sending — see the
+                // note at the point it is captured, below (issue #553).
+                var sentBoundaryLineCount = 0;
+
                 try
                 {
                     if (stream.CanTimeout)
@@ -461,9 +465,25 @@ namespace Daqifi.Core.Device.Internal
                             staleLineCount));
                     }
 
+                    // Test-only seam (issue #553): a no-op on the real device, so this changes
+                    // nothing here. It exists so a test double can release a line into the transport
+                    // in the capture-to-send window below — normally sub-millisecond, and otherwise
+                    // unreachable by any delay-based or access-counted test double.
+                    _host.OnStaleLineBoundaryCaptured();
+
                     // Execute the setup action (sends SCPI commands). ConfigureAwait(false)
                     // matches the surrounding lock-protected awaits.
                     await setupActionAsync(cancellationToken).ConfigureAwait(false);
+
+                    // A second boundary, captured only to catch a blank line that arrived in the
+                    // window above: after the stale-line boundary was captured, but before the
+                    // command actually went out (issue #553). A blank cannot be a terminator for a
+                    // command the device has not yet received, so any blank at or before this point
+                    // is necessarily a leftover from an earlier exchange. Content lines are left on
+                    // the wider boundary above — narrowing it risks discarding a genuinely fast
+                    // reply, a real device having answered before setupActionAsync returns being a
+                    // bench question rather than one this fix can settle.
+                    sentBoundaryLineCount = CollectedLineCount();
 
                     Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Setup action completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));
 
@@ -547,7 +567,16 @@ namespace Daqifi.Core.Device.Internal
                 List<string> result;
                 lock (collectedLinesGate)
                 {
-                    var afterStale = collectedLines.Skip(staleLineCount);
+                    var afterStale = collectedLines
+                        .Select((line, index) => (line, index))
+                        .Skip(staleLineCount)
+                        // A blank line captured at or before sentBoundaryLineCount arrived no later
+                        // than the moment the setup action finished sending, so it cannot be this
+                        // exchange's terminator (issue #553) — drop it here, before the
+                        // keepBlankLines projection below ever sees it. Content lines are untouched:
+                        // only the wider staleLineCount boundary above applies to them.
+                        .Where(t => t.line.Length > 0 || t.index >= sentBoundaryLineCount)
+                        .Select(t => t.line);
                     // keepBlankLines is how a caller asks to see the firmware's
                     // end-of-dump blank line. SYSTem:LOG? terminates its dump with
                     // one unconditionally, so its presence is the difference between

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -483,6 +483,17 @@ namespace Daqifi.Core.Device.Internal
                     // the wider boundary above — narrowing it risks discarding a genuinely fast
                     // reply, a real device having answered before setupActionAsync returns being a
                     // bench question rather than one this fix can settle.
+                    //
+                    // Deliberately captured right here, not after also draining the outbound queue
+                    // to wait for the write to physically land (setupActionAsync only guarantees the
+                    // command was enqueued to MessageProducer, not written yet). That stricter
+                    // boundary was tried and reverted: on a real Nq1 it turned every text exchange
+                    // ~2-2.5x slower — the drain call itself measured under 15ms, but the device's
+                    // reply was then reliably delayed by roughly two seconds, 9/9 runs, for a cause
+                    // that did not resolve within the scope of this fix. Trading a measured
+                    // regression on every exchange for a theoretical, low-severity race is the wrong
+                    // trade, so this boundary keeps the same "setup action returned" definition the
+                    // rest of the engine already used before this fix.
                     sentBoundaryLineCount = CollectedLineCount();
 
                     Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Setup action completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -480,20 +480,30 @@ namespace Daqifi.Core.Device.Internal
                     // command actually went out (issue #553). A blank cannot be a terminator for a
                     // command the device has not yet received, so any blank at or before this point
                     // is necessarily a leftover from an earlier exchange. Content lines are left on
-                    // the wider boundary above — narrowing it risks discarding a genuinely fast
-                    // reply, a real device having answered before setupActionAsync returns being a
-                    // bench question rather than one this fix can settle.
+                    // the wider boundary above — narrowing it would risk discarding a genuinely fast
+                    // reply, and nothing needs it narrowed. On a bench Nq1 the real terminator lands
+                    // safely after this point, 10/10 runs, so the blank rule costs nothing either.
                     //
-                    // Deliberately captured right here, not after also draining the outbound queue
-                    // to wait for the write to physically land (setupActionAsync only guarantees the
-                    // command was enqueued to MessageProducer, not written yet). That stricter
-                    // boundary was tried and reverted: on a real Nq1 it turned every text exchange
-                    // ~2-2.5x slower — the drain call itself measured under 15ms, but the device's
-                    // reply was then reliably delayed by roughly two seconds, 9/9 runs, for a cause
-                    // that did not resolve within the scope of this fix. Trading a measured
-                    // regression on every exchange for a theoretical, low-severity race is the wrong
-                    // trade, so this boundary keeps the same "setup action returned" definition the
-                    // rest of the engine already used before this fix.
+                    // Captured right here, and it must never be moved later — in particular not
+                    // after also draining the outbound queue to wait for the write to physically
+                    // land (setupActionAsync only guarantees the command was enqueued to
+                    // MessageProducer, not written yet). That stricter boundary looks like a
+                    // tightening of the rule below and is in fact an inversion of it: measured on a
+                    // real Nq1, the device answers roughly 6ms after the write, faster than the
+                    // drain's own 10ms poll tick, so draining first lands the device's genuine
+                    // terminator on the far side of this boundary and the filter below discards it
+                    // as stale. SYSTem:LOG? then reports "the device did not answer" for a device
+                    // that answered on time, 10/10 runs. What makes this boundary safe is not
+                    // precision about when the write landed — it is being strictly earlier than any
+                    // reply can physically exist. See #593, which records the residual window this
+                    // leaves and why it cannot be closed this way.
+                    //
+                    // The ~2-2.5x slowdown a drain also shows on the bench is the engine, not the
+                    // device: the wait loop below infers "the device answered" from a count increase
+                    // observed inside the loop, so a line that landed before its first poll is
+                    // invisible to it and the exchange sits out the full responseTimeoutMs. That is
+                    // #592, and with it fixed a drain costs nothing (1058ms vs 1056ms) — it is still
+                    // wrong, for the reason above, just not slow.
                     sentBoundaryLineCount = CollectedLineCount();
 
                     Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Setup action completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));


### PR DESCRIPTION
## Summary
- `TextExchangeEngine.ExecuteAsync`'s stale-line boundary was captured before `setupActionAsync` ran, so a late reply to an *earlier* exchange landing in the sub-millisecond gap between the capture and the send completing was still counted as this exchange's answer.
- Content lines keep the existing (wider) boundary unchanged — narrowing it risks discarding a genuinely fast reply, and whether that race is even reachable on real hardware is a bench question, not one this PR settles.
- A blank line landing in that gap is now dropped: a device cannot emit a terminator for a command it hasn't been sent yet, so a blank there is necessarily a leftover from an earlier exchange. This matters most for `SYSTem:LOG?` (added in #552), which reads "any line arrived" as "the device answered" — a stale blank there would otherwise report an empty log for a device that had gone silent.
- Adds a narrow test-only seam, `ITextExchangeHost.OnStaleLineBoundaryCaptured` (a no-op on the real device), fired at the boundary capture point, so a test double can release a line into the transport at that exact instant. The previous attempt at this fix (recorded on #553) was reverted because the existing access-counted mock transport can't reach that window — both of its hookable `Stream` accesses land before the boundary is even captured.

## Test plan
- [x] New regression test (`ExecuteTextCommand_DropsABlankThatArrivesWhileTheCommandIsStillBeingSent`) fails without the fix (verified by reverting the engine change locally and re-running: exactly 1 failure) and passes with it.
- [x] Complement test (`ExecuteTextCommand_KeepsAContentLineThatArrivesWhileTheCommandIsStillBeingSent`) documents that content lines are deliberately left alone.
- [x] Full `Daqifi.Core.Tests` suite: 3726 passed, 0 failed.
- [x] Bench-verified against a real DAQiFi Nyquist over serial: `SYSTem:LOG?` (x3) and `SYSTem:LOG:CLEar` still round-trip correctly through the changed engine.

Fixes #553.