### PR TITLE
chore: unify SD card timestamp reconstruction across CSV/JSON/binary parsers

### DIFF
--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -336,9 +336,8 @@ public sealed class SdCardCsvFileParser
     {
         var timestampFreq = config.TimestampFrequency;
         var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
+        var timestampReconstructor = new SdCardTimestampReconstructor(tickPeriod);
 
-        uint? previousTimestamp = null;
-        var elapsedSeconds = 0.0;
         var linesProcessed = 0;
         var bytesRead = 0L;
         var totalBytes = totalBytesProvider();
@@ -376,23 +375,10 @@ public sealed class SdCardCsvFileParser
             var analogValues = SdCardAnalogScaling.ScaleRawAnalogValues(rawAnalogValues, config);
 
             // Reconstruct absolute timestamp using first channel timestamp
-            var absoluteTime = baseTime;
-            var hasDeviceTimestamp = tickPeriod > 0;
-            if (hasDeviceTimestamp)
-            {
-                if (previousTimestamp == null)
-                {
-                    previousTimestamp = rowTimestamp;
-                }
-                else
-                {
-                    var delta = SdCardTickDelta.Compute(previousTimestamp.Value, rowTimestamp);
-                    elapsedSeconds += delta * tickPeriod;
-                    previousTimestamp = rowTimestamp;
-                }
-
-                absoluteTime = baseTime.AddSeconds(elapsedSeconds);
-            }
+            var hasDeviceTimestamp = timestampReconstructor.HasDeviceClock;
+            var absoluteTime = hasDeviceTimestamp
+                ? timestampReconstructor.Advance(rowTimestamp, baseTime)
+                : baseTime;
 
             yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, perChannelTimestamps)
             {

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -309,8 +309,7 @@ public sealed class SdCardFileParser
         SdCardDeviceConfiguration? config,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        uint? previousTimestamp = null;
-        var elapsedSeconds = 0.0;
+        var timestampReconstructor = new SdCardTimestampReconstructor(tickPeriod);
 
         var enumerator = openMessages(ct).GetAsyncEnumerator(ct);
         await using (enumerator.ConfigureAwait(false))
@@ -371,24 +370,10 @@ public sealed class SdCardFileParser
                 }
 
                 // Reconstruct timestamp
-                var timestamp = baseTime;
-                var hasDeviceTimestamp = msg.MsgTimeStamp != 0 && tickPeriod > 0;
-                if (hasDeviceTimestamp)
-                {
-                    if (previousTimestamp == null)
-                    {
-                        // First stream message — anchor to base time
-                        previousTimestamp = msg.MsgTimeStamp;
-                    }
-                    else
-                    {
-                        var delta = SdCardTickDelta.Compute(previousTimestamp.Value, msg.MsgTimeStamp);
-                        elapsedSeconds += delta * tickPeriod;
-                        previousTimestamp = msg.MsgTimeStamp;
-                    }
-
-                    timestamp = baseTime.AddSeconds(elapsedSeconds);
-                }
+                var hasDeviceTimestamp = msg.MsgTimeStamp != 0 && timestampReconstructor.HasDeviceClock;
+                var timestamp = hasDeviceTimestamp
+                    ? timestampReconstructor.Advance(msg.MsgTimeStamp, baseTime)
+                    : baseTime;
 
                 // Extract analog values (prefer float, fall back to scaled raw int)
                 IReadOnlyList<double> analogValues;

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -149,9 +149,8 @@ public sealed class SdCardJsonFileParser
     {
         var timestampFreq = config.TimestampFrequency;
         var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
+        var timestampReconstructor = new SdCardTimestampReconstructor(tickPeriod);
 
-        uint? previousTimestamp = null;
-        var elapsedSeconds = 0.0;
         var linesProcessed = 0;
         var bytesRead = 0L;
         var totalBytes = totalBytesProvider();
@@ -177,23 +176,10 @@ public sealed class SdCardJsonFileParser
             var analogValues = SdCardAnalogScaling.ScaleRawAnalogValues(rawAnalogValues, config);
 
             // Reconstruct absolute timestamp
-            var absoluteTime = baseTime;
-            var hasDeviceTimestamp = tickPeriod > 0;
-            if (hasDeviceTimestamp)
-            {
-                if (previousTimestamp == null)
-                {
-                    previousTimestamp = timestamp;
-                }
-                else
-                {
-                    var delta = SdCardTickDelta.Compute(previousTimestamp.Value, timestamp);
-                    elapsedSeconds += delta * tickPeriod;
-                    previousTimestamp = timestamp;
-                }
-
-                absoluteTime = baseTime.AddSeconds(elapsedSeconds);
-            }
+            var hasDeviceTimestamp = timestampReconstructor.HasDeviceClock;
+            var absoluteTime = hasDeviceTimestamp
+                ? timestampReconstructor.Advance(timestamp, baseTime)
+                : baseTime;
 
             yield return new SdCardLogEntry(absoluteTime, analogValues, digitalData, null)
             {

--- a/src/Daqifi.Core/Device/SdCard/SdCardTimestampReconstructor.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTimestampReconstructor.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace Daqifi.Core.Device.SdCard;
+
+/// <summary>
+/// Reconstructs absolute sample timestamps from a device's raw tick counter.
+/// </summary>
+/// <remarks>
+/// The CSV, JSON, and binary/protobuf SD card log parsers each walk their samples in order and
+/// accumulate elapsed device-clock time the same way — this now lives here once so the three
+/// formats can't drift out of sync with each other, the same reasoning that already unified
+/// their per-sample tick delta in <see cref="SdCardTickDelta"/>.
+/// </remarks>
+/// <param name="tickPeriod">
+/// The duration of one device clock tick, in seconds (<c>1 / TimestampFrequency</c>), or
+/// <c>0</c> when the frequency is unknown.
+/// </param>
+internal sealed class SdCardTimestampReconstructor(double tickPeriod)
+{
+    private uint? _previousTimestamp;
+    private double _elapsedSeconds;
+
+    /// <summary>
+    /// Whether the device clock's tick period is known. Callers should only call
+    /// <see cref="Advance"/> when this is <see langword="true"/> — with an unknown tick period
+    /// every sample would report the same elapsed time, which is not a reconstruction so much
+    /// as a stall.
+    /// </summary>
+    public bool HasDeviceClock => tickPeriod > 0;
+
+    /// <summary>
+    /// Advances the reconstruction by one sample and returns its absolute timestamp.
+    /// </summary>
+    /// <param name="rawTimestamp">The sample's raw device tick count.</param>
+    /// <param name="baseTime">The absolute time the session anchors its first sample to.</param>
+    /// <returns>
+    /// <paramref name="baseTime"/> for the first sample seen; for every later sample,
+    /// <paramref name="baseTime"/> plus the elapsed device-clock time accumulated since,
+    /// computed via <see cref="SdCardTickDelta.Compute"/> so a wraparound of the 32-bit tick
+    /// counter is treated as elapsed time rather than time moving backwards.
+    /// </returns>
+    public DateTime Advance(uint rawTimestamp, DateTime baseTime)
+    {
+        if (_previousTimestamp == null)
+        {
+            _previousTimestamp = rawTimestamp;
+            return baseTime;
+        }
+
+        var delta = SdCardTickDelta.Compute(_previousTimestamp.Value, rawTimestamp);
+        _elapsedSeconds += delta * tickPeriod;
+        _previousTimestamp = rawTimestamp;
+
+        return baseTime.AddSeconds(_elapsedSeconds);
+    }
+}


### PR DESCRIPTION
## What was wrong

The CSV, JSON, and binary/protobuf SD card log parsers each carried an identical, hand-copied block of code: track the previous raw device timestamp, accumulate elapsed seconds using the device's tick period, and reconstruct each sample's absolute time from it. Same variable names, same order of operations, in three separate places. That's the same kind of duplication already fixed once for the tick-delta math itself (`SdCardTickDelta`) — this is the same problem one level up, and it means a future fix to the reconstruction logic could easily be applied to one format and missed in the other two.

## How it was fixed

Extracted the shared state into a small internal `SdCardTimestampReconstructor` class and had all three parsers call it instead of inlining the block. This is pure code motion — same formula, same order of operations, no behavior change. Each parser still only advances the reconstructor when its own "do we have a device timestamp for this sample" condition holds, and that condition differs slightly between formats (the binary parser also requires a nonzero `MsgTimeStamp`) — that per-format difference is preserved exactly as it was.

## Verification

Full `Daqifi.Core.Tests` suite green on net9.0 and net10.0 (3726 passed, 2 skipped, 0 failed — unchanged counts, no new tests needed since this is a pure refactor already covered by the existing parser tests).

Bench-validated against a real Nq1 over serial: downloaded and parsed a live CSV log (76 samples, correct 50ms-spaced timestamps) and a live binary/protobuf log (307 samples, correct ~10ms-spaced timestamps) through the refactored code paths — timestamps reconstruct identically to before. (A JSON log downloaded and parsed to 0 samples, but that's a pre-existing firmware/parser schema mismatch in the JSON field-parsing code this change doesn't touch — not a regression from this change.)

Maintenance routine: duplicate/abstraction unifier (next in the rotation after #586/#588/#590).

Not merging — for review.