### PR TITLE
chore(device): flatten OnTransportStatusChanged into guard clauses

### DIFF
--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -2307,48 +2307,50 @@ namespace Daqifi.Core.Device
         /// <param name="e">The transport status event arguments.</param>
         private void OnTransportStatusChanged(object? sender, TransportStatusEventArgs e)
         {
+            // Transport connected: device status on the way up is managed by Connect(), so there
+            // is nothing to do here.
             if (e.IsConnected)
             {
-                // Transport connected, but device status is managed by Connect() method
+                return;
             }
-            else
+
+            // Transport disconnected — only report Lost for unexpected drops,
+            // not during an intentional Disconnect() call
+            if (Status != ConnectionStatus.Connected || _isDisconnecting)
             {
-                // Transport disconnected — only report Lost for unexpected drops,
-                // not during an intentional Disconnect() call
-                if (Status == ConnectionStatus.Connected && !_isDisconnecting)
+                return;
+            }
+
+            // Read before raising Lost: a handler is free to call Connect or Disconnect
+            // synchronously from inside it, and if it does, this drop must not start a
+            // reconnect for a session the caller has already moved on from.
+            var epochAtDrop = Volatile.Read(ref _sessionEpoch);
+
+            // Snapshot the session BEFORE anything observes the drop. Raising Lost runs
+            // consumer handlers synchronously on this thread, and a handler is entirely
+            // entitled to start tearing the device down — by which point what the session
+            // looked like is no longer recoverable. No-op unless reconnect is enabled, so
+            // the default path does exactly what it did before (issue #379).
+            //
+            // Skipped while a reconnect is already running: a drop during an attempt would
+            // otherwise overwrite the snapshot of the session being restored with the empty
+            // half-built one, and the loop would go on to restore nothing.
+            if (ReconnectOptions.Enabled && !IsReconnecting)
+            {
+                try
                 {
-                    // Read before raising Lost: a handler is free to call Connect or Disconnect
-                    // synchronously from inside it, and if it does, this drop must not start a
-                    // reconnect for a session the caller has already moved on from.
-                    var epochAtDrop = Volatile.Read(ref _sessionEpoch);
-
-                    // Snapshot the session BEFORE anything observes the drop. Raising Lost runs
-                    // consumer handlers synchronously on this thread, and a handler is entirely
-                    // entitled to start tearing the device down — by which point what the session
-                    // looked like is no longer recoverable. No-op unless reconnect is enabled, so
-                    // the default path does exactly what it did before (issue #379).
-                    //
-                    // Skipped while a reconnect is already running: a drop during an attempt would
-                    // otherwise overwrite the snapshot of the session being restored with the empty
-                    // half-built one, and the loop would go on to restore nothing.
-                    if (ReconnectOptions.Enabled && !IsReconnecting)
-                    {
-                        try
-                        {
-                            CaptureSessionSnapshot();
-                        }
-                        catch (Exception ex)
-                        {
-                            SafeLog(() => _logger.LogWarning(
-                                ex, "[Reconnect] Capturing the session state after a drop failed; the session cannot be restored."));
-                        }
-                    }
-
-                    Status = ConnectionStatus.Lost;
-
-                    BeginReconnectIfEnabled(epochAtDrop);
+                    CaptureSessionSnapshot();
+                }
+                catch (Exception ex)
+                {
+                    SafeLog(() => _logger.LogWarning(
+                        ex, "[Reconnect] Capturing the session state after a drop failed; the session cannot be restored."));
                 }
             }
+
+            Status = ConnectionStatus.Lost;
+
+            BeginReconnectIfEnabled(epochAtDrop);
         }
 
         #region Automatic reconnection (issue #379)


### PR DESCRIPTION
Produced by the LOGIC-SIMPLIFIER maintenance routine, which looks for nested conditionals that flatten with provably no behavior change. This is the one item that met the bar in the firmware-update, connection/reconnect, discovery and MCP areas.

## What was wrong

`DaqifiDevice.OnTransportStatusChanged` — the handler that turns a transport drop into `ConnectionStatus.Lost` and kicks off automatic reconnection — was shaped like this:

```csharp
if (e.IsConnected)
{
    // Transport connected, but device status is managed by Connect() method
}
else
{
    if (Status == ConnectionStatus.Connected && !_isDisconnecting)
    {
        // ~25 lines: the entire reason this method exists
    }
}
```

The `if` branch is empty; it exists only to hold a comment. Everything the method actually does — the session-epoch read, the snapshot-before-Lost dance, the status transition, the reconnect kick — lived three levels of indentation deep inside the `else`, behind what are really just two preconditions. That matters for a maintainer because this is delicate code (the ordering comments in it are load-bearing, issue #379), and the reader has to hold an inverted, empty-branch conditional in their head before they get to any of it.

## How it was fixed

Two guard clauses at the top, then the body at method level:

```csharp
// Transport connected: device status on the way up is managed by Connect(), so there
// is nothing to do here.
if (e.IsConnected)
{
    return;
}

// Transport disconnected — only report Lost for unexpected drops,
// not during an intentional Disconnect() call
if (Status != ConnectionStatus.Connected || _isDisconnecting)
{
    return;
}
```

Why the behavior is identical — the part worth checking:

- The second guard is the De Morgan negation of `Status == ConnectionStatus.Connected && !_isDisconnecting`. Short-circuit evaluation reads the same operands in the same order in both forms: `_isDisconnecting` is consulted only when `Status == Connected`, before and after.
- Neither operand has side effects, and each is still read exactly once. `Status`'s getter is `get => _status` (the side-effecting logic is in its *setter*, which this method calls later and which is untouched). `IsConnected` is a get-only auto-property on `TransportStatusEventArgs`. `_isDisconnecting` is a plain `bool` field.
- No statement moved relative to any other, nothing was added or removed, and no `try`/`catch`/`lock` scope changed. The body is byte-identical apart from being unindented; the only new lines are the two `return;`s and the relocated comment.

## Verification

Full suite green on net9.0 and net10.0 (3742 tests, 2 pre-existing hardware skips) plus the MCP suite (217). Build clean, 0 warnings. No bench validation needed — this is a pure source-shape change with no wire or timing effect.

Not merging — opened for review.
