### PR TITLE
chore(device): move the SD-card members off the shared device-operation seam

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsOperationsTests.cs
@@ -481,9 +481,6 @@ public class DeviceDiagnosticsOperationsTests
         public void EnsureSupported(DeviceFeature feature) => throw new NotSupportedException();
         public FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
             => throw new NotSupportedException();
-        public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
-        public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
-        public void RaiseLowSdSpaceWarning(Daqifi.Core.Device.SdCard.LowSdSpaceWarningEventArgs e) => throw new NotSupportedException();
         public void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e) => throw new NotSupportedException();
         public void RaiseGapDetected(TimestampGapEventArgs e) => throw new NotSupportedException();
         public void RaiseRawStreamFrame(DaqifiOutMessage message) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/ChannelControlOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ChannelControlOperationsTests.cs
@@ -2,7 +2,6 @@ using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Internal;
-using Daqifi.Core.Device.SdCard;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -714,9 +713,6 @@ public class ChannelControlOperationsTests
         public void EnsureSupported(DeviceFeature feature) => throw new NotSupportedException();
         public FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
             => throw new NotSupportedException();
-        public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
-        public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
-        public void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => throw new NotSupportedException();
         public void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e) => throw new NotSupportedException();
         public void RaiseGapDetected(TimestampGapEventArgs e) => throw new NotSupportedException();
         public void RaiseRawStreamFrame(DaqifiOutMessage message) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -4,7 +4,6 @@ using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Internal;
-using Daqifi.Core.Device.SdCard;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -136,8 +135,6 @@ public class ConnectionGuardTests
         public bool IsUsbConnection => throw new NotSupportedException();
         public bool IsStreaming { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
         public int StreamingFrequency => throw new NotSupportedException();
-        public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
-        public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
         public DeviceMetadata Metadata => throw new NotSupportedException();
         public long ChannelStateVersion => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
@@ -163,7 +160,6 @@ public class ConnectionGuardTests
         public void EnsureSupported(DeviceFeature feature) => throw new NotSupportedException();
         public FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
             => throw new NotSupportedException();
-        public void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => throw new NotSupportedException();
         public void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e) => throw new NotSupportedException();
         public void RaiseGapDetected(TimestampGapEventArgs e) => throw new NotSupportedException();
         public void RaiseRawStreamFrame(DaqifiOutMessage message) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -2,7 +2,6 @@ using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Internal;
-using Daqifi.Core.Device.SdCard;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -602,8 +601,6 @@ public class DeviceAdministrationOperationsTests
         public bool IsUsbConnection => throw new NotSupportedException();
         public bool IsStreaming { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
         public int StreamingFrequency => throw new NotSupportedException();
-        public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
-        public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
         public void StartStreaming() => throw new NotSupportedException();
         public IReadOnlyList<IChannel> SnapshotChannels() => throw new NotSupportedException();
@@ -647,7 +644,6 @@ public class DeviceAdministrationOperationsTests
         public void EnsureSupported(DeviceFeature feature) => throw new NotSupportedException();
         public FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
             => throw new NotSupportedException();
-        public void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => throw new NotSupportedException();
         public void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e) => throw new NotSupportedException();
         public void RaiseGapDetected(TimestampGapEventArgs e) => throw new NotSupportedException();
         public void RaiseRawStreamFrame(DaqifiOutMessage message) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -2,7 +2,6 @@ using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Internal;
-using Daqifi.Core.Device.SdCard;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -516,8 +515,6 @@ public class LiveSampleStreamTests
         public bool IsStreaming { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
         public int StreamingFrequency => throw new NotSupportedException();
         public DeviceMetadata Metadata => throw new NotSupportedException();
-        public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
-        public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
         public void StartStreaming() => throw new NotSupportedException();
         public void Send<T>(IOutboundMessage<T> message) => throw new NotSupportedException();
@@ -540,7 +537,6 @@ public class LiveSampleStreamTests
         public void EnsureSupported(DeviceFeature feature) => throw new NotSupportedException();
         public FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
             => throw new NotSupportedException();
-        public void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => throw new NotSupportedException();
         public void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e) => throw new NotSupportedException();
         public void RaiseGapDetected(TimestampGapEventArgs e) => throw new NotSupportedException();
         public void RaiseRawStreamFrame(DaqifiOutMessage message) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -2,7 +2,6 @@ using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Internal;
-using Daqifi.Core.Device.SdCard;
 using Google.Protobuf;
 using System;
 using System.Collections.Generic;
@@ -894,8 +893,6 @@ public class StreamFrameDecoderTests
         public bool IsUsbConnection => throw new NotSupportedException();
         public int StreamingFrequency => throw new NotSupportedException();
         public DeviceMetadata Metadata => throw new NotSupportedException();
-        public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
-        public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();
         public void StartStreaming() => throw new NotSupportedException();
         public void Disconnect() => throw new NotSupportedException();
@@ -918,7 +915,6 @@ public class StreamFrameDecoderTests
         public void EnsureSupported(DeviceFeature feature) => throw new NotSupportedException();
         public FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
             => throw new NotSupportedException();
-        public void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => throw new NotSupportedException();
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurationOperationsTests.cs
@@ -4,7 +4,6 @@ using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Device;
 using Daqifi.Core.Device.Internal;
 using Daqifi.Core.Device.Network;
-using Daqifi.Core.Device.SdCard;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -509,9 +508,6 @@ public class NetworkConfigurationOperationsTests
         public void EnsureSupported(DeviceFeature feature) => throw new NotSupportedException();
         public FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature)
             => throw new NotSupportedException();
-        public TimeSpan SdCardDownloadTimeout => throw new NotSupportedException();
-        public TimeSpan SdCardTransferIdleTimeout => throw new NotSupportedException();
-        public void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => throw new NotSupportedException();
         public void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e) => throw new NotSupportedException();
         public void RaiseGapDetected(TimestampGapEventArgs e) => throw new NotSupportedException();
         public void RaiseRawStreamFrame(DaqifiOutMessage message) => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsCollaboratorTests.cs
@@ -1397,7 +1397,7 @@ public class SdCardOperationsCollaboratorTests
     }
 
     /// <summary>
-    /// An <see cref="IDeviceOperationHost"/> that records, in order, everything the SD block is
+    /// An <see cref="ISdCardOperationHost"/> that records, in order, everything the SD block is
     /// allowed to do to a device: send a command, open a text exchange, run a raw capture, consult
     /// the firmware feature gate, and raise the low-space warning. Everything else throws, so a
     /// change that reaches further fails loudly.
@@ -1410,7 +1410,7 @@ public class SdCardOperationsCollaboratorTests
     /// still reading them; the exchange bookkeeping needs no guard, since a text exchange only ever
     /// runs on the test's own flow.
     /// </remarks>
-    private sealed class FakeHost : IDeviceOperationHost
+    private sealed class FakeHost : ISdCardOperationHost
     {
         private readonly List<string> _calls = new();
         private readonly Queue<IReadOnlyList<string>> _responses = new();

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -27,7 +27,7 @@ namespace Daqifi.Core.Device
     /// Represents a DAQiFi device that supports data streaming functionality.
     /// Extends the base DaqifiDevice with streaming-specific operations.
     /// </summary>
-    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, ILiveSampleSource, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost
+    public class DaqifiStreamingDevice : DaqifiDevice, IStreamingDevice, ILiveSampleSource, INetworkConfigurable, ISdCardOperations, ILanChipInfoProvider, IDeviceDiagnostics, IDeviceOperationHost, ISdCardOperationHost
     {
         /// <summary>
         /// Response window allowed for the USB stream-interface command sent during
@@ -1271,7 +1271,7 @@ namespace Daqifi.Core.Device
 
         #endregion
 
-        #region IDeviceOperationHost
+        #region IDeviceOperationHost / ISdCardOperationHost
 
         // Explicit implementation: this is how the collaborators reach the device, and none of it
         // belongs on the public surface. Every member forwards to the member it names, so the
@@ -1336,11 +1336,11 @@ namespace Daqifi.Core.Device
         FeatureNotSupportedException IDeviceOperationHost.CreateFeatureNotSupportedException(DeviceFeature feature)
             => CreateFeatureNotSupportedException(feature);
 
-        TimeSpan IDeviceOperationHost.SdCardDownloadTimeout => SdCardDownloadTimeout;
+        TimeSpan ISdCardOperationHost.SdCardDownloadTimeout => SdCardDownloadTimeout;
 
-        TimeSpan IDeviceOperationHost.SdCardTransferIdleTimeout => SdCardTransferIdleTimeout;
+        TimeSpan ISdCardOperationHost.SdCardTransferIdleTimeout => SdCardTransferIdleTimeout;
 
-        void IDeviceOperationHost.RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => OnLowSdSpaceWarning(e);
+        void ISdCardOperationHost.RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e) => OnLowSdSpaceWarning(e);
 
         void IDeviceOperationHost.RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e)
             => RaiseStreamFrameDiscarded(e);

--- a/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
+++ b/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
-using Daqifi.Core.Device.SdCard;
 
 #nullable enable
 
@@ -26,6 +25,13 @@ namespace Daqifi.Core.Device.Internal
     /// to intercept device I/O. Routing the collaborators through the device's own virtual members
     /// keeps those overrides in the path; a collaborator that reached for the transport directly
     /// would silently step around every one of them.
+    /// </para>
+    /// <para>
+    /// Kept to what <em>every</em> collaborator needs. A concern that belongs to one of them and to
+    /// a peripheral only some devices have — the SD card's transfer budgets and its low-space event
+    /// — lives on a facet that extends this seam
+    /// (<see cref="SdCard.ISdCardOperationHost"/>) instead, so channel control, administration,
+    /// network configuration and diagnostics never have to see it.
     /// </para>
     /// <para>
     /// <see cref="DaqifiStreamingDevice"/> implements this explicitly, so none of it widens the
@@ -128,35 +134,14 @@ namespace Daqifi.Core.Device.Internal
         FeatureNotSupportedException CreateFeatureNotSupportedException(DeviceFeature feature);
 
         /// <summary>
-        /// Overall wall-clock budget for one SD card download, read through the device so a
-        /// subclass's override of it still applies.
-        /// </summary>
-        TimeSpan SdCardDownloadTimeout { get; }
-
-        /// <summary>
-        /// Inactivity window for an SD card transfer, read through the device so a subclass's
-        /// override of it still applies.
-        /// </summary>
-        TimeSpan SdCardTransferIdleTimeout { get; }
-
-        /// <summary>
-        /// Raises the device's <see cref="DaqifiStreamingDevice.LowSdSpaceWarning"/> event.
-        /// </summary>
-        /// <remarks>
-        /// Deliberately a call back into the device rather than an event the collaborator owns.
-        /// The event is part of <see cref="ISdCardOperations"/>, so its <c>sender</c> has to remain
-        /// the device a subscriber attached to — a collaborator raising it in its own name would be
-        /// a silent, compile-clean behavior change.
-        /// </remarks>
-        void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e);
-
-        /// <summary>
         /// Raises the device's <see cref="DaqifiStreamingDevice.StreamFrameDiscarded"/> event,
         /// isolating a throwing subscriber.
         /// </summary>
         /// <remarks>
-        /// Same reasoning as <see cref="RaiseLowSdSpaceWarning"/>: the event is part of the device's
-        /// public surface, so its <c>sender</c> must stay the device.
+        /// Deliberately a call back into the device rather than an event the collaborator owns: the
+        /// event is part of the device's public surface, so its <c>sender</c> must stay the device a
+        /// subscriber attached to — a collaborator raising it in its own name would be a silent,
+        /// compile-clean behavior change.
         /// </remarks>
         void RaiseStreamFrameDiscarded(StreamFrameDiscardedEventArgs e);
 

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperationHost.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperationHost.cs
@@ -1,0 +1,53 @@
+using Daqifi.Core.Device.Internal;
+using System;
+
+#nullable enable
+
+namespace Daqifi.Core.Device.SdCard
+{
+    /// <summary>
+    /// The extra slice of a streaming device that <see cref="SdCardOperations"/> needs on top of
+    /// <see cref="IDeviceOperationHost"/>: the two SD transfer budgets and the low-space event.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These three members used to sit on <see cref="IDeviceOperationHost"/> itself, which made an
+    /// SD card — a peripheral only some devices have — part of the seam that <em>every</em>
+    /// operation collaborator works through. Channel control, device administration, network
+    /// configuration, diagnostics, the live-sample stream and the frame decoder all had to depend
+    /// on an interface that talked about SD downloads, and every test double for them had to stub
+    /// storage members it would never call.
+    /// </para>
+    /// <para>
+    /// Same arrangement as the seam it extends: every member forwards to a member
+    /// <see cref="DaqifiStreamingDevice"/> already had, the device implements it explicitly, and the
+    /// two timeouts are read through the device on each access so a subclass's override of them
+    /// still applies.
+    /// </para>
+    /// </remarks>
+    internal interface ISdCardOperationHost : IDeviceOperationHost
+    {
+        /// <summary>
+        /// Overall wall-clock budget for one SD card download, read through the device so a
+        /// subclass's override of it still applies.
+        /// </summary>
+        TimeSpan SdCardDownloadTimeout { get; }
+
+        /// <summary>
+        /// Inactivity window for an SD card transfer, read through the device so a subclass's
+        /// override of it still applies.
+        /// </summary>
+        TimeSpan SdCardTransferIdleTimeout { get; }
+
+        /// <summary>
+        /// Raises the device's <see cref="DaqifiStreamingDevice.LowSdSpaceWarning"/> event.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately a call back into the device rather than an event the collaborator owns.
+        /// The event is part of <see cref="ISdCardOperations"/>, so its <c>sender</c> has to remain
+        /// the device a subscriber attached to — a collaborator raising it in its own name would be
+        /// a silent, compile-clean behavior change.
+        /// </remarks>
+        void RaiseLowSdSpaceWarning(LowSdSpaceWarningEventArgs e);
+    }
+}

--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -25,7 +25,7 @@ namespace Daqifi.Core.Device.SdCard
     /// Holds the SD-scoped device state — whether a logging session is running, the most recent
     /// directory listing, and the single-download gate — so that state lives next to the only code
     /// that reads it. Everything that touches the wire goes through
-    /// <see cref="IDeviceOperationHost"/>, which keeps the device's virtual members (and therefore
+    /// <see cref="ISdCardOperationHost"/>, which keeps the device's virtual members (and therefore
     /// any subclass override of them) in the path.
     /// </remarks>
     internal sealed class SdCardOperations
@@ -64,7 +64,7 @@ namespace Daqifi.Core.Device.SdCard
         /// </summary>
         private const int ScpiErrorCodeUndefinedHeader = -113;
 
-        private readonly IDeviceOperationHost _host;
+        private readonly ISdCardOperationHost _host;
 
         private bool _isLoggingToSdCard;
         private IReadOnlyList<SdCardFileInfo> _sdCardFiles = Array.Empty<SdCardFileInfo>();
@@ -86,7 +86,7 @@ namespace Daqifi.Core.Device.SdCard
         /// </remarks>
         private readonly SemaphoreSlim _sdDownloadGate = new(1, 1);
 
-        internal SdCardOperations(IDeviceOperationHost host)
+        internal SdCardOperations(ISdCardOperationHost host)
         {
             _host = host ?? throw new ArgumentNullException(nameof(host));
         }


### PR DESCRIPTION
Produced by the **abstraction-police** maintenance routine, which looks for protocol- or hardware-specific detail leaking into device-agnostic abstractions. This is internal-only and non-breaking — details below.

## What was wrong

`IDeviceOperationHost` is the internal seam every operation collaborator on a streaming device works through: channel control, device administration, network configuration, diagnostics, the live-sample stream and the frame decoder all reach the device through it. Three of its members had nothing to do with any of them — they described an SD card, a peripheral only some devices even have:

- `SdCardDownloadTimeout`
- `SdCardTransferIdleTimeout`
- `RaiseLowSdSpaceWarning(...)`

Only `SdCardOperations` ever called them. The cost of having them there shows up plainly in the test doubles: six unrelated fakes each carried three `throw new NotSupportedException()` stubs for storage members they would never touch, and had to import the SD-card namespace to do it. The more practical problem is directional — an interface that already mentions SD downloads is where the *next* peripheral-specific member gets added too.

## How it was fixed

The three members moved to `ISdCardOperationHost`, a small internal facet that extends `IDeviceOperationHost`. `SdCardOperations` now takes that; everything else keeps the narrower seam and stops seeing storage entirely.

**Why it is non-breaking.** `IDeviceOperationHost`, the new `ISdCardOperationHost` and `SdCardOperations` are all `internal`, so nothing here is part of the package's API surface. `DaqifiStreamingDevice`'s public surface is unchanged: it implements the facet explicitly, the way it already implemented the seam, and the members it publicly exposes (`SdCardDownloadTimeout` / `SdCardTransferIdleTimeout` are `internal virtual`, `LowSdSpaceWarning` is a public event raised via `protected virtual OnLowSdSpaceWarning`) are all untouched. Each moved member still forwards to exactly the same device member as before, so a subclass override — including the test devices that shorten these timeouts — stays in the path.

The one thing worth pushing back on is whether the facet earns its file at all, given a single consumer. I think it does: the seam's whole value is that it states what a collaborator is allowed to do to the device, and that statement is weaker when it also describes hardware most collaborators cannot touch.

## Verification

Full suite green on net9.0 and net10.0 — 3730 passed, 0 failed, 2 skipped on each; solution builds with 0 warnings (`TreatWarningsAsErrors` is on for `Daqifi.Core`). No behavior change is intended or expected: every call site resolves to the member it resolved to before.

Not merging — opened for review.