### PR TITLE
fix(scpi): reject non-finite DIO state values and format them invariantly

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -188,6 +188,77 @@ public class ScpiMessageProducerTests
         AssertMessageFormat(message);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void SetDioPortState_FormatsDocumentedStatesIdenticallyUnderCommaDecimalCulture(double value)
+    {
+        // The documented contract is 0 = low, 1 = high. Those render the same under every
+        // culture, so changing how `value` is formatted must leave them byte-for-byte alone.
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var message = ScpiMessageProducer.SetDioPortState(1, value);
+            Assert.Equal($"DIO:PORt:STATe 1,{(int)value}", message.Data);
+            AssertMessageFormat(message);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void SetDioPortState_FormatsFractionalValueWithInvariantDecimalPoint()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            // A culture whose decimal separator is a comma must not corrupt the SCPI argument:
+            // a comma here would read as a third argument rather than a fractional state.
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var message = ScpiMessageProducer.SetDioPortState(1, 1.5);
+            Assert.Equal("DIO:PORt:STATe 1,1.5", message.Data);
+            AssertMessageFormat(message);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void SetDioPortState_WithNonFiniteValue_Throws(double value)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetDioPortState(1, value));
+
+        // The finite check is shared with the other double-valued setters, so pin the
+        // parameter name and wording this call site is responsible for supplying.
+        Assert.Equal("value", ex.ParamName);
+        Assert.Contains("State value must be a finite number.", ex.Message);
+    }
+
+    [Fact]
+    public void SetDioPortState_WithNonFiniteValue_ThrowsBeforeBuildingAMessage()
+    {
+        // The guard must reject the value rather than let a culture-dependent
+        // infinity symbol reach the command text.
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetDioPortState(1, double.PositiveInfinity));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
     [Fact]
     public void EnableDioPorts_ReturnsCorrectCommand()
     {

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -550,13 +550,17 @@ public class ScpiMessageProducer
     /// </summary>
     /// <param name="channel">The channel number.</param>
     /// <param name="value">The state value (0 = low, 1 = high).</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is not a finite number.</exception>
     /// <remarks>
+    /// The value is formatted with an invariant decimal point so the command is locale-independent.
     /// Command: DIO:PORt:STATe channel,value
     /// Example: messageProducer.Send(ScpiMessageProducer.SetDioPortState(1, 1)); // Set channel 1 to high
     /// </remarks>
     public static IOutboundMessage<string> SetDioPortState(int channel, double value)
     {
-        return new ScpiMessage($"DIO:PORt:STATe {channel},{value}");
+        RequireFinite(value, nameof(value), "State value");
+
+        return new ScpiMessage($"DIO:PORt:STATe {channel},{value.ToString(CultureInfo.InvariantCulture)}");
     }
 
     /// <summary>


### PR DESCRIPTION
## What was wrong

`ScpiMessageProducer.SetDioPortState` takes a `double`, and it did nothing to check or format that number before pasting it into the command it sends the device. Two things followed from that.

Pass it `double.NaN` and the device receives `DIO:PORt:STATe 1,NaN` — a token the firmware cannot parse. `double.PositiveInfinity` is worse: the symbol .NET uses for infinity depends on the user's culture and is `∞` under many of them, so a non-ASCII character ends up in a SCPI frame.

And because the number was rendered with whatever culture the app happens to be running under, a fractional value on a German or French machine came out with a comma — the same character SCPI uses to separate arguments. `SetDioPortState(1, 1.5)` emitted `DIO:PORt:STATe 1,1,5`, which the device reads as three arguments instead of two.

The method's three sibling double-valued setters (`SetAnalogOutputVoltage`, `SetAdcCalibrationSlope`, `SetAdcCalibrationOffset`) already guarded against both. This one was simply the copy that got missed.

## How it was fixed

`SetDioPortState` now calls the same `RequireFinite` helper its siblings use and formats the value with `CultureInfo.InvariantCulture` — three lines, bringing the fourth setter in line with the other three.

The one thing worth pushing back on: **this is a deliberate behavior change to a public method.** A caller who was passing NaN or Infinity used to get a malformed message and now gets an `ArgumentOutOfRangeException`. That is the point of the fix, but it is a change, which is why it is its own commit rather than folded into the refactor that found it (#630). For every in-contract value the method is documented for — `0` and `1` — the bytes on the wire are unchanged, in every culture.

Also deliberately **not** included: the missing negative-channel guard on this same method, which is tracked separately as #624 so the two changes do not collide.

## Verification

- The behavior-preservation test (`0`/`1` render identically under `de-DE`) was written and confirmed green against the **unchanged** code first, so it genuinely guards the change rather than describing it.
- The five new tests covering the new behavior were confirmed to **fail** against the unchanged code before the fix, and pass after.
- Clean solution build: 0 warnings, 0 errors (`TreatWarningsAsErrors`).
- Full suite green on net9.0 and net10.0: 3822 passed / 0 failed / 2 pre-existing skips per TFM, plus 217 in `Daqifi.Mcp.Tests`.
- Bench: example CLI built against this branch's core and run against the board on `/dev/cu.usbmodem1101` — connect, status, 4 s of streaming, clean disconnect. The CLI exposes no DIO command, so `SetDioPortState` itself is covered by the byte-exact unit tests rather than on hardware; for the documented `0`/`1` states the emitted frame is provably identical to before.

closes #629

**Not merging — for review.**
