### PR TITLE
fix(tests): stop the serial-probe teardown tests racing a 1s response window

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialProbeTeardownTests.cs
@@ -66,7 +66,7 @@ public class SerialProbeTeardownTests
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
 
-        await stream.WaitForFirstReadAsync();
+        stream.WaitForFirstRead();
         stream.RespondWithStatus();
         await observed;
 
@@ -93,7 +93,7 @@ public class SerialProbeTeardownTests
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
 
-        await stream.WaitForFirstReadAsync();
+        stream.WaitForFirstRead();
         stream.RespondWithStatus();
 
         await observed;
@@ -130,7 +130,7 @@ public class SerialProbeTeardownTests
         using var cts = new CancellationTokenSource();
 
         var exchange = SerialDeviceFinder.RequestDeviceStatusAsync(stream, cts.Token);
-        await stream.WaitForFirstReadAsync();
+        stream.WaitForFirstRead();
         await cts.CancelAsync();
 
         // Cancellation ends the wait but is reported as "no device on this port" rather than as an
@@ -324,10 +324,28 @@ public class SerialProbeTeardownTests
             get { lock (_gate) { return _firstReaderThread; } }
         }
 
-        public async Task WaitForFirstReadAsync()
+        /// <summary>
+        /// Blocks the calling thread until the consumer has entered its first read, so a test can
+        /// answer the probe while the reader is genuinely parked in <see cref="Read(byte[], int, int)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately synchronous. The exchange this gates is bounded by a fixed 1s wall-clock
+        /// response window that is already running by the time a test gets here, and the previous
+        /// async form -- <c>await Task.Run(() =&gt; _firstRead.Wait(token))</c> -- spent two
+        /// thread-pool queue hops inside that window: one to dispatch the <c>Task.Run</c> body and
+        /// one to resume the awaiting test method. On a CI runner with both target frameworks'
+        /// test processes running xunit collections in parallel, a saturated pool injects new
+        /// worker threads only about twice a second, so those two hops were observed to push the
+        /// "device answers" call past the response window: the probe then returned <c>null</c> and
+        /// the test failed on an assertion about teardown that never got to run. The consumer's
+        /// reader is a dedicated <see cref="Thread"/> rather than a pool work item, so it reaches
+        /// its first read regardless of pool pressure and this wait returns promptly.
+        /// </remarks>
+        public void WaitForFirstRead()
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            await Task.Run(() => _firstRead.Wait(cts.Token), cts.Token);
+            Assert.True(
+                _firstRead.Wait(TimeSpan.FromSeconds(5)),
+                "the consumer never entered its first read");
         }
 
         public void RespondWithStatus()


### PR DESCRIPTION
Produced by the FLAKY-TEST-FIXER maintenance routine. Test-only change: no production code is touched and no assertion was weakened, so the only thing it can affect is how reliably the existing assertions get a chance to run.

**What was wrong.** `SerialProbeTeardownTests.RequestDeviceStatusAsync_WhenItReturns_ReaderThreadHasExited` failed on CI on net10.0 while the *same commit* passed on net9.0 (run [31724429734](https://github.com/daqifi/daqifi-core/actions/runs/31724429734), merge-queue run for #514) with `Assert.NotNull() Failure: Value is null` — the probe returned "no device" instead of the status it was scripted to receive. The cause is a wall-clock race, not a bug in the probe. `SerialDeviceFinder.RequestDeviceStatusAsync` gives a device a fixed 1000 ms (`ResponseTimeoutMs`) to answer, and that clock starts the moment the test calls it. The test then let the device answer only after `await stream.WaitForFirstReadAsync()`, whose body was `await Task.Run(() => _firstRead.Wait(token))` — two thread-pool queue hops (one to dispatch the `Task.Run` body, one to resume the awaiting test method) spent *inside* that 1000 ms budget. CI runs both target frameworks' test processes at once, each running xunit collections in parallel; when the pool is saturated it injects new workers only about twice a second, so those two hops can easily outlast the window. The probe gave up and returned null before the test ever got to call `RespondWithStatus()`. Two sibling tests in the same file used the same helper and carried the same latent race.

**How it was fixed.** `WaitForFirstReadAsync` becomes a plain synchronous `WaitForFirstRead()` that waits the `ManualResetEventSlim` directly on the calling thread. That is what removes the race rather than hiding it: the thing being waited *for* is the consumer's reader, which `StreamMessageConsumer` runs on a dedicated `Thread` rather than a pool work item, so it reaches its first read regardless of pool pressure — while the old helper needed the pool to schedule two continuations before the test was allowed to answer. Nothing about the scenario changes: the device still answers while the reader is genuinely parked in `Read()`, the `ContinueWith` is still attached before any answer can arrive (so it still samples reader-liveness at completion rather than running vacuously inline), and every assertion is byte-for-byte the same. Widening a timeout or relaxing `Assert.NotNull` would have been the hiding fix; this deletes the pool dependency instead. The `Wait` is still bounded at 5 s and now asserts on expiry, so a genuine regression that stops the reader from reading fails loudly instead of hanging.

Verified: full suite green on both target frameworks locally (3730 passed / 0 failed on net9.0 and net10.0, plus Daqifi.Mcp.Tests 217/0), build clean with 0 warnings, and the touched class passes 11/11 on both.

Not merging — opened for review.