### PR TITLE
chore: single-source the WiFi bridge-mode port sequence

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/WifiBridgeActivatorTests.cs
@@ -52,6 +52,18 @@ public class WifiBridgeActivatorTests
         Assert.ThrowsAny<Exception>(() => WifiBridgeActivator.Deactivate("COM999"));
     }
 
+    // Activate and Deactivate share one private sequence method, so the null guard now fires
+    // one frame below the public parameter. Pin the reported parameter name for both directions
+    // so the shared guard keeps blaming the caller's argument rather than an internal one.
+    [Fact]
+    public void NullPortName_BothDirections_BlameThePortNameParameter()
+    {
+        Assert.Equal("portName", Assert.Throws<ArgumentNullException>(
+            () => WifiBridgeActivator.Activate(null!)).ParamName);
+        Assert.Equal("portName", Assert.Throws<ArgumentNullException>(
+            () => WifiBridgeActivator.Deactivate(null!)).ParamName);
+    }
+
     [Fact]
     public async Task ActivateAsync_NullPortName_ThrowsArgumentNullException()
     {

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -107,6 +107,12 @@ public static class WifiBridgeActivator
     private static void RunModeChangeSequence(string portName, IOutboundMessage<string> modeCommand, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(portName);
+
+        // Guarded even though both current callers pass a non-null literal: this method is meant to
+        // be the one place a future direction or step gets added, and a null here would otherwise
+        // surface as an NRE inside WriteCommand's GetBytes() with the port already open.
+        ArgumentNullException.ThrowIfNull(modeCommand);
+
         cancellationToken.ThrowIfCancellationRequested();
 
         using var transport = new SerialStreamTransport(portName);

--- a/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
+++ b/src/Daqifi.Core/Firmware/WifiBridgeActivator.cs
@@ -68,24 +68,8 @@ public static class WifiBridgeActivator
     /// <exception cref="OperationCanceledException">Cancellation was requested.</exception>
     public static void Activate(string portName, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(portName);
-        cancellationToken.ThrowIfCancellationRequested();
-
-        using var transport = new SerialStreamTransport(portName);
-        transport.Connect();
-
-        // Allow firmware to recognise DTR before sending commands.
-        WaitOrCancel(DtrSettleDelay, cancellationToken);
-
         // Re-assert the FW-update-requested flag (idempotent with the earlier handshake).
-        WriteCommand(transport, ScpiMessageProducer.SetLanFirmwareUpdateMode, cancellationToken);
-        WaitOrCancel(InterCommandDelay, cancellationToken);
-
-        // Trigger the WiFi manager REINIT to bridge-mode state machine.
-        WriteCommand(transport, ScpiMessageProducer.ApplyNetworkLan, cancellationToken);
-
-        // Give firmware time to enqueue APPLY before the port closes.
-        WaitOrCancel(ApplySettleDelay, cancellationToken);
+        RunModeChangeSequence(portName, ScpiMessageProducer.SetLanFirmwareUpdateMode, cancellationToken);
     }
 
     /// <summary>
@@ -99,6 +83,29 @@ public static class WifiBridgeActivator
     /// <exception cref="OperationCanceledException">Cancellation was requested.</exception>
     public static void Deactivate(string portName, CancellationToken cancellationToken = default)
     {
+        // Turn off transparent mode so the port goes back to the SCPI console.
+        RunModeChangeSequence(portName, ScpiMessageProducer.SetUsbTransparencyMode(0), cancellationToken);
+    }
+
+    /// <summary>
+    /// The scripted port sequence both <see cref="Activate(string, CancellationToken)"/> and
+    /// <see cref="Deactivate(string, CancellationToken)"/> run: open the port, let firmware see
+    /// DTR, send <paramref name="modeCommand"/>, then trigger the WiFi manager's REINIT with
+    /// <c>LAN:APPLY</c> and hold the port open long enough for firmware to enqueue it.
+    /// </summary>
+    /// <remarks>
+    /// The two directions differ only in <paramref name="modeCommand"/>; every step around it —
+    /// and in particular the three delays — is a property of the firmware's mode-transition state
+    /// machine, not of the direction being driven, which is why entering and leaving bridge mode
+    /// are paced identically. Single-sourcing the sequence keeps it that way: a step added or
+    /// re-ordered for one direction can no longer silently miss the other. (Same reasoning as
+    /// <see cref="InterCommandDelay"/>, which is already shared with <c>WifiModuleUpdater</c>.)
+    /// </remarks>
+    /// <param name="portName">The serial port name.</param>
+    /// <param name="modeCommand">The direction-specific command sent before <c>LAN:APPLY</c>.</param>
+    /// <param name="cancellationToken">Cancellation token observed between port-open, each command write, and each inter-command delay.</param>
+    private static void RunModeChangeSequence(string portName, IOutboundMessage<string> modeCommand, CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(portName);
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -108,11 +115,10 @@ public static class WifiBridgeActivator
         // Allow firmware to recognise DTR before sending commands.
         WaitOrCancel(DtrSettleDelay, cancellationToken);
 
-        // Turn off transparent mode so the port goes back to the SCPI console.
-        WriteCommand(transport, ScpiMessageProducer.SetUsbTransparencyMode(0), cancellationToken);
+        WriteCommand(transport, modeCommand, cancellationToken);
         WaitOrCancel(InterCommandDelay, cancellationToken);
 
-        // Trigger the WiFi manager REINIT out of bridge-mode state machine.
+        // Trigger the WiFi manager REINIT state machine.
         WriteCommand(transport, ScpiMessageProducer.ApplyNetworkLan, cancellationToken);
 
         // Give firmware time to enqueue APPLY before the port closes.


### PR DESCRIPTION
Produced by the **DUPLICATE-UNIFIER** maintenance routine.

## What was wrong

`WifiBridgeActivator.Activate` and `WifiBridgeActivator.Deactivate` were the same eighteen lines twice. Both open a short-lived serial port, wait for firmware to see DTR, send one mode command, wait, send `LAN:APPLY`, and hold the port open long enough for firmware to enqueue it. The only difference between the two copies was a single argument — `SetLanFirmwareUpdateMode` going into bridge mode, `SetUsbTransparencyMode(0)` coming back out.

Everything wrapped around that one argument is a property of the firmware's mode-transition state machine rather than of the direction being driven, which is why the two directions are paced identically today. The risk was that they would stop being: a settle step added for one direction, a write re-ordered, an extra command inserted after a firmware change, and only one of the two paths gets it — with no compiler or test complaint, and a symptom that only shows up on a bench. The file already makes exactly this argument for `InterCommandDelay`, which it deliberately shares with `WifiModuleUpdater`'s managed-connection twin of `Deactivate` "so the two paths that walk a device out of bridge mode cannot pace it differently." The three delay constants were already single-sourced on that reasoning; the choreography around them was not.

**The copies had not diverged.** They agreed step for step, so this is a straight unification — no behavior is being chosen over another, and there is no drift to report.

## How it was fixed

One private `RunModeChangeSequence(portName, modeCommand, cancellationToken)` holds the sequence; `Activate` and `Deactivate` become one-liners that pass their direction-specific command. The per-direction comments move to the call sites, where they now read as the explanation of the argument.

Two things a reviewer may want to push on:

- **Argument evaluation order.** The null and cancellation guards moved down into the shared method, so the mode command is now constructed before them. Both producers just return a new `ScpiMessage` with a constant string — pure, no device contact, cannot throw — so nothing observable changes. `ArgumentNullException` still reports `portName`, since the helper's parameter carries the same name; the added test pins that, as it is the one detail this refactor could plausibly have changed by accident.
- **Should the two directions be free to diverge?** If firmware ever needs different pacing entering versus leaving bridge mode, that becomes a parameter on the shared method. That is a deliberate, visible edit — which is the point, versus today's arrangement where the two can drift apart by omission.

## Verification

`dotnet build`: 0 warnings, 0 errors. Full `dotnet test` green on **net9.0 and net10.0** under a test lock — 3758 passed / 0 failed / 2 pre-existing skips per TFM, plus 217 in `Daqifi.Mcp.Tests`. No board interaction: this changes no protocol bytes and no timing, so there was nothing for the bench to confirm.

Not merging — opened for review.