### PR TITLE
chore(tests): remove assertions that structurally cannot fail

### DIFF
--- a/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
@@ -222,7 +222,6 @@ namespace Daqifi.Core.Tests.Device
             Assert.Equal(1, ai0.OutOfOrderSampleCount);
             Assert.Equal(TimeSpan.FromMilliseconds(1), ai0.MinSampleInterval);
             Assert.Equal(TimeSpan.FromMilliseconds(2), ai0.MaxSampleInterval);
-            Assert.True(ai0.MinSampleInterval >= TimeSpan.Zero, "a backwards step must not be reported as a gap");
         }
 
         [Fact]
@@ -691,8 +690,6 @@ namespace Daqifi.Core.Tests.Device
             // 1.0 V -> 2.0 PSI (the MAXIMUM); 2.0 V -> -1.0 PSI (the MINIMUM).
             Assert.Equal(-1.0, channelStats.MinValue);
             Assert.Equal(2.0, channelStats.MaxValue);
-            Assert.True(channelStats.MinValue < channelStats.MaxValue,
-                "an inverting scaling must not leave the extremes transposed");
         }
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/SerialDeviceFinderTests.cs
@@ -100,9 +100,9 @@ public class SerialDeviceFinderTests
     {
         var fakeProvider = new RecordingUsbLocationProvider(_ => "Port_#0001.Hub_#0001");
 
+        // As with the baud-rate overload above: the provider is a private field with no accessor,
+        // so "the constructor accepts it and does not throw" is the whole of what a test can say.
         using var finder = new SerialDeviceFinder(9600, usbPortDescriptorProvider: null, usbLocationProvider: fakeProvider);
-
-        Assert.NotNull(finder);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/FeatureNotSupportedExceptionTests.cs
+++ b/src/Daqifi.Core.Tests/Device/FeatureNotSupportedExceptionTests.cs
@@ -7,6 +7,26 @@ namespace Daqifi.Core.Tests.Device
     public class FeatureNotSupportedExceptionTests
     {
         [Fact]
+        public void Constructor_SetsAllProperties()
+        {
+            // The message is built from the constructor *parameters* before the properties are
+            // assigned, so the message tests below cannot catch a regression that drops one of
+            // these assignments. This is the only coverage that they are actually stored.
+            var requiredVersion = new FirmwareVersion(3, 5, 0, null, 0);
+
+            var ex = new FeatureNotSupportedException(
+                DeviceFeature.SdStorageQuery,
+                requiredVersion,
+                "3.4.3",
+                DeviceType.Nyquist1);
+
+            Assert.Equal(DeviceFeature.SdStorageQuery, ex.Feature);
+            Assert.Equal(requiredVersion, ex.RequiredVersion);
+            Assert.Equal("3.4.3", ex.ActualVersion);
+            Assert.Equal(DeviceType.Nyquist1, ex.Board);
+        }
+
+        [Fact]
         public void Constructor_WithOnlyFeature_LeavesOptionalPropertiesNull()
         {
             var ex = new FeatureNotSupportedException(DeviceFeature.AnalogOutput);

--- a/src/Daqifi.Core.Tests/Device/FeatureNotSupportedExceptionTests.cs
+++ b/src/Daqifi.Core.Tests/Device/FeatureNotSupportedExceptionTests.cs
@@ -7,23 +7,6 @@ namespace Daqifi.Core.Tests.Device
     public class FeatureNotSupportedExceptionTests
     {
         [Fact]
-        public void Constructor_SetsAllProperties()
-        {
-            var requiredVersion = new FirmwareVersion(3, 5, 0, null, 0);
-
-            var ex = new FeatureNotSupportedException(
-                DeviceFeature.SdStorageQuery,
-                requiredVersion,
-                "3.4.3",
-                DeviceType.Nyquist1);
-
-            Assert.Equal(DeviceFeature.SdStorageQuery, ex.Feature);
-            Assert.Equal(requiredVersion, ex.RequiredVersion);
-            Assert.Equal("3.4.3", ex.ActualVersion);
-            Assert.Equal(DeviceType.Nyquist1, ex.Board);
-        }
-
-        [Fact]
         public void Constructor_WithOnlyFeature_LeavesOptionalPropertiesNull()
         {
             var ex = new FeatureNotSupportedException(DeviceFeature.AnalogOutput);

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileInfoTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileInfoTests.cs
@@ -7,6 +7,30 @@ namespace Daqifi.Core.Tests.Device.SdCard
     public class SdCardFileInfoTests
     {
         [Fact]
+        public void Constructor_SetsFileName()
+        {
+            // Arrange & Act
+            var fileInfo = new SdCardFileInfo("test.bin");
+
+            // Assert
+            Assert.Equal("test.bin", fileInfo.FileName);
+        }
+
+        [Fact]
+        public void Constructor_WithDate_SetsCreatedDate()
+        {
+            // Arrange
+            var date = new DateTime(2024, 1, 15, 10, 30, 0);
+
+            // Act
+            var fileInfo = new SdCardFileInfo("log_20240115_103000.bin", date);
+
+            // Assert
+            Assert.Equal("log_20240115_103000.bin", fileInfo.FileName);
+            Assert.Equal(date, fileInfo.CreatedDate);
+        }
+
+        [Fact]
         public void Constructor_WithoutDate_SetsNullCreatedDate()
         {
             // Arrange & Act

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileInfoTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardFileInfoTests.cs
@@ -7,30 +7,6 @@ namespace Daqifi.Core.Tests.Device.SdCard
     public class SdCardFileInfoTests
     {
         [Fact]
-        public void Constructor_SetsFileName()
-        {
-            // Arrange & Act
-            var fileInfo = new SdCardFileInfo("test.bin");
-
-            // Assert
-            Assert.Equal("test.bin", fileInfo.FileName);
-        }
-
-        [Fact]
-        public void Constructor_WithDate_SetsCreatedDate()
-        {
-            // Arrange
-            var date = new DateTime(2024, 1, 15, 10, 30, 0);
-
-            // Act
-            var fileInfo = new SdCardFileInfo("log_20240115_103000.bin", date);
-
-            // Assert
-            Assert.Equal("log_20240115_103000.bin", fileInfo.FileName);
-            Assert.Equal(date, fileInfo.CreatedDate);
-        }
-
-        [Fact]
         public void Constructor_WithoutDate_SetsNullCreatedDate()
         {
             // Arrange & Act

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardOperationsTests.cs
@@ -826,7 +826,6 @@ namespace Daqifi.Core.Tests.Device.SdCard
             var ex = await Assert.ThrowsAsync<SdCardOperationException>(
                 () => device.DeleteSdCardFileAsync("locked.bin"));
 
-            Assert.IsNotType<SdCardListIncompleteException>(ex);
             Assert.Contains("-200", ex.Message);
             Assert.Empty(device.SdCardFiles);
         }
@@ -1096,8 +1095,6 @@ namespace Daqifi.Core.Tests.Device.SdCard
 
             var ex = await Assert.ThrowsAsync<SdCardFilesystemException>(
                 () => device.GetSdCardFilesAsync());
-
-            Assert.IsNotType<SdCardDirectoryNotFoundException>(ex);
         }
 
         [Fact]

--- a/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/FirmwareUpdateServiceTests.cs
@@ -2004,7 +2004,6 @@ public class FirmwareUpdateServiceTests
 
             // The structural discriminator: the state itself, not the Operation progress string.
             Assert.Equal(FirmwareUpdateState.ReconnectingAfterFlash, exception.FailedState);
-            Assert.NotEqual(FirmwareUpdateState.Verifying, exception.FailedState);
             Assert.Contains(FirmwareUpdateState.ReconnectingAfterFlash, stateTransitions);
 
             // Guidance is keyed on the same discriminator, so a successful flash no longer tells

--- a/src/Daqifi.Mcp.Tests/LiveDataToolsTests.cs
+++ b/src/Daqifi.Mcp.Tests/LiveDataToolsTests.cs
@@ -259,8 +259,6 @@ public class LiveSampleCaptureTests
                     () => throw new DeviceNotConnectedException(),
                     CancellationToken.None)
                 .WaitAsync(Bound));
-
-        Assert.IsType<DeviceNotConnectedException>(ex);
     }
 
     // ------------------------------------------------------------------ helpers


### PR DESCRIPTION
Produced by the **USELESS-TEST-PRUNER** maintenance routine. This is safe because nothing removed here was capable of failing — each assertion was either already guaranteed by a line above it, or checked something the C# language makes impossible.

## What was wrong

Seven assertions across six test files could never have caught a bug:

**Already guaranteed by an earlier assertion in the same test.** `FirmwareUpdateServiceTests` asserted `FailedState != Verifying` on the line right after asserting `FailedState == ReconnectingAfterFlash` — two distinct enum constants (6 and 12), so the second line was decided the moment the first passed. `AcquisitionStatisticsTests` did the same twice: `MinSampleInterval >= TimeSpan.Zero` after pinning it to exactly 1 ms, and `MinValue < MaxValue` after pinning them to exactly -1.0 and 2.0.

**Re-checking a type xunit had already pinned exactly.** `Assert.ThrowsAsync<T>` in xunit 2.x requires the *exact* runtime type, not an assignable one. So the trailing `Assert.IsType<DeviceNotConnectedException>(ex)` in `LiveDataToolsTests` was re-asserting what `ThrowsAsync` had just proved, and the two `Assert.IsNotType<Derived>(ex)` calls in `SdCardOperationsTests` could never fire — a derived exception would already have failed the `ThrowsAsync` line above. Those tests still enforce exactly what their names claim; the enforcement just lives on the `ThrowsAsync` line.

**Asserting a `new` expression is not null.** `SerialDeviceFinderTests` ended with `Assert.NotNull(finder)` on an object constructed two lines earlier. The sibling test directly above it already handles this case honestly — it has no assertion at all and a comment explaining that "does not throw" is the whole of what a test can say when the value under test is a private field. I removed the assertion and matched that comment.

## What I kept, and why

The judgment worth checking is what I left alone. I evaluated and deliberately kept:

- **`BootloaderSessionDevice.Metadata_IsNonNull`** — looks like a NotNull-on-`new`, but it reads a property whose non-null initializer is a real invariant callers depend on without a guard. Changing that initializer would fail this test.
- **`ReconnectOptions` and `DeviceNotConnectedException` defaults/type-contract tests** — these pin production defaults and an inheritance relationship that downstream `catch` sites rely on. Trivial-looking, genuinely load-bearing.
- **Two redundancies in `FirmwareUpdateServiceTests` and `LanChipInfoProviderExtensionsTests`** where the implication runs through a test double or is documented in the test as deliberate edit-resistant redundancy. Structurally unfailable today, but they regain teeth if the fixture changes, so pruning them would be overreach.
- **`WiFiDeviceFinderTests.ShouldIncludeInterface_MixedNicList_...`** — a per-NIC loop currently implied by an exact-list assertion above it, but it would regain independent value if a row's expectation were edited, and it carries the per-NIC failure message.
- **All `Assert.True(TryParse(...)); Assert.NotNull(result);` pairs** in the parser tests — these are *not* vacuous. Asserting the bool does not prove the out-parameter is non-null at runtime; they guard the `[NotNullWhen(true)]` contract.
- Constant-pinning assertions throughout (a test literal against a *production* constant) — those are meant to fail on an unintended change.

## Changed after review

The first push also removed two constructor round-trip tests (`FeatureNotSupportedException` and `SdCardFileInfo`). Qodo pushed back on both and was right, so they are restored. In each case the test was the only coverage that the constructor actually *stores* what it is handed — `FeatureNotSupportedException` in particular builds its message from the constructor parameters before assigning the properties, so a dropped assignment would leave every message test green. That is a plausible regression rather than a structurally unfailable assertion, which is the line this routine is supposed to draw. The restored test carries a comment recording why.

## Verification

Full suite green on both target frameworks: net9.0 (3757 Core + 217 Mcp) and net10.0 (3757 Core), 0 failed.

Not merging — opened for review.
