### PR TITLE
fix(device): drop a blank line that arrives while the command is still queued

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
@@ -2,6 +2,7 @@ using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text;
 
 namespace Daqifi.Core.Tests.Communication.Producers;
@@ -494,13 +495,15 @@ public class MessageProducerTests
 
         public bool WaitForWriteStarted(TimeSpan timeout)
         {
-            var deadline = DateTime.UtcNow + timeout;
+            // Monotonic on purpose: a wall-clock step (NTP, a VM resuming) must not be able to
+            // cut this wait short or stretch it, which is how a bounded test wait turns flaky.
+            var clock = Stopwatch.StartNew();
 
             lock (_gate)
             {
                 while (!_writeStarted)
                 {
-                    var remaining = deadline - DateTime.UtcNow;
+                    var remaining = timeout - clock.Elapsed;
                     if (remaining <= TimeSpan.Zero)
                     {
                         return false;
@@ -538,7 +541,8 @@ public class MessageProducerTests
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            var limit = TimeSpan.FromSeconds(10);
+            var clock = Stopwatch.StartNew();
 
             lock (_gate)
             {
@@ -549,7 +553,7 @@ public class MessageProducerTests
                 // than wedge the producer thread for the rest of the run.
                 while (!_released)
                 {
-                    var remaining = deadline - DateTime.UtcNow;
+                    var remaining = limit - clock.Elapsed;
                     if (remaining <= TimeSpan.Zero)
                     {
                         return;

--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
@@ -384,6 +384,10 @@ public class MessageProducerTests
         Assert.Equal(1L, producer.StartedWriteCount);
 
         stream.ReleaseWrite();
+        Assert.False(
+            stream.HoldExpired,
+            "The write hold expired on its own bound, so the write was no longer in flight when the count was read.");
+
         Assert.True(producer.StopSafely(2000));
         Assert.Equal(1L, producer.StartedWriteCount);
     }
@@ -492,6 +496,27 @@ public class MessageProducerTests
         private readonly object _gate = new();
         private bool _writeStarted;
         private bool _released;
+        private bool _holdExpired;
+
+        /// <summary>
+        /// True if the held write gave up on its bound instead of being released by the test.
+        /// The bound only exists so a test that never releases fails on its own assertion rather
+        /// than wedging the producer thread for the rest of the run; if it ever does expire, the
+        /// write was no longer in flight and anything read about it afterwards is meaningless.
+        /// Recorded rather than thrown: this runs on the producer's thread, where an exception
+        /// would be swallowed into SendFailed and the failure-run counter instead of reaching the
+        /// test.
+        /// </summary>
+        public bool HoldExpired
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _holdExpired;
+                }
+            }
+        }
 
         public bool WaitForWriteStarted(TimeSpan timeout)
         {
@@ -550,12 +575,14 @@ public class MessageProducerTests
                 Monitor.PulseAll(_gate);
 
                 // Bounded: a test that forgets to release must fail on its own assertion rather
-                // than wedge the producer thread for the rest of the run.
+                // than wedge the producer thread for the rest of the run. Expiry is recorded so it
+                // cannot pass for a release: see HoldExpired.
                 while (!_released)
                 {
                     var remaining = limit - clock.Elapsed;
                     if (remaining <= TimeSpan.Zero)
                     {
+                        _holdExpired = true;
                         return;
                     }
 

--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
@@ -483,12 +483,44 @@ public class MessageProducerTests
     /// </summary>
     private sealed class BlockingWriteStream : Stream
     {
-        private readonly ManualResetEventSlim _writeStarted = new(false);
-        private readonly ManualResetEventSlim _writeRelease = new(false);
+        /// <summary>
+        /// A plain monitor rather than a pair of events, so there is nothing here that has to be
+        /// disposed: disposable wait handles would need the parked writer to have left them before
+        /// teardown could free them, which is a race a test double should not have.
+        /// </summary>
+        private readonly object _gate = new();
+        private bool _writeStarted;
+        private bool _released;
 
-        public bool WaitForWriteStarted(TimeSpan timeout) => _writeStarted.Wait(timeout);
+        public bool WaitForWriteStarted(TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
 
-        public void ReleaseWrite() => _writeRelease.Set();
+            lock (_gate)
+            {
+                while (!_writeStarted)
+                {
+                    var remaining = deadline - DateTime.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        return false;
+                    }
+
+                    Monitor.Wait(_gate, remaining);
+                }
+
+                return true;
+            }
+        }
+
+        public void ReleaseWrite()
+        {
+            lock (_gate)
+            {
+                _released = true;
+                Monitor.PulseAll(_gate);
+            }
+        }
 
         public override bool CanRead => false;
         public override bool CanSeek => false;
@@ -506,20 +538,34 @@ public class MessageProducerTests
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            _writeStarted.Set();
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
 
-            // Bounded: a test that forgets to release must fail on its own assertion rather than
-            // wedge the producer thread for the rest of the run.
-            _writeRelease.Wait(TimeSpan.FromSeconds(10));
+            lock (_gate)
+            {
+                _writeStarted = true;
+                Monitor.PulseAll(_gate);
+
+                // Bounded: a test that forgets to release must fail on its own assertion rather
+                // than wedge the producer thread for the rest of the run.
+                while (!_released)
+                {
+                    var remaining = deadline - DateTime.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        return;
+                    }
+
+                    Monitor.Wait(_gate, remaining);
+                }
+            }
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                _writeRelease.Set();
-                _writeStarted.Dispose();
-                _writeRelease.Dispose();
+                // Frees a writer that a failed test left parked; nothing here needs disposing.
+                ReleaseWrite();
             }
 
             base.Dispose(disposing);

--- a/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/MessageProducerTests.cs
@@ -361,6 +361,48 @@ public class MessageProducerTests
         Assert.Equal(0, producer.QueuedMessageCount);
     }
 
+    [Fact]
+    public void MessageProducer_StartedWriteCount_CountsAWriteAsSoonAsItBegins()
+    {
+        // The number has to rise BEFORE the bytes go out, not after they are done, because a
+        // reader on another thread uses it to conclude "nothing had been asked yet" (issue #593).
+        // A count of completions would still read zero while a command was physically on the wire,
+        // and a device that answered in the meantime would have its reply written off as a
+        // leftover. The write is held open here so the difference is observable at all.
+        using var stream = new BlockingWriteStream();
+        using var producer = new MessageProducer<string>(stream);
+
+        Assert.Equal(0L, producer.StartedWriteCount);
+
+        producer.Start();
+        producer.Send(new ScpiMessage("TEST:COMMAND"));
+
+        Assert.True(stream.WaitForWriteStarted(TimeSpan.FromSeconds(5)), "The producer never started the write.");
+
+        // Still inside the blocking write, so this write has begun and has not finished.
+        Assert.Equal(1L, producer.StartedWriteCount);
+
+        stream.ReleaseWrite();
+        Assert.True(producer.StopSafely(2000));
+        Assert.Equal(1L, producer.StartedWriteCount);
+    }
+
+    [Fact]
+    public void MessageProducer_StartedWriteCount_CountsAWriteThatFailed()
+    {
+        // A write that threw part-way may still have put bytes on the wire, so "it never started"
+        // is the answer that could get a genuine reply discarded. Counting it is the safe way to
+        // be wrong: at worst a leftover reply is kept, which is what happened before #593 anyway.
+        using var stream = new ThrowOnWriteStream();
+        using var producer = new MessageProducer<string>(stream);
+        producer.Start();
+
+        producer.Send(new ScpiMessage("TEST:COMMAND"));
+        Assert.True(producer.StopSafely(2000));
+
+        Assert.Equal(1L, producer.StartedWriteCount);
+    }
+
     /// <summary>
     /// Captures log entries in-memory so tests can assert that the producer logs as expected.
     /// </summary>
@@ -433,5 +475,54 @@ public class MessageProducerTests
         public override void SetLength(long value) => throw new NotSupportedException();
 
         public override void Write(byte[] buffer, int offset, int count) => throw _exceptionToThrow;
+    }
+
+    /// <summary>
+    /// A write-only stream that parks inside <see cref="Write"/> until released, so a test can
+    /// observe the producer's state while a write is genuinely in flight.
+    /// </summary>
+    private sealed class BlockingWriteStream : Stream
+    {
+        private readonly ManualResetEventSlim _writeStarted = new(false);
+        private readonly ManualResetEventSlim _writeRelease = new(false);
+
+        public bool WaitForWriteStarted(TimeSpan timeout) => _writeStarted.Wait(timeout);
+
+        public void ReleaseWrite() => _writeRelease.Set();
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _writeStarted.Set();
+
+            // Bounded: a test that forgets to release must fail on its own assertion rather than
+            // wedge the producer thread for the rest of the run.
+            _writeRelease.Wait(TimeSpan.FromSeconds(10));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _writeRelease.Set();
+                _writeStarted.Dispose();
+                _writeRelease.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -1066,38 +1066,68 @@ public class DaqifiDeviceStaleTextLineTests
             _isConnected = false;
             _disposed = true;
 
-            // A test that failed before releasing must not leave the producer thread parked, so
-            // the release comes first and the stream's own dispose — which frees its wait handles
-            // — only afterwards.
+            // A test that failed before releasing must not leave the producer thread parked.
             _stream.ReleaseWrite();
-            _stream.Dispose();
         }
 
         private sealed class HoldableStream : Stream
         {
             private readonly object _gate = new();
             private readonly Queue<byte[]> _pending = new();
-            private readonly ManualResetEventSlim _writeStarted = new(false);
-            private readonly ManualResetEventSlim _writeRelease = new(true);
+
+            /// <summary>
+            /// Guards the write hold. A plain monitor rather than a pair of events, so there is
+            /// nothing here that has to be disposed: the writer parks on it, and a test that fails
+            /// before releasing simply leaves a background thread waiting on an object that gets
+            /// collected. Disposable wait handles would need the writer to have left them before
+            /// teardown could free them, which is a race nobody needs in a test double.
+            /// </summary>
+            private readonly object _writeGate = new();
             private byte[]? _current;
             private int _position;
-            private volatile bool _holdWrites;
+            private bool _holdWrites;
+            private bool _writeStarted;
             private int _writeCount;
 
             public int WriteCount => Volatile.Read(ref _writeCount);
 
             public void HoldWrites()
             {
-                _writeRelease.Reset();
-                _holdWrites = true;
+                lock (_writeGate)
+                {
+                    _holdWrites = true;
+                    _writeStarted = false;
+                }
             }
 
-            public bool WaitForWriteStarted(TimeSpan timeout) => _writeStarted.Wait(timeout);
+            public bool WaitForWriteStarted(TimeSpan timeout)
+            {
+                var deadline = DateTime.UtcNow + timeout;
+
+                lock (_writeGate)
+                {
+                    while (!_writeStarted)
+                    {
+                        var remaining = deadline - DateTime.UtcNow;
+                        if (remaining <= TimeSpan.Zero)
+                        {
+                            return false;
+                        }
+
+                        Monitor.Wait(_writeGate, remaining);
+                    }
+
+                    return true;
+                }
+            }
 
             public void ReleaseWrite()
             {
-                _holdWrites = false;
-                _writeRelease.Set();
+                lock (_writeGate)
+                {
+                    _holdWrites = false;
+                    Monitor.PulseAll(_writeGate);
+                }
             }
 
             public void ReleaseLine(string line)
@@ -1147,33 +1177,35 @@ public class DaqifiDeviceStaleTextLineTests
             {
                 // Counted, not kept: nothing reads the device's outbound bytes back, but a test
                 // that wants to say "the command did reach the wire in the end" needs something
-                // to point at.
+                // to point at. Counted outside the gate so the count stays readable while a write
+                // is held.
                 Interlocked.Increment(ref _writeCount);
 
-                if (!_holdWrites)
+                var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+
+                lock (_writeGate)
                 {
-                    return;
+                    if (!_holdWrites)
+                    {
+                        return;
+                    }
+
+                    _writeStarted = true;
+                    Monitor.PulseAll(_writeGate);
+
+                    // Bounded, so a test that never releases fails on its own assertion rather
+                    // than wedging the producer thread for the rest of the run.
+                    while (_holdWrites)
+                    {
+                        var remaining = deadline - DateTime.UtcNow;
+                        if (remaining <= TimeSpan.Zero)
+                        {
+                            return;
+                        }
+
+                        Monitor.Wait(_writeGate, remaining);
+                    }
                 }
-
-                _writeStarted.Set();
-
-                // Bounded, so a test that never releases fails on its own assertion rather than
-                // wedging the producer thread for the rest of the run.
-                _writeRelease.Wait(TimeSpan.FromSeconds(30));
-            }
-
-            protected override void Dispose(bool disposing)
-            {
-                if (disposing)
-                {
-                    // Released before the handles go away, so a writer parked in Write above is
-                    // woken rather than left to fault on a disposed event.
-                    _writeRelease.Set();
-                    _writeStarted.Dispose();
-                    _writeRelease.Dispose();
-                }
-
-                base.Dispose(disposing);
             }
         }
     }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -216,6 +216,9 @@ public class DaqifiDeviceStaleTextLineTests
         Assert.Empty(lines);
 
         transport.ReleaseWrite();
+        Assert.False(
+            transport.HoldExpired,
+            "The write hold expired on its own bound, so the queued-behind-a-held-write window this test needs was not actually held open.");
 
         // The command was queued the whole time, not lost: released, the writer sends both it and
         // the earlier command it was stuck behind. Without this the test would also pass against a
@@ -259,6 +262,10 @@ public class DaqifiDeviceStaleTextLineTests
         Assert.All(lines, line => Assert.Equal(string.Empty, line));
 
         transport.ReleaseWrite();
+        Assert.False(
+            transport.HoldExpired,
+            "The write hold expired on its own bound, so the queued-behind-a-held-write window this test needs was not actually held open.");
+
         device.Disconnect();
     }
 
@@ -295,6 +302,10 @@ public class DaqifiDeviceStaleTextLineTests
         Assert.Contains(lines, l => l.Contains("No error"));
 
         transport.ReleaseWrite();
+        Assert.False(
+            transport.HoldExpired,
+            "The write hold expired on its own bound, so the queued-behind-a-held-write window this test needs was not actually held open.");
+
         device.Disconnect();
     }
 
@@ -1033,6 +1044,9 @@ public class DaqifiDeviceStaleTextLineTests
         /// <summary>Waits for the producer thread to actually enter a held write.</summary>
         public bool WaitForWriteStarted(TimeSpan timeout) => _stream.WaitForWriteStarted(timeout);
 
+        /// <summary>See <see cref="HoldableStream.HoldExpired"/>.</summary>
+        public bool HoldExpired => _stream.HoldExpired;
+
         /// <summary>Lets the held write — and every write after it — through.</summary>
         public void ReleaseWrite() => _stream.ReleaseWrite();
 
@@ -1087,9 +1101,30 @@ public class DaqifiDeviceStaleTextLineTests
             private int _position;
             private bool _holdWrites;
             private bool _writeStarted;
+            private bool _holdExpired;
             private int _writeCount;
 
             public int WriteCount => Volatile.Read(ref _writeCount);
+
+            /// <summary>
+            /// True if a held write gave up on its bound instead of being released by the test.
+            /// The bound only exists so a test that never releases fails on its own assertion
+            /// rather than wedging the producer thread for the rest of the run; if it ever does
+            /// expire, the window the test was holding open closed underneath it and any result
+            /// gathered after that is meaningless. Recorded rather than thrown: this runs on the
+            /// producer's thread, where an exception would be swallowed into SendFailed and the
+            /// failure-run counter instead of reaching the test.
+            /// </summary>
+            public bool HoldExpired
+            {
+                get
+                {
+                    lock (_writeGate)
+                    {
+                        return _holdExpired;
+                    }
+                }
+            }
 
             public void HoldWrites()
             {
@@ -1197,12 +1232,14 @@ public class DaqifiDeviceStaleTextLineTests
                     Monitor.PulseAll(_writeGate);
 
                     // Bounded, so a test that never releases fails on its own assertion rather
-                    // than wedging the producer thread for the rest of the run.
+                    // than wedging the producer thread for the rest of the run. Expiry is recorded
+                    // so it cannot pass for a release: see HoldExpired.
                     while (_holdWrites)
                     {
                         var remaining = limit - clock.Elapsed;
                         if (remaining <= TimeSpan.Zero)
                         {
+                            _holdExpired = true;
                             return;
                         }
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -1102,13 +1102,15 @@ public class DaqifiDeviceStaleTextLineTests
 
             public bool WaitForWriteStarted(TimeSpan timeout)
             {
-                var deadline = DateTime.UtcNow + timeout;
+                // Monotonic on purpose: a wall-clock step (NTP, a VM resuming) must not be able to
+                // cut this wait short or stretch it, which is how a bounded test wait turns flaky.
+                var clock = Stopwatch.StartNew();
 
                 lock (_writeGate)
                 {
                     while (!_writeStarted)
                     {
-                        var remaining = deadline - DateTime.UtcNow;
+                        var remaining = timeout - clock.Elapsed;
                         if (remaining <= TimeSpan.Zero)
                         {
                             return false;
@@ -1181,7 +1183,8 @@ public class DaqifiDeviceStaleTextLineTests
                 // is held.
                 Interlocked.Increment(ref _writeCount);
 
-                var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+                var limit = TimeSpan.FromSeconds(30);
+                var clock = Stopwatch.StartNew();
 
                 lock (_writeGate)
                 {
@@ -1197,7 +1200,7 @@ public class DaqifiDeviceStaleTextLineTests
                     // than wedging the producer thread for the rest of the run.
                     while (_holdWrites)
                     {
-                        var remaining = deadline - DateTime.UtcNow;
+                        var remaining = limit - clock.Elapsed;
                         if (remaining <= TimeSpan.Zero)
                         {
                             return;

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -1,3 +1,4 @@
+using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using System.Diagnostics;
@@ -171,6 +172,121 @@ public class DaqifiDeviceStaleTextLineTests
 
         Assert.Contains(lines, l => l.Contains("No error"));
 
+        device.Disconnect();
+    }
+
+    // ── The queue-to-write window (#593) — what is left of #553 once #591 has run. The setup
+    // action returns when the command has been handed to the producer, not when the producer has
+    // written it, so a blank can still arrive after the exchange believes it has sent and before
+    // the device has been asked anything. The boundary #591 captures cannot be moved later to
+    // cover it (that is the drain, and it breaks SYSTem:LOG? outright); each line carries the
+    // producer's started-write count instead. The producer is parked inside a blocking write here
+    // to hold the window open, which on real hardware is sub-millisecond. ─────────────────────
+
+    [Fact]
+    public async Task ExecuteTextCommand_DropsABlankThatArrivesAfterTheCommandIsQueuedButBeforeItIsWritten()
+    {
+        // An earlier command holds the producer thread, so the command this exchange queues
+        // cannot reach the wire at all while the blank arrives. Nothing has been asked of the
+        // device, so a blank — which only ever terminates a dump — cannot be answering: without
+        // the fix it is returned as "the device answered, and its log is empty".
+        using var transport = new QueuedWriteTransport();
+        using var device = new StaleLineTestableDevice("Queued-Command Device", transport);
+
+        device.Connect();
+
+        transport.HoldWrites();
+        device.Send(new ScpiMessage("EARLIER:COMMAND"));
+        Assert.True(
+            transport.WaitForWriteStarted(TimeSpan.FromSeconds(10)),
+            "The producer never picked up the earlier command.");
+
+        var lines = await device.CallExecuteTextCommandAsync(
+            () =>
+            {
+                device.Send(new ScpiMessage("SYSTem:LOG?"));
+
+                // Released only after this setup action has returned, so the line-count boundary
+                // from #591 cannot be what drops it: by then the exchange believes it has sent,
+                // and only the write count knows the command is still sitting in the queue.
+                _ = Task.Delay(75).ContinueWith(_ => transport.ReleaseLine("\r\n"));
+            },
+            keepBlankLines: true);
+
+        Assert.Empty(lines);
+
+        transport.ReleaseWrite();
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_KeepsABlankThatArrivesOnceTheCommandIsBeingWritten()
+    {
+        // The guard #593 asks for by name. SYSTem:LOG? terminates its dump with a blank line, and
+        // on a bench Nq1 that blank comes back about 6ms after the write starts — while the write
+        // may well still be in progress. Anything that writes such a blank off as a leftover
+        // reports a healthy device as silent, which is exactly what draining before the boundary
+        // did, 10/10 runs. The write is deliberately still open when the blank lands here, so a
+        // marker keyed off the write FINISHING rather than starting would fail this test.
+        using var transport = new QueuedWriteTransport();
+        using var device = new StaleLineTestableDevice("Answering Log Device", transport);
+
+        device.Connect();
+
+        transport.HoldWrites();
+
+        var lines = await device.CallExecuteTextCommandAsync(
+            () =>
+            {
+                device.Send(new ScpiMessage("SYSTem:LOG?"));
+                Assert.True(
+                    transport.WaitForWriteStarted(TimeSpan.FromSeconds(10)),
+                    "The producer never started the command's write.");
+
+                _ = Task.Delay(75).ContinueWith(_ => transport.ReleaseLine("\r\n"));
+            },
+            keepBlankLines: true);
+
+        Assert.NotEmpty(lines);
+        Assert.All(lines, line => Assert.Equal(string.Empty, line));
+
+        transport.ReleaseWrite();
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_DoesNotExitEarlyWhenAQueuedCommandsBlankPrecedesTheRealResponse()
+    {
+        // The wait loop has to agree with the projection about what counts as an answer. A blank
+        // that arrives while the command is still queued is discarded later, so treating it as
+        // "the device has started replying" flips the loop into its short completion timeout and
+        // ends collection before the real response arrives — returning empty for a device that
+        // did answer, which is the failure this whole boundary exists to prevent.
+        using var transport = new QueuedWriteTransport();
+        using var device = new StaleLineTestableDevice("Late-Answering Device", transport);
+
+        device.Connect();
+
+        transport.HoldWrites();
+        device.Send(new ScpiMessage("EARLIER:COMMAND"));
+        Assert.True(
+            transport.WaitForWriteStarted(TimeSpan.FromSeconds(10)),
+            "The producer never picked up the earlier command.");
+
+        var lines = await device.CallExecuteTextCommandAsync(
+            () =>
+            {
+                device.Send(new ScpiMessage("SYSTem:ERRor?"));
+                _ = Task.Delay(75).ContinueWith(_ => transport.ReleaseLine("\r\n"));
+                _ = Task.Delay(500).ContinueWith(_ => transport.ReleaseLine("0,\"No error\"\r\n"));
+            },
+            responseTimeoutMs: 3000,
+            completionTimeoutMs: 150);
+
+        // Without the fix the loop breaks around 225ms — well before the real reply at 500ms.
+        Assert.Contains(lines, l => l.Contains("No error"));
+
+        transport.ReleaseWrite();
         device.Disconnect();
     }
 
@@ -551,9 +667,17 @@ public class DaqifiDeviceStaleTextLineTests
         {
         }
 
-        public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(Action setupAction)
+        public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(
+            Action setupAction,
+            bool keepBlankLines = false,
+            int responseTimeoutMs = 500,
+            int completionTimeoutMs = 150)
         {
-            return ExecuteTextCommandAsync(setupAction, responseTimeoutMs: 500, completionTimeoutMs: 150);
+            return ExecuteTextCommandAsync(
+                setupAction,
+                responseTimeoutMs: responseTimeoutMs,
+                completionTimeoutMs: completionTimeoutMs,
+                keepBlankLines: keepBlankLines);
         }
 
         public Task<IReadOnlyList<string>> CallWithPrepareAsync(
@@ -850,6 +974,175 @@ public class DaqifiDeviceStaleTextLineTests
             public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
             public override void SetLength(long value) => throw new NotSupportedException();
             public override void Write(byte[] buffer, int offset, int count) { }
+        }
+    }
+
+    /// <summary>
+    /// Transport whose stream can be told to park inside <see cref="Stream.Write"/>, and which
+    /// hands canned lines to the reader on demand.
+    /// </summary>
+    /// <remarks>
+    /// Holding the write open is what makes the queue-to-write window of issue #593 targetable:
+    /// while the producer thread sits in a write, everything a caller queues behind it stays
+    /// queued, so a test can put a line on the wire at a moment when the device provably has not
+    /// been asked anything. On real hardware that window is sub-millisecond and no delay-based
+    /// double can land in it. Writes pass straight through until <see cref="HoldWrites"/> is
+    /// called, so connecting the device is unaffected.
+    /// </remarks>
+    private sealed class QueuedWriteTransport : IStreamTransport
+    {
+        private readonly HoldableStream _stream = new();
+        private bool _isConnected;
+        private bool _disposed;
+
+        public Stream Stream
+        {
+            get
+            {
+                if (_disposed) throw new ObjectDisposedException(nameof(QueuedWriteTransport));
+                return _stream;
+            }
+        }
+
+        public bool IsConnected => _isConnected && !_disposed;
+
+        public string ConnectionInfo => _isConnected ? "Queued: Connected" : "Queued: Disconnected";
+
+        public event EventHandler<TransportStatusEventArgs>? StatusChanged;
+
+        /// <summary>Makes every subsequent write park until <see cref="ReleaseWrite"/>.</summary>
+        public void HoldWrites() => _stream.HoldWrites();
+
+        /// <summary>Waits for the producer thread to actually enter a held write.</summary>
+        public bool WaitForWriteStarted(TimeSpan timeout) => _stream.WaitForWriteStarted(timeout);
+
+        /// <summary>Lets the held write — and every write after it — through.</summary>
+        public void ReleaseWrite() => _stream.ReleaseWrite();
+
+        /// <summary>Puts a line on the wire for the reader to pick up.</summary>
+        public void ReleaseLine(string line) => _stream.ReleaseLine(line);
+
+        public Task ConnectAsync() => ConnectAsync(null);
+
+        public Task ConnectAsync(ConnectionRetryOptions? retryOptions)
+        {
+            if (_disposed) throw new ObjectDisposedException(nameof(QueuedWriteTransport));
+            _isConnected = true;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(true, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            _isConnected = false;
+            StatusChanged?.Invoke(this, new TransportStatusEventArgs(false, ConnectionInfo));
+            return Task.CompletedTask;
+        }
+
+        public void Connect() => ConnectAsync().Wait();
+
+        public void Disconnect() => DisconnectAsync().Wait();
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _isConnected = false;
+            _disposed = true;
+
+            // A test that failed before releasing must not leave the producer thread parked.
+            _stream.ReleaseWrite();
+        }
+
+        private sealed class HoldableStream : Stream
+        {
+            private readonly object _gate = new();
+            private readonly Queue<byte[]> _pending = new();
+            private readonly ManualResetEventSlim _writeStarted = new(false);
+            private readonly ManualResetEventSlim _writeRelease = new(true);
+            private byte[]? _current;
+            private int _position;
+            private volatile bool _holdWrites;
+
+            public void HoldWrites()
+            {
+                _writeRelease.Reset();
+                _holdWrites = true;
+            }
+
+            public bool WaitForWriteStarted(TimeSpan timeout) => _writeStarted.Wait(timeout);
+
+            public void ReleaseWrite()
+            {
+                _holdWrites = false;
+                _writeRelease.Set();
+            }
+
+            public void ReleaseLine(string line)
+            {
+                lock (_gate)
+                {
+                    _pending.Enqueue(Encoding.ASCII.GetBytes(line));
+                }
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                lock (_gate)
+                {
+                    if (_current == null || _position >= _current.Length)
+                    {
+                        _current = _pending.Count > 0 ? _pending.Dequeue() : null;
+                        _position = 0;
+                    }
+
+                    if (_current != null)
+                    {
+                        var toCopy = Math.Min(count, _current.Length - _position);
+                        Array.Copy(_current, _position, buffer, offset, toCopy);
+                        _position += toCopy;
+                        return toCopy;
+                    }
+                }
+
+                // Idle link: nothing to hand over, and no busy-spin in the reader thread.
+                Thread.Sleep(10);
+                return 0;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                if (!_holdWrites)
+                {
+                    return;
+                }
+
+                _writeStarted.Set();
+
+                // Bounded, so a test that never releases fails on its own assertion rather than
+                // wedging the producer thread for the rest of the run.
+                _writeRelease.Wait(TimeSpan.FromSeconds(30));
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _writeRelease.Set();
+                }
+
+                base.Dispose(disposing);
+            }
         }
     }
 }

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -216,6 +216,14 @@ public class DaqifiDeviceStaleTextLineTests
         Assert.Empty(lines);
 
         transport.ReleaseWrite();
+
+        // The command was queued the whole time, not lost: released, the writer sends both it and
+        // the earlier command it was stuck behind. Without this the test would also pass against a
+        // double that quietly swallowed everything queued.
+        Assert.True(
+            SpinWait.SpinUntil(() => transport.WriteCount >= 2, TimeSpan.FromSeconds(5)),
+            "The queued command never reached the wire once the writer was released.");
+
         device.Disconnect();
     }
 
@@ -986,8 +994,14 @@ public class DaqifiDeviceStaleTextLineTests
     /// while the producer thread sits in a write, everything a caller queues behind it stays
     /// queued, so a test can put a line on the wire at a moment when the device provably has not
     /// been asked anything. On real hardware that window is sub-millisecond and no delay-based
-    /// double can land in it. Writes pass straight through until <see cref="HoldWrites"/> is
-    /// called, so connecting the device is unaffected.
+    /// double can land in it.
+    /// <para>
+    /// Only the timing of the write call is modelled: until <see cref="HoldWrites"/> is called a
+    /// write returns immediately, and afterwards it parks. The bytes themselves are discarded
+    /// either way, as they are by every other stream double in this file — nothing here ever reads
+    /// back what the device wrote, and what these tests turn on is whether the writer thread is
+    /// moving, not what it said.
+    /// </para>
     /// </remarks>
     private sealed class QueuedWriteTransport : IStreamTransport
     {
@@ -1012,6 +1026,9 @@ public class DaqifiDeviceStaleTextLineTests
 
         /// <summary>Makes every subsequent write park until <see cref="ReleaseWrite"/>.</summary>
         public void HoldWrites() => _stream.HoldWrites();
+
+        /// <summary>How many writes the stream has been handed, held or not.</summary>
+        public int WriteCount => _stream.WriteCount;
 
         /// <summary>Waits for the producer thread to actually enter a held write.</summary>
         public bool WaitForWriteStarted(TimeSpan timeout) => _stream.WaitForWriteStarted(timeout);
@@ -1049,8 +1066,11 @@ public class DaqifiDeviceStaleTextLineTests
             _isConnected = false;
             _disposed = true;
 
-            // A test that failed before releasing must not leave the producer thread parked.
+            // A test that failed before releasing must not leave the producer thread parked, so
+            // the release comes first and the stream's own dispose — which frees its wait handles
+            // — only afterwards.
             _stream.ReleaseWrite();
+            _stream.Dispose();
         }
 
         private sealed class HoldableStream : Stream
@@ -1062,6 +1082,9 @@ public class DaqifiDeviceStaleTextLineTests
             private byte[]? _current;
             private int _position;
             private volatile bool _holdWrites;
+            private int _writeCount;
+
+            public int WriteCount => Volatile.Read(ref _writeCount);
 
             public void HoldWrites()
             {
@@ -1122,6 +1145,11 @@ public class DaqifiDeviceStaleTextLineTests
 
             public override void Write(byte[] buffer, int offset, int count)
             {
+                // Counted, not kept: nothing reads the device's outbound bytes back, but a test
+                // that wants to say "the command did reach the wire in the end" needs something
+                // to point at.
+                Interlocked.Increment(ref _writeCount);
+
                 if (!_holdWrites)
                 {
                     return;
@@ -1138,7 +1166,11 @@ public class DaqifiDeviceStaleTextLineTests
             {
                 if (disposing)
                 {
+                    // Released before the handles go away, so a writer parked in Write above is
+                    // woken rather than left to fault on a disposed event.
                     _writeRelease.Set();
+                    _writeStarted.Dispose();
+                    _writeRelease.Dispose();
                 }
 
                 base.Dispose(disposing);

--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -190,6 +190,7 @@ public class ConnectionGuardTests
         public void EnterOperationLockOwnership() => throw new NotSupportedException();
         public void ExitOperationLockOwnership() => throw new NotSupportedException();
         public Task DrainOutboundQueueAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public OutboundWriterSample? SampleOutboundWriter() => throw new NotSupportedException();
         public IDisposable SubscribeConsumerErrors(IMessageConsumer<string> consumer) => throw new NotSupportedException();
         public void OnStaleLineBoundaryCaptured() => throw new NotSupportedException();
     }

--- a/src/Daqifi.Core/Communication/Producers/IMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/IMessageProducer.cs
@@ -74,6 +74,34 @@ public interface IMessageProducer<T> : IDisposable
     bool IsIdle => QueuedMessageCount == 0;
 
     /// <summary>
+    /// How many writes this producer has <b>begun</b>, or <c>null</c> from a producer that does not
+    /// keep count.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Counts writes <i>started</i>, not writes finished: it is incremented immediately before the
+    /// bytes are handed to the stream. That is deliberate, and it is what makes the number usable as
+    /// a happens-before marker by a reader on another thread. A device cannot answer a command whose
+    /// write had not started, so anything read off the wire while this still reads <c>n</c> is
+    /// necessarily not an answer to the (n+1)th message — a fact the device's text exchange uses to
+    /// recognise a leftover reply from an earlier command (issue #593). Counting completions instead
+    /// would make the marker depend on the producer thread being scheduled promptly after its write,
+    /// and a marker that lands late can misclassify a fast device's genuine reply as a leftover.
+    /// </para>
+    /// <para>
+    /// Monotonic for the life of the instance, and incremented whether or not the write then
+    /// succeeds — a write that failed part-way may still have put bytes on the wire, so treating it
+    /// as "never started" would be the unsafe direction.
+    /// </para>
+    /// <para>
+    /// The default is <c>null</c> — "this producer does not say" — so existing implementations keep
+    /// compiling and every consumer of the number has to have an answer for not having one.
+    /// <see cref="MessageProducer{T}"/> overrides it.
+    /// </para>
+    /// </remarks>
+    long? StartedWriteCount => null;
+
+    /// <summary>
     /// Gets a value indicating whether the producer is currently running.
     /// </summary>
     bool IsRunning { get; }

--- a/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/MessageProducer.cs
@@ -42,6 +42,11 @@ public class MessageProducer<T> : IMessageProducer<T>
     private long _wakeCount;
 
     /// <summary>
+    /// Number of writes the background loop has started. See <see cref="StartedWriteCount"/>.
+    /// </summary>
+    private long _startedWriteCount;
+
+    /// <summary>
     /// Initializes a new instance of the MessageProducer class.
     /// </summary>
     /// <param name="stream">The stream to write messages to.</param>
@@ -104,6 +109,16 @@ public class MessageProducer<T> : IMessageProducer<T>
     /// statement about the value not changing, which a cumulative count states just as well.
     /// </remarks>
     internal long WakeCount => Interlocked.Read(ref _wakeCount);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Incremented on the background thread immediately before the write, and read here with an
+    /// interlocked read so a reader on another thread — the text exchange's line collector — cannot
+    /// see a torn or stale value. The pairing is what makes the count a happens-before marker: the
+    /// increment precedes the bytes leaving, so a reader that still sees the old value knows the
+    /// bytes had not left when it looked.
+    /// </remarks>
+    public long? StartedWriteCount => Interlocked.Read(ref _startedWriteCount);
 
     /// <inheritdoc />
     public event EventHandler<MessageSendFailedEventArgs<T>>? SendFailed;
@@ -249,6 +264,14 @@ public class MessageProducer<T> : IMessageProducer<T>
                         {
                             try
                             {
+                                // Claimed BEFORE the write, and counted even if the write then
+                                // throws. Readers on other threads use this as the marker for
+                                // "nothing this producer was given can have been answered yet"
+                                // (issue #593), so it has to rise no later than the bytes leave —
+                                // a marker that rises afterwards can land, on a preempted thread,
+                                // after a fast device has already replied.
+                                Interlocked.Increment(ref _startedWriteCount);
+
                                 WriteMessageToStream(message);
 
                                 // A successful write clears any run of failures the transport has

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1983,6 +1983,27 @@ namespace Daqifi.Core.Device
             _operations.DrainOutboundQueueAsync(cancellationToken);
 
         /// <inheritdoc />
+        /// <remarks>
+        /// The producer is snapshotted once, like every other read of this field off the lock:
+        /// teardown nulls it from another thread, so null-checking the field and then dereferencing
+        /// it would read it twice. A null answer is the honest one on a device with no producer —
+        /// nothing it sends goes through one — and the engine has a branch for it.
+        /// </remarks>
+        OutboundWriterSample? ITextExchangeHost.SampleOutboundWriter()
+        {
+            var producer = _messageProducer;
+
+            // Read first, so a write that begins between the two reads is reported as "not started
+            // yet, work outstanding" rather than the reverse. That direction is the safe one: it
+            // describes the instant the sample was asked for.
+            var startedWrites = producer?.StartedWriteCount;
+
+            return startedWrites.HasValue
+                ? new OutboundWriterSample(startedWrites.Value, !producer!.IsIdle)
+                : null;
+        }
+
+        /// <inheritdoc />
         IDisposable ITextExchangeHost.SubscribeConsumerErrors(IMessageConsumer<string> consumer) =>
             new ConsumerErrorSubscription(this, consumer);
 

--- a/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
+++ b/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
@@ -1,4 +1,5 @@
 using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device.Protocol;
 using Microsoft.Extensions.Logging;
@@ -121,6 +122,26 @@ namespace Daqifi.Core.Device.Internal
 
         /// <inheritdoc cref="OperationSerializer.DrainOutboundQueueAsync"/>
         Task DrainOutboundQueueAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Takes an instantaneous reading of the device's outbound writer.
+        /// </summary>
+        /// <remarks>
+        /// <b>Read, never waited on.</b> The exchange samples this to tell a leftover reply from its
+        /// own (issue #593); waiting for the writer to catch up — which is what draining the
+        /// outbound queue amounts to — is the fix that must not be made, because it puts a fast
+        /// device's genuine reply on the wrong side of the exchange's stale-line boundary. The whole
+        /// point of a sample is that it costs nothing and delays nothing.
+        /// <para>
+        /// Called on the text consumer's reader thread as well as the exchange's own, so it must
+        /// stay cheap and must not take any lock the exchange holds.
+        /// </para>
+        /// <para>
+        /// <c>null</c> on a device with no queued producer, and on one whose producer does not count
+        /// its writes. The engine treats that as "cannot tell" and falls back to what it did before.
+        /// </para>
+        /// </remarks>
+        OutboundWriterSample? SampleOutboundWriter();
 
         /// <summary>
         /// Forwards the temporary text consumer's failures to the device's

--- a/src/Daqifi.Core/Device/Internal/OutboundWriterSample.cs
+++ b/src/Daqifi.Core/Device/Internal/OutboundWriterSample.cs
@@ -1,0 +1,32 @@
+#nullable enable
+
+namespace Daqifi.Core.Device.Internal
+{
+    /// <summary>
+    /// What the device's outbound writer looked like at one instant, sampled by the text exchange
+    /// to tell a leftover reply from its own (issue #593).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The two facts are taken together because neither means anything alone. A write count that
+    /// has not moved since the exchange opened says the writer has not put this exchange's command
+    /// on the wire — but it says the same thing about an exchange that sends by some other route,
+    /// or sends nothing at all, and those have every right to a reply. Pairing it with "the writer
+    /// still has work outstanding" narrows it to the case that is actually in question: a command
+    /// handed over and not yet written.
+    /// </para>
+    /// <para>
+    /// A sample, never a wait. The exchange reads this and moves on; making it block until the
+    /// writer catches up is the fix #593 exists to rule out.
+    /// </para>
+    /// </remarks>
+    /// <param name="StartedWrites">
+    /// <see cref="Daqifi.Core.Communication.Producers.IMessageProducer{T}.StartedWriteCount"/> at
+    /// the instant of the sample.
+    /// </param>
+    /// <param name="HasWorkOutstanding">
+    /// True when the writer had something queued or part-way to the stream — the inverse of
+    /// <see cref="Daqifi.Core.Communication.Producers.IMessageProducer{T}.IsIdle"/>.
+    /// </param>
+    internal readonly record struct OutboundWriterSample(long StartedWrites, bool HasWorkOutstanding);
+}

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -339,7 +339,7 @@ namespace Daqifi.Core.Device.Internal
                 // subscribing the inbound handler a second time and dispatching every frame twice.
                 await _host.DrainOutboundQueueAsync(cancellationToken).ConfigureAwait(false);
 
-                var collectedLines = new List<string>();
+                var collectedLines = new List<CollectedLine>();
 
                 // The list is appended to from the text consumer's reader thread and read from
                 // this one, so every touch of it goes through this gate. Stopping the consumer is
@@ -368,6 +368,47 @@ namespace Daqifi.Core.Device.Internal
                 // Number of lines collected by the time the setup action finished sending — see the
                 // note at the point it is captured, below (issue #553).
                 var sentBoundaryLineCount = 0;
+
+                // What the outbound writer looked like when this exchange opened, or null on a
+                // device that cannot say — see the note at the point it is captured, below
+                // (issue #593).
+                OutboundWriterSample? writerBoundary = null;
+
+                // A blank this exchange can prove is not its own answer: one that was already
+                // collected when the setup action finished queueing the command (issue #553), or
+                // one that arrived while a command was queued behind a writer that had not written
+                // anything for this exchange yet (issue #593). Either way the device had not been
+                // asked yet, and a blank only ever means "end of dump" — there is nothing for it to
+                // terminate.
+                //
+                // The two rules are complementary rather than nested: the line count catches a
+                // blank that beat the setup action's return, the writer sample catches one that
+                // beat the queued command onto the wire. Neither is a wait, and neither moves the
+                // boundary the exchange's safety rests on.
+                //
+                // Both halves of the writer sample are load-bearing. A write count that has not
+                // moved is not on its own evidence that nothing was asked: a setup action that
+                // sends by another route, or sends nothing at all and expects the device to be
+                // mid-dump already, leaves it exactly as still. Requiring work to be outstanding as
+                // well narrows the rule to the case actually in question — something handed to the
+                // writer and not yet written.
+                //
+                // Content lines are deliberately subject to neither rule: the wider staleLineCount
+                // boundary is all that applies to them, so a genuinely fast reply is never at risk
+                // (the decision recorded in #553). A device whose writer cannot be sampled falls
+                // back to the line-count rule alone, which is what it had before.
+                //
+                // Declared out here rather than beside its first use because both the wait loop
+                // and the projection ask it, and they sit on opposite sides of the consumer swap's
+                // try/finally.
+                bool IsPreSendBlank(int index, CollectedLine collected) =>
+                    collected.Text.Length == 0
+                    && (index < sentBoundaryLineCount
+                        || (writerBoundary.HasValue
+                            && collected.WriterAtArrival.HasValue
+                            && collected.WriterAtArrival.Value.HasWorkOutstanding
+                            && collected.WriterAtArrival.Value.StartedWrites
+                                <= writerBoundary.Value.StartedWrites));
 
                 try
                 {
@@ -421,9 +462,18 @@ namespace Daqifi.Core.Device.Internal
                     // nothing would read (issue #490).
                     textConsumer.MessageParsed += parsed =>
                     {
+                        // Each line is stamped with what the outbound writer looked like when it
+                        // was parsed. Read here rather than at projection time because it is a
+                        // fact about the line's arrival that is gone a moment later, and it is
+                        // what lets the projection recognise a line that reached the wire before
+                        // this exchange's command did (issue #593). Sampling, on the reader's own
+                        // thread, costs nothing and delays nothing — deliberately unlike the drain
+                        // that #593 rules out.
+                        var writer = _host.SampleOutboundWriter();
+
                         lock (collectedLinesGate)
                         {
-                            collectedLines.Add(parsed.Data);
+                            collectedLines.Add(new CollectedLine(parsed.Data, writer));
                         }
                     };
 
@@ -458,6 +508,14 @@ namespace Daqifi.Core.Device.Internal
                     // a stale line as proof that the device answered a query it never even received,
                     // and report a complete listing for a device that has gone silent.
                     staleLineCount = CollectedLineCount();
+
+                    // Captured with the line boundary above, and for the same reason: it marks
+                    // "before this exchange". A line stamped with no more started writes than this
+                    // was parsed before any command of this exchange had begun going out, so it
+                    // cannot be an answer to one — which is the half of the boundary a line count
+                    // cannot express, because the setup action returns when the command is
+                    // *queued*, not when it is written (issue #593).
+                    writerBoundary = _host.SampleOutboundWriter();
                     if (staleLineCount > 0)
                     {
                         Log(logger => logger.LogDebug(
@@ -495,8 +553,13 @@ namespace Daqifi.Core.Device.Internal
                     // as stale. SYSTem:LOG? then reports "the device did not answer" for a device
                     // that answered on time, 10/10 runs. What makes this boundary safe is not
                     // precision about when the write landed — it is being strictly earlier than any
-                    // reply can physically exist. See #593, which records the residual window this
-                    // leaves and why it cannot be closed this way.
+                    // reply can physically exist. See #593, which records that argument in full.
+                    //
+                    // The window that leaves — queued but not yet written — is closed without moving
+                    // this boundary at all, by the writer sample each collected line carries (see
+                    // the MessageParsed handler above and the projection below). Asking a line what
+                    // the writer was doing when it arrived answers the same question a later
+                    // boundary was meant to answer, without making any reply wait for the answer.
                     //
                     // The ~2-2.5x slowdown a drain also shows on the bench is the engine, not the
                     // device: the wait loop below infers "the device answered" from a count increase
@@ -510,9 +573,8 @@ namespace Daqifi.Core.Device.Internal
 
                     // Whether anything beyond staleLineCount would actually survive the projection
                     // below as evidence this exchange got an answer -- i.e. not a blank that will be
-                    // dropped as a pre-send leftover (index < sentBoundaryLineCount, issue #553). A
-                    // raw count comparison against staleLineCount is NOT equivalent to this: a blank
-                    // that arrived in the capture-to-send window bumps the count but is discarded
+                    // dropped as a pre-send leftover. A raw count comparison against staleLineCount
+                    // is NOT equivalent to this: such a blank bumps the count but is discarded
                     // later, and treating it as evidence would flip the wait loop into the short
                     // completion-timeout phase before the real response has a chance to arrive.
                     bool HasResponseEvidenceBeyondStaleBoundary()
@@ -521,7 +583,7 @@ namespace Daqifi.Core.Device.Internal
                         {
                             for (var i = staleLineCount; i < collectedLines.Count; i++)
                             {
-                                if (collectedLines[i].Length > 0 || i >= sentBoundaryLineCount)
+                                if (!IsPreSendBlank(i, collectedLines[i]))
                                 {
                                     return true;
                                 }
@@ -548,9 +610,9 @@ namespace Daqifi.Core.Device.Internal
                     // bounds collection either way (issue #592).
                     //
                     // Seeded via HasResponseEvidenceBeyondStaleBoundary rather than a raw count
-                    // comparison against staleLineCount: a blank that arrived in the capture-to-send
-                    // window bumps the count but is dropped later as a pre-send leftover (#553), and
-                    // treating that bump as evidence would flip this into the short completion-
+                    // comparison against staleLineCount: a blank that arrived before the command
+                    // did bumps the count but is dropped later as a pre-send leftover (#553, #593),
+                    // and treating that bump as evidence would flip this into the short completion-
                     // timeout phase before the real response arrives, discarding it early.
                     var hasReceivedAny = HasResponseEvidenceBeyondStaleBoundary();
                     if (hasReceivedAny)
@@ -565,7 +627,13 @@ namespace Daqifi.Core.Device.Internal
                         if (CollectedLineCount() > previousCount)
                         {
                             lastMessageTime = DateTime.UtcNow;
-                            if (!hasReceivedAny)
+
+                            // A count increase is not the same thing as an answer: the new line can
+                            // be a leftover blank that the projection below will discard. Asking
+                            // the same question the projection asks keeps the two from disagreeing
+                            // — otherwise the loop stops early on a line that then vanishes, and
+                            // the exchange reports silence for a device that was still answering.
+                            if (!hasReceivedAny && HasResponseEvidenceBeyondStaleBoundary())
                             {
                                 hasReceivedAny = true;
                                 Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] First response at {ElapsedMs}ms", sw.ElapsedMilliseconds));
@@ -631,15 +699,15 @@ namespace Daqifi.Core.Device.Internal
                 lock (collectedLinesGate)
                 {
                     var afterStale = collectedLines
-                        .Select((line, index) => (line, index))
+                        .Select((collected, index) => (collected, index))
                         .Skip(staleLineCount)
-                        // A blank line captured at or before sentBoundaryLineCount arrived no later
-                        // than the moment the setup action finished sending, so it cannot be this
-                        // exchange's terminator (issue #553) — drop it here, before the
-                        // keepBlankLines projection below ever sees it. Content lines are untouched:
-                        // only the wider staleLineCount boundary above applies to them.
-                        .Where(t => t.line.Length > 0 || t.index >= sentBoundaryLineCount)
-                        .Select(t => t.line);
+                        // Blank lines that arrived before this exchange's command did are dropped
+                        // here, before the keepBlankLines projection below ever sees them — a blank
+                        // is only ever an end-of-dump terminator, and there is nothing for it to
+                        // terminate yet. Content lines are untouched: only the wider staleLineCount
+                        // boundary above applies to them (issues #553 and #593).
+                        .Where(t => !IsPreSendBlank(t.index, t.collected))
+                        .Select(t => t.collected.Text);
                     // keepBlankLines is how a caller asks to see the firmware's
                     // end-of-dump blank line. SYSTem:LOG? terminates its dump with
                     // one unconditionally, so its presence is the difference between
@@ -811,5 +879,18 @@ namespace Daqifi.Core.Device.Internal
                 // A logger that throws is not permitted to take down device operation.
             }
         }
+
+        /// <summary>
+        /// One line the text consumer produced, together with what the outbound writer had already
+        /// started when the line was parsed.
+        /// </summary>
+        /// <param name="Text">The parsed line, exactly as the caller will see it.</param>
+        /// <param name="WriterAtArrival">
+        /// <see cref="ITextExchangeHost.SampleOutboundWriter"/> taken as the line arrived, or
+        /// <c>null</c> when the device could not say. It is a fact about the line's arrival and
+        /// nothing else can recover it afterwards, which is why it is taken here rather than
+        /// re-read at projection time.
+        /// </param>
+        private readonly record struct CollectedLine(string Text, OutboundWriterSample? WriterAtArrival);
     }
 }


### PR DESCRIPTION
## What was wrong

Ask a DAQiFi device for its system log and, very occasionally, you would get an answer that was not yours. `SYSTem:LOG?` ends its dump with a blank line, and that blank is the whole signal the library uses to tell "the device answered and its log is empty" apart from "the device never answered at all". A blank left over from an *earlier* command that gave up could still arrive in the moment between the library queueing your command and actually writing it to the wire — and it would be counted as your answer. The visible result is an empty log reported for a device that had not yet been asked anything, and, worse, a diagnostics read that stops waiting early because it thinks the reply has already started coming in.

PR #591 closed most of this window. What remained is the gap between "the command has been handed to the writer" and "the writer has put it on the wire", which is where this fix lands.

## How it was fixed

Every line the exchange collects now carries a snapshot of the outbound writer taken at the moment the line arrived: how many writes the writer had begun, and whether it still had something waiting. A blank that arrived while a command sat queued behind a writer that had not begun writing anything for this exchange cannot be answering that exchange, so it is dropped. Anything from the instant the write begins onward is kept.

The obvious alternative — waiting for the outbound queue to drain before deciding — is what issue #593 exists to rule out: on a real Nq1 that breaks `SYSTem:LOG?` outright, 10/10 runs, because the device answers faster than the drain's own poll tick and its genuine terminator lands on the wrong side of the boundary. Nothing here waits for anything; the writer is only ever sampled.

Two things a reviewer may want to push back on, both deliberate:

- **The write count rises before the write, not after.** A marker recorded after the write can, on a preempted thread, land *later* than a fast device's reply — which would discard a genuine terminator, the exact failure the drain caused. Counting the write as started is the safe direction, and it still closes nearly all of the window (the queue wait, which is what the window is made of).
- **Both halves of the snapshot are load-bearing.** A write count that has not moved is not by itself evidence that nothing was asked: a setup action that sends by another route, or sends nothing and expects the device to be mid-dump, leaves it just as still. Requiring work to be outstanding as well narrows the rule to the case in question. The full suite caught this: without it, the `SYSTem:LOG?` framing test regressed exactly the way the drain does.

## Verification

- Full suite green on net9.0 and net10.0 (3733 passed, 2 skipped, each framework).
- New tests fail without the fix and pass with it; the "a blank that arrives once the write has begun is kept" test passes either way — it is the guard against becoming the drain.
- Bench, Nq1 firmware 3.7.2 over serial (`/dev/cu.usbmodem1101`), example CLI and a read-only probe built against this branch: `SYSTem:LOG?` 10/10 clean at ~1056 ms per call — the same figure #593 records for the healthy baseline — with a populated log on the first read and the blank-terminated empty log on the rest. Connect/initialize, `--show-status`, `--lan-chip-info` and a short 10 Hz stream all behaved normally. Nothing destructive was run.

closes #593

**Not merging — for review.**