### PR TITLE
chore: unify the numeric "first parseable line" response loop

### DIFF
--- a/src/Daqifi.Core/Device/Capabilities/CapabilityDocumentParser.cs
+++ b/src/Daqifi.Core/Device/Capabilities/CapabilityDocumentParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
+using Daqifi.Core.Device;
 
 namespace Daqifi.Core.Device.Capabilities;
 
@@ -143,27 +144,16 @@ public static class CapabilityDocumentParser
     {
         ArgumentNullException.ThrowIfNull(lines);
 
-        apiVersion = 0;
-
-        foreach (var line in lines)
+        return LineParsing.TryParseFirst<int>(lines, static (string? line, out int value) =>
         {
             if (string.IsNullOrWhiteSpace(line) || ScpiResponseClassifier.IsErrorResponseLine(line))
             {
-                continue;
+                value = 0;
+                return false;
             }
 
-            if (int.TryParse(
-                    line.Trim(),
-                    NumberStyles.Integer,
-                    CultureInfo.InvariantCulture,
-                    out var value))
-            {
-                apiVersion = value;
-                return true;
-            }
-        }
-
-        return false;
+            return int.TryParse(line.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+        }, out apiVersion);
     }
 
     private static CapabilityIdentity? ReadIdentity(JsonElement root)

--- a/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Device.Internal;
+using Daqifi.Core.Device;
 
 #nullable enable
 
@@ -196,17 +197,18 @@ namespace Daqifi.Core.Device.Diagnostics
 
             ThrowIfCorruptedByStreamData(lines, "the error-count query");
 
-            foreach (var line in lines)
+            if (LineParsing.TryParseFirst<int>(lines, static (string? line, out int count) =>
             {
                 if (string.IsNullOrWhiteSpace(line))
                 {
-                    continue;
+                    count = 0;
+                    return false;
                 }
 
-                if (int.TryParse(line.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var count))
-                {
-                    return count;
-                }
+                return int.TryParse(line.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out count);
+            }, out var errorCount))
+            {
+                return errorCount;
             }
 
             throw new DeviceDiagnosticsException(

--- a/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
@@ -1,5 +1,6 @@
 using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Producers;
+using Daqifi.Core.Device;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -393,14 +394,13 @@ namespace Daqifi.Core.Device.Internal
                     $"The device rejected a readback of analog output {channelNumber}. It answered: {DescribeLines(lines)}");
             }
 
-            foreach (var line in lines)
+            if (LineParsing.TryParseFirst<double>(lines, static (string? line, out double volts) =>
+                    double.TryParse(line?.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out volts)
+                    && double.IsFinite(volts),
+                out var readbackVolts))
             {
-                if (double.TryParse(line?.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var volts)
-                    && double.IsFinite(volts))
-                {
-                    FindAnalogOutputChannel(channelNumber)?.SetOutputVoltage(volts, DateTime.Now);
-                    return volts;
-                }
+                FindAnalogOutputChannel(channelNumber)?.SetOutputVoltage(readbackVolts, DateTime.Now);
+                return readbackVolts;
             }
 
             throw new InvalidOperationException(

--- a/src/Daqifi.Core/Device/LineParsing.cs
+++ b/src/Daqifi.Core/Device/LineParsing.cs
@@ -16,6 +16,16 @@ namespace Daqifi.Core.Device;
 internal delegate bool TryParseLine<T>(string? line, [NotNullWhen(true)] out T? result) where T : class;
 
 /// <summary>
+/// Tries to parse a single response line into <typeparamref name="T"/>, following the standard
+/// <c>Try*</c> pattern, for a value-typed <typeparamref name="T"/> (e.g. <see langword="int"/> or
+/// <see langword="double"/>). See <see cref="TryParseLine{T}"/> for the reference-type variant.
+/// </summary>
+/// <typeparam name="T">The parsed result type.</typeparam>
+/// <param name="line">A single response line. May be <see langword="null"/> or empty.</param>
+/// <param name="result">The parsed value, or <c>default</c> if parsing failed.</param>
+internal delegate bool TryParseLineValue<T>(string? line, out T result) where T : struct;
+
+/// <summary>
 /// Shared helper for the several device/firmware response parsers whose multi-line variant tries
 /// each line in order and returns the first one that parses successfully.
 /// </summary>
@@ -58,6 +68,42 @@ internal static class LineParsing
         }
 
         result = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Tries each line in <paramref name="lines"/> in order against <paramref name="tryParse"/>,
+    /// returning the first successful parse. Value-typed counterpart of
+    /// <see cref="TryParseFirst{T}(IEnumerable{string}, TryParseLine{T}, out T)"/> for results such
+    /// as <see langword="int"/> or <see langword="double"/>.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the "first parseable line wins" numeric response parsers (e.g. the capability
+    /// API-version query, the system error-count query, and the analog-output readback) so each
+    /// only needs to supply its own single-line <c>TryParse</c>, including any line-skipping
+    /// (blank lines, error lines, etc.) it wants to apply before attempting to parse.
+    /// </remarks>
+    /// <typeparam name="T">The parsed result type.</typeparam>
+    /// <param name="lines">The response lines to try, in order.</param>
+    /// <param name="tryParse">The single-line parse function to apply to each line.</param>
+    /// <param name="result">The first successfully parsed value, or <c>default</c> if none parsed.</param>
+    /// <returns><see langword="true"/> if any line was successfully parsed; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="lines"/> or <paramref name="tryParse"/> is <see langword="null"/>.</exception>
+    public static bool TryParseFirst<T>(IEnumerable<string> lines, TryParseLineValue<T> tryParse, out T result)
+        where T : struct
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+        ArgumentNullException.ThrowIfNull(tryParse);
+
+        foreach (var line in lines)
+        {
+            if (tryParse(line, out result))
+            {
+                return true;
+            }
+        }
+
+        result = default;
         return false;
     }
 }


### PR DESCRIPTION
**Duplicate/abstraction-unifier maintenance routine.** Three unrelated device operations — reading the capability schema version, the system error count, and an analog-output voltage readback — each hand-rolled the same small loop: walk the response lines, skip the ones that don't apply, and return the first line that parses as a number. The three copies had already drifted slightly in which lines they skip, which made it easy for a future edit to one to silently miss the others.

`LineParsing.cs` already has a shared `TryParseFirst` helper for exactly this "first parseable line wins" pattern, used by several reference-type parsers (`LogLevelParser`, `LanChipInfoParser`, `SdCardSpaceParser`), but it was constrained to reference types. This adds a value-type overload (`TryParseLineValue<T>`) and points `CapabilityDocumentParser.TryParseApiVersion`, `DeviceDiagnosticsOperations.GetSystemErrorCountAsync`, and `ChannelControlOperations.GetAnalogOutputAsync` at it, with each site keeping its own line-skipping rule as the delegate it supplies to the shared loop.

This is purely internal — `LineParsing` and all three call sites are internal-only; no public API or parsing behavior changes.

Verified: full `dotnet test` suite green on net9.0 and net10.0 (3726 passed, 2 pre-existing skips unrelated to this change). Bench-validated against real hardware over serial (`--show-status`), which exercises the capability-parsing path this touches — connected, read status (fw 3.7.2), disconnected cleanly.

Not merging — for review.