### PR TITLE
fix(sdcard): a blank file-derived string is a gap, not an answer, in the SD card config merge

### DIFF
--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardConfigurationMergeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardConfigurationMergeTests.cs
@@ -274,23 +274,33 @@ public class SdCardConfigurationMergeTests
     [Fact]
     public void Merge_WhenBothSidesAreBlank_ReportsTheGapAsNull()
     {
-        // Arrange — nothing to fall back on: the device snapshot is as silent as the file.
+        // Arrange — nothing to fall back on: the device snapshot is as silent as the file. Blank
+        // rather than null on the override side is the realistic shape, because DeviceMetadata
+        // initializes its strings to string.Empty, so a device that has not reported a firmware
+        // revision yet hands FromDevice an empty one.
         var parsed = Empty() with { DeviceSerialNumber = "", DevicePartNumber = "  " };
+        var overrideConfig = Empty() with
+        {
+            DeviceSerialNumber = "",
+            DevicePartNumber = "",
+            FirmwareRevision = ""
+        };
 
         // Act
-        var merged = SdCardConfigurationMerge.Merge(parsed, Empty());
+        var merged = SdCardConfigurationMerge.Merge(parsed, overrideConfig);
 
         // Assert — a blank left over from an empty header is normalized to the record's documented
         // "not present" value, so callers have one absence to test for instead of two.
         Assert.Null(merged.DeviceSerialNumber);
         Assert.Null(merged.DevicePartNumber);
+        Assert.Null(merged.FirmwareRevision);
     }
 
     [Fact]
     public void Merge_WhenOnlyTheOverrideIsBlank_KeepsTheFileValue()
     {
-        // Arrange — the reverse direction: a blank on the override side is not a value either,
-        // and it must not be mistaken for one now that blanks are meaningful.
+        // Arrange — the reverse direction: a blank on the override side is not a value either, and
+        // a device whose metadata has not been populated yet supplies exactly that.
         var parsed = Empty() with { DeviceSerialNumber = "SN-FILE", DevicePartNumber = "PN-FILE" };
         var overrideConfig = Empty() with { DeviceSerialNumber = "", DevicePartNumber = "   " };
 

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardConfigurationMergeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardConfigurationMergeTests.cs
@@ -238,4 +238,67 @@ public class SdCardConfigurationMergeTests
         Assert.Null(merged.PortRange);
         Assert.Null(merged.InternalScaleM);
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Merge_WhenFileStatesBlankMetadataStrings_OverrideFillsThem(string blank)
+    {
+        // Arrange — a truncated or label-only header line ("# Serial Number:" with nothing after
+        // it) parses to an empty string rather than null, so the file appears to state a value
+        // while carrying no information. It must not shadow the connected device's real metadata,
+        // exactly as a zero port count does not shadow the device's real channel layout.
+        var parsed = Empty() with
+        {
+            DeviceSerialNumber = blank,
+            DevicePartNumber = blank,
+            FirmwareRevision = blank
+        };
+        var overrideConfig = Empty() with
+        {
+            DeviceSerialNumber = "SN-DEVICE",
+            DevicePartNumber = "PN-DEVICE",
+            FirmwareRevision = "1.2.3"
+        };
+
+        // Act
+        var merged = SdCardConfigurationMerge.Merge(parsed, overrideConfig);
+
+        // Assert
+        Assert.Equal("SN-DEVICE", merged.DeviceSerialNumber);
+        Assert.Equal("PN-DEVICE", merged.DevicePartNumber);
+        Assert.Equal("1.2.3", merged.FirmwareRevision);
+    }
+
+    [Fact]
+    public void Merge_WhenBothSidesAreBlank_ReportsTheGapAsNull()
+    {
+        // Arrange — nothing to fall back on: the device snapshot is as silent as the file.
+        var parsed = Empty() with { DeviceSerialNumber = "", DevicePartNumber = "  " };
+
+        // Act
+        var merged = SdCardConfigurationMerge.Merge(parsed, Empty());
+
+        // Assert — a blank left over from an empty header is normalized to the record's documented
+        // "not present" value, so callers have one absence to test for instead of two.
+        Assert.Null(merged.DeviceSerialNumber);
+        Assert.Null(merged.DevicePartNumber);
+    }
+
+    [Fact]
+    public void Merge_WhenOnlyTheOverrideIsBlank_KeepsTheFileValue()
+    {
+        // Arrange — the reverse direction: a blank on the override side is not a value either,
+        // and it must not be mistaken for one now that blanks are meaningful.
+        var parsed = Empty() with { DeviceSerialNumber = "SN-FILE", DevicePartNumber = "PN-FILE" };
+        var overrideConfig = Empty() with { DeviceSerialNumber = "", DevicePartNumber = "   " };
+
+        // Act
+        var merged = SdCardConfigurationMerge.Merge(parsed, overrideConfig);
+
+        // Assert
+        Assert.Equal("SN-FILE", merged.DeviceSerialNumber);
+        Assert.Equal("PN-FILE", merged.DevicePartNumber);
+    }
 }

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardCsvFileParserTests.cs
@@ -511,6 +511,43 @@ public sealed class SdCardCsvFileParserTests
         Assert.Equal(1, session.DeviceConfig.DigitalPortCount);
     }
 
+    [Fact]
+    public async Task ParseAsync_ConfigurationOverride_FillsHeaderLabelsThatStateNoValue()
+    {
+        // Arrange — a truncated header writes the labels but no values:
+        //   "# Device:"  /  "# Serial Number:"
+        // Those parse to empty strings, not null. The connected device knows both, so the
+        // session must report the device's metadata rather than a pair of blanks.
+        await using var stream = SdCardTestCsvFileBuilder.BuildCsvFileSharedTimestamp(
+            deviceName: "", serialNumber: "", 50_000_000u,
+            (1000u, new[] { 1.0, 2.0 })
+        );
+
+        var overrideConfig = new global::Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration(
+            AnalogPortCount: 2,
+            DigitalPortCount: 0,
+            TimestampFrequency: 50_000_000u,
+            DeviceSerialNumber: "7E2815916200E898",
+            DevicePartNumber: "Nyquist 1",
+            FirmwareRevision: "3.7.2",
+            CalibrationValues: null
+        );
+
+        var parser = new global::Daqifi.Core.Device.SdCard.SdCardCsvFileParser();
+        var options = new global::Daqifi.Core.Device.SdCard.SdCardParseOptions
+        {
+            ConfigurationOverride = overrideConfig
+        };
+
+        // Act
+        var session = await parser.ParseAsync(stream, "test.csv", options);
+
+        // Assert
+        Assert.NotNull(session.DeviceConfig);
+        Assert.Equal("7E2815916200E898", session.DeviceConfig.DeviceSerialNumber);
+        Assert.Equal("Nyquist 1", session.DeviceConfig.DevicePartNumber);
+    }
+
     // -------------------------------------------------------------------------
     // Progress reporting & cancellation
     // -------------------------------------------------------------------------

--- a/src/Daqifi.Core/Device/SdCard/SdCardConfigurationMerge.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardConfigurationMerge.cs
@@ -21,6 +21,10 @@ internal static class SdCardConfigurationMerge
     /// <see cref="string.Empty"/>, not null — and an empty label carries no more information than
     /// an absent one, so it must not shadow the real serial a connected device reported. The
     /// binary parser's own merge already treats an empty part number or firmware revision this way.
+    /// The same test applies to the override side, where blanks are if anything more common:
+    /// <see cref="DeviceMetadata"/> initializes its metadata strings to <see cref="string.Empty"/>,
+    /// so a device that has not reported a firmware revision yet carries one. The merged result
+    /// then reports a field nobody stated as null, the value the record documents for absent.
     /// <para>
     /// The list fields keep the plain null test. Both text parsers hand those in as literal null,
     /// so an empty-but-non-null list cannot reach here, and whether an explicitly empty channel
@@ -40,9 +44,9 @@ internal static class SdCardConfigurationMerge
             AnalogPortCount: parsed.AnalogPortCount > 0 ? parsed.AnalogPortCount : overrideConfig.AnalogPortCount,
             DigitalPortCount: parsed.DigitalPortCount > 0 ? parsed.DigitalPortCount : overrideConfig.DigitalPortCount,
             TimestampFrequency: parsed.TimestampFrequency > 0 ? parsed.TimestampFrequency : overrideConfig.TimestampFrequency,
-            DeviceSerialNumber: Stated(parsed.DeviceSerialNumber) ?? overrideConfig.DeviceSerialNumber,
-            DevicePartNumber: Stated(parsed.DevicePartNumber) ?? overrideConfig.DevicePartNumber,
-            FirmwareRevision: Stated(parsed.FirmwareRevision) ?? overrideConfig.FirmwareRevision,
+            DeviceSerialNumber: Stated(parsed.DeviceSerialNumber) ?? Stated(overrideConfig.DeviceSerialNumber),
+            DevicePartNumber: Stated(parsed.DevicePartNumber) ?? Stated(overrideConfig.DevicePartNumber),
+            FirmwareRevision: Stated(parsed.FirmwareRevision) ?? Stated(overrideConfig.FirmwareRevision),
             CalibrationValues: parsed.CalibrationValues ?? overrideConfig.CalibrationValues,
             Resolution: parsed.Resolution > 0 ? parsed.Resolution : overrideConfig.Resolution,
             PortRange: parsed.PortRange ?? overrideConfig.PortRange,

--- a/src/Daqifi.Core/Device/SdCard/SdCardConfigurationMerge.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardConfigurationMerge.cs
@@ -12,8 +12,21 @@ internal static class SdCardConfigurationMerge
 {
     /// <summary>
     /// Merges <paramref name="overrideConfig"/> into <paramref name="parsed"/>. File-derived
-    /// values are primary; the override fills in gaps (zero or null fields).
+    /// values are primary; the override fills in gaps.
     /// </summary>
+    /// <remarks>
+    /// A gap is a field the file states no value for: a non-positive number, a null reference, or
+    /// a blank string. Blank counts because a text header spells a field's label out even when it
+    /// has no value to put after it — <c>"# Serial Number:"</c> alone on a line parses to
+    /// <see cref="string.Empty"/>, not null — and an empty label carries no more information than
+    /// an absent one, so it must not shadow the real serial a connected device reported. The
+    /// binary parser's own merge already treats an empty part number or firmware revision this way.
+    /// <para>
+    /// The list fields keep the plain null test. Both text parsers hand those in as literal null,
+    /// so an empty-but-non-null list cannot reach here, and whether an explicitly empty channel
+    /// list means "absent" is a separate question, worth answering when a parser can produce one.
+    /// </para>
+    /// </remarks>
     public static SdCardDeviceConfiguration Merge(
         SdCardDeviceConfiguration parsed,
         SdCardDeviceConfiguration? overrideConfig)
@@ -27,12 +40,18 @@ internal static class SdCardConfigurationMerge
             AnalogPortCount: parsed.AnalogPortCount > 0 ? parsed.AnalogPortCount : overrideConfig.AnalogPortCount,
             DigitalPortCount: parsed.DigitalPortCount > 0 ? parsed.DigitalPortCount : overrideConfig.DigitalPortCount,
             TimestampFrequency: parsed.TimestampFrequency > 0 ? parsed.TimestampFrequency : overrideConfig.TimestampFrequency,
-            DeviceSerialNumber: parsed.DeviceSerialNumber ?? overrideConfig.DeviceSerialNumber,
-            DevicePartNumber: parsed.DevicePartNumber ?? overrideConfig.DevicePartNumber,
-            FirmwareRevision: parsed.FirmwareRevision ?? overrideConfig.FirmwareRevision,
+            DeviceSerialNumber: Stated(parsed.DeviceSerialNumber) ?? overrideConfig.DeviceSerialNumber,
+            DevicePartNumber: Stated(parsed.DevicePartNumber) ?? overrideConfig.DevicePartNumber,
+            FirmwareRevision: Stated(parsed.FirmwareRevision) ?? overrideConfig.FirmwareRevision,
             CalibrationValues: parsed.CalibrationValues ?? overrideConfig.CalibrationValues,
             Resolution: parsed.Resolution > 0 ? parsed.Resolution : overrideConfig.Resolution,
             PortRange: parsed.PortRange ?? overrideConfig.PortRange,
             InternalScaleM: parsed.InternalScaleM ?? overrideConfig.InternalScaleM);
     }
+
+    /// <summary>
+    /// Returns <paramref name="value"/> when the file actually stated something, or
+    /// <see langword="null"/> when it left a gap for the override to fill.
+    /// </summary>
+    private static string? Stated(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
 }


### PR DESCRIPTION
## What was wrong

If an SD card log's header line states a field's label but no value — `# Serial Number:` with nothing after it, from a truncated or partially written file — the CSV parser produces an empty string for that field, not `null`. `SdCardConfigurationMerge` only treated `null` as "the file didn't say", so the empty string counted as a real answer and won over the override.

The visible effect: parse that log with a connected device's snapshot in `SdCardParseOptions.ConfigurationOverride` (from `SdCardDeviceConfiguration.FromDevice`, which knows the real serial), and `session.DeviceConfig.DeviceSerialNumber` still comes back as `""`. The device's answer was available and was thrown away. Same for `DevicePartNumber` via `# Device:`.

The merge already had the right instinct for numbers — `AnalogPortCount` uses `> 0`, so a zero port count is a gap the device fills. The strings just used `??`, so only `null` was a gap. That is the inconsistency.

## How it was fixed

A blank string now counts as a gap, on the same footing as a non-positive number. `DeviceSerialNumber`, `DevicePartNumber` and `FirmwareRevision` route through a small `Stated()` helper that maps null-or-whitespace to `null`, on **both** sides of the `??`.

Two judgement calls a reviewer should weigh:

**Whitespace, not just empty.** `string.IsNullOrWhiteSpace`, so `"   "` is a gap too. The CSV parser trims, so only `""` is reachable today; whitespace is included because a label with nothing but spaces after it says exactly as much as one with nothing at all. Note this is slightly wider than the neighbouring precedent — the binary parser's `MergeConfigurations` uses `IsNullOrEmpty` for the same two fields. That precedent is the reason I'm confident "empty means absent" is the intended reading here; I took the whitespace-tolerant version of it rather than copying it exactly.

**A blank with nothing to fall back on now reports `null`.** If neither side states the field, the result is `null` where it used to be `""`. That is the one behaviour change beyond the bug itself, and it applies to the override side too — which is the more common source of blanks, since `DeviceMetadata` initializes `SerialNumber`, `PartNumber` and `FirmwareVersion` to `string.Empty`, so `FromDevice` on a device that hasn't reported a firmware revision yet carries an empty one. Normalizing on `null` matches what the record documents as absent (`string? DeviceSerialNumber` — "Device serial number, if present"), so callers have one absence to check instead of two.

(This second half — normalizing the override side — came out of the first Qodo round, which correctly spotted that the original push normalized only the parsed side while a test comment claimed otherwise.)

**Scope kept narrow on the lists.** The issue also suggests giving `CalibrationValues` / `PortRange` / `InternalScaleM` a `Count > 0` test. I left them on `??`. Both text parsers pass those in as literal `null`, so an empty-but-non-null list cannot reach this merge — the change would be untriggerable, and "an explicitly empty channel list" is a different question from "a blank label" that's better answered when a parser can actually produce one. The reasoning is recorded in the method's `<remarks>` rather than left implicit.

## Verification

Five new assertions, all confirmed failing against the pre-fix implementation (stashed the source change, re-ran: 5 failed; restored, 17 passed):

- `SdCardConfigurationMergeTests` — blank strings (`""`, `"   "`, `"\t"`) let the override through; blank-on-both-sides (with real blanks on the override, the shape `FromDevice` actually produces) reports `null`; a blank on the *override* side does not clobber a real file value.
- `SdCardCsvFileParserTests.ParseAsync_ConfigurationOverride_FillsHeaderLabelsThatStateNoValue` — the end-to-end shape from the issue: a CSV whose `# Device:` and `# Serial Number:` lines are label-only, parsed with a device override, now reports the device's metadata.

Full suite green on net9.0 and net10.0: 3772 passed, 2 skipped, 0 failed on each.

closes #618

---

**Not merging — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
