### PR TITLE
fix(device): stop the wait loop stalling a text exchange when the reply beats its first poll

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -140,6 +140,41 @@ public class DaqifiDeviceStaleTextLineTests
     }
 
     [Fact]
+    public async Task ExecuteTextCommand_DoesNotExitEarlyWhenOnlyAStaleBlankPrecedesTheRealResponse()
+    {
+        // Regression: hasReceivedAny must not be seeded true by a blank that arrived in the
+        // capture-to-send window (issue #553) and will be discarded as stale by the projection
+        // below (index < sentBoundaryLineCount). A raw line-count comparison against
+        // staleLineCount cannot tell that blank apart from real evidence, and would flip the wait
+        // loop into phase 2's short completionTimeoutMs immediately -- ending collection before
+        // the real response (released deliberately late here) has a chance to arrive, and
+        // returning empty for a device that did, in fact, answer.
+        using var transport = new TwoStageReleaseTransport(staleLine: "\r\n", contentLine: "0,\"No error\"\r\n");
+        using var device = new StaleBoundaryHookTestableDevice(
+            "Stale-Then-Real Device", transport, onStaleLineBoundaryCaptured: () => transport.ReleaseStale());
+
+        device.Connect();
+
+        var lines = await device.CallExecuteTextCommandAsync(
+            () =>
+            {
+                // Give the reader thread time to actually collect the stale blank released by the
+                // boundary hook above before the command is considered sent, then release the real
+                // response after this setup action has already returned -- squarely inside the
+                // wait loop's window, and after phase 2's short timeout would have already fired
+                // on the bug's seed.
+                Thread.Sleep(50);
+                _ = Task.Delay(150).ContinueWith(_ => transport.ReleaseContent());
+            },
+            responseTimeoutMs: 1000,
+            completionTimeoutMs: 100);
+
+        Assert.Contains(lines, l => l.Contains("No error"));
+
+        device.Disconnect();
+    }
+
+    [Fact]
     public async Task ExecuteTextCommandWithPrepare_RunsPrepareBeforeTheSetupAction()
     {
         using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
@@ -663,6 +698,146 @@ public class DaqifiDeviceStaleTextLineTests
                         var toCopy = Math.Min(count, _line.Length - _position);
                         Array.Copy(_line, _position, buffer, offset, toCopy);
                         _position += toCopy;
+                        return toCopy;
+                    }
+                }
+
+                // Idle link: nothing to hand over, and no busy-spin in the reader thread.
+                Thread.Sleep(10);
+                return 0;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) { }
+        }
+    }
+
+    /// <summary>
+    /// Transport whose stream withholds two canned lines, released independently -- a "stale"
+    /// line and a "content" line -- so a test can put one in flight before the other without
+    /// either racing the reader thread against the other's release.
+    /// </summary>
+    private sealed class TwoStageReleaseTransport : IStreamTransport
+    {
+        private readonly TwoStageStream _stream;
+        private bool _isConnected;
+        private bool _disposed;
+
+        public TwoStageReleaseTransport(string staleLine, string contentLine)
+        {
+            _stream = new TwoStageStream(staleLine, contentLine);
+        }
+
+        public Stream Stream
+        {
+            get
+            {
+                if (_disposed) throw new ObjectDisposedException(nameof(TwoStageReleaseTransport));
+                return _stream;
+            }
+        }
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "TwoStage: Connected" : "TwoStage: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        /// <summary>Releases the stale line into the stream immediately.</summary>
+        public void ReleaseStale() => _stream.ReleaseStale();
+
+        /// <summary>Releases the content line into the stream immediately.</summary>
+        public void ReleaseContent() => _stream.ReleaseContent();
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(TwoStageReleaseTransport));
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().Wait();
+
+        public void Disconnect() => DisconnectAsync().Wait();
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _isConnected = false;
+            _disposed = true;
+        }
+
+        private sealed class TwoStageStream : Stream
+        {
+            private readonly byte[] _stale;
+            private readonly byte[] _content;
+            private readonly object _gate = new();
+            private bool _staleReleased;
+            private bool _contentReleased;
+            private int _stalePosition;
+            private int _contentPosition;
+
+            public TwoStageStream(string staleLine, string contentLine)
+            {
+                _stale = Encoding.ASCII.GetBytes(staleLine);
+                _content = Encoding.ASCII.GetBytes(contentLine);
+            }
+
+            public void ReleaseStale()
+            {
+                lock (_gate)
+                {
+                    _staleReleased = true;
+                }
+            }
+
+            public void ReleaseContent()
+            {
+                lock (_gate)
+                {
+                    _contentReleased = true;
+                }
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                lock (_gate)
+                {
+                    // The stale line always drains first -- it is the one released earliest on
+                    // real hardware too (a leftover from an earlier exchange, arriving before this
+                    // exchange has sent anything).
+                    if (_staleReleased && _stalePosition < _stale.Length)
+                    {
+                        var toCopy = Math.Min(count, _stale.Length - _stalePosition);
+                        Array.Copy(_stale, _stalePosition, buffer, offset, toCopy);
+                        _stalePosition += toCopy;
+                        return toCopy;
+                    }
+
+                    if (_contentReleased && _contentPosition < _content.Length)
+                    {
+                        var toCopy = Math.Min(count, _content.Length - _contentPosition);
+                        Array.Copy(_content, _contentPosition, buffer, offset, toCopy);
+                        _contentPosition += toCopy;
                         return toCopy;
                     }
                 }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -1,5 +1,6 @@
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
+using System.Diagnostics;
 using System.Text;
 
 namespace Daqifi.Core.Tests.Device;
@@ -99,6 +100,41 @@ public class DaqifiDeviceStaleTextLineTests
         var lines = await device.CallExecuteTextCommandAsync(() => Thread.Sleep(100));
 
         Assert.Contains(lines, l => l.Contains("No error"));
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_DoesNotStallWhenTheReplyArrivesBeforeTheWaitLoopStarts()
+    {
+        // Regression for #592: the wait loop's hasReceivedAny flag only flipped on a line-count
+        // increase OBSERVED INSIDE the loop, so a reply already sitting in collectedLines by the
+        // time the loop took its first sample was invisible to it -- the exchange then sat out
+        // the full responseTimeoutMs instead of the short completionTimeoutMs, even though
+        // nothing was actually missing. The content line is released at the stale-line boundary
+        // (before the setup action even runs), and the setup action then sleeps well past any
+        // reasonable read-thread latency, so the reply is guaranteed to already be in
+        // collectedLines by the time the wait loop takes its first sample -- deterministically
+        // reproducing the "reply beat the loop" case a fast device produces on real hardware.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleBoundaryHookTestableDevice(
+            "Already-Answered Device", transport, onStaleLineBoundaryCaptured: () => transport.Release());
+
+        device.Connect();
+
+        var sw = Stopwatch.StartNew();
+        var lines = await device.CallExecuteTextCommandAsync(
+            () => Thread.Sleep(100),
+            responseTimeoutMs: 3000,
+            completionTimeoutMs: 100);
+        sw.Stop();
+
+        Assert.Contains(lines, l => l.Contains("No error"));
+        // Well short of responseTimeoutMs (3000ms): without the fix this reliably took >=3000ms,
+        // because hasReceivedAny never flipped and phase 1's full timeout ran out.
+        Assert.True(
+            sw.ElapsedMilliseconds < 2000,
+            $"Expected the exchange to finish near completionTimeoutMs (100ms), took {sw.ElapsedMilliseconds}ms.");
 
         device.Disconnect();
     }
@@ -413,12 +449,15 @@ public class DaqifiDeviceStaleTextLineTests
         internal override void OnStaleLineBoundaryCaptured() => _onStaleLineBoundaryCaptured();
 
         public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(
-            Action setupAction, bool keepBlankLines = false)
+            Action setupAction,
+            bool keepBlankLines = false,
+            int responseTimeoutMs = 500,
+            int completionTimeoutMs = 150)
         {
             return ExecuteTextCommandAsync(
                 setupAction,
-                responseTimeoutMs: 500,
-                completionTimeoutMs: 150,
+                responseTimeoutMs: responseTimeoutMs,
+                completionTimeoutMs: completionTimeoutMs,
                 keepBlankLines: keepBlankLines);
         }
     }

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -514,7 +514,22 @@ namespace Daqifi.Core.Device.Internal
                     var lastMessageTime = DateTime.UtcNow;
                     var maxWait = TimeSpan.FromMilliseconds(responseTimeoutMs * 5);
                     var startTime = DateTime.UtcNow;
-                    var hasReceivedAny = false;
+
+                    // Seeded from staleLineCount, not sentBoundaryLineCount (issue #592): a reply
+                    // can land between sentBoundaryLineCount being captured just above and this
+                    // loop's first poll -- single-digit milliseconds on a real device, but enough.
+                    // Without this seed, hasReceivedAny only flips on a count *increase observed
+                    // inside the loop*, so a reply that already arrived by the time the loop starts
+                    // is invisible to it: the exchange then sits out the full responseTimeoutMs
+                    // instead of the short completionTimeoutMs -- an ~8x stall on some diagnostics
+                    // reads, though never a wrong answer, since maxWait still bounds collection
+                    // either way. sentBoundaryLineCount would not work here -- it is captured
+                    // immediately above, so comparing the count to itself always yields false.
+                    var hasReceivedAny = CollectedLineCount() > staleLineCount;
+                    if (hasReceivedAny)
+                    {
+                        Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] First response already present entering wait loop"));
+                    }
 
                     while (DateTime.UtcNow - startTime < maxWait)
                     {

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -508,6 +508,29 @@ namespace Daqifi.Core.Device.Internal
 
                     Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Setup action completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));
 
+                    // Whether anything beyond staleLineCount would actually survive the projection
+                    // below as evidence this exchange got an answer -- i.e. not a blank that will be
+                    // dropped as a pre-send leftover (index < sentBoundaryLineCount, issue #553). A
+                    // raw count comparison against staleLineCount is NOT equivalent to this: a blank
+                    // that arrived in the capture-to-send window bumps the count but is discarded
+                    // later, and treating it as evidence would flip the wait loop into the short
+                    // completion-timeout phase before the real response has a chance to arrive.
+                    bool HasResponseEvidenceBeyondStaleBoundary()
+                    {
+                        lock (collectedLinesGate)
+                        {
+                            for (var i = staleLineCount; i < collectedLines.Count; i++)
+                            {
+                                if (collectedLines[i].Length > 0 || i >= sentBoundaryLineCount)
+                                {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        }
+                    }
+
                     // Wait for responses using a two-phase inactivity-based timeout:
                     // Phase 1: Wait up to responseTimeoutMs for the first response.
                     // Phase 2: After receiving data, wait completionTimeoutMs of inactivity to finish.
@@ -515,17 +538,21 @@ namespace Daqifi.Core.Device.Internal
                     var maxWait = TimeSpan.FromMilliseconds(responseTimeoutMs * 5);
                     var startTime = DateTime.UtcNow;
 
-                    // Seeded from staleLineCount, not sentBoundaryLineCount (issue #592): a reply
-                    // can land between sentBoundaryLineCount being captured just above and this
-                    // loop's first poll -- single-digit milliseconds on a real device, but enough.
-                    // Without this seed, hasReceivedAny only flips on a count *increase observed
-                    // inside the loop*, so a reply that already arrived by the time the loop starts
-                    // is invisible to it: the exchange then sits out the full responseTimeoutMs
-                    // instead of the short completionTimeoutMs -- an ~8x stall on some diagnostics
-                    // reads, though never a wrong answer, since maxWait still bounds collection
-                    // either way. sentBoundaryLineCount would not work here -- it is captured
-                    // immediately above, so comparing the count to itself always yields false.
-                    var hasReceivedAny = CollectedLineCount() > staleLineCount;
+                    // A reply can land between sentBoundaryLineCount being captured just above and
+                    // this loop's first poll -- single-digit milliseconds on a real device, but
+                    // enough. Without this seed, hasReceivedAny only flips on a count *increase
+                    // observed inside the loop*, so a reply that already arrived by the time the
+                    // loop starts is invisible to it: the exchange then sits out the full
+                    // responseTimeoutMs instead of the short completionTimeoutMs -- an ~8x stall on
+                    // some diagnostics reads, though never a wrong answer, since maxWait still
+                    // bounds collection either way (issue #592).
+                    //
+                    // Seeded via HasResponseEvidenceBeyondStaleBoundary rather than a raw count
+                    // comparison against staleLineCount: a blank that arrived in the capture-to-send
+                    // window bumps the count but is dropped later as a pre-send leftover (#553), and
+                    // treating that bump as evidence would flip this into the short completion-
+                    // timeout phase before the real response arrives, discarding it early.
+                    var hasReceivedAny = HasResponseEvidenceBeyondStaleBoundary();
                     if (hasReceivedAny)
                     {
                         Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] First response already present entering wait loop"));


### PR DESCRIPTION
## Summary
A device that answers a text command (SCPI query, SD listing, diagnostics read, etc.) quickly could still make the caller wait out the *full* response timeout instead of returning promptly. `TextExchangeEngine`'s wait loop only noticed a reply if the line count went up *while the loop was watching* — a reply that had already arrived by the time the loop took its first sample was invisible to it, so it sat out the entire `responseTimeoutMs` (e.g. 2000ms for diagnostics) instead of the short `completionTimeoutMs` (e.g. 250ms) it should have used, even though the answer was already collected. The answer itself was always correct — this was purely an intermittent multi-second latency stall.

## How it was fixed
`hasReceivedAny` (the flag that decides which timeout phase to use) is now seeded from a comparison against the line count captured before this exchange sent anything, instead of always starting `false`. That closes the gap between "the reply already landed" and "the loop noticed."

Found and bench-confirmed against a real DAQiFi Nyquist while investigating #591 — this same bug is also what made an unrelated fix there look like it cost ~2.5x latency, when in fact the device was answering on time and the engine just wasn't noticing.

## Verification
- New regression test reproduces "reply beat the loop" deterministically via the existing `OnStaleLineBoundaryCaptured` seam, and fails without the fix (reliably hits the full 3s timeout instead of finishing near `completionTimeoutMs`).
- Full `Daqifi.Core.Tests` suite: 3727 passed, 0 failed, net9.0 and net10.0.
- Bench-verified against a real DAQiFi Nyquist over serial: SD storage query round-trips correctly and consistently through the changed engine.

closes #592

Not merging — for review.