### PR TITLE
chore(sdcard): unify the SD operations' streaming-pause preamble

### DIFF
--- a/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardOperations.cs
@@ -216,13 +216,7 @@ namespace Daqifi.Core.Device.SdCard
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Captured before the defensive stop below so the finally can tell "this operation
-            // silenced a live stream" apart from "nothing was streaming to begin with" (#533).
-            var wasStreaming = _host.IsStreaming;
-
-            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
-            _host.Send(ScpiMessageProducer.StopStreaming);
-            _host.IsStreaming = false;
+            var wasStreaming = PauseStreamingForSdOperation();
 
             try
             {
@@ -364,6 +358,35 @@ namespace Daqifi.Core.Device.SdCard
         }
 
         /// <summary>
+        /// Silences streaming ahead of an SD-card operation and reports whether a live stream was
+        /// actually running, so <see cref="RestoreStreamingIfNeeded"/> can put it back afterwards
+        /// (#533). The stop half is unconditional even when the flag says nothing is streaming,
+        /// because the flag can be stale (issue #118).
+        /// </summary>
+        /// <returns>
+        /// <see cref="IDeviceOperationHost.IsStreaming"/> as it stood immediately before the stop.
+        /// Pass it to <see cref="RestoreStreamingIfNeeded"/> from the operation's <c>finally</c>,
+        /// which uses it to tell "this operation silenced a live stream" apart from "nothing was
+        /// streaming to begin with".
+        /// </returns>
+        /// <remarks>
+        /// The capture has to come before the stop with nothing in between: read it afterwards and
+        /// it reports state this method has already cleared, so the stream is never resumed. Owning
+        /// both halves here is what holds that ordering at every call site, rather than each one
+        /// re-deriving it.
+        /// </remarks>
+        private bool PauseStreamingForSdOperation()
+        {
+            var wasStreaming = _host.IsStreaming;
+
+            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
+            _host.Send(ScpiMessageProducer.StopStreaming);
+            _host.IsStreaming = false;
+
+            return wasStreaming;
+        }
+
+        /// <summary>
         /// Resumes streaming after an SD-card operation's defensive stop, if a live stream was
         /// actually running when the operation started (#533). Every SD operation stops streaming
         /// unconditionally before it touches the card, whether or not anyone was consuming it; left
@@ -502,12 +525,7 @@ namespace Daqifi.Core.Device.SdCard
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
-            var wasStreaming = _host.IsStreaming;
-
-            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
-            _host.Send(ScpiMessageProducer.StopStreaming);
-            _host.IsStreaming = false;
+            var wasStreaming = PauseStreamingForSdOperation();
 
             try
             {
@@ -797,12 +815,8 @@ namespace Daqifi.Core.Device.SdCard
 
             ValidateSdCardFileName(fileName);
 
-            // Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
-            var wasStreaming = _host.IsStreaming;
+            var wasStreaming = PauseStreamingForSdOperation();
 
-            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
-            _host.Send(ScpiMessageProducer.StopStreaming);
-            _host.IsStreaming = false;
             try
             {
                 // Same prepare/finalize treatment as GetSdCardFilesAsync, for the same reasons — the
@@ -1037,12 +1051,7 @@ namespace Daqifi.Core.Device.SdCard
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
-            var wasStreaming = _host.IsStreaming;
-
-            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
-            _host.Send(ScpiMessageProducer.StopStreaming);
-            _host.IsStreaming = false;
+            var wasStreaming = PauseStreamingForSdOperation();
 
             try
             {
@@ -1165,12 +1174,7 @@ namespace Daqifi.Core.Device.SdCard
                 throw new SdCardBusyException(Array.Empty<string>());
             }
 
-            // Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
-            var wasStreaming = _host.IsStreaming;
-
-            // Defensive: always send stop command even if IsStreaming is stale (see issue #118)
-            _host.Send(ScpiMessageProducer.StopStreaming);
-            _host.IsStreaming = false;
+            var wasStreaming = PauseStreamingForSdOperation();
 
             var stopwatch = Stopwatch.StartNew();
             long fileSize = 0;


### PR DESCRIPTION
The maintenance routine **DUPLICATE-UNIFIER** produced this. It is a pure refactor of `SdCardOperations` — no behavior change, no wire change.

## What was wrong

Every SD-card operation has to silence streaming before it touches the card, because the card and the LAN share the SPI bus. Doing that safely takes two steps in a specific order: read `IsStreaming` *first*, then send the unconditional stop. The read has to come first or it reports state the stop has already cleared — and then the `finally` at the end of the operation concludes nothing was streaming and never resumes it. A caller sitting in `StreamSamplesAsync` goes quiet for the rest of the read with no error, because the device is still connected, just no longer streaming. That is the bug #533 fixed.

The restore half of that pair has had a shared owner since #533 — `RestoreStreamingIfNeeded(bool wasStreaming)`, with a long comment explaining exactly why the flag matters. The pause half never got one. It was copy-pasted verbatim into five operations (list, storage, delete, format, download), each carrying its own copy of the ordering requirement as a comment:

```csharp
// Captured before the defensive stop below — see GetSdCardFilesAsync (#533).
var wasStreaming = _host.IsStreaming;

// Defensive: always send stop command even if IsStreaming is stale (see issue #118)
_host.Send(ScpiMessageProducer.StopStreaming);
_host.IsStreaming = false;
```

All five copies still agree byte for byte, so nothing has drifted yet. The risk is that the invariant they encode is invisible to whoever writes the sixth operation: a new SD operation that stops the stream but forgets the capture, or slips a line between the two halves, reintroduces #533 silently — the code compiles, the operation works, and only a concurrent stream consumer notices.

## How it was fixed

`PauseStreamingForSdOperation()` — a private helper returning `bool`, sitting directly above the `RestoreStreamingIfNeeded` it mirrors. Each of the five call sites becomes `var wasStreaming = PauseStreamingForSdOperation();`, still feeding the same `RestoreStreamingIfNeeded(wasStreaming)` in the same `finally`. The capture and the stop can no longer be separated because a single method owns both, and the ordering rationale is documented once instead of five times.

Two things a reviewer may want to push on:

- **One copy of the stop was deliberately left behind.** `StopSdCardLoggingAsync` sends `StopStreaming` and clears the flag, but never captures `wasStreaming` and never restores. That is correct — it is a *stop*, not a *pause*; the caller asked for streaming to end. Folding it into a helper named "pause" that returns a value it would discard would obscure that difference rather than remove duplication.
- **`StartSdCardLoggingSessionAsync` was untouched.** It sets `IsStreaming = true` on its way out; it has no pause/restore pair to unify.

## Verification

- `dotnet build`: 0 warnings, 0 errors (`TreatWarningsAsErrors=true`).
- Full `dotnet test`: green on net9.0 and net10.0 — 3766 passed / 0 failed / 2 pre-existing skips per TFM, plus 217 in Daqifi.Mcp.Tests.
- No new tests. `SdCardOperationsCollaboratorTests` already pins both branches at all five sites (`..._WasStreaming_Resumes...` and `..._WasNotStreaming_LeavesStreamingOff` for list, storage, delete, format and download), which is precisely the property the helper now guarantees. Adding another assertion of it would be redundant.
- No board interaction: the change alters no bytes, no ordering and no timing on the wire — only which method holds the two statements.

**Not merging — opened for review.**
