### PR TITLE
chore(tests): drop three dead leftovers the compiler can prove unused

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DeviceReconnectTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DeviceReconnectTests.cs
@@ -1624,7 +1624,7 @@ public class DeviceReconnectTests
             EnterLifecycle();
             try
             {
-                ConnectCore(retryOptions);
+                ConnectCore();
             }
             finally
             {
@@ -1634,7 +1634,7 @@ public class DeviceReconnectTests
             return Task.CompletedTask;
         }
 
-        private void ConnectCore(ConnectionRetryOptions? retryOptions)
+        private void ConnectCore()
         {
             // Outside the lock: a test holding the gate must still be able to inspect the
             // transport and drive the device while the connect is parked here.

--- a/src/Daqifi.Core.Tests/Firmware/Pic32FirmwareUpdaterTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32FirmwareUpdaterTests.cs
@@ -20,9 +20,7 @@ namespace Daqifi.Core.Tests.Firmware;
 /// </remarks>
 public class Pic32FirmwareUpdaterTests
 {
-    private const byte VersionRequest = 0x11;
     private const byte EraseRequest = 0x22;
-    private const byte ProgramRequest = 0x33;
     private const byte JumpRequest = 0x55;
 
     private static readonly byte[] VersionOk = [0x01, 0x10];


### PR DESCRIPTION
Produced by the dead-code maintenance routine. Safe because every item removed here is provably unreachable from any caller — the compiler's own unused-member analysis is what found them — and none of them affects what any test asserts.

**What was wrong.** Three things in the test project were dead:

`Pic32FirmwareUpdaterTests` declared four PIC32 bootloader request-byte constants, but only uses two of them. When #527 split the bootloader exchange tests into their own file, the whole block of constants was copied across; `Pic32BootloaderSessionTests` genuinely asserts on `VersionRequest` and `ProgramRequest`, this suite never has. It only ever checks `EraseRequest` and `JumpRequest`.

Separately, the fake transport in `DeviceReconnectTests` threaded a `retryOptions` argument from `ConnectAsync` down into its private `ConnectCore` helper, which has never read it — it has been passed and dropped since the fake was introduced in #418.

**How it was fixed.** Deleted the two unused constants, and dropped the parameter from `ConnectCore`. The public `ConnectAsync(ConnectionRetryOptions?)` keeps its parameter: that one is `IStreamTransport` contract, not dead code — this fake simply chooses to ignore it, which the pass-through was quietly implying otherwise.

Evidence that nothing references them: `rg` across the whole repo, production and test projects both, and a build of the full solution with `EnforceCodeStyleInBuild` turned on, which reports exactly these three (IDE0051 for the constants, IDE0060 for the parameter) and nothing else anywhere in `Daqifi.Core`, `Daqifi.Mcp`, or the two test projects.

Worth noting for whoever reviews the routine's coverage: the sweep this round deliberately targeted code newly orphaned by the recent consolidation merges (#595–#599). Those left nothing behind — the helpers they extracted are all still called, and no branch became unreachable. The production assemblies are clean; these three test-project items are the only dead code the analyzers can find on current `main`.

Verified with the full suite green on net9.0 and net10.0 (3,730 core tests, 217 MCP tests).

Not merging — for review.
