### PR TITLE
test(diagnostics): direct tests for KeyValueResponseParser's guards

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Diagnostics/KeyValueResponseParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/KeyValueResponseParserTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using Daqifi.Core.Device.Diagnostics;
+
+namespace Daqifi.Core.Tests.Device.Diagnostics;
+
+/// <summary>
+/// Direct tests for the shared <c>Key=Value</c> diagnostics response parser. It was previously
+/// exercised only through its two wrappers (<c>StreamStatsParser</c>, <c>MemoryDiagnosticsParser</c>),
+/// which pin the happy path but never reach its malformed-line guards, its numeric bounds, or the
+/// <c>TryParse</c> contract guards. These cover exactly those.
+/// </summary>
+public class KeyValueResponseParserTests
+{
+    [Fact]
+    public void Parse_NullLines_ReturnsEmptyInsteadOfThrowing()
+    {
+        // A device that answered with nothing at all must not take the caller down.
+        var values = KeyValueResponseParser.Parse(null!);
+
+        Assert.Empty(values);
+    }
+
+    [Theory]
+    [InlineData("=5")]              // separator first: no key at all
+    [InlineData("   =5")]           // same, once the line is trimmed
+    [InlineData("HeapFree=")]       // separator last: no value at all
+    [InlineData("HeapFree")]        // no separator at all
+    public void Parse_MalformedPairShapes_AreSkipped(string line)
+    {
+        var values = KeyValueResponseParser.Parse(new[] { line });
+
+        Assert.Empty(values);
+    }
+
+    [Theory]
+    [InlineData("-1")]                       // counters are unsigned; a negative is not a counter
+    [InlineData("18446744073709551616")]     // one past ulong.MaxValue
+    [InlineData("0x10")]                     // hex is not accepted
+    [InlineData("1.5")]                      // no decimal point
+    [InlineData("1,000")]                    // no group separators
+    public void Parse_NonUnsignedIntegerValues_AreSkipped(string value)
+    {
+        var values = KeyValueResponseParser.Parse(new[] { $"HeapFree={value}" });
+
+        Assert.Empty(values);
+    }
+
+    [Fact]
+    public void Parse_LeadingPlusSign_IsAccepted()
+    {
+        var values = KeyValueResponseParser.Parse(new[] { "HeapFree=+7" });
+
+        Assert.Equal(7UL, values["HeapFree"]);
+    }
+
+    [Fact]
+    public void Parse_WhitespaceAroundKeyAndValue_IsTrimmed()
+    {
+        var values = KeyValueResponseParser.Parse(new[] { "  HeapFree  =  42  " });
+
+        Assert.Equal(42UL, values["HeapFree"]);
+    }
+
+    [Fact]
+    public void Parse_DuplicateKey_KeepsTheLastValue()
+    {
+        // The device can repeat a field across a re-emitted block; the freshest reading wins.
+        var values = KeyValueResponseParser.Parse(new[] { "HeapFree=10", "HeapFree=20" });
+
+        Assert.Equal(20UL, values["HeapFree"]);
+        Assert.Single(values);
+    }
+
+    [Fact]
+    public void Parse_KeysThatDifferOnlyByCase_AreDistinctFields()
+    {
+        // Case-insensitive keys would silently collapse two firmware counters into one.
+        var values = KeyValueResponseParser.Parse(new[] { "HeapFree=1", "HEAPFREE=2" });
+
+        Assert.Equal(2, values.Count);
+        Assert.Equal(1UL, values["HeapFree"]);
+        Assert.Equal(2UL, values["HEAPFREE"]);
+    }
+
+    [Fact]
+    public void Parse_ErrorLineCarryingAPair_IsDroppedWholesale()
+    {
+        // "ERROR<tab>..." is a SCPI error line. It must be rejected before the '=' split runs,
+        // or its text lands in the map as a bogus field.
+        var values = KeyValueResponseParser.Parse(new[] { "ERROR\tHeapFree=0" });
+
+        Assert.Empty(values);
+    }
+
+    [Fact]
+    public void TryParse_NullLines_ReturnsFalseWithoutInvokingTheFactory()
+    {
+        var invoked = false;
+
+        var ok = KeyValueResponseParser.TryParse<object>(
+            null!,
+            _ =>
+            {
+                invoked = true;
+                return new object();
+            },
+            out var result);
+
+        Assert.False(ok);
+        Assert.Null(result);
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public void TryParse_NullFactory_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => KeyValueResponseParser.TryParse<object>(new[] { "HeapFree=1" }, null!, out _));
+    }
+
+    [Fact]
+    public void TryParse_FactoryReturningNull_Throws()
+    {
+        // TryParse advertises a non-null result when it returns true; a factory that breaks
+        // that must fail loudly rather than hand callers a null they will not null-check.
+        Assert.Throws<InvalidOperationException>(
+            () => KeyValueResponseParser.TryParse<object>(new[] { "HeapFree=1" }, _ => null!, out _));
+    }
+
+    [Fact]
+    public void TryParse_PassesTheParsedPairsToTheFactory()
+    {
+        IReadOnlyDictionary<string, ulong>? seen = null;
+
+        var ok = KeyValueResponseParser.TryParse(
+            new[] { "", "HeapFree=1", "no separator here", "HeapUsed=2" },
+            pairs =>
+            {
+                seen = pairs;
+                return new object();
+            },
+            out var result);
+
+        Assert.True(ok);
+        Assert.NotNull(result);
+        Assert.NotNull(seen);
+        Assert.Equal(2, seen!.Count);
+        Assert.Equal(1UL, seen["HeapFree"]);
+        Assert.Equal(2UL, seen["HeapUsed"]);
+    }
+}


### PR DESCRIPTION
Produced by the COVERAGE-GAP maintenance routine; safe because it adds only test code — no production file is touched.

**What was wrong.** `KeyValueResponseParser` is the shared parser behind both `Key=Value` diagnostics responses — `SYSTem:STReam:STATS?` (`StreamStatsParser`) and the memory-diagnostics query (`MemoryDiagnosticsParser`). It had no tests of its own. Everything it does was exercised only through those two wrappers, and their tests pin the happy path: well-formed pairs, blank lines, a `**ERROR:` line, a non-numeric value. That left the parser's actual defensive logic unpinned. A regression in any of those guards would have shipped with a green suite and shown up as quietly wrong diagnostics numbers — a counter silently merged with another, a bogus field appearing in the map, or a null slipping out of a `TryParse` that promises never to return one.

**How it was fixed.** A new `KeyValueResponseParserTests` with 12 cases, all aimed at branches the wrappers never reach. On `Parse`: a null line sequence returns empty instead of throwing; a line whose `=` is first (`=5`, empty key) or last (`HeapFree=`, empty value) is skipped, as is a line with no separator at all; values that are not non-negative 64-bit integers are rejected (negative, one past `ulong.MaxValue`, hex, decimal, comma-grouped) while a leading `+` is accepted; whitespace around both key and value is trimmed; a duplicate key keeps the last value; keys differing only by case stay distinct fields; and a SCPI error line that itself contains a `Key=Value` pair is dropped whole rather than split. On `TryParse`: a null line sequence returns false without invoking the factory, a null factory throws `ArgumentNullException`, a factory returning null throws `InvalidOperationException`, and the factory receives exactly the parsed pairs.

Two of these encode judgment calls a reviewer may want to weigh in on rather than obvious truths. `Parse_LeadingPlusSign_IsAccepted` pins that `+7` parses, which follows from `NumberStyles.Integer` but is not something the firmware is known to emit — it is here so a narrowing of the number style is a deliberate change rather than a silent one. `Parse_KeysThatDifferOnlyByCase_AreDistinctFields` pins the plain (ordinal, case-sensitive) `Dictionary`, which the class doc already calls out; the test exists because switching to a case-insensitive comparer would collapse two firmware counters into one with no other test noticing.

Verified with the full suite on net9.0 and net10.0: 3766 tests, 0 failures on each, plus 217 in `Daqifi.Mcp.Tests`.

Not merging — opened for review.