### PR TITLE
chore: unify the non-finite guard in ScpiMessageProducer's double setters

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -525,7 +525,12 @@ public class ScpiMessageProducerTests
     [InlineData(double.NegativeInfinity)]
     public void SetAdcCalibrationSlope_WithNonFiniteValue_Throws(double calM)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAdcCalibrationSlope(0, calM));
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAdcCalibrationSlope(0, calM));
+
+        // The finite check is shared with the other double-valued setters, so pin the
+        // parameter name and wording this call site is responsible for supplying.
+        Assert.Equal("calM", ex.ParamName);
+        Assert.Contains("Calibration slope must be a finite number.", ex.Message);
     }
 
     [Fact]
@@ -564,7 +569,12 @@ public class ScpiMessageProducerTests
     [InlineData(double.NegativeInfinity)]
     public void SetAdcCalibrationOffset_WithNonFiniteValue_Throws(double calB)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAdcCalibrationOffset(0, calB));
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAdcCalibrationOffset(0, calB));
+
+        // The finite check is shared with the other double-valued setters, so pin the
+        // parameter name and wording this call site is responsible for supplying.
+        Assert.Equal("calB", ex.ParamName);
+        Assert.Contains("Calibration offset must be a finite number.", ex.Message);
     }
 
     [Fact]
@@ -846,7 +856,12 @@ public class ScpiMessageProducerTests
     [InlineData(double.NegativeInfinity)]
     public void SetAnalogOutputVoltage_WithNonFiniteVoltage_Throws(double voltage)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAnalogOutputVoltage(0, voltage));
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetAnalogOutputVoltage(0, voltage));
+
+        // The finite check is shared with the other double-valued setters, so pin the
+        // parameter name and wording this call site is responsible for supplying.
+        Assert.Equal("voltage", ex.ParamName);
+        Assert.Contains("Voltage must be a finite number.", ex.Message);
     }
 
     [Fact]

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -663,11 +663,7 @@ public class ScpiMessageProducer
     {
         ValidateChannel(channel);
 
-        if (!double.IsFinite(voltage))
-        {
-            // NaN/Infinity would render as "NaN"/"Infinity" — tokens the firmware cannot parse.
-            throw new ArgumentOutOfRangeException(nameof(voltage), voltage, "Voltage must be a finite number.");
-        }
+        RequireFinite(voltage, nameof(voltage), "Voltage");
 
         return new ScpiMessage($"SOURce:VOLTage:LEVel {channel},{voltage.ToString(CultureInfo.InvariantCulture)}");
     }
@@ -753,11 +749,7 @@ public class ScpiMessageProducer
     {
         ValidateChannel(channel);
 
-        if (!double.IsFinite(calM))
-        {
-            // NaN/Infinity would render as "NaN"/"Infinity" — tokens the firmware cannot parse.
-            throw new ArgumentOutOfRangeException(nameof(calM), calM, "Calibration slope must be a finite number.");
-        }
+        RequireFinite(calM, nameof(calM), "Calibration slope");
 
         return new ScpiMessage($"CONFigure:ADC:chanCALM {channel},{calM.ToString(CultureInfo.InvariantCulture)}");
     }
@@ -779,11 +771,7 @@ public class ScpiMessageProducer
     {
         ValidateChannel(channel);
 
-        if (!double.IsFinite(calB))
-        {
-            // NaN/Infinity would render as "NaN"/"Infinity" — tokens the firmware cannot parse.
-            throw new ArgumentOutOfRangeException(nameof(calB), calB, "Calibration offset must be a finite number.");
-        }
+        RequireFinite(calB, nameof(calB), "Calibration offset");
 
         return new ScpiMessage($"CONFigure:ADC:chanCALB {channel},{calB.ToString(CultureInfo.InvariantCulture)}");
     }
@@ -831,6 +819,19 @@ public class ScpiMessageProducer
         if (channel < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(channel), channel, "Channel number cannot be negative.");
+        }
+    }
+
+    // The double-valued setters render their argument straight into the command text,
+    // so a non-finite value would reach the firmware as "NaN"/"Infinity" — tokens it
+    // cannot parse. Kept in one place so the rule (and its message) cannot drift
+    // between commands. The caller supplies paramName and description so the thrown
+    // exception still names that caller's own parameter, as before.
+    private static void RequireFinite(double value, string paramName, string description)
+    {
+        if (!double.IsFinite(value))
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, $"{description} must be a finite number.");
         }
     }
 


### PR DESCRIPTION
Produced by the **duplicate-unifier** maintenance routine. Safe because the extracted guard is byte-identical at all three call sites — same exception type, same `ParamName`, same actual value, same message text.

## What was wrong

`ScpiMessageProducer` has three public setters that take a `double` and render it straight into the SCPI command text. Each carried its own private copy of the same check:

```csharp
if (!double.IsFinite(voltage))
{
    // NaN/Infinity would render as "NaN"/"Infinity" — tokens the firmware cannot parse.
    throw new ArgumentOutOfRangeException(nameof(voltage), voltage, "Voltage must be a finite number.");
}
```

The same four lines appear in `SetAnalogOutputVoltage`, `SetAdcCalibrationSlope` and `SetAdcCalibrationOffset`, differing only in the parameter name and one noun. The rule they enforce — a `double` bound for the wire must be finite, because `NaN`/`Infinity` stringify into tokens the firmware cannot parse — was stated three times as a comment and owned by nothing.

**The drift risk here is not hypothetical; it has already happened.** There is a fourth double-valued setter, `SetDioPortState(int channel, double value)`, and it has no finite check at all — it interpolates its `double` directly into `DIO:PORt:STATe {channel},{value}`. A convention that lives only in copy-paste does not reach the next method that needs it, and this class already demonstrates that. Giving the rule a name is what lets a future setter call it instead of re-deriving it.

(That `SetDioPortState` gap is a behavior change to a public method, so it is **not** fixed here — filed separately as #629.)

## How it was fixed

One private helper, placed directly beside the `ValidateChannel` and `RequireIPv4` guards it mirrors:

```csharp
private static void RequireFinite(double value, string paramName, string description)
```

Each call site becomes one line, e.g. `RequireFinite(voltage, nameof(voltage), "Voltage");`.

**What a reviewer may push back on:** the helper takes `paramName` and `description` rather than generating them. That is deliberate and is what keeps the change behavior-free — the three exceptions must keep naming *their own* caller's parameter (`voltage`/`calM`/`calB`) and their own wording ("Voltage" / "Calibration slope" / "Calibration offset"). Collapsing them to one generic message would have been a smaller helper but a real behavior change to public API. The file's existing `RequireIPv4(address, paramName)` is the precedent for threading `paramName` this way.

The `.ToString(CultureInfo.InvariantCulture)` on each return was deliberately **not** folded into the helper. It pairs with the guard conceptually, but folding it in would put a `throw` inside a string interpolation — validation as a side effect of formatting — against the statement-position convention the class's two existing guards establish.

## Verification

- `dotnet build`: 0 warnings, 0 errors (`TreatWarningsAsErrors=true`).
- Full `dotnet test` under a `tests.N` lock: green on **net9.0 and net10.0** — Daqifi.Core.Tests 3804 passed / 0 failed / 2 pre-existing skips per TFM, plus Daqifi.Mcp.Tests 217 passed.
- The three existing non-finite theories asserted only the exception *type*, so they would not have caught a mis-threaded `paramName` — exactly the one thing this refactor could break. They now also assert `ParamName` and message text, pinning the per-call-site values the helper passes through.
- **No board interaction.** This changes no bytes, no ordering and no timing on the wire — only which method holds the check. Bench validation is inapplicable, not deferred for lack of hardware.

**Not merging — opened for review.**
