### PR TITLE
chore: unify the "last SCPI error line" lookup in ScpiResponseClassifier

### DIFF
--- a/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/DeviceAdministrationOperations.cs
@@ -286,7 +286,7 @@ namespace Daqifi.Core.Device.Internal
             // it rather than claim the device was silent.
             string? codeZeroLine = null;
 
-            var volunteeredError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
+            var volunteeredError = ScpiResponseClassifier.GetLastScpiErrorLine(lines);
             if (volunteeredError != null)
             {
                 if (!ScpiResponseClassifier.TryExtractErrorCode(volunteeredError, out var volunteeredCode))

--- a/src/Daqifi.Core/Device/Internal/UsbStreamInterfaceInitializer.cs
+++ b/src/Daqifi.Core/Device/Internal/UsbStreamInterfaceInitializer.cs
@@ -117,7 +117,7 @@ namespace Daqifi.Core.Device.Internal
                 }
             }
 
-            var lastScpiError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
+            var lastScpiError = ScpiResponseClassifier.GetLastScpiErrorLine(lines);
             throw new ScpiInitializationErrorException(
                 "Device returned a SCPI error while setting stream interface to USB.",
                 lines,

--- a/src/Daqifi.Core/Device/LanChipInfoOperations.cs
+++ b/src/Daqifi.Core/Device/LanChipInfoOperations.cs
@@ -44,10 +44,10 @@ namespace Daqifi.Core.Device
             // return this specific SCPI error instead of JSON. Surface it distinctly
             // so the caller's retry loop can react (kick LAN:APPLY) instead of just
             // waiting out a blind delay.
-            var errorLine = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine);
+            var errorLine = ScpiResponseClassifier.GetLastScpiErrorLine(lines);
             if (errorLine != null && ScpiResponseClassifier.TryExtractErrorCode(errorLine, out var errorCode) && errorCode == -200)
             {
-                throw new LanNotInitializedException(errorLine.Trim());
+                throw new LanNotInitializedException(errorLine);
             }
 
             return null;

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -64,6 +64,18 @@ namespace Daqifi.Core.Device
         }
 
         /// <summary>
+        /// Returns the last genuine SCPI-formatted error line in the response, trimmed, or
+        /// <c>null</c> if none is present. Several callers translate a device response into a
+        /// typed exception and need exactly this line — the most recent thing the device said
+        /// that is shaped like a real SCPI error, per <see cref="IsScpiErrorLine"/> — so this
+        /// centralizes the "get it, trimmed" step they all otherwise repeated identically.
+        /// </summary>
+        internal static string? GetLastScpiErrorLine(IReadOnlyList<string> lines)
+        {
+            return lines.LastOrDefault(IsScpiErrorLine)?.Trim();
+        }
+
+        /// <summary>
         /// Returns true when the response contains at least one non-empty line and every non-empty
         /// line is an error/status line per <see cref="IsErrorResponseLine"/> — i.e. the device
         /// answered, and had nothing but a complaint to say. A response with no lines at all is not

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -554,7 +554,7 @@ namespace Daqifi.Core.Device.SdCard
                 }
 
                 // Parser failed — translate the firmware response into a typed exception.
-                var lastScpiError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
+                var lastScpiError = ScpiResponseClassifier.GetLastScpiErrorLine(lines);
 
                 if (ContainsNoSdCardMarker(lines))
                 {
@@ -881,7 +881,7 @@ namespace Daqifi.Core.Device.SdCard
                 // as "the delete operation failed" for a delete that had already
                 // succeeded and was never re-sent.
                 var deleteExchangeError = ScpiResponseClassifier.ContainsScpiError(lines)
-                    ? lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim()
+                    ? ScpiResponseClassifier.GetLastScpiErrorLine(lines)
                     : null;
 
                 // Prove the EXCHANGE finished before judging what it contained. A
@@ -1631,7 +1631,7 @@ namespace Daqifi.Core.Device.SdCard
             // LastScpiError must only carry a real SCPI-formatted error so callers
             // can rely on its shape. Firmware status text ("Error !! ...") is
             // surfaced via the exception's Message and RawDeviceResponse instead.
-            var lastScpiError = lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim();
+            var lastScpiError = ScpiResponseClassifier.GetLastScpiErrorLine(lines);
 
             // Specific firmware-emitted error markers take precedence over generic
             // content/error checks. They're plain text (not SCPI-shaped), so a


### PR DESCRIPTION
**Duplicate/abstraction-unifier maintenance routine.** Safe because it's internal-only (no public API change) and behavior-preserving (same LINQ expression, now defined once).

## What was wrong
Six spots across four files — `LanChipInfoOperations`, `DeviceAdministrationOperations`, `UsbStreamInterfaceInitializer`, and three places in `SdCardOperations` — each independently re-typed the same line to pull the device's most recent SCPI-formatted error line out of a response before turning it into a typed exception: `lines.LastOrDefault(ScpiResponseClassifier.IsScpiErrorLine)?.Trim()`. Nothing was broken, but the rule "get the last real SCPI error line, trimmed" lived in six places instead of one, which is exactly the kind of thing that drifts over time.

## How it was fixed
Added `ScpiResponseClassifier.GetLastScpiErrorLine(lines)` next to the classifier's existing `IsScpiErrorLine`/`ContainsScpiError` helpers, and pointed all six call sites at it. No behavior change — same expression, now defined once.

Verified: `dotnet build` 0 warnings/errors; full `dotnet test` green on net9.0 and net10.0 (3726 passed, 2 pre-existing unrelated skips). Not bench-validated separately — this is a pure internal refactor of an already-tested code path (all six call sites are covered by existing SCPI error-handling tests), no protocol/timing behavior changed.

Not merging — for review.