### PR TITLE
chore(firmware): flatten IntelHexParser.UpdateBaseAddress with a guard clause

### DIFF
--- a/src/Daqifi.Core/Firmware/IntelHexParser.cs
+++ b/src/Daqifi.Core/Firmware/IntelHexParser.cs
@@ -207,25 +207,28 @@ public class IntelHexParser
     private static ushort UpdateBaseAddress(byte[] hexRecord, ushort currentBaseAddress, string line)
     {
         var recordType = hexRecord[3];
-        if (recordType == 0x04)
+        if (recordType != 0x04)
         {
-            // A type-04 (extended linear address) record must carry exactly 2 data bytes — the
-            // upper 16 bits of the 32-bit address. Its byte-count field can equal its data length
-            // yet still be wrong (e.g. a zero-count type-04 record whose count "matches" its zero
-            // data bytes), so ValidateRecordLength alone doesn't cover this. Guard the slice
-            // explicitly so a short/corrupt type-04 record throws the documented InvalidDataException
-            // rather than a raw ArgumentException from BitConverter.ToUInt16 on an undersized array.
-            if (hexRecord.Length - 5 != 2)
-            {
-                throw new InvalidDataException(
-                    $"The hex record \"{line}\" is a type-04 extended-address record but does not carry exactly 2 data bytes");
-            }
-
-            var dataArray = hexRecord.Skip(4).Take(2).ToArray();
-            if (BitConverter.IsLittleEndian) Array.Reverse(dataArray);
-            return BitConverter.ToUInt16(dataArray, 0);
+            // Only a type-04 (extended linear address) record changes the base address; every
+            // other record type leaves it as it stands.
+            return currentBaseAddress;
         }
-        return currentBaseAddress;
+
+        // A type-04 (extended linear address) record must carry exactly 2 data bytes — the
+        // upper 16 bits of the 32-bit address. Its byte-count field can equal its data length
+        // yet still be wrong (e.g. a zero-count type-04 record whose count "matches" its zero
+        // data bytes), so ValidateRecordLength alone doesn't cover this. Guard the slice
+        // explicitly so a short/corrupt type-04 record throws the documented InvalidDataException
+        // rather than a raw ArgumentException from BitConverter.ToUInt16 on an undersized array.
+        if (hexRecord.Length - 5 != 2)
+        {
+            throw new InvalidDataException(
+                $"The hex record \"{line}\" is a type-04 extended-address record but does not carry exactly 2 data bytes");
+        }
+
+        var dataArray = hexRecord.Skip(4).Take(2).ToArray();
+        if (BitConverter.IsLittleEndian) Array.Reverse(dataArray);
+        return BitConverter.ToUInt16(dataArray, 0);
     }
 
     private bool IsProtectedHexRecord(byte[] hexRecord, ushort baseAddress)


### PR DESCRIPTION
Produced by the **logic-simplifier** maintenance routine (flatten nested conditionals in scaling/parsing code, no behavior change).

## What was wrong

`IntelHexParser.UpdateBaseAddress` handles exactly one interesting case — a type-04 extended-linear-address record, which is how an Intel HEX file moves the upper 16 bits of the address window — and it wrapped that entire case in an `if (recordType == 0x04) { ... }` block with the boring `return currentBaseAddress;` trailing off the end. The result was that the six lines of comment explaining the type-04 length guard, the guard itself, and the actual address decode all sat one indent deeper than they needed to, and the method's real answer for the common case was the last line of the method rather than the first thing you read.

That matters more than usual here because the method directly below it, `IsProtectedHexRecord`, does the same job — read `hexRecord[3]`, dispatch on the record type — and already uses the opposite, flatter shape (`if (recordType != 0x00) return false;`). Two adjacent record-type dispatchers written inside-out from each other is a small but real tax every time someone comes back to this parser.

## How it was fixed

Inverted the test into a guard clause: `if (recordType != 0x04) { return currentBaseAddress; }`, then de-indented the rest of the body. That is the whole change — no expression, comparison, or statement order was altered.

Why the behavior is identical, which is the part worth pushing back on: `recordType` is a `byte` already read into a local on the preceding line, so re-testing it has no side effect and cannot observe a different value. `byte` is a total order with no NaN-style trap value, so `!= 0x04` is the exact complement of `== 0x04` for every one of the 256 possible inputs. And the original outer block had only two exits — the `InvalidDataException` throw and the `return BitConverter.ToUInt16(...)` — with no `break`, no fallthrough, and nothing at all between the closing brace and `return currentBaseAddress;`. So every input that previously reached the trailing return now reaches it via the guard, and every input that previously entered the block now skips the guard and runs the same statements in the same order. Both callers (`ParseHexRecords` and `ParseRecords`) use the return value the same way they did.

## Verification

`dotnet build` clean (0 warnings), and the full suite green on both target frameworks: 3730 passed / 0 failed on net9.0 and net10.0, plus the MCP tests. The existing `IntelHexParserTests` cover type-04 records, the malformed-length rejection, and the base-address carry into subsequent records, so the paths on both sides of the inverted test are exercised.

---

Not merging — opened for your review.
