### PR TITLE
fix(tests): release the blank at the send boundary instead of after a fixed delay

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -191,7 +191,21 @@ public class DaqifiDeviceStaleTextLineTests
         // device, so a blank — which only ever terminates a dump — cannot be answering: without
         // the fix it is returned as "the device answered, and its log is empty".
         using var transport = new QueuedWriteTransport();
-        using var device = new StaleLineTestableDevice("Queued-Command Device", transport);
+
+        // Released at the send boundary, so it is released strictly after this exchange's setup
+        // action has returned and the line-count boundary from #591 provably cannot be what drops
+        // it: by then the exchange believes it has sent, and only the write count knows the command
+        // is still sitting in the queue. A delay used to stand in for "after the setup action" and
+        // could only guess at it — see the sibling test below and issue #632.
+        var blankReleased = false;
+        using var device = new StaleLineTestableDevice(
+            "Queued-Command Device",
+            transport,
+            onSendBoundaryCaptured: () =>
+            {
+                blankReleased = true;
+                transport.ReleaseLine("\r\n");
+            });
 
         device.Connect();
 
@@ -202,17 +216,14 @@ public class DaqifiDeviceStaleTextLineTests
             "The producer never picked up the earlier command.");
 
         var lines = await device.CallExecuteTextCommandAsync(
-            () =>
-            {
-                device.Send(new ScpiMessage("SYSTem:LOG?"));
-
-                // Released only after this setup action has returned, so the line-count boundary
-                // from #591 cannot be what drops it: by then the exchange believes it has sent,
-                // and only the write count knows the command is still sitting in the queue.
-                _ = Task.Delay(75).ContinueWith(_ => transport.ReleaseLine("\r\n"));
-            },
+            () => device.Send(new ScpiMessage("SYSTem:LOG?")),
             keepBlankLines: true);
 
+        // Without this the empty result below would also be satisfied by a blank that was never
+        // put on the wire at all, which is what a delay-based release can silently degrade into.
+        Assert.True(
+            blankReleased,
+            "The exchange never reached its send boundary, so the blank was never put on the wire.");
         Assert.Empty(lines);
 
         transport.ReleaseWrite();
@@ -240,7 +251,24 @@ public class DaqifiDeviceStaleTextLineTests
         // did, 10/10 runs. The write is deliberately still open when the blank lands here, so a
         // marker keyed off the write FINISHING rather than starting would fail this test.
         using var transport = new QueuedWriteTransport();
-        using var device = new StaleLineTestableDevice("Answering Log Device", transport);
+
+        // The blank is released at the send boundary itself, not after a delay. It has to land
+        // strictly after that boundary — a blank at or before it is a pre-send leftover by both
+        // rules — and the exchange captures it microseconds after the setup action returns, which
+        // no wall-clock delay can aim at. A delay only guesses, and on a loaded runner the guess
+        // races the exchange's own responseTimeoutMs and loses, which is issue #632. Releasing on
+        // the boundary makes the ordering the runtime's rather than the scheduler's. Nothing about
+        // the window under test moves: the write is held from before the exchange until after it,
+        // so the blank still lands with the command's write in progress — which is the whole point.
+        var blankReleased = false;
+        using var device = new StaleLineTestableDevice(
+            "Answering Log Device",
+            transport,
+            onSendBoundaryCaptured: () =>
+            {
+                blankReleased = true;
+                transport.ReleaseLine("\r\n");
+            });
 
         device.Connect();
 
@@ -253,11 +281,15 @@ public class DaqifiDeviceStaleTextLineTests
                 Assert.True(
                     transport.WaitForWriteStarted(TimeSpan.FromSeconds(10)),
                     "The producer never started the command's write.");
-
-                _ = Task.Delay(75).ContinueWith(_ => transport.ReleaseLine("\r\n"));
             },
             keepBlankLines: true);
 
+        // Checked before the result, so a failure says which side lost: without it, an exchange
+        // that never reached its send boundary and an exchange that dropped the blank both surface
+        // as the same bare empty-result assertion.
+        Assert.True(
+            blankReleased,
+            "The exchange never reached its send boundary, so the blank was never put on the wire.");
         Assert.NotEmpty(lines);
         Assert.All(lines, line => Assert.Equal(string.Empty, line));
 
@@ -681,10 +713,21 @@ public class DaqifiDeviceStaleTextLineTests
     /// <summary>Exposes the protected text-exchange entry points.</summary>
     private class StaleLineTestableDevice : DaqifiDevice
     {
-        public StaleLineTestableDevice(string name, IStreamTransport transport)
+        private readonly Action? _onSendBoundaryCaptured;
+
+        public StaleLineTestableDevice(
+            string name, IStreamTransport transport, Action? onSendBoundaryCaptured = null)
             : base(name, transport)
         {
+            _onSendBoundaryCaptured = onSendBoundaryCaptured;
         }
+
+        /// <summary>
+        /// Exposes <see cref="DaqifiDevice.OnSendBoundaryCaptured"/> so a test can release a line
+        /// into the transport at the exact instant the exchange captures its send boundary — the
+        /// first point at which a blank is provably past the pre-send rules of #553 and #593.
+        /// </summary>
+        internal override void OnSendBoundaryCaptured() => _onSendBoundaryCaptured?.Invoke();
 
         public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(
             Action setupAction,

--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -188,5 +188,6 @@ public class ConnectionGuardTests
         public OutboundWriterSample? SampleOutboundWriter() => throw new NotSupportedException();
         public IDisposable SubscribeConsumerErrors(IMessageConsumer<string> consumer) => throw new NotSupportedException();
         public void OnStaleLineBoundaryCaptured() => throw new NotSupportedException();
+        public void OnSendBoundaryCaptured() => throw new NotSupportedException();
     }
 }

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -2020,6 +2020,18 @@ namespace Daqifi.Core.Device
         {
         }
 
+        /// <inheritdoc />
+        void ITextExchangeHost.OnSendBoundaryCaptured() => OnSendBoundaryCaptured();
+
+        /// <summary>
+        /// A no-op on the real device. Overridable for tests, mirroring
+        /// <see cref="OnStaleLineBoundaryCaptured"/> — see
+        /// <see cref="ITextExchangeHost.OnSendBoundaryCaptured"/> for why this seam exists.
+        /// </summary>
+        internal virtual void OnSendBoundaryCaptured()
+        {
+        }
+
         #endregion
 
         #region IOperationSerializationHost — the serializer's view of this device

--- a/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
+++ b/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
@@ -169,5 +169,21 @@ namespace Daqifi.Core.Device.Internal
         /// because it is normally sub-millisecond.
         /// </summary>
         void OnStaleLineBoundaryCaptured();
+
+        /// <summary>
+        /// Called the instant the exchange has captured its send boundary — after
+        /// <c>setupActionAsync</c> has returned, and before the reply wait loop starts. A no-op on
+        /// the real device; the counterpart to <see cref="OnStaleLineBoundaryCaptured"/>, and it
+        /// exists for the same reason.
+        /// </summary>
+        /// <remarks>
+        /// A test that needs a line to land <em>after</em> the send boundary — i.e. one the pre-send
+        /// blank rule must NOT discard (issues #553 and #593) — otherwise has to guess, because the
+        /// boundary is captured within microseconds of the setup action returning and nothing about
+        /// that moment is observable from the transport. Guessing means a wall-clock delay racing
+        /// the exchange's own response timeout, which is a flake (issue #632). This seam replaces
+        /// the guess with an ordering the runtime guarantees.
+        /// </remarks>
+        void OnSendBoundaryCaptured();
     }
 }

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -569,6 +569,13 @@ namespace Daqifi.Core.Device.Internal
                     // wrong, for the reason above, just not slow.
                     sentBoundaryLineCount = CollectedLineCount();
 
+                    // Test-only seam (issue #632), the counterpart of the one above: a no-op on the
+                    // real device, so this changes nothing here. It exists so a test double can
+                    // release a line into the transport at a point the pre-send rules provably do
+                    // not cover, instead of guessing at that point with a wall-clock delay racing
+                    // this exchange's own response timeout.
+                    _host.OnSendBoundaryCaptured();
+
                     Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Setup action completed at {ElapsedMs}ms", sw.ElapsedMilliseconds));
 
                     // Whether anything beyond staleLineCount would actually survive the projection


### PR DESCRIPTION
**Not merging — for review.**

## What was wrong

`DaqifiDeviceStaleTextLineTests.ExecuteTextCommand_KeepsABlankThatArrivesOnceTheCommandIsBeingWritten` fails intermittently in CI — on `main` with no PR involved, and on one TFM while the other passes in the same run (see #632 for the run links). The failure is always the bare `Assert.NotEmpty(lines)`.

The test needs a blank line to arrive *after* the exchange has captured its send boundary (otherwise the pre-send blank rules of #553/#593 correctly discard it), and it arranged that with a wall-clock guess:

```csharp
_ = Task.Delay(75).ContinueWith(_ => transport.ReleaseLine("\r\n"));
```

That 75 ms continuation is a thread-pool work item, and so is the exchange's own wait-loop continuation (`await Task.Delay(50)` inside `TextExchangeEngine`). When the pool is starved — which is what a CI runner executing ~3,800 xUnit tests in parallel looks like — the wait loop's continuation is queued *ahead* of the release, phase 1's `responseTimeoutMs` (500 ms) is measured against the wall clock and expires, and the loop breaks before the blank is ever put on the wire. Collection closes, `lines` comes back empty, and the test fails even though the engine did exactly the right thing. Two racing pool items against one fixed timeout — the same shape as #601 and #609.

## How it was fixed

Added `ITextExchangeHost.OnSendBoundaryCaptured()`, the exact counterpart of the `OnStaleLineBoundaryCaptured()` seam that already exists for the same reason (#553). It is a no-op on the real device, and the engine fires it the instant after it captures `sentBoundaryLineCount`. The two tests that need a line to land past that boundary now release it *there*, so the ordering is guaranteed by the runtime instead of guessed at by a timer.

**Why this removes the race rather than hiding it** — this is the part worth pushing back on, since the test guards the invariant #591 and #602 established, so here is the argument in full:

- **Nothing about the window under test moved.** `HoldWrites()` is still taken before the exchange and `ReleaseWrite()` is still called after it, so the command's write is *still in progress* when the blank lands. `WriterAtArrival.StartedWrites` is still `1` against a `writerBoundary` of `0`, which is precisely the "the command is being written" case the test is named for. A marker keyed off the write *finishing* would still fail this test, exactly as the test's comment demands.
- **No assertion was weakened.** `Assert.NotEmpty(lines)` and `Assert.All(lines, line => Assert.Equal(string.Empty, line))` are unchanged, and the `HoldExpired` guard is unchanged. The only additions are assertions: each test now also asserts the blank was actually put on the wire, so a future failure says *which* side lost instead of surfacing as a bare empty collection (the diagnosability point raised in #632).
- **No timeout was widened.** `responseTimeoutMs` is untouched at its default 500 ms; the delay was deleted, not raised.
- **The release is now strictly earlier than it was, not later.** Firing at the boundary is the earliest instant at which a blank is provably past *both* pre-send rules — so the test proves a strictly tighter property than the 75 ms version did, which merely made it likely.
- **The sibling test got stronger too.** `ExecuteTextCommand_DropsABlankThatArrivesAfterTheCommandIsQueuedButBeforeItIsWritten` had the identical `Task.Delay(75)`, and its comment claims the blank is "released only after this setup action has returned" — which the delay could not actually guarantee. Worse, it asserts `Assert.Empty`, so a release that arrived late made it pass *vacuously*. It now releases at the boundary and asserts the release happened, so it can only pass by the writer-count rule actually discarding the blank — which is what it was written to prove.

## How it was verified

Reproduced deterministically rather than probabilistically. External CPU load does not starve the .NET thread pool, so a temporary harness saturated the pool from inside the test process (`ProcessorCount * 8` blocking work items) and ran the old and new arrangements side by side:

| arrangement | starved runs | failures |
|---|---|---|
| old (`Task.Delay(75)`) | 10 (5 × net9.0, 5 × net10.0) | **9** — all `Assert.NotEmpty() Failure: Collection was empty` |
| new (send boundary) | 10 (5 × net9.0, 5 × net10.0) | **0** |

The one starved run where the old arrangement survived was on net10.0, which reproduces the one-TFM-red/one-TFM-green split reported in #632. The harness was removed before committing.

Repeat runs of the whole `DaqifiDeviceStaleTextLineTests` class on the committed code, with 4 background CPU spinners for contention: **net9.0 25/25 green, net10.0 25/25 green** (0 failures).

Full suite green on both TFMs: `Daqifi.Core.Tests` 3811 passed / 0 failed / 2 skipped on net9.0 and net10.0, `Daqifi.Mcp.Tests` 217 passed.

closes #632
