### PR TITLE
chore: unify the SCPI error-code numeric-prefix parse

### DIFF
--- a/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ScpiResponseClassifierTests.cs
@@ -109,6 +109,22 @@ namespace Daqifi.Core.Tests.Device
         }
 
         [Theory]
+        // The device reports the same error two ways: bare in a SYSTem:ERRor? reply, and prefixed
+        // with an ERROR token when it volunteers one alongside a command's output. Both readers now
+        // share one numeric-prefix parse, so this pins them to the same answer for the same code.
+        [InlineData("-200,\"Execution error\"", "**ERROR: -200,\"Execution error\"", -200)]
+        [InlineData("-113, \"Undefined header\"", "ERROR\t-113, \"Undefined header\"", -113)]
+        [InlineData("  0,\"No error\"  \r\n", "  ERROR: 0, \"No error\"  \r\n", 0)]
+        public void BothErrorFormsReadTheSameCode(string queueReply, string volunteeredLine, int expected)
+        {
+            Assert.True(ScpiResponseClassifier.TryParseSystemErrorReplyCode(queueReply, out var replyCode));
+            Assert.True(ScpiResponseClassifier.TryExtractErrorCode(volunteeredLine, out var volunteeredCode));
+
+            Assert.Equal(expected, replyCode);
+            Assert.Equal(expected, volunteeredCode);
+        }
+
+        [Theory]
         // The shape captured off the bench in #537: a partial protobuf frame welded onto the front
         // of the first reply line, with the real key and value still attached behind it.
         [InlineData("\u0008\uFFFD\\3\uFFFD\u0004\u0012\u0003\u0008\u0000TotalSamplesStreamed=203")]

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -2111,9 +2110,7 @@ namespace Daqifi.Core.Device
                 // error to capture. Parse the numeric prefix rather than
                 // substring-matching "No error" so a hypothetical error message
                 // containing that phrase can't be mistaken for the terminator.
-                var commaIndex = reply.IndexOf(',');
-                var codeSpan = commaIndex >= 0 ? reply.AsSpan(0, commaIndex).Trim() : reply.AsSpan().Trim();
-                if (int.TryParse(codeSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out var code) && code == 0)
+                if (ScpiResponseClassifier.TryParseSystemErrorReplyCode(reply, out var code) && code == 0)
                 {
                     return popped;
                 }

--- a/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
+++ b/src/Daqifi.Core/Device/ScpiResponseClassifier.cs
@@ -226,7 +226,23 @@ namespace Daqifi.Core.Device
         /// <returns><c>true</c> if a numeric code was read; otherwise <c>false</c>.</returns>
         internal static bool TryParseSystemErrorReplyCode(string line, out int code)
         {
-            var trimmed = line.Trim();
+            return TryParseLeadingCode(line, out code);
+        }
+
+        /// <summary>
+        /// Reads the numeric code that prefixes a SCPI error payload: the text up to the first
+        /// comma (or the whole of it when there is no comma), trimmed, parsed as a culture-invariant
+        /// integer. Single-sourced here because both error forms the device produces end in this same
+        /// step — the bare <c>-200,"Execution error"</c> of a <c>SYSTem:ERRor?</c> reply and the
+        /// <c>**ERROR: -200,"Execution error"</c> the device volunteers — and they must agree on
+        /// what counts as a code.
+        /// </summary>
+        /// <param name="text">The error payload, with any leading <c>ERROR</c> token already stripped.</param>
+        /// <param name="code">The parsed code when the method returns <c>true</c>; otherwise 0.</param>
+        /// <returns><c>true</c> if a numeric code was read; otherwise <c>false</c>.</returns>
+        private static bool TryParseLeadingCode(ReadOnlySpan<char> text, out int code)
+        {
+            var trimmed = text.Trim();
             var commaIndex = trimmed.IndexOf(',');
             var codeSpan = (commaIndex >= 0 ? trimmed[..commaIndex] : trimmed).Trim();
             return int.TryParse(codeSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out code);
@@ -274,9 +290,7 @@ namespace Daqifi.Core.Device
 
             afterToken = afterToken.TrimStart(TokenDelimiters);
 
-            var commaIndex = afterToken.IndexOf(',');
-            var codeSpan = (commaIndex >= 0 ? afterToken[..commaIndex] : afterToken).Trim();
-            return int.TryParse(codeSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out code);
+            return TryParseLeadingCode(afterToken, out code);
         }
 
         /// <summary>


### PR DESCRIPTION
Produced by the DUPLICATE-UNIFIER maintenance routine, which looks for near-identical parsing or protocol-handling logic that has been copied between call sites.

**What was wrong.** The device reports a SCPI error two different ways — bare in a `SYSTem:ERRor?` reply (`-200,"Execution error"`), and prefixed with an `ERROR` token when it volunteers one alongside a command's output (`**ERROR: -200,"Execution error"`). The two forms differ only in the header; once the header is off, reading the code out of them is the same four-line step: take the text up to the first comma, trim it, `int.TryParse` it with `InvariantCulture`. That step existed in three places — `ScpiResponseClassifier.TryParseSystemErrorReplyCode`, the tail of `ScpiResponseClassifier.TryExtractErrorCode`, and a hand-rolled `AsSpan` copy inside `DaqifiDevice.DrainErrorQueueAsync`.

The three agreed exactly, so nothing is broken today. The risk is what the classifier's own comments already worry about elsewhere in the same file: it deliberately single-sources the accepted `ERROR`-token delimiters "so detection and extraction can't drift", and then leaves the code-reading half copied three ways. The third copy is the one that bothers me most — `DrainErrorQueueAsync` decides whether the device's error queue is empty by parsing the code itself, in a file that is not the one that owns SCPI reply parsing. If the accepted code format ever changes (a `+0` form, a code with trailing text, a wider integer), whoever changes it will find the classifier and miss the device.

**How it was fixed.** A private `ScpiResponseClassifier.TryParseLeadingCode(ReadOnlySpan<char>, out int)` now holds that step, and both classifier entry points call it. `DrainErrorQueueAsync` drops its copy and calls the existing internal `TryParseSystemErrorReplyCode` — the tested, documented method that was already sitting there for exactly this.

Two things a reviewer might want to push back on:

- The helper takes a `ReadOnlySpan<char>` rather than a `string`. That is deliberate: `DrainErrorQueueAsync` was using `AsSpan` specifically to avoid allocating a substring per loop iteration, and a `string`-based helper would have quietly regressed that. With the span helper the drain loop stays allocation-free.
- Taking a span also makes `TryParseSystemErrorReplyCode(null!)` return `false` where it previously threw a `NullReferenceException` (a null string converts to an empty span). Nullable reference types are enabled and the parameter is non-nullable, so null was already a contract violation either way; no caller passes one.

Verified with `dotnet build` clean at 0 warnings, and the full suite green on both net9.0 and net10.0 (3741 passed / 0 failed / 2 pre-existing skips per TFM, plus Daqifi.Mcp.Tests 217 passed) under the shared test lock. No board interaction — this touches no protocol bytes or timing, only how an already-received reply string is read. The existing `ScpiResponseClassifierTests` and `DaqifiDeviceDrainErrorQueueTests` cover all three former call sites; I added one theory, `BothErrorFormsReadTheSameCode`, that asserts the two wire forms yield the same code for the same error, which is the property the shared helper is there to guarantee.

Not merging — opened for review.
