### PR TITLE
fix(tests): wait for the quarantine TTL re-probe instead of racing it

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -507,13 +507,23 @@ public class SerialDeviceFinderTests
         {
             var hungForever = new TaskCompletionSource<IDeviceInfo?>();
             var probeStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var reProbeStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var hungProbeCalls = 0;
             using var finder = CreateFinderWithProbes(
                 new[] { "COM_HUNG_TTL" },
                 (_, _) =>
                 {
-                    Interlocked.Increment(ref hungProbeCalls);
-                    probeStarted.TrySetResult(true);
+                    // Signalled separately per sweep: the test has to wait for each sweep's probe
+                    // delegate to actually RUN, not merely to have been queued.
+                    if (Interlocked.Increment(ref hungProbeCalls) == 1)
+                    {
+                        probeStarted.TrySetResult(true);
+                    }
+                    else
+                    {
+                        reProbeStarted.TrySetResult(true);
+                    }
+
                     return hungForever.Task;
                 },
                 hardTimeoutMs: 100);
@@ -524,7 +534,20 @@ public class SerialDeviceFinderTests
 
             await finder.DiscoverAsync(CancellationToken.None);
 
-            Assert.True(Volatile.Read(ref hungProbeCalls) >= 2,
+            // The re-probe is dispatched with Task.Run and then races
+            // Task.Delay(PortProbeHardTimeoutMs) — the same hazard documented on
+            // CreateFinderWithProbes, and here the ceiling is only 100ms. So this sweep can
+            // return with the TTL retry correctly won and the probe task queued, but the pool
+            // not yet having run the delegate that increments the counter. Reading the counter
+            // the instant the sweep returned therefore failed on CI (run 32307072541: net9.0
+            // red, net10.0 green on the very same commit). Wait for the re-probe to actually
+            // start, bounded, so it is a real quarantine regression that fails this — not a
+            // thread-pool scheduling gap.
+            var reProbed = (await Task.WhenAny(
+                reProbeStarted.Task,
+                Task.Delay(TimeSpan.FromSeconds(5)))) == reProbeStarted.Task;
+
+            Assert.True(reProbed && Volatile.Read(ref hungProbeCalls) >= 2,
                 "TTL elapsed but the quarantined port was never re-probed — recovery requires app restart.");
         }
         finally


### PR DESCRIPTION
Produced by the **flaky-test-fixer** maintenance routine: scanning recent CI history for tests that failed and then passed with no intervening code change.

## What was wrong

`SerialDeviceFinderTests.DiscoverAsync_QuarantineTtl_AllowsPeriodicRetry` fails intermittently on CI with:

> TTL elapsed but the quarantined port was never re-probed — recovery requires app restart.

The proof that it is the test and not the product: in run [32307072541](https://github.com/daqifi/daqifi-core/actions/runs/32307072541) this test failed on **net9.0** and passed on **net10.0** in the same job, on the same commit. Two runs of identical code, one red one green — nothing about the quarantine changed between them.

The cause is a scheduling race the test never accounted for. It drives a port whose probe hangs forever, lets the quarantine TTL lapse, sweeps a second time, and then immediately reads a counter that the probe delegate increments. But a sweep dispatches its probe with `Task.Run` and races it against `Task.Delay(PortProbeHardTimeoutMs)` — and this test deliberately sets that ceiling to just 100 ms. So the second sweep can return having done everything right (TTL retry won, fresh probe queued) while the thread pool simply has not run the delegate yet. The counter is still 1, and the test blames the quarantine for a thread-pool delay. The first sweep was already protected against exactly this by an explicit wait; the second one was not.

This is the same hazard already documented on `CreateFinderWithProbes` in this file, which is why the neighbouring quarantine tests use a 2000 ms ceiling.

## How it was fixed

The probe delegate now signals its *first* start and its *later* starts on two separate `TaskCompletionSource`s, and the test waits (bounded at 5 s) for the re-probe to actually begin before asserting — mirroring the wait the first sweep already had. Nothing outside the test changed; `SerialDeviceFinder` and the quarantine policy are untouched.

Worth a reviewer's attention: the assertion is now `reProbed && count >= 2` rather than just the count. That is deliberate so a genuine regression — a re-probe that never happens — still fails with the original diagnostic message rather than an opaque timeout. Raising `hardTimeoutMs` was the other option, but it would have made the first sweep wait out the larger ceiling before abandoning the claim and still left the second sweep racing; waiting on the actual signal removes the race rather than widening it.

## Verification

Full `dotnet test Daqifi.Core.sln`: **3728 passed / 0 failed on net9.0 and net10.0**, plus 217 in `Daqifi.Mcp.Tests`. The `SerialDeviceFinderTests` class passes 32/32 on its own.

---

Not merging — opened for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)