### PR TITLE
fix(firmware): give all four PIC32 bootloader decoders the same null answer

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderMessageConsumerTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/Pic32BootloaderMessageConsumerTests.cs
@@ -200,6 +200,82 @@ public class Pic32BootloaderMessageConsumerTests
 
     #endregion
 
+    #region Null input
+
+    // DecodeReadCrcResponse has always answered a null frame with a named ArgumentNullException,
+    // but nothing pinned that. It is the reference the other three decoders are aligned to, so
+    // pin it first: the exact exception type (not the InvalidDataException this method throws for
+    // every other malformed frame), the parameter it blames, and the message a caller sees.
+    [Fact]
+    public void DecodeReadCrcResponse_WithNullData_ThrowsArgumentNullExceptionNamingData()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(null!));
+
+        Assert.Equal("data", ex.ParamName);
+        Assert.Equal(new ArgumentNullException("data").Message, ex.Message);
+    }
+
+    [Fact]
+    public void DecodeVersionResponse_WithNullData_ThrowsArgumentNullExceptionNamingData()
+    {
+        // Not "Error": a null frame is the caller's bug, not a bootloader response this decoder
+        // can classify, so the guard has to win over the "Error" string every other bad frame gets.
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => Pic32BootloaderMessageConsumer.DecodeVersionResponse(null!));
+
+        Assert.Equal("data", ex.ParamName);
+    }
+
+    [Fact]
+    public void DecodeProgramFlashResponse_WithNullData_ThrowsArgumentNullExceptionNamingData()
+    {
+        // Not false: same reasoning as the version decoder, and the guard sits in the shared
+        // IsAckFor helper, so this also pins that a caller is blamed for its own "data" parameter
+        // rather than for a private one a frame below.
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => Pic32BootloaderMessageConsumer.DecodeProgramFlashResponse(null!));
+
+        Assert.Equal("data", ex.ParamName);
+    }
+
+    [Fact]
+    public void DecodeEraseFlashResponse_WithNullData_ThrowsArgumentNullExceptionNamingData()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => Pic32BootloaderMessageConsumer.DecodeEraseFlashResponse(null!));
+
+        Assert.Equal("data", ex.ParamName);
+    }
+
+    // The point of the change: one catch covers all four decoders, and a caller that learns one
+    // decoder's null behavior has learned all of them. Comparing against the exception
+    // DecodeReadCrcResponse throws — the one that was always guarded — keeps the three converted
+    // decoders pinned to it rather than to a copy of the expected text.
+    [Fact]
+    public void AllFourDecoders_WithNullData_ThrowTheSameArgumentNullException()
+    {
+        var reference = Assert.Throws<ArgumentNullException>(
+            () => Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(null!));
+
+        Action[] others =
+        [
+            () => Pic32BootloaderMessageConsumer.DecodeVersionResponse(null!),
+            () => Pic32BootloaderMessageConsumer.DecodeProgramFlashResponse(null!),
+            () => Pic32BootloaderMessageConsumer.DecodeEraseFlashResponse(null!)
+        ];
+
+        foreach (var decode in others)
+        {
+            var ex = Assert.Throws<ArgumentNullException>(decode);
+
+            Assert.Equal(reference.ParamName, ex.ParamName);
+            Assert.Equal(reference.Message, ex.Message);
+        }
+    }
+
+    #endregion
+
     #region DecodeReadCrcResponse
 
     // Mirrors the firmware's response framing: content = [0x04, crcLo, crcHi];

--- a/src/Daqifi.Core/Firmware/Pic32BootloaderMessageConsumer.cs
+++ b/src/Daqifi.Core/Firmware/Pic32BootloaderMessageConsumer.cs
@@ -18,8 +18,11 @@ public static class Pic32BootloaderMessageConsumer
     /// </summary>
     /// <param name="data">The raw response bytes.</param>
     /// <returns>A version string in "Major.Minor" format, or "Error" if the response is invalid.</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="data"/> is null.</exception>
     public static string DecodeVersionResponse(byte[] data)
     {
+        ArgumentNullException.ThrowIfNull(data);
+
         var majorVersion = 0;
         var minorVersion = 0;
 
@@ -54,6 +57,7 @@ public static class Pic32BootloaderMessageConsumer
     /// </summary>
     /// <param name="data">The raw response bytes.</param>
     /// <returns>True if the response is a valid program flash acknowledgment.</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="data"/> is null.</exception>
     public static bool DecodeProgramFlashResponse(byte[] data) => IsAckFor(data, ProgramFlashCommand);
 
     /// <summary>
@@ -61,6 +65,7 @@ public static class Pic32BootloaderMessageConsumer
     /// </summary>
     /// <param name="data">The raw response bytes.</param>
     /// <returns>True if the response is a valid erase flash acknowledgment.</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="data"/> is null.</exception>
     public static bool DecodeEraseFlashResponse(byte[] data) => IsAckFor(data, EraseFlashCommand);
 
     /// <summary>
@@ -154,14 +159,17 @@ public static class Pic32BootloaderMessageConsumer
     /// <param name="data">The raw, framed response bytes.</param>
     /// <param name="command">The opcode the acknowledgment is expected to echo.</param>
     /// <returns>True if <paramref name="data"/> acknowledges <paramref name="command"/>.</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="data"/> is null.</exception>
     /// <remarks>
-    /// Deliberately not null-guarded. Both callers are public methods that have always thrown
-    /// <see cref="System.NullReferenceException"/> on a null <paramref name="data"/>, and adding a
-    /// guard here would change that observable behavior. The null-handling asymmetry between the
-    /// decoders on this type is tracked separately, not settled by this extraction.
+    /// The guard lives here rather than in the two public callers so that all four decoders on
+    /// this type report a null frame identically. The parameter is named <c>data</c> here too, so
+    /// the <see cref="System.ArgumentException.ParamName"/> a caller sees is the name of the
+    /// public parameter it actually passed.
     /// </remarks>
     private static bool IsAckFor(byte[] data, byte command)
     {
+        ArgumentNullException.ThrowIfNull(data);
+
         if (data.Length < 2) return false;
         if (data[0] != StartOfHeader) return false;
 


### PR DESCRIPTION
## What was wrong

`Pic32BootloaderMessageConsumer` has four public decoders for bootloader responses, reachable from outside the library through `IBootloaderProtocol`. If you handed one of them a null buffer — say a serial read came back with nothing and you didn't check — three of the four blew up with a bare `NullReferenceException`, the kind whose message tells you nothing about which argument was bad. The fourth, `DecodeReadCrcResponse`, answered the same mistake with a proper `ArgumentNullException` naming `data`.

So the same mistake, against four adjacent methods on the same class, produced two different errors. You couldn't write one `catch` that covered all four, and testing one decoder's behavior taught you nothing about the other three.

## How it was fixed

The three unguarded decoders now open with `ArgumentNullException.ThrowIfNull(data)`, matching the one that already did it — same exception type, same `ParamName`, same message. All four are documented with the `<exception>` tag the guarded one already carried.

**The thing to push back on:** this is a deliberate behavior change. Three public methods that used to throw `NullReferenceException` now throw `ArgumentNullException`. That is the whole point of the ticket rather than a side effect — issue #621 lays out the alternatives and lands on this one — but anyone catching `NullReferenceException` around these calls today would need to know. No in-tree caller does, and all four parameters are non-nullable `byte[]` under `<Nullable>enable</Nullable>`, so passing null was already a contract violation.

One judgement call worth naming: for the two acknowledgment decoders the guard sits in the shared private `IsAckFor` helper rather than being written out twice. That helper's parameter is also named `data`, so the `ParamName` a caller sees is still the name of the public parameter it actually passed — there's a test pinning exactly that.

## How it was verified

Nothing pinned any of the null behavior before this, so the tests were built in that order: the already-guarded decoder's exception type, `ParamName` and message were pinned first and confirmed passing against unmodified code, and the current `NullReferenceException` of the other three was confirmed with a throwaway probe before touching them. The three converted decoders are then asserted against the reference exception directly rather than against a hand-copied string, so they cannot drift from it.

- `dotnet build --no-incremental`: 0 warnings, 0 errors.
- Full suite green on **net9.0 and net10.0** — 3820 passed / 0 failed / 2 pre-existing skips per TFM, plus 217 in `Daqifi.Mcp.Tests`.
- The example CLI builds against this branch's core, and a non-destructive bench run over `/dev/cu.usbmodem1101` (connect, status, 50 Hz stream, disconnect) was clean on fw 3.7.2. The decoders themselves sit on the bootloader path, which is only reachable through a firmware update — out of bounds for bench validation — and this change alters no wire bytes and no timing.

Builds on #622, which extracted `IsAckFor` and deliberately left the null behavior alone with a comment pointing here; that comment is replaced by this change.

closes #621

**Not merging — for review.**
