### PR TITLE
chore: unify the negative-channel guard in ScpiMessageProducer

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -1033,6 +1033,42 @@ public class ScpiMessageProducerTests
         Assert.False(ScpiMessageProducer.IsFriendlyNameValid(name));
     }
 
+    // Each channel-addressed producer already has its own test proving it throws on a
+    // negative channel. None of them pinned what callers can actually observe about that
+    // throw, so nothing stopped the nine copies of the rule from drifting apart. They now
+    // share one ValidateChannel helper; this pins the contract it is there to hold.
+    [Fact]
+    public void EveryChannelAddressedProducer_RejectsNegativeChannelIdentically()
+    {
+        var producers = new (string Name, Action Act)[]
+        {
+            (nameof(ScpiMessageProducer.SetPwmChannelEnabled), () => ScpiMessageProducer.SetPwmChannelEnabled(-1, true)),
+            (nameof(ScpiMessageProducer.SetPwmChannelFrequency), () => ScpiMessageProducer.SetPwmChannelFrequency(-1, 100)),
+            (nameof(ScpiMessageProducer.SetPwmChannelDutyCycle), () => ScpiMessageProducer.SetPwmChannelDutyCycle(-1, 50)),
+            (nameof(ScpiMessageProducer.SetAnalogOutputVoltage), () => ScpiMessageProducer.SetAnalogOutputVoltage(-1, 1.0)),
+            (nameof(ScpiMessageProducer.GetAnalogOutputVoltage), () => ScpiMessageProducer.GetAnalogOutputVoltage(-1)),
+            (nameof(ScpiMessageProducer.SetAdcCalibrationSlope), () => ScpiMessageProducer.SetAdcCalibrationSlope(-1, 1.0)),
+            (nameof(ScpiMessageProducer.SetAdcCalibrationOffset), () => ScpiMessageProducer.SetAdcCalibrationOffset(-1, 1.0)),
+            (nameof(ScpiMessageProducer.GetAdcCalibrationSlope), () => ScpiMessageProducer.GetAdcCalibrationSlope(-1)),
+            (nameof(ScpiMessageProducer.GetAdcCalibrationOffset), () => ScpiMessageProducer.GetAdcCalibrationOffset(-1)),
+        };
+
+        var observed = new List<(string Producer, string? ParamName, object? ActualValue, string Message)>();
+        foreach (var (name, act) in producers)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(act);
+            observed.Add((name, ex.ParamName, ex.ActualValue, ex.Message));
+        }
+
+        Assert.Equal(9, observed.Count);
+        Assert.All(observed, o =>
+        {
+            Assert.Equal("channel", o.ParamName);
+            Assert.Equal(-1, o.ActualValue);
+            Assert.StartsWith("Channel number cannot be negative.", o.Message, StringComparison.Ordinal);
+        });
+    }
+
     private static void AssertMessageFormat(IOutboundMessage<string> message)
     {
         var bytes = message.GetBytes();

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -597,10 +597,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetPwmChannelEnabled(int channel, bool enabled)
     {
-        if (channel < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
-        }
+        ValidateChannel(channel);
 
         return new ScpiMessage($"PWM:CHannel:ENable {channel},{(enabled ? 1 : 0)}");
     }
@@ -618,10 +615,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetPwmChannelFrequency(int channel, int frequencyHz)
     {
-        if (channel < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
-        }
+        ValidateChannel(channel);
 
         if (frequencyHz <= 0)
         {
@@ -642,10 +636,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetPwmChannelDutyCycle(int channel, int dutyCyclePercent)
     {
-        if (channel < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
-        }
+        ValidateChannel(channel);
 
         if (dutyCyclePercent is < 0 or > 100)
         {
@@ -670,10 +661,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetAnalogOutputVoltage(int channel, double voltage)
     {
-        if (channel < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
-        }
+        ValidateChannel(channel);
 
         if (!double.IsFinite(voltage))
         {
@@ -710,10 +698,7 @@ public class ScpiMessageProducer
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="channel"/> is negative.</exception>
     public static IOutboundMessage<string> GetAnalogOutputVoltage(int channel)
     {
-        if (channel < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
-        }
+        ValidateChannel(channel);
 
         return new ScpiMessage($"SOURce:VOLTage:LEVel? {channel}");
     }
@@ -766,10 +751,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetAdcCalibrationSlope(int channel, double calM)
     {
-        if (channel < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
-        }
+        ValidateChannel(channel);
 
         if (!double.IsFinite(calM))
         {
@@ -795,10 +777,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetAdcCalibrationOffset(int channel, double calB)
     {
-        if (channel < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
-        }
+        ValidateChannel(channel);
 
         if (!double.IsFinite(calB))
         {
@@ -821,10 +800,7 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> GetAdcCalibrationSlope(int channel)
     {
-        if (channel < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
-        }
+        ValidateChannel(channel);
 
         return new ScpiMessage($"CONFigure:ADC:chanCALM? {channel}");
     }
@@ -841,12 +817,21 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> GetAdcCalibrationOffset(int channel)
     {
+        ValidateChannel(channel);
+
+        return new ScpiMessage($"CONFigure:ADC:chanCALB? {channel}");
+    }
+
+    // Every channel-addressed SCPI command rejects a negative channel with the same
+    // ArgumentOutOfRangeException. Kept in one place so the rule (and its message)
+    // cannot drift between commands. The parameter is named `channel` so the thrown
+    // exception's ParamName matches each caller's own parameter, as before.
+    private static void ValidateChannel(int channel)
+    {
         if (channel < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
         }
-
-        return new ScpiMessage($"CONFigure:ADC:chanCALB? {channel}");
     }
 
     /// <summary>


### PR DESCRIPTION
Produced by the **duplicate-unifier** maintenance routine, which looks for logic that has been copy-pasted into several places and folds it back into one.

## What was wrong

`ScpiMessageProducer` has nine public methods addressed to a specific channel — the three PWM commands, the two analog-output commands, and the four ADC-calibration commands. Every one of them opened with the same four lines, byte for byte:

```csharp
if (channel < 0)
{
    throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
}
```

Nine copies of one rule. Nothing held them together, and nothing in the test suite would have noticed them coming apart: each method had a test asserting only that *some* `ArgumentOutOfRangeException` is thrown, so a copy could have quietly acquired a different message, a different `ParamName`, or a different boundary and every test would still have passed. The copies had not actually drifted yet — I checked all nine and they agreed exactly — so this is unification, not a repair, and there was no "which behavior is correct" question to answer.

## How it was fixed

One private `ValidateChannel(int channel)` holds the rule; the nine call sites become a single line each. Net 19 lines added, 34 removed.

The one detail worth a reviewer's attention is the exception's `ParamName`. It comes from `nameof(channel)`, which is evaluated wherever it is written — so moving the throw into a helper would normally change `ParamName` to whatever the helper calls its parameter. The helper's parameter is therefore named `channel`, exactly matching all nine callers, and `ParamName` stays `"channel"` as before. Thrown type, `ParamName`, `ActualValue` and message text are all unchanged; the emitted SCPI is untouched.

I deliberately did **not** rewrite the guard as `ArgumentOutOfRangeException.ThrowIfNegative`, which would have been tidier but changes the message text — a behavior change smuggled into a refactor.

The new test pins the part callers can actually observe (`ParamName`, `ActualValue`, message) identically across all nine entry points. That is the property the shared helper exists to guarantee, and it was the property nothing was checking.

Scope stops at this file. `DeviceAdministrationOperations` has its own `ValidateChannelNumber` with a parameter named `channelNumber`; merging the two would change `ParamName` on that side, so they stay separate.

## Filed separately

Two more methods in the same class, `SetDioPortDirection` and `SetDioPortState`, also take an `int channel` but do **not** guard it — `SetDioPortDirection(-1, 1)` happily produces `DIO:PORt:DIRection -1,1` and sends it. That is a real inconsistency in the public contract, but closing it changes behavior, so it is **#624** rather than part of this PR.

## Verification

`dotnet build`: 0 warnings, 0 errors. Full `dotnet test`: green on net9.0 and net10.0 — 3767 passed / 0 failed / 2 pre-existing skips per TFM, plus 217 in Daqifi.Mcp.Tests.

No board interaction: the change alters no protocol bytes and no timing, only which method holds a comparison.

**Not merging — for review.**
