### PR TITLE
chore: unify the duplicated record-walk loop in IntelHexParser

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/IntelHexParserTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/IntelHexParserTests.cs
@@ -11,7 +11,12 @@ public class IntelHexParserTests
     [Fact]
     public void ParseHexRecords_WithNullLines_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => _parser.ParseHexRecords(null!));
+        var ex = Assert.Throws<ArgumentNullException>(() => _parser.ParseHexRecords(null!));
+
+        // The guard is eager and names the caller's own parameter. Both matter: if the walk
+        // were ever moved behind a lazy iterator that carried the null check with it, the
+        // throw would move to first enumeration instead of the call itself.
+        Assert.Equal("lines", ex.ParamName);
     }
 
     [Fact]
@@ -261,7 +266,79 @@ public class IntelHexParserTests
     [Fact]
     public void ParseRecords_WithNullLines_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => _parser.ParseRecords(null!));
+        var ex = Assert.Throws<ArgumentNullException>(() => _parser.ParseRecords(null!));
+
+        Assert.Equal("lines", ex.ParamName);
+    }
+
+    [Fact]
+    public void ParseRecords_WithBlankLines_SkipsThem()
+    {
+        var lines = new[] { "", "  ", "\t" };
+
+        var result = _parser.ParseRecords(lines);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseRecords_InvalidChecksum_ThrowsInvalidDataException()
+    {
+        // Valid record is :020000041D00DD, corrupt the checksum.
+        var lines = new[] { ":020000041D00AA" };
+
+        var ex = Assert.Throws<InvalidDataException>(() => _parser.ParseRecords(lines));
+        Assert.Contains("invalid checksum", ex.Message);
+    }
+
+    [Fact]
+    public void ParseRecords_DataInProtectedRange_IsFilteredAndBaseAddressStillTracked()
+    {
+        var lines = new[]
+        {
+            ":020000041D1EBF",                                   // Extended address 0x1D1E
+            ":10000000AABBCCDDEEFF00112233445566778899F8",       // Data at 0x1D1E0000 - protected
+            ":020000041D00DD",                                   // Extended address 0x1D00
+            ":10010000AABBCCDDEEFF00112233445566778899F7",       // Data at 0x1D000100 - kept
+            ":00000001FF"                                        // EOF
+        };
+
+        var result = _parser.ParseRecords(lines);
+
+        // The protected data record is dropped, and dropping it must not disturb the running
+        // base address that the records after it are addressed against.
+        Assert.Equal(4, result.Count);
+        Assert.Equal((byte)0x04, result[0].RecordType);
+        Assert.Equal((byte)0x04, result[1].RecordType);
+        Assert.Equal((byte)0x00, result[2].RecordType);
+        Assert.Equal(0x1D000100u, result[2].Address);
+        Assert.Equal((byte)0x01, result[3].RecordType);
+    }
+
+    [Fact]
+    public void ParseRecords_AndParseHexRecords_SelectTheSameRecords()
+    {
+        // Both public entry points walk, validate and filter identically; they differ only in
+        // what they project. Pin that agreement so the two cannot drift apart.
+        var lines = new[]
+        {
+            "",
+            ":020000041D1EBF",                                   // Extended address 0x1D1E
+            ":10000000AABBCCDDEEFF00112233445566778899F8",       // Data at 0x1D1E0000 - protected
+            ":020000041D00DD",                                   // Extended address 0x1D00
+            "   ",
+            ":10010000AABBCCDDEEFF00112233445566778899F7",       // Data at 0x1D000100 - kept
+            ":00000001FF"                                        // EOF
+        };
+
+        var hexRecords = _parser.ParseHexRecords(lines);
+        var records = _parser.ParseRecords(lines);
+
+        Assert.Equal(hexRecords.Count, records.Count);
+        for (var i = 0; i < hexRecords.Count; i++)
+        {
+            Assert.Equal(hexRecords[i], records[i].Data);
+        }
     }
 
     [Fact]

--- a/src/Daqifi.Core/Firmware/IntelHexParser.cs
+++ b/src/Daqifi.Core/Firmware/IntelHexParser.cs
@@ -50,31 +50,14 @@ public class IntelHexParser
     /// <exception cref="InvalidDataException">Thrown when a line is malformed or has an invalid checksum.</exception>
     public List<byte[]> ParseHexRecords(string[] lines)
     {
+        // Validate eagerly, before touching the iterator, so a null array throws here at the
+        // call rather than on first enumeration.
         ArgumentNullException.ThrowIfNull(lines);
 
-        ushort baseAddress = 0;
         var hexRecords = new List<byte[]>();
 
-        foreach (var line in lines)
+        foreach (var (hexLine, _) in EnumerateUnprotectedRecords(lines))
         {
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                continue;
-            }
-
-            ValidateLine(line);
-
-            var hexLine = ConvertLineToBytes(line);
-            ValidateRecordLength(hexLine, line);
-            ValidateChecksum(hexLine, line);
-
-            baseAddress = UpdateBaseAddress(hexLine, baseAddress, line);
-
-            if (IsProtectedHexRecord(hexLine, baseAddress))
-            {
-                continue;
-            }
-
             hexRecords.Add(hexLine);
         }
 
@@ -91,10 +74,42 @@ public class IntelHexParser
     /// <exception cref="InvalidDataException">Thrown when a line is malformed or has an invalid checksum.</exception>
     public List<HexFileRecord> ParseRecords(string[] lines)
     {
+        // Validate eagerly, before touching the iterator, so a null array throws here at the
+        // call rather than on first enumeration.
         ArgumentNullException.ThrowIfNull(lines);
 
-        ushort baseAddress = 0;
         var records = new List<HexFileRecord>();
+
+        foreach (var (hexLine, baseAddress) in EnumerateUnprotectedRecords(lines))
+        {
+            var offsetAddressArray = hexLine.Skip(1).Take(2).ToArray();
+            if (BitConverter.IsLittleEndian) Array.Reverse(offsetAddressArray);
+            var offsetAddress = BitConverter.ToUInt16(offsetAddressArray, 0);
+            var fullAddress = ((uint)baseAddress << 16) | offsetAddress;
+
+            records.Add(new HexFileRecord(fullAddress, hexLine, hexLine[3]));
+        }
+
+        return records;
+    }
+
+    /// <summary>
+    /// Walks the HEX lines once: skips blank lines, validates and decodes each record, tracks
+    /// the running extended-linear base address, and yields only the records that fall outside
+    /// the protected memory range. This is the sequencing shared by both public parse methods;
+    /// they differ only in what they project from each yielded record.
+    /// </summary>
+    /// <remarks>
+    /// This is a lazy iterator and deliberately performs no argument validation of its own.
+    /// A <c>ThrowIfNull</c> placed here would not run until first enumeration, which would move
+    /// where the public methods' documented <see cref="ArgumentNullException"/> surfaces; each
+    /// public method therefore keeps its own eager guard. The <see cref="InvalidDataException"/>s
+    /// raised while walking are unaffected: both callers enumerate to completion inside their own
+    /// body, so those still surface from the public call exactly as before.
+    /// </remarks>
+    private IEnumerable<(byte[] HexLine, ushort BaseAddress)> EnumerateUnprotectedRecords(string[] lines)
+    {
+        ushort baseAddress = 0;
 
         foreach (var line in lines)
         {
@@ -108,7 +123,6 @@ public class IntelHexParser
             var hexLine = ConvertLineToBytes(line);
             ValidateRecordLength(hexLine, line);
             ValidateChecksum(hexLine, line);
-            var recordType = hexLine[3];
 
             baseAddress = UpdateBaseAddress(hexLine, baseAddress, line);
 
@@ -117,15 +131,8 @@ public class IntelHexParser
                 continue;
             }
 
-            var offsetAddressArray = hexLine.Skip(1).Take(2).ToArray();
-            if (BitConverter.IsLittleEndian) Array.Reverse(offsetAddressArray);
-            var offsetAddress = BitConverter.ToUInt16(offsetAddressArray, 0);
-            var fullAddress = ((uint)baseAddress << 16) | offsetAddress;
-
-            records.Add(new HexFileRecord(fullAddress, hexLine, recordType));
+            yield return (hexLine, baseAddress);
         }
-
-        return records;
     }
 
     private static void ValidateLine(string line)


### PR DESCRIPTION
Produced by the maintenance routine **duplicate-unifier**. Behavior-preserving; safe because nothing observable moves — the same checks run in the same order, and the tests were strengthened *before* the refactor to pin the behaviors it could break.

## What was wrong

`IntelHexParser` has two public entry points, and each carried its own verbatim copy of the same ~13-line walk over the HEX lines:

skip blank lines → `ValidateLine` → `ConvertLineToBytes` → `ValidateRecordLength` → `ValidateChecksum` → `UpdateBaseAddress` → drop records inside the protected memory range.

PR #605 extracted the individual sub-validators, but it left the **loop that sequences them** duplicated. The two copies differ only in what they build at the end: `ParseHexRecords` appends the raw byte array, `ParseRecords` computes a full 32-bit address and builds a `HexFileRecord`.

The concrete risk is drift. Everything about *which* records are legal and *which* records survive filtering lives in that loop, in two places. Add a validation step, tighten the protected range, or fix an address-tracking bug in one copy and the other keeps the old behavior — and the two entry points are used by the same caller (`Pic32BootloaderProtocol` calls `ParseHexRecords` at :105 and `ParseRecords` at :116), so a divergence means one firmware upload path validates differently from the other. This is the half-extracted shape where the risk is highest: the pieces already look factored, so the remaining copy is easy to miss.

## How it was fixed

The walk is now a single private iterator:

```csharp
private IEnumerable<(byte[] HexLine, ushort BaseAddress)> EnumerateUnprotectedRecords(string[] lines)
```

Both public methods enumerate it and project what they need. `ParseHexRecords` takes `HexLine`; `ParseRecords` additionally uses the yielded `BaseAddress` to compute the full address. Net effect on the class: one copy of the sequencing instead of two, ~30 duplicated lines gone.

### The eager-vs-lazy decision (the thing worth reviewing)

Converting a loop into a `yield`-returning iterator moves *when* the method body runs. If `ArgumentNullException.ThrowIfNull(lines)` had been folded into the iterator, a null array would no longer throw at the call — it would throw on first enumeration. That is a real, observable behavior change to a documented `ArgumentNullException`, and it is exactly the trap this refactor invites.

**Chosen: eager, via the standard C# split.** Each public method keeps its own `ThrowIfNull` before it touches the iterator; the iterator itself does no argument validation, and a comment on it says why so nobody "helpfully" adds one later.

The `InvalidDataException`s raised *during* the walk are unaffected, and this is worth being explicit about rather than hand-waving: both callers enumerate to completion inside their own method body before returning, and both still return an eagerly-built `List<T>`, so a malformed line surfaces from the public call exactly as it did before. Laziness is not observable across the public API at all here — the only place it *would* have been observable is the null guard, which is why that one stayed eager.

### Two things deliberately not done

- **`ParseHexRecords` is not defined as `ParseRecords(lines).Select(r => r.Data)`.** That would be the shortest possible diff, but it is not behavior-free: it would construct a `HexFileRecord` and compute a full address for every record only to throw them away. Different allocation profile on the firmware-upload hot path, for no benefit.
- **`ParseRecords` still reads `hexLine[3]` for the record type rather than having the iterator yield it.** The original read it into a local *before* `UpdateBaseAddress`; nothing in the loop mutates `hexLine` (both `UpdateBaseAddress` and `IsProtectedHexRecord` slice into fresh copies via `Skip/Take/ToArray`), so reading it after is identical. Kept the tuple to the two values that genuinely have to cross the boundary.

## Tests strengthened first

The existing suite would **not** have caught the most likely ways to get this wrong, so it was strengthened before the refactor and confirmed green against the *unrefactored* code first:

- Both null-guard tests asserted only the exception *type*. They now assert `ParamName == "lines"` — and carry a comment naming the eager-vs-lazy hazard, so the guard's placement is pinned, not just its existence.
- `ParseRecords` had **no** coverage for blank-line skipping, checksum validation, or protected-range filtering — all of which now come from shared code. Added.
- Added a test that filtering a protected record does not disturb the running base address for records after it (a protected record between two type-04 records, asserting the later record's address). This is the subtlest thing the extraction could have broken.
- Added a test that both entry points select the *same* records from the same input — the drift invariant the PR is about, now enforced.

29 `IntelHexParser` tests pass before the refactor and after.

## Verification

- `dotnet build`: 0 warnings, 0 errors (`TreatWarningsAsErrors=true`).
- Full `dotnet test` under a `tests.1` lock: green on **net9.0 and net10.0** — Daqifi.Core.Tests 3809 passed / 0 failed / 2 pre-existing skips per TFM, plus Daqifi.Mcp.Tests 217 passed.
- No board interaction: this changes no bytes and no ordering on the wire, only which method holds the loop. Bench validation is inapplicable, not deferred for lack of hardware.

## Asymmetry check

Checked for behavior gaps beside the refactor and found none worth filing — recording the negative result:

- `UpdateBaseAddress` handles type-04 (extended linear address) but not type-02 (extended segment address). Justified: PIC32 hex output uses type-04, and a type-02 record would fail `ValidateRecordLength`/checksum handling no differently than today. Not a regression, not introduced here.
- `IsProtectedHexRecord` tests only a record's *start* address against the range. A record starting below `0x1D1E0000` cannot extend into it: the boundary is 16-byte aligned and data records are at most 16 bytes, so no overlap is expressible. Justified difference, not a bug.

---

Not merging — opened for review.
