### PR TITLE
chore: flatten nested guard checks in WifiFlashProgressParser

### DIFF
--- a/src/Daqifi.Core/Firmware/WifiFlashProgressParser.cs
+++ b/src/Daqifi.Core/Firmware/WifiFlashProgressParser.cs
@@ -90,26 +90,28 @@ internal sealed class WifiFlashProgressParser
 
         // Block-address lines advance the current phase. Ignored before the device flash
         // starts (PreFlash) so the image-build phase never moves the bar.
-        if (_phase != Phase.PreFlash)
+        if (_phase == Phase.PreFlash)
         {
-            var highestAddress = HighestBlockAddress(line);
-            if (highestAddress.HasValue)
-            {
-                // Block addresses are absolute; measure coverage from the range base so a
-                // non-zero start doesn't make the fraction saturate to 1 immediately.
-                var covered = highestAddress.Value - _rangeStart + BlockSize;
-                if (covered > _totalRange)
-                {
-                    _totalRange = covered;
-                }
-
-                var fraction = Math.Clamp(covered / (double)_totalRange, 0, 1);
-                var (start, end) = BandFor(_phase);
-                return Advance(_phase, start + (fraction * (end - start)));
-            }
+            return null;
         }
 
-        return null;
+        var highestAddress = HighestBlockAddress(line);
+        if (!highestAddress.HasValue)
+        {
+            return null;
+        }
+
+        // Block addresses are absolute; measure coverage from the range base so a
+        // non-zero start doesn't make the fraction saturate to 1 immediately.
+        var covered = highestAddress.Value - _rangeStart + BlockSize;
+        if (covered > _totalRange)
+        {
+            _totalRange = covered;
+        }
+
+        var fraction = Math.Clamp(covered / (double)_totalRange, 0, 1);
+        var (start, end) = BandFor(_phase);
+        return Advance(_phase, start + (fraction * (end - start)));
     }
 
     private double? Advance(Phase phase, double candidatePercent)
@@ -136,16 +138,18 @@ internal sealed class WifiFlashProgressParser
         long? highest = null;
         foreach (Match match in BlockAddressRegex.Matches(line))
         {
-            if (long.TryParse(
+            if (!long.TryParse(
                     match.Groups["addr"].Value,
                     NumberStyles.HexNumber,
                     CultureInfo.InvariantCulture,
                     out var address))
             {
-                if (highest is null || address > highest.Value)
-                {
-                    highest = address;
-                }
+                continue;
+            }
+
+            if (highest is null || address > highest.Value)
+            {
+                highest = address;
             }
         }
 


### PR DESCRIPTION
**logic-simplifier routine.** The block-address-advance logic in `Observe()` and the address-parse loop in `HighestBlockAddress()` (both in `WifiFlashProgressParser`, which drives the WiFi flash progress bar) nested their real work one level deeper than the rest of the codebase's usual leading-guard-clause style — an `if (condition) { ...everything else... }` with nothing after it, instead of an early return.

Inverted both into guard clauses / a `continue` with the exact same order of operations — no logic change, same behavior, just flatter control flow that's easier to scan.

This is one of the six priority-5 maintenance routines from the autonomous work loop; the other five (dead-code remover, duplicate/abstraction unifier, flaky-test-fixer, useless-test-pruner, abstraction police) came back clean this cycle with nothing safely fixable.

Verified: `dotnet build` clean (0 warnings/errors), full `dotnet test` green on net9.0 and net10.0 (3728 passed, 2 pre-existing unrelated skips). No bench validation — pure internal control-flow refactor of an already-unit-tested parser, no protocol/timing behavior changed.

Not merging — for review.