### PR TITLE
chore(core): drop two internals nothing calls

### DIFF
--- a/src/Daqifi.Core.Tests/Channel/AnalogOutputChannelTests.cs
+++ b/src/Daqifi.Core.Tests/Channel/AnalogOutputChannelTests.cs
@@ -159,21 +159,6 @@ namespace Daqifi.Core.Tests.Channel
         }
 
         [Fact]
-        public void ClearPending_DropsTheStagedValueWithoutDrivingIt()
-        {
-            var channel = new AnalogOutputChannel(0);
-            var samples = Subscribe(channel);
-
-            channel.Stage(4.0);
-            channel.ClearPending();
-
-            Assert.Null(channel.PendingVoltage);
-            Assert.Null(channel.OutputVoltage);
-            Assert.False(channel.Latch(DateTime.Now));
-            Assert.Empty(samples);
-        }
-
-        [Fact]
         public void SetOutputVoltage_RecordsTheValueWithoutStaging()
         {
             var channel = new AnalogOutputChannel(0);

--- a/src/Daqifi.Core/Channel/AnalogOutputChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogOutputChannel.cs
@@ -253,18 +253,6 @@ public sealed class AnalogOutputChannel : IAnalogOutputChannel
     }
 
     /// <summary>
-    /// Discards a staged voltage without driving it — used when the device rejects or never
-    /// receives the latch.
-    /// </summary>
-    internal void ClearPending()
-    {
-        lock (_lock)
-        {
-            _pendingVoltage = null;
-        }
-    }
-
-    /// <summary>
     /// Records a voltage as the value now driven on this channel, bypassing the staging step.
     /// Used by the device readback, which reports what the hardware currently holds.
     /// </summary>

--- a/src/Daqifi.Core/Device/TimestampProcessor.cs
+++ b/src/Daqifi.Core/Device/TimestampProcessor.cs
@@ -151,7 +151,7 @@ public sealed class TimestampProcessor : ITimestampProcessor
                 state.PreviousDeviceTimestamp = deviceTimestamp;
                 state.HasPreviousTimestamp = true;
 
-                return TimestampResult.CreateFirstMessage(now, deviceTimestamp, usedFallbackTickPeriod);
+                return TimestampResult.CreateFirstMessage(now, usedFallbackTickPeriod);
             }
 
             // Calculate clock cycles between messages, handling rollover

--- a/src/Daqifi.Core/Device/TimestampResult.cs
+++ b/src/Daqifi.Core/Device/TimestampResult.cs
@@ -76,14 +76,12 @@ public sealed class TimestampResult
     /// Creates a result for the first message in a session.
     /// </summary>
     /// <param name="timestamp">The current system timestamp.</param>
-    /// <param name="deviceTimestamp">The device timestamp.</param>
     /// <param name="usedFallbackTickPeriod">
     /// Whether the fallback tick period was used because the device had no configured frequency.
     /// </param>
     /// <returns>A new <see cref="TimestampResult"/> for the first message.</returns>
     internal static TimestampResult CreateFirstMessage(
         DateTime timestamp,
-        uint deviceTimestamp,
         bool usedFallbackTickPeriod = false)
     {
         return new TimestampResult(


### PR DESCRIPTION
Produced by the **dead-code maintenance routine**, which sweeps for unreachable branches and unused non-public members. It turned up two, both `internal`, so nothing here changes the public API a consumer can see.

## What was wrong

`AnalogOutputChannel.ClearPending()` has never been called by anything but a test. It shipped with the analog-output channel work (#526) carrying a doc comment describing when it would be used — "when the device rejects or never receives the latch" — but that path was never written, and it can't be written as things stand: `StageAnalogOutput` puts the SCPI write on the wire *before* it stages the value locally, so the modelled pending voltage is a mirror of what the device is already holding. Silently dropping it host-side would make the model disagree with the hardware, not agree with it. The library also has no rejection signal for these fire-and-forget writes to react to.

Separately, `TimestampResult.CreateFirstMessage` declares a `uint deviceTimestamp` parameter it never reads. Its one caller in `TimestampProcessor` dutifully passes the device tick through for nothing.

## How it was fixed

Deleted `ClearPending()` and the single test that existed only to exercise it; dropped the unused parameter from `CreateFirstMessage` and its caller.

The thing worth pushing back on is the first one: if you read `ClearPending()` as a *missing call* rather than a dead one — a latch that throws leaves the channel showing a pending voltage forever — then the fix is to add the caller instead of removing the method. I landed on removal because after a throw the device has the staged value too, so the model is still telling the truth. Happy to take the other read if you'd rather keep the hook.

## Verification

`dotnet build` clean (0 warnings, `TreatWarningsAsErrors` on) and the full suite green on both target frameworks: 3727 passed / 0 failed on net9.0 and net10.0 for `Daqifi.Core.Tests`, 217 passed for `Daqifi.Mcp.Tests`.

Not merging — opened for your review.
