### PR TITLE
test(device): direct tests for the shared LineParsing first-parseable-line helper

### DIFF
--- a/src/Daqifi.Core.Tests/Device/LineParsingTests.cs
+++ b/src/Daqifi.Core.Tests/Device/LineParsingTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Core.Tests.Device;
+
+/// <summary>
+/// Direct tests for <see cref="LineParsing"/>, the shared "first parseable line wins" helper behind
+/// six response parsers (<c>SdCardSpaceParser</c>, <c>LogLevelParser</c>, <c>LanChipInfoParser</c>,
+/// the capability API-version query, the system error-count query, and the analog-output readback).
+/// Those callers only ever exercise the happy path with well-formed inputs, so the helper's own
+/// contract — argument guards, ordering, the failed-parse output value, the non-null result check,
+/// and lazy enumeration — had nothing pinning it. These cover exactly that contract.
+/// </summary>
+public class LineParsingTests
+{
+    /// <summary>A reference-typed parse result, standing in for the parser DTOs the real callers use.</summary>
+    private sealed class Parsed(string value)
+    {
+        public string Value { get; } = value;
+    }
+
+    /// <summary>Parses any line that is a valid integer into a <see cref="Parsed"/>.</summary>
+    private static bool TryParseNumericLine(string? line, [NotNullWhen(true)] out Parsed? result)
+    {
+        if (line is not null && int.TryParse(line, out _))
+        {
+            result = new Parsed(line);
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Yields <paramref name="lines"/>, then throws if enumeration continues past the last one.
+    /// Used to prove the helper stops pulling as soon as a line parses.
+    /// </summary>
+    private static IEnumerable<string> ThrowingAfter(params string[] lines)
+    {
+        foreach (var line in lines)
+        {
+            yield return line;
+        }
+
+        throw new InvalidOperationException("Enumerated past the first successful line.");
+    }
+
+    // ---- reference-type overload -------------------------------------------------------------
+
+    [Fact]
+    public void TryParseFirst_Reference_NullLines_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => LineParsing.TryParseFirst<Parsed>(null!, TryParseNumericLine, out _));
+
+        Assert.Equal("lines", ex.ParamName);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_NullTryParse_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => LineParsing.TryParseFirst<Parsed>(new[] { "1" }, null!, out _));
+
+        Assert.Equal("tryParse", ex.ParamName);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_FirstParseableLineWins()
+    {
+        // Two lines parse; the helper must return the earlier one, not the last one seen.
+        var parsed = LineParsing.TryParseFirst<Parsed>(
+            new[] { "not a number", "11", "22" }, TryParseNumericLine, out var result);
+
+        Assert.True(parsed);
+        Assert.Equal("11", result!.Value);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_TriesLinesInOrderAndStopsAtTheFirstSuccess()
+    {
+        var attempted = new List<string?>();
+
+        LineParsing.TryParseFirst<Parsed>(
+            new[] { "header", "", "7", "8" },
+            (string? line, [NotNullWhen(true)] out Parsed? value) =>
+            {
+                attempted.Add(line);
+                return TryParseNumericLine(line, out value);
+            },
+            out _);
+
+        Assert.Equal(new string?[] { "header", "", "7" }, attempted);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_DoesNotEnumeratePastTheFirstSuccess()
+    {
+        // A materializing implementation (lines.ToList()) would trip the sentinel throw.
+        var parsed = LineParsing.TryParseFirst<Parsed>(
+            ThrowingAfter("skip", "5"), TryParseNumericLine, out var result);
+
+        Assert.True(parsed);
+        Assert.Equal("5", result!.Value);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_NoLineParses_ReturnsFalseAndClearsAStaleResult()
+    {
+        // The last attempt writes a non-null result while still returning false; the helper must
+        // not leak it, because callers rely on null meaning "nothing parsed".
+        var parsed = LineParsing.TryParseFirst<Parsed>(
+            new[] { "a", "b" },
+            (string? line, [NotNullWhen(true)] out Parsed? value) =>
+            {
+                value = new Parsed(line!);
+                return false;
+            },
+            out var result);
+
+        Assert.False(parsed);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_EmptyLines_ReturnsFalseWithoutInvokingTryParse()
+    {
+        var invocations = 0;
+
+        var parsed = LineParsing.TryParseFirst<Parsed>(
+            Array.Empty<string>(),
+            (string? line, [NotNullWhen(true)] out Parsed? value) =>
+            {
+                invocations++;
+                value = null;
+                return false;
+            },
+            out var result);
+
+        Assert.False(parsed);
+        Assert.Null(result);
+        Assert.Equal(0, invocations);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_NullLineElement_IsHandedToTryParseRatherThanSkipped()
+    {
+        // The delegate signature accepts string?, and the real single-line parsers do their own
+        // null handling, so the helper must not filter nulls out on their behalf.
+        var attempted = new List<string?>();
+
+        LineParsing.TryParseFirst<Parsed>(
+            new string[] { null!, "3" },
+            (string? line, [NotNullWhen(true)] out Parsed? value) =>
+            {
+                attempted.Add(line);
+                return TryParseNumericLine(line, out value);
+            },
+            out _);
+
+        Assert.Equal(new string?[] { null, "3" }, attempted);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_TrueWithNullResult_ThrowsInvalidOperationException()
+    {
+        // A misbehaving single-line parser must be caught here rather than handing a null back
+        // through a [NotNullWhen(true)] out parameter.
+        var ex = Assert.Throws<InvalidOperationException>(() => LineParsing.TryParseFirst<Parsed>(
+            new[] { "1" },
+            (string? line, [NotNullWhen(true)] out Parsed? value) =>
+            {
+                // Deliberately violates the Try* contract: null result alongside true.
+                value = null!;
+                return true;
+            },
+            out _));
+
+        Assert.Contains("null result", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryParseFirst_Reference_TryParseException_Propagates()
+    {
+        // Parse failures are signalled by returning false; a thrown exception is a real fault and
+        // must not be swallowed into a "nothing parsed" result.
+        Assert.Throws<FormatException>(() => LineParsing.TryParseFirst<Parsed>(
+            new[] { "1" },
+            (string? line, [NotNullWhen(true)] out Parsed? value) => throw new FormatException("boom"),
+            out _));
+    }
+
+    // ---- value-type overload -----------------------------------------------------------------
+
+    [Fact]
+    public void TryParseFirst_Value_NullLines_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => LineParsing.TryParseFirst<int>(
+            null!, static (string? line, out int value) => { value = 0; return false; }, out _));
+
+        Assert.Equal("lines", ex.ParamName);
+    }
+
+    [Fact]
+    public void TryParseFirst_Value_NullTryParse_ThrowsArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => LineParsing.TryParseFirst<int>(new[] { "1" }, null!, out _));
+
+        Assert.Equal("tryParse", ex.ParamName);
+    }
+
+    [Fact]
+    public void TryParseFirst_Value_FirstParseableLineWins()
+    {
+        var parsed = LineParsing.TryParseFirst<int>(
+            new[] { "junk", "11", "22" },
+            static (string? line, out int value) => int.TryParse(line, out value),
+            out var result);
+
+        Assert.True(parsed);
+        Assert.Equal(11, result);
+    }
+
+    [Fact]
+    public void TryParseFirst_Value_NoLineParses_ReturnsFalseAndResetsAStaleResult()
+    {
+        // Same leak risk as the reference overload: a failing attempt that still wrote to the out
+        // parameter must not survive into the caller's variable.
+        var parsed = LineParsing.TryParseFirst<int>(
+            new[] { "a", "b" },
+            static (string? line, out int value) => { value = 99; return false; },
+            out var result);
+
+        Assert.False(parsed);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void TryParseFirst_Value_DefaultValuedSuccess_IsReportedAsSuccess()
+    {
+        // Unlike the reference overload, default(T) is a legitimate parsed value here: "0 errors"
+        // and "0 bytes free" are real device answers and must not be mistaken for a parse failure.
+        var parsed = LineParsing.TryParseFirst<int>(
+            new[] { "0", "5" },
+            static (string? line, out int value) => int.TryParse(line, out value),
+            out var result);
+
+        Assert.True(parsed);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void TryParseFirst_Value_DoesNotEnumeratePastTheFirstSuccess()
+    {
+        var parsed = LineParsing.TryParseFirst<int>(
+            ThrowingAfter("skip", "5"),
+            static (string? line, out int value) => int.TryParse(line, out value),
+            out var result);
+
+        Assert.True(parsed);
+        Assert.Equal(5, result);
+    }
+}


### PR DESCRIPTION
Produced by the **COVERAGE-GAP** maintenance routine. Tests only — no production code is touched, so the change cannot alter runtime behaviour.

## What was wrong

`LineParsing.TryParseFirst` is the small shared helper that every "ask the device, take the first line that parses" response parser sits on: `SdCardSpaceParser`, `LogLevelParser`, `LanChipInfoParser`, the capability API-version query, the system error-count query, and the analog-output readback. Six call sites, and it had no tests of its own — it was only ever reached through those parsers, all of which feed it clean, well-formed input.

That meant essentially none of the helper's own contract was pinned. If someone had refactored it into materializing the sequence up front, or iterating in reverse, or quietly skipping null lines, or leaving a stale value in the `out` parameter after a failed parse, the whole existing suite would still have gone green. The stale-`out` case is the one most likely to bite for real: a single-line parse function that writes to `result` and *then* returns `false` is perfectly legal, and callers treat a non-null result as "we parsed something".

## How it was fixed

Adds `src/Daqifi.Core.Tests/Device/LineParsingTests.cs` — 16 cases across both the reference-typed and value-typed overloads:

- `ArgumentNullException` on a null line sequence and on a null parse function, with the right `ParamName`, on both overloads
- lines are tried in order and the helper stops at the first success (not the last match)
- the sequence is enumerated lazily — a rewrite that materialized it first is caught
- a null element inside the sequence is handed to the parse function rather than filtered out, because the real single-line parsers do their own null handling
- when nothing parses, the result is cleared even if the last attempt wrote to it before returning `false`
- `InvalidOperationException` when a parse function returns `true` with a null result, which is what keeps the `[NotNullWhen(true)]` promise honest
- an exception thrown by the parse function propagates instead of being read as "no match"
- `default(T)` is a legitimate success in the value overload — "0 errors" and "0 bytes free" are real device answers and must not read as a parse failure

**Every one of the 16 cases was verified to fail against a mutated implementation.** Three mutation rounds were run and each round killed exactly the cases it targeted: stripping the argument guards killed 4, a round of behaviour mutations (skip nulls / drop the null-result check / swallow exceptions / initialise the `out` value at the top / treat `default` as failure) killed 6, and a round of eager-materialise-plus-reverse-iteration killed 7. No case survives all three.

One thing a reviewer might reasonably push on: the deliberately-misbehaving lambda in the `InvalidOperationException` test assigns `value = null!;`. That `!` is load-bearing — the delegate is declared `[NotNullWhen(true)] out T?`, so without it the file will not compile, and simulating a parse function that violates that contract is the entire point of the test.

## Verification

`dotnet build` clean, 0 warnings. Full solution suite: net9.0 3782 passed / 2 skipped, net10.0 3782 passed / 2 skipped, `Daqifi.Mcp.Tests` 217 passed, 0 failures. Run under the shared test lock. No bug was found in the helper — it behaves correctly on every edge probed, so no issue was opened.

Not merging — opened for review.