### PR TITLE
ci: publish the coverage report CI already computes

### DIFF
--- a/.github/scripts/coverage-summary.py
+++ b/.github/scripts/coverage-summary.py
@@ -64,6 +64,14 @@ class Report:
             self.by_file[filename] = (covered, valid)
 
 
+def warn(message):
+    """Best-effort diagnostic. Even complaining must not be able to fail a build."""
+    try:
+        print(message, file=sys.stderr)
+    except Exception:  # noqa: BLE001 - nothing here may fail the build
+        pass
+
+
 # Control characters are stripped from anything the report supplies: this text is
 # echoed to the step log, where a bare newline could forge a `::` workflow command,
 # and a pipe would silently split a Markdown table cell.
@@ -170,22 +178,29 @@ def main(argv):
 
     markdown = render(reports, failures)
 
+    # Prefer mangling an exotic character to losing the whole report, on the rare
+    # runner whose stdout encoding cannot represent it.
+    try:
+        sys.stdout.reconfigure(errors="replace")
+    except Exception:  # noqa: BLE001 - nothing here may fail the build
+        pass
+
     # Always echo to stdout: GitHub's job summary is not readable through the API,
     # so the step log is the only place the rendered numbers can be checked after
     # the fact (and it is where you are already looking when a run goes wrong).
     try:
         sys.stdout.write(markdown)
         sys.stdout.flush()
-    except OSError as error:
-        print(f"could not echo the coverage summary: {error}", file=sys.stderr)
+    except Exception as error:  # noqa: BLE001 - nothing here may fail the build
+        warn(f"could not echo the coverage summary: {error}")
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:
         try:
-            with open(summary_path, "a", encoding="utf-8") as handle:
+            with open(summary_path, "a", encoding="utf-8", errors="replace") as handle:
                 handle.write(markdown)
-        except OSError as error:
-            print(f"could not write the job summary: {error}", file=sys.stderr)
+        except Exception as error:  # noqa: BLE001 - nothing here may fail the build
+            warn(f"could not write the job summary: {error}")
     return 0
 
 

--- a/.github/scripts/coverage-summary.py
+++ b/.github/scripts/coverage-summary.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Render a Markdown coverage summary from coverlet's Cobertura reports.
+
+Usage: coverage-summary.py <report.xml> [<report.xml> ...]
+
+Reads one Cobertura file per target framework, prints a Markdown table with the
+same line/branch/method percentages coverlet prints to the console, plus a
+collapsed list of the files with the most uncovered lines. Written against the
+Python standard library only, so CI needs no third-party action, tool install,
+or secret to display coverage.
+
+Exits non-zero only when it cannot read a report -- it never judges the numbers,
+because this repo deliberately has no build-failing coverage threshold (#641).
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+# How many of the least-covered files to list under the summary table.
+WORST_FILE_COUNT = 10
+
+
+class Report:
+    """The numbers for a single Cobertura file (i.e. one target framework)."""
+
+    def __init__(self, label, path):
+        self.label = label
+        self.path = path
+        root = ET.parse(path).getroot()
+
+        self.lines_covered = int(root.get("lines-covered", 0))
+        self.lines_valid = int(root.get("lines-valid", 0))
+        self.branches_covered = int(root.get("branches-covered", 0))
+        self.branches_valid = int(root.get("branches-valid", 0))
+
+        # Cobertura has no method totals, so derive them the way coverlet's own
+        # console table does: a method counts as covered if any of its lines ran.
+        self.methods_covered = 0
+        self.methods_valid = 0
+        # Multiple <class> entries can share a filename (partial/nested types),
+        # so accumulate per file rather than per class.
+        self.by_file = {}
+
+        for cls in root.iter("class"):
+            filename = cls.get("filename") or "(unknown)"
+            covered, valid = self.by_file.get(filename, (0, 0))
+
+            for method in cls.iter("method"):
+                self.methods_valid += 1
+                if any(int(line.get("hits", 0)) > 0 for line in method.iter("line")):
+                    self.methods_covered += 1
+
+            lines = cls.find("lines")
+            if lines is not None:
+                for line in lines:
+                    valid += 1
+                    if int(line.get("hits", 0)) > 0:
+                        covered += 1
+
+            self.by_file[filename] = (covered, valid)
+
+
+def percent(covered, valid):
+    """Format a coverage ratio, tolerating the zero-denominator case."""
+    if valid == 0:
+        return "n/a"
+    return f"{covered * 100.0 / valid:.2f}%"
+
+
+def framework_label(path):
+    """Recover the TFM from coverlet's `coverage.<tfm>.cobertura.xml` naming."""
+    name = os.path.basename(path)
+    prefix, suffix = "coverage.", ".cobertura.xml"
+    if name.startswith(prefix) and name.endswith(suffix) and len(name) > len(prefix) + len(suffix):
+        return name[len(prefix):-len(suffix)]
+    return name
+
+
+def render(reports):
+    out = ["## Code coverage", ""]
+    out.append("| Target framework | Line | Branch | Method |")
+    out.append("| --- | ---: | ---: | ---: |")
+    for r in reports:
+        out.append(
+            f"| {r.label} "
+            f"| {percent(r.lines_covered, r.lines_valid)} "
+            f"({r.lines_covered}/{r.lines_valid}) "
+            f"| {percent(r.branches_covered, r.branches_valid)} "
+            f"({r.branches_covered}/{r.branches_valid}) "
+            f"| {percent(r.methods_covered, r.methods_valid)} "
+            f"({r.methods_covered}/{r.methods_valid}) |"
+        )
+    out.append("")
+
+    # One "least covered" list is enough; the TFMs cover the same source.
+    worst = sorted(
+        ((name, cov, val) for name, (cov, val) in reports[0].by_file.items() if val > cov),
+        key=lambda item: (item[2] - item[1], item[0]),
+        reverse=True,
+    )[:WORST_FILE_COUNT]
+
+    if worst:
+        out.append(f"<details><summary>Files with the most uncovered lines ({reports[0].label})</summary>")
+        out.append("")
+        out.append("| File | Line coverage | Uncovered lines |")
+        out.append("| --- | ---: | ---: |")
+        for name, covered, valid in worst:
+            out.append(f"| `{name}` | {percent(covered, valid)} | {valid - covered} |")
+        out.append("")
+        out.append("</details>")
+        out.append("")
+
+    out.append("_No coverage threshold is enforced; this is reporting only._")
+    out.append("")
+    return "\n".join(out)
+
+
+def main(argv):
+    paths = argv[1:]
+    if not paths:
+        print("usage: coverage-summary.py <report.xml> [<report.xml> ...]", file=sys.stderr)
+        return 2
+
+    reports = [Report(framework_label(p), p) for p in sorted(paths)]
+    markdown = render(reports)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(markdown)
+    else:
+        sys.stdout.write(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/coverage-summary.py
+++ b/.github/scripts/coverage-summary.py
@@ -125,12 +125,15 @@ def main(argv):
     reports = [Report(framework_label(p), p) for p in sorted(paths)]
     markdown = render(reports)
 
+    # Always echo to stdout: GitHub's job summary is not readable through the API,
+    # so the step log is the only place the rendered numbers can be checked after
+    # the fact (and it is where you are already looking when a run goes wrong).
+    sys.stdout.write(markdown)
+
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:
         with open(summary_path, "a", encoding="utf-8") as handle:
             handle.write(markdown)
-    else:
-        sys.stdout.write(markdown)
     return 0
 
 

--- a/.github/scripts/coverage-summary.py
+++ b/.github/scripts/coverage-summary.py
@@ -9,8 +9,11 @@ collapsed list of the files with the most uncovered lines. Written against the
 Python standard library only, so CI needs no third-party action, tool install,
 or secret to display coverage.
 
-Exits non-zero only when it cannot read a report -- it never judges the numbers,
-because this repo deliberately has no build-failing coverage threshold (#641).
+This is reporting only, so it must never be what turns a build red: an
+unreadable or malformed report is reported as a warning in the summary and the
+script still exits 0. It also never judges the numbers, because this repo
+deliberately has no build-failing coverage threshold (#641). The one non-zero
+exit is a usage error, which only a hand-run with no arguments can produce.
 """
 
 import os
@@ -77,8 +80,28 @@ def framework_label(path):
     return name
 
 
-def render(reports):
+def warning_block(failures):
+    """Markdown for any report that could not be read. Empty when all were fine."""
+    if not failures:
+        return []
+    out = ["> [!WARNING]", "> Some coverage reports could not be read:", ">"]
+    for path, error in failures:
+        out.append(f"> - `{path}`: {type(error).__name__}: {error}")
+    out.append("")
+    return out
+
+
+def render(reports, failures=()):
     out = ["## Code coverage", ""]
+
+    if not reports:
+        out.append("No readable coverage report was produced by this run.")
+        out.append("")
+        out.extend(warning_block(failures))
+        out.append("_No coverage threshold is enforced; this is reporting only._")
+        out.append("")
+        return "\n".join(out)
+
     out.append("| Target framework | Line | Branch | Method |")
     out.append("| --- | ---: | ---: | ---: |")
     for r in reports:
@@ -111,6 +134,7 @@ def render(reports):
         out.append("</details>")
         out.append("")
 
+    out.extend(warning_block(failures))
     out.append("_No coverage threshold is enforced; this is reporting only._")
     out.append("")
     return "\n".join(out)
@@ -122,8 +146,17 @@ def main(argv):
         print("usage: coverage-summary.py <report.xml> [<report.xml> ...]", file=sys.stderr)
         return 2
 
-    reports = [Report(framework_label(p), p) for p in sorted(paths)]
-    markdown = render(reports)
+    reports = []
+    failures = []
+    for path in sorted(paths):
+        # A malformed or truncated report is a reporting problem, not a build
+        # problem, so it becomes a warning in the summary rather than a red job.
+        try:
+            reports.append(Report(framework_label(path), path))
+        except Exception as error:  # noqa: BLE001 - nothing here may fail the build
+            failures.append((path, error))
+
+    markdown = render(reports, failures)
 
     # Always echo to stdout: GitHub's job summary is not readable through the API,
     # so the step log is the only place the rendered numbers can be checked after
@@ -132,8 +165,11 @@ def main(argv):
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:
-        with open(summary_path, "a", encoding="utf-8") as handle:
-            handle.write(markdown)
+        try:
+            with open(summary_path, "a", encoding="utf-8") as handle:
+                handle.write(markdown)
+        except OSError as error:
+            print(f"could not write the job summary: {error}", file=sys.stderr)
     return 0
 
 

--- a/.github/scripts/coverage-summary.py
+++ b/.github/scripts/coverage-summary.py
@@ -64,6 +64,18 @@ class Report:
             self.by_file[filename] = (covered, valid)
 
 
+# Control characters are stripped from anything the report supplies: this text is
+# echoed to the step log, where a bare newline could forge a `::` workflow command,
+# and a pipe would silently split a Markdown table cell.
+_UNSAFE = {c: " " for c in range(0x20)}
+_UNSAFE[0x7F] = " "
+
+
+def cell(text):
+    """Make a report-derived string safe to drop into a log line or table cell."""
+    return str(text).translate(_UNSAFE).replace("|", "\\|").strip()
+
+
 def percent(covered, valid):
     """Format a coverage ratio, tolerating the zero-denominator case."""
     if valid == 0:
@@ -86,7 +98,7 @@ def warning_block(failures):
         return []
     out = ["> [!WARNING]", "> Some coverage reports could not be read:", ">"]
     for path, error in failures:
-        out.append(f"> - `{path}`: {type(error).__name__}: {error}")
+        out.append(f"> - `{cell(path)}`: {cell(type(error).__name__)}: {cell(error)}")
     out.append("")
     return out
 
@@ -106,7 +118,7 @@ def render(reports, failures=()):
     out.append("| --- | ---: | ---: | ---: |")
     for r in reports:
         out.append(
-            f"| {r.label} "
+            f"| {cell(r.label)} "
             f"| {percent(r.lines_covered, r.lines_valid)} "
             f"({r.lines_covered}/{r.lines_valid}) "
             f"| {percent(r.branches_covered, r.branches_valid)} "
@@ -124,12 +136,12 @@ def render(reports, failures=()):
     )[:WORST_FILE_COUNT]
 
     if worst:
-        out.append(f"<details><summary>Files with the most uncovered lines ({reports[0].label})</summary>")
+        out.append(f"<details><summary>Files with the most uncovered lines ({cell(reports[0].label)})</summary>")
         out.append("")
         out.append("| File | Line coverage | Uncovered lines |")
         out.append("| --- | ---: | ---: |")
         for name, covered, valid in worst:
-            out.append(f"| `{name}` | {percent(covered, valid)} | {valid - covered} |")
+            out.append(f"| `{cell(name)}` | {percent(covered, valid)} | {valid - covered} |")
         out.append("")
         out.append("</details>")
         out.append("")
@@ -161,7 +173,11 @@ def main(argv):
     # Always echo to stdout: GitHub's job summary is not readable through the API,
     # so the step log is the only place the rendered numbers can be checked after
     # the fact (and it is where you are already looking when a run goes wrong).
-    sys.stdout.write(markdown)
+    try:
+        sys.stdout.write(markdown)
+        sys.stdout.flush()
+    except OSError as error:
+        print(f"could not echo the coverage summary: {error}", file=sys.stderr)
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,32 @@ jobs:
       
     - name: Test
       run: dotnet test Daqifi.Core.sln
+
+    # Daqifi.Core.Tests.csproj collects coverage on every run, so the cobertura
+    # report already exists by this point; the next two steps are only about not
+    # throwing it away when the job ends. Reporting only — deliberately no
+    # threshold that can fail the build (#641). `always()` so a red test run still
+    # publishes whatever coverage was written before the failure.
+    - name: Coverage summary
+      if: always()
+      shell: bash
+      run: |
+        shopt -s nullglob
+        reports=(src/coverage/*.cobertura.xml)
+        if [ ${#reports[@]} -eq 0 ]; then
+          echo "No coverage reports were produced by this run." >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+        python_bin=python3
+        command -v python3 >/dev/null 2>&1 || python_bin=python
+        "$python_bin" .github/scripts/coverage-summary.py "${reports[@]}"
+
+    # Keyed by runner.os so the artifact names stay unique if the job ever becomes
+    # a multi-OS matrix (#635).
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-${{ runner.os }}
+        path: src/coverage/*.cobertura.xml
+        if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ artifacts/
 *.scc
 # Agent scratch journal — local-only, never committed
 SESSION_LOG.md
+
+# Python bytecode from .github/scripts
+__pycache__/


### PR DESCRIPTION
## What was wrong

Every CI run already measures test coverage — `Daqifi.Core.Tests.csproj` has `CollectCoverage` turned on, so each build pays the instrumentation cost and writes a cobertura report — and then the runner is torn down and the report goes with it. The practical effect is that a reviewer looking at a PR has no way to see whether it added an untested code path or deleted the tests covering one, short of checking the branch out and running the suite locally. The project is investing real effort in coverage and none of it is visible where merge decisions get made.

## How it was fixed

Two steps at the end of the CI job: upload the cobertura file as a run artifact, and render the numbers into the job summary so they're readable without downloading anything. The summary is produced by a small stdlib-only Python script (`.github/scripts/coverage-summary.py`) rather than a marketplace action — given `CONTRIBUTING.md`'s stance on what code this project accepts, adding a third-party action or an external coverage service to every run felt like the wrong trade for a display feature. The only new dependency is `actions/upload-artifact`, which is first-party. **This is reporting only — there is deliberately no coverage threshold that can fail the build.**

Both steps use `if: always()` so a red test run still publishes whatever coverage was written before the failure, and the artifact is named `coverage-${{ runner.os }}` so it stays unique if the job ever becomes a multi-OS matrix (#635).

Scope is deliberately narrow: three files, all under `.github/` plus a `__pycache__/` line in `.gitignore`. No csproj or props file is touched (that is #647's territory), the test matrix is unchanged, and nothing here needs a secret the repo lacks.

The one thing worth pushing back on: the summary script derives method coverage itself (cobertura stores no method totals), counting a method as covered if any of its lines ran. That reproduces coverlet's own console table on this repo: run locally against the reports this branch's test run just wrote, the script prints 88.50% line / 83.67% branch / 94.37% method against coverlet's 88.5% / 83.66% / 94.37% — identical apart from coverlet truncating the branch figure where the script rounds it. It is still a reimplementation, so it's worth a look.

## Hardening that came out of review

Three Qodo findings were conceded and fixed, all on the same theme — a *display* feature must never be what turns a build red:

- `09958af` — each report is parsed in its own `try`, so a malformed or truncated cobertura file becomes a `> [!WARNING]` block in the summary instead of a non-zero exit under `bash -e`.
- `20fa32f` — report-derived text (chiefly `class/@filename`) is stripped of control characters and has `|` escaped before it reaches the step log or a table cell, closing a log-injection path and a plain Markdown-table correctness bug.
- `e1f4d97` — stdout and the summary file are opened with `errors="replace"` and the writes catch broadly, so an unencodable path or a closed stdout degrades a character rather than failing the step.

## Confirming it took effect

Checked on this PR's own CI run at the **current head `e1f4d97`**, not assumed and not carried over from an earlier push. Run [`32748877925`](https://github.com/daqifi/daqifi-core/actions/runs/32748877925):

- the `Coverage summary` and `Upload coverage report` steps both ran and succeeded;
- the artifact `coverage-Linux` (436,004 bytes, artifact ID `9528253517`) is attached to the run;
- the step log shows the rendered table with real numbers — 88.07% line / 83.45% branch / 94.12% method on net10.0 and 88.08% / 83.46% / 94.12% on net9.0 — plus the per-file list, with `Communication/Transport/MacOsHidPlatform.cs` at 0% of 377 lines and `Device/Discovery/WindowsUsbLocationProvider.cs` at 0% of 86, the exact figures the issue cites as what #635 will need.

(GitHub exposes no API for reading a job summary after the fact, which is why the script also echoes the same Markdown to the step log — that echo is how the numbers above were read back.)

Re-validated against current `main` by test-merge, not by raw diff: `origin/main` (`602a1b7`, i.e. including #642/#645/#646) merged into a scratch branch cleanly and the full suite is green there on net9.0 and net10.0.

## Left for a follow-up

PR-diff coverage deltas (item 3 in the issue) are not here. That needs either Codecov or a stored baseline to diff against, and both are bigger decisions than "stop throwing the report away" — worth their own issue if wanted.

Bench validation does not apply — this is a CI-only change and touches no device code.

closes #641

Not merging — for review.
