### PR TITLE
chore: unify the two PIC32 bootloader acknowledgment decoders

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderMessageConsumerTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderMessageConsumerTests.cs
@@ -180,6 +180,26 @@ public class Pic32BootloaderMessageConsumerTests
 
     #endregion
 
+    #region Shared acknowledgment framing
+
+    // The two ack decoders read one framing rule and differ only in which opcode they accept.
+    // Nothing above pins the shared half: each decoder's rejection cases were asserted on their
+    // own, so the two rules could have drifted apart without a test noticing. This asserts the
+    // frames one decoder rejects are rejected by the other as well.
+    [Theory]
+    [InlineData(new byte[] { })]              // empty
+    [InlineData(new byte[] { SOH })]          // SOH only, one byte short of an ack
+    [InlineData(new byte[] { 0x00, 0x02 })]   // erase opcode, but not SOH-framed
+    [InlineData(new byte[] { 0x00, 0x03 })]   // program opcode, but not SOH-framed
+    [InlineData(new byte[] { SOH, 0xFF })]    // well framed, but not an opcode either one answers
+    public void BadlyFramedAcknowledgment_IsRejectedByBothAckDecoders(byte[] response)
+    {
+        Assert.False(Pic32BootloaderMessageConsumer.DecodeProgramFlashResponse(response));
+        Assert.False(Pic32BootloaderMessageConsumer.DecodeEraseFlashResponse(response));
+    }
+
+    #endregion
+
     #region DecodeReadCrcResponse
 
     // Mirrors the firmware's response framing: content = [0x04, crcLo, crcHi];

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderMessageConsumer.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderMessageConsumer.cs
@@ -54,26 +54,14 @@ public static class Pic32BootloaderMessageConsumer
     /// </summary>
     /// <param name="data">The raw response bytes.</param>
     /// <returns>True if the response is a valid program flash acknowledgment.</returns>
-    public static bool DecodeProgramFlashResponse(byte[] data)
-    {
-        if (data.Length < 2) return false;
-        if (data[0] != StartOfHeader) return false;
-
-        return data[1] == ProgramFlashCommand;
-    }
+    public static bool DecodeProgramFlashResponse(byte[] data) => IsAckFor(data, ProgramFlashCommand);
 
     /// <summary>
     /// Decodes an erase flash acknowledgment response.
     /// </summary>
     /// <param name="data">The raw response bytes.</param>
     /// <returns>True if the response is a valid erase flash acknowledgment.</returns>
-    public static bool DecodeEraseFlashResponse(byte[] data)
-    {
-        if (data.Length < 2) return false;
-        if (data[0] != StartOfHeader) return false;
-
-        return data[1] == EraseFlashCommand;
-    }
+    public static bool DecodeEraseFlashResponse(byte[] data) => IsAckFor(data, EraseFlashCommand);
 
     /// <summary>
     /// Decodes a <c>READ_CRC</c> response and returns the flash CRC-16 the
@@ -156,5 +144,27 @@ public static class Pic32BootloaderMessageConsumer
         }
 
         return flashCrc;
+    }
+
+    /// <summary>
+    /// Matches a bare acknowledgment frame &#8212; <c>SOH &lt;opcode&gt;</c>, with no payload to
+    /// unescape. ERASE_FLASH and PROGRAM_FLASH are both acknowledged this way, so the only thing
+    /// that tells the two acks apart is which opcode the bootloader echoed back.
+    /// </summary>
+    /// <param name="data">The raw, framed response bytes.</param>
+    /// <param name="command">The opcode the acknowledgment is expected to echo.</param>
+    /// <returns>True if <paramref name="data"/> acknowledges <paramref name="command"/>.</returns>
+    /// <remarks>
+    /// Deliberately not null-guarded. Both callers are public methods that have always thrown
+    /// <see cref="System.NullReferenceException"/> on a null <paramref name="data"/>, and adding a
+    /// guard here would change that observable behavior. The null-handling asymmetry between the
+    /// decoders on this type is tracked separately, not settled by this extraction.
+    /// </remarks>
+    private static bool IsAckFor(byte[] data, byte command)
+    {
+        if (data.Length < 2) return false;
+        if (data[0] != StartOfHeader) return false;
+
+        return data[1] == command;
     }
 }


### PR DESCRIPTION
Produced by the DUPLICATE-UNIFIER maintenance routine. Safe because the extracted helper is the same three lines both callers already ran, and nothing about the bytes on the wire changes.

**What was wrong.** `Pic32BootloaderMessageConsumer` decodes the bootloader's bare acknowledgment frame — `SOH <opcode>`, no payload — in two places. `DecodeProgramFlashResponse` and `DecodeEraseFlashResponse` were byte-for-byte identical apart from the opcode each compares against:

```csharp
if (data.Length < 2) return false;
if (data[0] != StartOfHeader) return false;
return data[1] == ProgramFlashCommand;   // ...or EraseFlashCommand
```

The two are not merely similar, they *have* to agree: the erase ack and the program ack are the same wire frame, so any change to how one is framed applies to the other. Split across two copies, a fix to one is a silent divergence from the other, and the failure would not be loud — it would be a live flash session mis-reading an acknowledgment on real hardware. The class's own doc comment already argues this case for the opcodes ("shared ... so the two sides cannot drift apart"); the rule that reads them was still written down twice.

**How it was fixed.** One private `IsAckFor(byte[] data, byte command)` now holds the framing rule; both public methods become expression-bodied one-liners passing their own opcode. Public signatures, return values, and behavior are unchanged.

The one thing worth pushing back on, so I'll raise it myself: the helper does **not** null-guard `data`, even though the file's `DecodeReadCrcResponse` does guard its input. That is on purpose. Both callers are public methods that have always thrown `NullReferenceException` on null, and adding `ArgumentNullException.ThrowIfNull` in the shared helper would change that observable behavior for both of them — a behavior change smuggled into a refactor that claims to have none. The helper carries a comment saying so. The underlying inconsistency (one of four decoders on this type null-guards, three don't) is real and is filed separately as #621; this PR does not settle it either way.

**Divergence check: none.** The two copies agreed exactly. So a straight unification was correct, with no behavior to choose between.

**Verified.** `dotnet build` 0 warnings / 0 errors. Full `dotnet test` green on net9.0 and net10.0 — 3762 passed, 0 failed, 2 pre-existing skips per TFM, plus 217 in Daqifi.Mcp.Tests. Added one theory, `BadlyFramedAcknowledgment_IsRejectedByBothAckDecoders`: the existing tests asserted each decoder's rejection cases independently, so nothing pinned the half the two share — the property the extraction exists to guarantee. No board interaction; this touches no protocol bytes and no timing, so bench validation is inapplicable rather than deferred.

Not merging — opened for review.
