### PR TITLE
chore(discovery): unify the part-number to DeviceType mapping across finders

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/DiscoveryDeviceTypeMapperTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/DiscoveryDeviceTypeMapperTests.cs
@@ -1,0 +1,44 @@
+using Daqifi.Core.Device.Discovery;
+
+namespace Daqifi.Core.Tests.Device.Discovery;
+
+/// <summary>
+/// Unit tests for <see cref="DiscoveryDeviceTypeMapper"/>, the single part-number to
+/// discovery <see cref="DeviceType"/> mapping shared by every transport's finder.
+/// </summary>
+public class DiscoveryDeviceTypeMapperTests
+{
+    // Issue #283: the WiFi finder kept its own part-number table with no "nq2" case,
+    // so a Nyquist2's part number was silently reported as Unknown.
+    [Theory]
+    [InlineData("nq1", DeviceType.Nyquist1)]
+    [InlineData("Nq1", DeviceType.Nyquist1)]
+    [InlineData("nq2", DeviceType.Nyquist2)]
+    [InlineData("Nq2", DeviceType.Nyquist2)]
+    [InlineData("nq3", DeviceType.Nyquist3)]
+    [InlineData("Nq3", DeviceType.Nyquist3)]
+    [InlineData("nq4", DeviceType.Unknown)]
+    [InlineData("", DeviceType.Unknown)]
+    [InlineData(null, DeviceType.Unknown)]
+    public void FromPartNumber_ReturnsCorrectType(string? partNumber, DeviceType expected)
+    {
+        var result = DiscoveryDeviceTypeMapper.FromPartNumber(partNumber);
+
+        Assert.Equal(expected, result);
+    }
+
+    // Issue #283: Discovery.DeviceType lacked a Nyquist2 member, so the conversion
+    // silently downgraded a correctly-detected Nyquist2 to Unknown.
+    [Theory]
+    [InlineData(Daqifi.Core.Device.DeviceType.Unknown, DeviceType.Unknown)]
+    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist1, DeviceType.Nyquist1)]
+    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist2, DeviceType.Nyquist2)]
+    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist3, DeviceType.Nyquist3)]
+    public void FromCoreDeviceType_MapsToMatchingDiscoveryType(
+        Daqifi.Core.Device.DeviceType deviceType, DeviceType expected)
+    {
+        var result = DiscoveryDeviceTypeMapper.FromCoreDeviceType(deviceType);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -14,22 +14,8 @@ namespace Daqifi.Core.Tests.Device.Discovery;
 [Collection("SerialDeviceFinder static port-claim state")]
 public class SerialDeviceFinderTests
 {
-    // Issue #283: Discovery.DeviceType lacked a Nyquist2 member, so
-    // ConvertDeviceType silently downgraded a correctly-detected Nyquist2 to
-    // Unknown.
-    [Theory]
-    [InlineData(Daqifi.Core.Device.DeviceType.Unknown, DeviceType.Unknown)]
-    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist1, DeviceType.Nyquist1)]
-    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist2, DeviceType.Nyquist2)]
-    [InlineData(Daqifi.Core.Device.DeviceType.Nyquist3, DeviceType.Nyquist3)]
-    public void ConvertDeviceType_MapsToMatchingDiscoveryType(
-        Daqifi.Core.Device.DeviceType deviceType, DeviceType expected)
-    {
-        var result = SerialDeviceFinder.ConvertDeviceType(deviceType);
-
-        Assert.Equal(expected, result);
-    }
-
+    // The part-number to DeviceType mapping this finder uses is covered by
+    // DiscoveryDeviceTypeMapperTests (issue #283).
     [Fact]
     public async Task DiscoverAsync_WithCancellationToken_ReturnsDevices()
     {

--- a/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WiFiDeviceFinderTests.cs
@@ -15,26 +15,8 @@ namespace Daqifi.Core.Tests.Device.Discovery;
 
 public class WiFiDeviceFinderTests
 {
-    // Issue #283: GetDeviceType had no "nq2" case, so a Nyquist2's part
-    // number was silently reported as Unknown, same class of bug as
-    // SerialDeviceFinder.ConvertDeviceType.
-    [Theory]
-    [InlineData("nq1", DeviceType.Nyquist1)]
-    [InlineData("Nq1", DeviceType.Nyquist1)]
-    [InlineData("nq2", DeviceType.Nyquist2)]
-    [InlineData("Nq2", DeviceType.Nyquist2)]
-    [InlineData("nq3", DeviceType.Nyquist3)]
-    [InlineData("Nq3", DeviceType.Nyquist3)]
-    [InlineData("nq4", DeviceType.Unknown)]
-    [InlineData("", DeviceType.Unknown)]
-    [InlineData(null, DeviceType.Unknown)]
-    public void GetDeviceType_PartNumber_ReturnsCorrectType(string? partNumber, DeviceType expected)
-    {
-        var result = WiFiDeviceFinder.GetDeviceType(partNumber);
-
-        Assert.Equal(expected, result);
-    }
-
+    // The part-number to DeviceType mapping this finder uses is covered by
+    // DiscoveryDeviceTypeMapperTests (issue #283).
     [Fact]
     public async Task DiscoverAsync_WithTimeout_CompletesWithinTimeout()
     {

--- a/src/Daqifi.Core/Device/Discovery/DiscoveryDeviceTypeMapper.cs
+++ b/src/Daqifi.Core/Device/Discovery/DiscoveryDeviceTypeMapper.cs
@@ -1,0 +1,37 @@
+namespace Daqifi.Core.Device.Discovery;
+
+/// <summary>
+/// Maps a device part number onto the discovery-facing <see cref="DeviceType"/>.
+/// </summary>
+/// <remarks>
+/// Part-number recognition itself lives in one place only —
+/// <see cref="DeviceTypeDetector.DetectFromPartNumber"/>. This type exists purely to
+/// carry that result across to the separate <c>Discovery.DeviceType</c> enum that
+/// <see cref="IDeviceInfo"/> exposes, so that every transport's finder shares a single
+/// part-number table. Issue #283 was a Nyquist2 reported as <see cref="DeviceType.Unknown"/>
+/// because per-transport copies of that table had drifted apart.
+/// </remarks>
+internal static class DiscoveryDeviceTypeMapper
+{
+    /// <summary>
+    /// Detects the discovery <see cref="DeviceType"/> for a device part number.
+    /// </summary>
+    /// <param name="partNumber">The device part number (e.g. "Nq1"), or null.</param>
+    /// <returns>The detected type, or <see cref="DeviceType.Unknown"/> if not recognized.</returns>
+    internal static DeviceType FromPartNumber(string? partNumber)
+        => FromCoreDeviceType(DeviceTypeDetector.DetectFromPartNumber(partNumber));
+
+    /// <summary>
+    /// Converts a <see cref="Device.DeviceType"/> to the matching discovery <see cref="DeviceType"/>.
+    /// </summary>
+    internal static DeviceType FromCoreDeviceType(Device.DeviceType deviceType)
+    {
+        return deviceType switch
+        {
+            Device.DeviceType.Nyquist1 => DeviceType.Nyquist1,
+            Device.DeviceType.Nyquist2 => DeviceType.Nyquist2,
+            Device.DeviceType.Nyquist3 => DeviceType.Nyquist3,
+            _ => DeviceType.Unknown
+        };
+    }
+}

--- a/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/SerialDeviceFinder.cs
@@ -1096,22 +1096,6 @@ public class SerialDeviceFinder : DeviceFinderBase, IBusyPortReporter
     }
 
     /// <summary>
-    /// Converts from the Device.DeviceType enum to the Discovery.DeviceType enum.
-    /// </summary>
-    /// <param name="deviceType">The Device namespace DeviceType.</param>
-    /// <returns>The Discovery namespace DeviceType.</returns>
-    internal static DeviceType ConvertDeviceType(Device.DeviceType deviceType)
-    {
-        return deviceType switch
-        {
-            Device.DeviceType.Nyquist1 => DeviceType.Nyquist1,
-            Device.DeviceType.Nyquist2 => DeviceType.Nyquist2,
-            Device.DeviceType.Nyquist3 => DeviceType.Nyquist3,
-            _ => DeviceType.Unknown
-        };
-    }
-
-    /// <summary>
     /// Maps a device's status message to <see cref="DeviceInfo"/>. Pure mapping logic split out
     /// from <see cref="TryGetDeviceInfoAsync"/> (which owns the SerialPort probe and any
     /// IUsbLocationProvider error handling) so it can be unit tested directly with a
@@ -1131,7 +1115,7 @@ public class SerialDeviceFinder : DeviceFinderBase, IBusyPortReporter
             FirmwareVersion = statusMessage.DeviceFwRev ?? "Unknown",
             ConnectionType = ConnectionType.Serial,
             PortName = portName,
-            Type = ConvertDeviceType(DeviceTypeDetector.DetectFromPartNumber(statusMessage.DevicePn)),
+            Type = DiscoveryDeviceTypeMapper.FromPartNumber(statusMessage.DevicePn),
             IsPowerOn = true,
             LocationKey = locationKey
         };

--- a/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
+++ b/src/Daqifi.Core/Device/Discovery/WiFiDeviceFinder.cs
@@ -417,7 +417,7 @@ public class WiFiDeviceFinder : DeviceFinderBase
                 MacAddress = NetworkAddressHelper.GetMacAddressString(message),
                 Port = (int)message.DevicePort,
                 LocalInterfaceAddress = localInterfaceAddress,
-                Type = GetDeviceType(message.DevicePn),
+                Type = DiscoveryDeviceTypeMapper.FromPartNumber(message.DevicePn),
                 IsPowerOn = message.PwrStatus == 1,
                 ConnectionType = ConnectionType.WiFi
             };
@@ -429,23 +429,6 @@ public class WiFiDeviceFinder : DeviceFinderBase
             // Invalid protobuf message, return null
             return null;
         }
-    }
-
-    /// <summary>
-    /// Determines device type from part number.
-    /// </summary>
-    internal static DeviceType GetDeviceType(string? partNumber)
-    {
-        if (string.IsNullOrWhiteSpace(partNumber))
-            return DeviceType.Unknown;
-
-        return partNumber.ToLowerInvariant() switch
-        {
-            "nq1" => DeviceType.Nyquist1,
-            "nq2" => DeviceType.Nyquist2,
-            "nq3" => DeviceType.Nyquist3,
-            _ => DeviceType.Unknown
-        };
     }
 
     /// <summary>


### PR DESCRIPTION
Produced by the DUPLICATE-UNIFIER maintenance routine. Safe because it is a pure de-duplication with no behavior change: every input maps to exactly the type it did before, and both finders' existing coverage was kept.

**What was wrong.** `WiFiDeviceFinder.GetDeviceType` kept its own private copy of the part-number lookup table (`nq1`/`nq2`/`nq3` plus a null/whitespace guard) that `DeviceTypeDetector.DetectFromPartNumber` already owns and that the serial finder already used. The two copies happen to agree at the moment, but this is not a hypothetical risk — they have already drifted once. Issue #283 was exactly this: the WiFi copy had no `"nq2"` case, so a Nyquist2 discovered over WiFi came back as `DeviceType.Unknown` while the identical board discovered over serial came back correctly. Adding a fourth board means remembering to edit two tables in two files, and nothing in the code makes that obligation visible.

**How it was fixed.** Both finders now go through one small internal `DiscoveryDeviceTypeMapper`. Part-number recognition stays where it already lived, in `DeviceTypeDetector`; the mapper's only extra job is carrying that result across to the separate `Discovery.DeviceType` enum that `IDeviceInfo` exposes. There are now zero part-number tables outside `DeviceTypeDetector`.

The one thing worth pushing back on is the new type. The enum-to-enum conversion previously lived on `SerialDeviceFinder` as `ConvertDeviceType`, and the smaller diff would have been to have the WiFi finder call it there — but a WiFi discovery path reaching into the serial finder for a pure mapping helper is worse coupling than a 35-line helper class, so the conversion moved onto the mapper alongside it. Both public finder APIs are unchanged; the removed `GetDeviceType` and `ConvertDeviceType` were `internal`.

Separately worth noting but deliberately **not** touched here: `Daqifi.Core.Device.DeviceType` and `Daqifi.Core.Device.Discovery.DeviceType` are two public enums with identical members and identical values, which is the reason a conversion step exists at all. Collapsing them would be a breaking API change and does not belong in a de-duplication PR.

**Verification.** Full suite green on net9.0 and net10.0 (3730 passed, 0 failed, per framework; plus the MCP tests). The `#283` regression cases for both the part-number table and the enum conversion were kept verbatim, consolidated into `DiscoveryDeviceTypeMapperTests` now that both target one place — moving the mapping test out of `SerialDeviceFinderTests` also frees it from that class's serialized static-state xUnit collection.

Not merging — opened for your review.
