### PR TITLE
chore: unify the SD card timestamp-frequency to tick-period conversion

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardTimestampReconstructorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardTimestampReconstructorTests.cs
@@ -1,0 +1,45 @@
+using System;
+using Daqifi.Core.Device.SdCard;
+using Xunit;
+
+namespace Daqifi.Core.Tests.Device.SdCard;
+
+/// <summary>
+/// Direct unit tests for <see cref="SdCardTimestampReconstructor.ForTimestampFrequency"/> — the
+/// frequency-to-tick-period conversion previously re-derived identically by the CSV, JSON, and
+/// binary/protobuf SD card log parsers.
+/// </summary>
+public class SdCardTimestampReconstructorTests
+{
+    [Fact]
+    public void ForTimestampFrequency_WithKnownFrequency_ReportsADeviceClock()
+    {
+        var reconstructor = SdCardTimestampReconstructor.ForTimestampFrequency(50_000_000u);
+
+        Assert.True(reconstructor.HasDeviceClock);
+    }
+
+    [Fact]
+    public void ForTimestampFrequency_WithUnknownFrequency_ReportsNoDeviceClock()
+    {
+        // Zero means "the log never said" — it has to land on an unknown tick period rather than
+        // dividing by zero and reconstructing every sample at an infinite offset.
+        var reconstructor = SdCardTimestampReconstructor.ForTimestampFrequency(0u);
+
+        Assert.False(reconstructor.HasDeviceClock);
+    }
+
+    [Fact]
+    public void ForTimestampFrequency_UsesTheReciprocalOfTheFrequencyAsTheTickPeriod()
+    {
+        var reconstructor = SdCardTimestampReconstructor.ForTimestampFrequency(50_000_000u);
+        var baseTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        Assert.Equal(baseTime, reconstructor.Advance(0u, baseTime));
+
+        // One second's worth of ticks at 50 MHz has to reconstruct as one second elapsed.
+        var oneSecondLater = reconstructor.Advance(50_000_000u, baseTime);
+
+        Assert.Equal(1.0, (oneSecondLater - baseTime).TotalSeconds, 6);
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardCsvFileParser.cs
@@ -334,9 +334,8 @@ public sealed class SdCardCsvFileParser
         IProgress<SdCardParseProgress>? progress,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var timestampFreq = config.TimestampFrequency;
-        var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
-        var timestampReconstructor = new SdCardTimestampReconstructor(tickPeriod);
+        var timestampReconstructor =
+            SdCardTimestampReconstructor.ForTimestampFrequency(config.TimestampFrequency);
 
         var linesProcessed = 0;
         var bytesRead = 0L;

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -186,17 +186,13 @@ public sealed class SdCardFileParser
             options.ConfigurationOverride?.TimestampFrequency ?? 0u,
             options.FallbackTimestampFrequency);
 
-        var tickPeriod = timestampFrequency > 0
-            ? 1.0 / timestampFrequency
-            : 0.0;
-
         var samples = ProduceSamples(
             token => openMessages(options.Progress, token),
             // Anchored once, here, rather than inside the iterator: a session whose samples can
             // be enumerated more than once must not shift its timestamps between reads when the
             // file name carries no date.
             fileCreatedDate ?? DateTime.UtcNow,
-            tickPeriod,
+            timestampFrequency,
             config,
             ct);
 
@@ -305,11 +301,12 @@ public sealed class SdCardFileParser
     private static async IAsyncEnumerable<SdCardLogEntry> ProduceSamples(
         Func<CancellationToken, IAsyncEnumerable<DaqifiOutMessage>> openMessages,
         DateTime baseTime,
-        double tickPeriod,
+        uint timestampFrequency,
         SdCardDeviceConfiguration? config,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var timestampReconstructor = new SdCardTimestampReconstructor(tickPeriod);
+        var timestampReconstructor =
+            SdCardTimestampReconstructor.ForTimestampFrequency(timestampFrequency);
 
         var enumerator = openMessages(ct).GetAsyncEnumerator(ct);
         await using (enumerator.ConfigureAwait(false))

--- a/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardJsonFileParser.cs
@@ -147,9 +147,8 @@ public sealed class SdCardJsonFileParser
         IProgress<SdCardParseProgress>? progress,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var timestampFreq = config.TimestampFrequency;
-        var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
-        var timestampReconstructor = new SdCardTimestampReconstructor(tickPeriod);
+        var timestampReconstructor =
+            SdCardTimestampReconstructor.ForTimestampFrequency(config.TimestampFrequency);
 
         var linesProcessed = 0;
         var bytesRead = 0L;

--- a/src/Daqifi.Core/Device/SdCard/SdCardTimestampReconstructor.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardTimestampReconstructor.cs
@@ -21,6 +21,20 @@ internal sealed class SdCardTimestampReconstructor(double tickPeriod)
     private double _elapsedSeconds;
 
     /// <summary>
+    /// Creates a reconstructor for a device clock ticking at <paramref name="timestampFrequencyHz"/>.
+    /// </summary>
+    /// <param name="timestampFrequencyHz">
+    /// The log's device clock frequency in Hz, or <c>0</c> when it could not be determined.
+    /// </param>
+    /// <remarks>
+    /// All three SD card log formats turn a timestamp frequency into a tick period the same
+    /// way, so the rule — including "an unknown frequency means an unknown tick period" rather
+    /// than a division by zero — lives here instead of being re-derived per format.
+    /// </remarks>
+    public static SdCardTimestampReconstructor ForTimestampFrequency(uint timestampFrequencyHz) =>
+        new(timestampFrequencyHz > 0 ? 1.0 / timestampFrequencyHz : 0.0);
+
+    /// <summary>
     /// Whether the device clock's tick period is known. Callers should only call
     /// <see cref="Advance"/> when this is <see langword="true"/> — with an unknown tick period
     /// every sample would report the same elapsed time, which is not a reconstruction so much


### PR DESCRIPTION
**Duplicate/abstraction-unifier maintenance routine.** Safe because it's internal-only (no public API change) and behavior-preserving — the same arithmetic, now written once.

## What was wrong

An SD card log can come off the device in three formats — CSV, JSON, and the binary/protobuf log — and each has its own parser. All three need the same thing before they can turn the device's raw tick counter into wall-clock timestamps: the duration of one tick, which is `1 / TimestampFrequency`. And all three worked it out for themselves, each re-typing the same guarded expression:

```csharp
var tickPeriod = timestampFreq > 0 ? 1.0 / timestampFreq : 0.0;
```

Nothing was broken. But the interesting part of that line is the guard, not the division: a log that never states its clock frequency reports `0`, and dividing by it would hand every sample an infinite offset. That rule lived in three places, one per format, while the class that consumes it — `SdCardTimestampReconstructor`, which already owns the tick-delta and elapsed-time logic precisely so the three formats can't drift apart — didn't know about it at all.

## How it was fixed

Moved the conversion onto the reconstructor as `SdCardTimestampReconstructor.ForTimestampFrequency(uint)` and pointed all three parsers at it. The guard now sits next to the `HasDeviceClock` property that exists to answer the same question.

One thing a reviewer may want to push back on: the binary parser previously computed the tick period up in `ParseAsync` and passed a `double tickPeriod` down into its private `ProduceSamples` iterator. That parameter is now `uint timestampFrequency` and the conversion happens at the point of use. It's a private method with a single caller, and the frequency was already sitting right there in scope, but it is the one signature this touches rather than a pure line-for-line substitution.

**Verified:** `dotnet build` 0 warnings/errors; full `dotnet test` green on net9.0 and net10.0 (3731 passed each, 2 pre-existing unrelated skips). Added three direct unit tests for the new factory, matching the precedent set by `SdCardTickDeltaTests` when the tick-delta calculation was unified out of these same three parsers. Not bench-validated separately — this is a pure internal refactor of an already-tested parsing path with no protocol or timing behavior changed.

Not merging — for review.
