### PR TITLE
chore(tests): remove assertions that cannot fail

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/UdpTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/UdpTransportTests.cs
@@ -15,7 +15,6 @@ public class UdpTransportTests
         using var transport = new UdpTransport();
 
         // Assert
-        Assert.NotNull(transport);
         Assert.False(transport.IsOpen);
     }
 
@@ -26,7 +25,6 @@ public class UdpTransportTests
         using var transport = new UdpTransport(30303);
 
         // Assert
-        Assert.NotNull(transport);
         Assert.False(transport.IsOpen);
     }
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -422,7 +422,6 @@ namespace Daqifi.Core.Tests.Device
             // and not the falsely-Ready state the old override could leave behind.
             await Assert.ThrowsAsync<OperationCanceledException>(() => device.InitializeAsync());
             Assert.Equal(DeviceState.Connected, device.State);
-            Assert.NotEqual(DeviceState.Ready, device.State);
         }
 
         [Theory]

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -101,10 +101,12 @@ public class SerialDeviceFinderTests
     [Fact]
     public void SerialDeviceFinder_CustomBaudRateConstructor_DoesNotThrow()
     {
-        // Keeps the public SerialDeviceFinder(int) overload exercised. The baud rate itself is a
-        // private field with no accessor, so "does not throw" is the whole of what a test can say
-        // here — the name says exactly that rather than implying the value is checked.
-        using var finder = new SerialDeviceFinder(9600);
+        // Keeps the public SerialDeviceFinder(int) overload exercised. 115200 rather than 9600 so
+        // this is a genuinely non-default rate — 9600 is DefaultBaudRate, which the parameterless
+        // constructor already covers. The baud rate itself is a private field with no accessor, so
+        // "does not throw" is the whole of what a test can say here, and the name says exactly that
+        // rather than implying the value is checked.
+        using var finder = new SerialDeviceFinder(115200);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -99,6 +99,15 @@ public class SerialDeviceFinderTests
     }
 
     [Fact]
+    public void SerialDeviceFinder_CustomBaudRateConstructor_DoesNotThrow()
+    {
+        // Keeps the public SerialDeviceFinder(int) overload exercised. The baud rate itself is a
+        // private field with no accessor, so "does not throw" is the whole of what a test can say
+        // here — the name says exactly that rather than implying the value is checked.
+        using var finder = new SerialDeviceFinder(9600);
+    }
+
+    [Fact]
     public void SerialDeviceFinder_CustomUsbLocationProvider_AcceptsProvider()
     {
         var fakeProvider = new RecordingUsbLocationProvider(_ => "Port_#0001.Hub_#0001");

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -99,26 +99,6 @@ public class SerialDeviceFinderTests
     }
 
     [Fact]
-    public void SerialDeviceFinder_DefaultConstructor_Uses9600Baud()
-    {
-        // Arrange & Act
-        using var finder = new SerialDeviceFinder();
-
-        // Assert
-        Assert.NotNull(finder);
-    }
-
-    [Fact]
-    public void SerialDeviceFinder_CustomBaudRate_AcceptsCustomBaudRate()
-    {
-        // Arrange & Act
-        using var finder = new SerialDeviceFinder(9600);
-
-        // Assert
-        Assert.NotNull(finder);
-    }
-
-    [Fact]
     public void SerialDeviceFinder_CustomUsbLocationProvider_AcceptsProvider()
     {
         var fakeProvider = new RecordingUsbLocationProvider(_ => "Port_#0001.Hub_#0001");

--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -106,27 +106,6 @@ public class WiFiDeviceFinderTests
         await Assert.ThrowsAsync<ObjectDisposedException>(() => finder.DiscoverAsync());
     }
 
-    [Fact]
-    public void WiFiDeviceFinder_DefaultConstructor_UsesPort30303()
-    {
-        // Arrange & Act
-        using var finder = new WiFiDeviceFinder();
-
-        // Assert
-        // Should not throw and should use default port 30303
-        Assert.NotNull(finder);
-    }
-
-    [Fact]
-    public void WiFiDeviceFinder_CustomPort_AcceptsCustomPort()
-    {
-        // Arrange & Act
-        using var finder = new WiFiDeviceFinder(12345);
-
-        // Assert
-        Assert.NotNull(finder);
-    }
-
     // Virtual / tunnel adapter filter — issue #179.
     // WSL2 mirrored networking, Hyper-V vEthernet, VPN/TAP adapters frequently share a /24
     // subnet with the real WiFi/Ethernet NIC and cause Windows routing to pick the wrong egress

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -3532,8 +3532,8 @@ public class FirmwareUpdateServiceTests
 
         var status = await service.CheckWifiFirmwareStatusAsync(device);
 
+        // Assert.False on a bool? already rejects null, so this alone pins "false, not unknown".
         Assert.False(status.MeetsMinimumSupportedVersion);
-        Assert.NotNull(status.MeetsMinimumSupportedVersion);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Firmware/Winc/WincBridgeProtocolTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Winc/WincBridgeProtocolTests.cs
@@ -187,6 +187,5 @@ public class WincBridgeProtocolTests
         // The device's read loop never terminates at or above its 2048-byte buffer, so 2047 is a
         // hard ceiling rather than a tuning choice.
         Assert.Equal(2047, WincBridgeProtocol.MaxReadBlockSize);
-        Assert.True(WincBridgeProtocol.MaxReadBlockSize < 2048);
     }
 }


### PR DESCRIPTION
Produced by the **useless-test-pruner** maintenance routine, which looks for tests that assert something no production change could ever break.

## What was wrong

Nine assertions in the suite could not fail, no matter what the library did.

Six of them were `Assert.NotNull(x)` where `x` had just been assigned from a `new` expression — `new SerialDeviceFinder()`, `new WiFiDeviceFinder(12345)`, `new UdpTransport()`. In C# `new` never evaluates to null, so the only thing these lines could ever react to is the constructor throwing, and a throwing constructor already fails the test on its own. The assertion contributes nothing.

Worse, four of those were the *entire* test. `SerialDeviceFinder_DefaultConstructor_Uses9600Baud` and `WiFiDeviceFinder_DefaultConstructor_UsesPort30303` read as if they verify the default baud rate and discovery port. They don't — both values live in private fields with no public accessor, so there is no way for a test to observe them. The names describe a check that was never written.

The other three assertions were dead because an earlier assertion in the same test had already settled the question:

- `WincBridgeProtocolTests` pinned `MaxReadBlockSize` to exactly `2047` and then asserted it was `< 2048`.
- `FirmwareUpdateServiceTests` asserted `Assert.False(status.MeetsMinimumSupportedVersion)` and then `Assert.NotNull(...)` on the same `bool?`. xUnit's `Assert.False(bool?)` already fails on null, so the "not null" half was discharged by the line above it.
- `DaqifiDeviceInitializeTests` asserted `State == Connected` and then `State != Ready`, on two distinct members of the same enum.

## How it was fixed

Deleted the nine dead assertions, and three of the four tests whose whole body was one of them. Nothing else was rewritten or weakened: where a test had other real assertions, only the dead line went. The `Assert.False(bool?)` site keeps its intent as a comment, because "false, not unknown" is genuinely what that test is about — it just needed one line to say it rather than two.

The fourth test was **kept and repaired instead of deleted**, and it is the one part of this PR worth a close look. Deleting `SerialDeviceFinder_CustomBaudRate_AcceptsCustomBaudRate` would have removed the only call site of the public `SerialDeviceFinder(int)` overload, leaving a shipped API entry point unexercised — a trade this project already declined once in #290. So it survives as `SerialDeviceFinder_CustomBaudRateConstructor_DoesNotThrow`: the tautological `Assert.NotNull` is gone, the name now states what it actually verifies rather than implying the baud rate is checked, and it passes `115200` rather than `9600` — the original value was `SerialDeviceFinder.DefaultBaudRate`, so the "custom baud rate" test had been exercising the exact value the parameterless constructor already covers. It asserts nothing beyond "construction does not throw", which is the whole of what is observable when `_baudRate` is private with no accessor.

Two related findings were deliberately left alone rather than pruned, and are worth naming so they don't look overlooked. `SerialDeviceFinder_CustomUsbLocationProvider_AcceptsProvider` has the same dead `Assert.NotNull`, but it is the only test that passes a `usbLocationProvider`, and removing it would also orphan its `RecordingUsbLocationProvider` helper — more churn than the finding justifies. And `CsvExporterTests.ExporterTypes_DoNotReferenceEfCoreOrWindows` asserts `NotNull` on a `new`, but its comment says outright that it is a compile-time guarantee, so the assertion is incidental to a deliberate design.

## Verification

Full suite green on both target frameworks against current `main`, re-run after every push: net9.0 `3727` passed in `Daqifi.Core.Tests` plus `217` in `Daqifi.Mcp.Tests`, net10.0 `3727` passed in `Daqifi.Core.Tests` (`Daqifi.Mcp.Tests` is net9.0-only by design, unchanged by this PR). Build is clean with zero warnings.

Coverage measured before and after on the same run configuration: line `88.43% -> 88.41%`, branch `83.43% -> 83.43%` (identical), method `94.36% -> 94.32%`. That method delta was the `SerialDeviceFinder(int)` overload, which the fix above has since put back — so the shipped state has no uncovered-constructor regression. No branch went uncovered at any point, which is the expected signature of removing assertions that were never exercising anything.

Not merging — this is for review only.
