### PR TITLE
chore(device): move IsUsbConnection off the shared operation seam onto the SD facet

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsOperationsTests.cs
@@ -425,7 +425,6 @@ public class DeviceDiagnosticsOperationsTests
         }
 
         public bool IsConnected { get; set; } = true;
-        public bool IsUsbConnection { get; set; } = true;
         public bool IsStreaming { get; set; }
         public int StreamingFrequency { get; set; } = 100;
         public long ChannelStateVersion { get; set; }

--- a/src/Daqifi.Core.Tests/Device/Internal/ChannelControlOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ChannelControlOperationsTests.cs
@@ -641,7 +641,6 @@ public class ChannelControlOperationsTests
         }
 
         public bool IsConnected { get; set; } = true;
-        public bool IsUsbConnection { get; set; } = true;
         public bool IsStreaming { get; set; }
         public int StreamingFrequency { get; set; } = 100;
         public long ChannelStateVersion { get; set; }

--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -132,7 +132,6 @@ public class ConnectionGuardTests
     {
         public bool IsConnected { get; set; }
 
-        public bool IsUsbConnection => throw new NotSupportedException();
         public bool IsStreaming { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
         public int StreamingFrequency => throw new NotSupportedException();
         public DeviceMetadata Metadata => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/DeviceAdministrationOperationsTests.cs
@@ -598,7 +598,6 @@ public class DeviceAdministrationOperationsTests
         public void Disconnect() => Calls.Add("disconnect");
 
         // Outside this block's remit — reaching for any of these is a regression, not a refinement.
-        public bool IsUsbConnection => throw new NotSupportedException();
         public bool IsStreaming { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
         public int StreamingFrequency => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/LiveSampleStreamTests.cs
@@ -511,7 +511,6 @@ public class LiveSampleStreamTests
         // Outside this block's remit — reaching for any of these is a regression, not a refinement.
         // In particular the live path must never send a command or take the channels lock: it is an
         // adapter over events the decoder already raises, and it runs on the decode thread.
-        public bool IsUsbConnection => throw new NotSupportedException();
         public bool IsStreaming { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
         public int StreamingFrequency => throw new NotSupportedException();
         public DeviceMetadata Metadata => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -890,7 +890,6 @@ public class StreamFrameDecoderTests
 
         // Not part of the decode path.
         public bool IsConnected => throw new NotSupportedException();
-        public bool IsUsbConnection => throw new NotSupportedException();
         public int StreamingFrequency => throw new NotSupportedException();
         public DeviceMetadata Metadata => throw new NotSupportedException();
         public void StopStreaming() => throw new NotSupportedException();

--- a/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurationOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Network/NetworkConfigurationOperationsTests.cs
@@ -484,7 +484,6 @@ public class NetworkConfigurationOperationsTests
         // Outside the network block's remit — reaching for any of these is a regression, not a
         // refinement.
         public void StartStreaming() => throw new NotSupportedException();
-        public bool IsUsbConnection => throw new NotSupportedException();
         public int StreamingFrequency => throw new NotSupportedException();
         public DeviceMetadata Metadata => throw new NotSupportedException();
         public void Disconnect() => throw new NotSupportedException();

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -1280,8 +1280,6 @@ namespace Daqifi.Core.Device
 
         bool IDeviceOperationHost.IsConnected => IsConnected;
 
-        bool IDeviceOperationHost.IsUsbConnection => IsUsbConnection;
-
         bool IDeviceOperationHost.IsStreaming
         {
             get => IsStreaming;
@@ -1335,6 +1333,8 @@ namespace Daqifi.Core.Device
 
         FeatureNotSupportedException IDeviceOperationHost.CreateFeatureNotSupportedException(DeviceFeature feature)
             => CreateFeatureNotSupportedException(feature);
+
+        bool ISdCardOperationHost.IsUsbConnection => IsUsbConnection;
 
         TimeSpan ISdCardOperationHost.SdCardDownloadTimeout => SdCardDownloadTimeout;
 

--- a/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
+++ b/src/Daqifi.Core/Device/Internal/IDeviceOperationHost.cs
@@ -12,8 +12,8 @@ namespace Daqifi.Core.Device.Internal
 {
     /// <summary>
     /// The slice of a streaming device that its operation collaborators work through: the
-    /// text-exchange and raw-capture primitives, the transport facts that change how a command must
-    /// be issued, and the few pieces of device state those operations own.
+    /// text-exchange and raw-capture primitives, and the few pieces of device state those
+    /// operations own.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -21,17 +21,18 @@ namespace Daqifi.Core.Device.Internal
     /// <c>virtual</c> on the device stay virtual through this seam. That matters more than it
     /// looks: subclasses — instrumented devices in the field, and the test doubles that stand in
     /// for hardware — override <see cref="ExecuteTextCommandAsync"/>,
-    /// <see cref="ExecuteRawCaptureAsync"/>, <see cref="Send"/> and <see cref="IsUsbConnection"/>
-    /// to intercept device I/O. Routing the collaborators through the device's own virtual members
+    /// <see cref="ExecuteRawCaptureAsync"/> and <see cref="Send"/> to intercept device I/O.
+    /// Routing the collaborators through the device's own virtual members
     /// keeps those overrides in the path; a collaborator that reached for the transport directly
     /// would silently step around every one of them.
     /// </para>
     /// <para>
     /// Kept to what <em>every</em> collaborator needs. A concern that belongs to one of them and to
-    /// a peripheral only some devices have — the SD card's transfer budgets and its low-space event
-    /// — lives on a facet that extends this seam
-    /// (<see cref="SdCard.ISdCardOperationHost"/>) instead, so channel control, administration,
-    /// network configuration and diagnostics never have to see it.
+    /// a peripheral only some devices have — the SD card's transfer budgets, its low-space event,
+    /// and the USB-versus-network transport fact that only its shared-SPI-bus handling turns on —
+    /// lives on a facet that extends this seam (<see cref="SdCard.ISdCardOperationHost"/>) instead,
+    /// so channel control, administration, network configuration and diagnostics never have to see
+    /// it.
     /// </para>
     /// <para>
     /// <see cref="DaqifiStreamingDevice"/> implements this explicitly, so none of it widens the
@@ -42,9 +43,6 @@ namespace Daqifi.Core.Device.Internal
     {
         /// <inheritdoc cref="DaqifiDevice.IsConnected"/>
         bool IsConnected { get; }
-
-        /// <inheritdoc cref="DaqifiStreamingDevice.IsUsbConnection"/>
-        bool IsUsbConnection { get; }
 
         /// <inheritdoc cref="DaqifiStreamingDevice.IsStreaming"/>
         /// <remarks>

--- a/src/Daqifi.Core/Device/SdCard/ISdCardOperationHost.cs
+++ b/src/Daqifi.Core/Device/SdCard/ISdCardOperationHost.cs
@@ -7,16 +7,17 @@ namespace Daqifi.Core.Device.SdCard
 {
     /// <summary>
     /// The extra slice of a streaming device that <see cref="SdCardOperations"/> needs on top of
-    /// <see cref="IDeviceOperationHost"/>: the two SD transfer budgets and the low-space event.
+    /// <see cref="IDeviceOperationHost"/>: whether the link is USB, the two SD transfer budgets,
+    /// and the low-space event.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// These three members used to sit on <see cref="IDeviceOperationHost"/> itself, which made an
-    /// SD card — a peripheral only some devices have — part of the seam that <em>every</em>
-    /// operation collaborator works through. Channel control, device administration, network
-    /// configuration, diagnostics, the live-sample stream and the frame decoder all had to depend
-    /// on an interface that talked about SD downloads, and every test double for them had to stub
-    /// storage members it would never call.
+    /// These members used to sit on <see cref="IDeviceOperationHost"/> itself, which made an SD
+    /// card — a peripheral only some devices have — part of the seam that <em>every</em> operation
+    /// collaborator works through. Channel control, device administration, network configuration,
+    /// diagnostics, the live-sample stream and the frame decoder all had to depend on an interface
+    /// that talked about SD downloads and about which kind of cable the device was on, and every
+    /// test double for them had to stub members it would never call.
     /// </para>
     /// <para>
     /// Same arrangement as the seam it extends: every member forwards to a member
@@ -27,6 +28,16 @@ namespace Daqifi.Core.Device.SdCard
     /// </remarks>
     internal interface ISdCardOperationHost : IDeviceOperationHost
     {
+        /// <inheritdoc cref="DaqifiStreamingDevice.IsUsbConnection"/>
+        /// <remarks>
+        /// The SD operations are the only collaborator that acts on the transport's identity, which
+        /// is why it lives on this facet rather than on the shared seam. The card and the WiFi/LAN
+        /// module share one SPI bus, so whether the link is USB decides how each SD command prepares
+        /// that bus, what a silent transport means to a file transfer, and whether SD logging can be
+        /// started at all. Read through the device so a subclass's override of it still applies.
+        /// </remarks>
+        bool IsUsbConnection { get; }
+
         /// <summary>
         /// Overall wall-clock budget for one SD card download, read through the device so a
         /// subclass's override of it still applies.


### PR DESCRIPTION
Produced by the **abstraction-police** maintenance routine, which looks for protocol- or hardware-specific detail leaking into device-agnostic seams.

## What was wrong

`IDeviceOperationHost` is the internal seam that *every* operation collaborator on a streaming device works through — channel control, device administration, network configuration, diagnostics, the live-sample stream, the frame decoder, and the SD card block. It carried `IsUsbConnection`.

That is raw transport identity: "is this device on a serial cable or on the network". It has nothing to do with enabling a channel or decoding a frame, and in fact none of those collaborators has ever read it. Only `SdCardOperations` does, and for a specific hardware reason — the SD card and the WiFi/LAN module share one SPI bus, so the link type decides how each SD command prepares that bus, what a silent transport means mid-transfer, and whether SD logging can start at all.

The cost of leaving it on the shared seam is the same one PR #604 fixed for the SD transfer budgets: anyone writing or reading a collaborator sees an interface that talks about cables, and every test double for an unrelated collaborator has to stub a member it will never call. Seven of them did, five by throwing `NotSupportedException` under a comment saying it was out of scope.

## How it was fixed

`IsUsbConnection` moves down one level, from `IDeviceOperationHost` to `ISdCardOperationHost` — the facet #604 introduced for precisely this kind of member. `SdCardOperations` already holds its host as `ISdCardOperationHost`, so its call sites are unchanged. The seven unrelated test doubles drop the stub. The XML docs on both interfaces are updated to say where the member now lives and why.

**Why this is non-breaking.** Both interfaces are `internal`, and `DaqifiStreamingDevice` implements both of them explicitly, so nothing here appears in the public API surface at all — the only edit in the device is `bool IDeviceOperationHost.IsUsbConnection => …` becoming `bool ISdCardOperationHost.IsUsbConnection => …`. The public `virtual DaqifiStreamingDevice.IsUsbConnection` property is untouched, and the facet member still forwards to it, so a subclass that overrides it still intercepts every SD operation exactly as before. No production behavior changes; this is a pure relocation of one internal member.

## Verification

`dotnet build` clean, 0 warnings. Full suite green on both target frameworks: `Daqifi.Core.Tests` 3740 passed / 0 failed / 2 skipped on net9.0 and again on net10.0, plus 217 in `Daqifi.Mcp.Tests`.

Not merging — opened for review.
