### PR TITLE
fix(scpi): reject a negative channel on the two DIO producers

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -181,11 +181,53 @@ public class ScpiMessageProducerTests
     }
 
     [Fact]
+    public void SetDioPortDirection_WithNegativeChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetDioPortDirection(-1, 1));
+    }
+
+    // Channel 0 is a real channel on every DAQiFi board, so the guard's boundary matters:
+    // rejecting only negatives must leave the lowest valid channel untouched.
+    [Fact]
+    public void SetDioPortDirection_WithChannelZero_StillReturnsCommand()
+    {
+        var message = ScpiMessageProducer.SetDioPortDirection(0, 0);
+        Assert.Equal("DIO:PORt:DIRection 0,0", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
     public void SetDioPortState_ReturnsCorrectCommand()
     {
         var message = ScpiMessageProducer.SetDioPortState(1, 1);
         Assert.Equal("DIO:PORt:STATe 1,1", message.Data);
         AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetDioPortState_WithNegativeChannel_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => ScpiMessageProducer.SetDioPortState(-1, 1));
+    }
+
+    [Fact]
+    public void SetDioPortState_WithChannelZero_StillReturnsCommand()
+    {
+        var message = ScpiMessageProducer.SetDioPortState(0, 1);
+        Assert.Equal("DIO:PORt:STATe 0,1", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetDioPortState_WithNegativeChannel_ThrowsBeforeCheckingTheValue()
+    {
+        // Both arguments are invalid here. The channel guard runs first, so the caller is
+        // told about `channel` rather than about `value`, matching the sibling setters that
+        // validate the channel before the value.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ScpiMessageProducer.SetDioPortState(-1, double.NaN));
+
+        Assert.Equal("channel", ex.ParamName);
     }
 
     [Theory]
@@ -1121,8 +1163,12 @@ public class ScpiMessageProducerTests
 
     // Each channel-addressed producer already has its own test proving it throws on a
     // negative channel. None of them pinned what callers can actually observe about that
-    // throw, so nothing stopped the nine copies of the rule from drifting apart. They now
+    // throw, so nothing stopped the copies of the rule from drifting apart. They now
     // share one ValidateChannel helper; this pins the contract it is there to hold.
+    //
+    // The list is the whole of ScpiMessageProducer's channel-addressed surface: the two
+    // DIO producers were the odd ones out until they were brought in, so a producer added
+    // here without the guard fails this test rather than quietly shipping an unguarded one.
     [Fact]
     public void EveryChannelAddressedProducer_RejectsNegativeChannelIdentically()
     {
@@ -1137,6 +1183,8 @@ public class ScpiMessageProducerTests
             (nameof(ScpiMessageProducer.SetAdcCalibrationOffset), () => ScpiMessageProducer.SetAdcCalibrationOffset(-1, 1.0)),
             (nameof(ScpiMessageProducer.GetAdcCalibrationSlope), () => ScpiMessageProducer.GetAdcCalibrationSlope(-1)),
             (nameof(ScpiMessageProducer.GetAdcCalibrationOffset), () => ScpiMessageProducer.GetAdcCalibrationOffset(-1)),
+            (nameof(ScpiMessageProducer.SetDioPortDirection), () => ScpiMessageProducer.SetDioPortDirection(-1, 1)),
+            (nameof(ScpiMessageProducer.SetDioPortState), () => ScpiMessageProducer.SetDioPortState(-1, 1)),
         };
 
         var observed = new List<(string Producer, string? ParamName, object? ActualValue, string Message)>();
@@ -1146,7 +1194,7 @@ public class ScpiMessageProducerTests
             observed.Add((name, ex.ParamName, ex.ActualValue, ex.Message));
         }
 
-        Assert.Equal(9, observed.Count);
+        Assert.Equal(11, observed.Count);
         Assert.All(observed, o =>
         {
             Assert.Equal("channel", o.ParamName);

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -540,8 +540,11 @@ public class ScpiMessageProducer
     /// Command: DIO:PORt:DIRection channel,direction
     /// Example: messageProducer.Send(ScpiMessageProducer.SetDioPortDirection(1, 1)); // Set channel 1 as output
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="channel"/> is negative.</exception>
     public static IOutboundMessage<string> SetDioPortDirection(int channel, int direction)
     {
+        ValidateChannel(channel);
+
         return new ScpiMessage($"DIO:PORt:DIRection {channel},{direction}");
     }
 
@@ -550,7 +553,7 @@ public class ScpiMessageProducer
     /// </summary>
     /// <param name="channel">The channel number.</param>
     /// <param name="value">The state value (0 = low, 1 = high).</param>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is not a finite number.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="channel"/> is negative, or <paramref name="value"/> is not a finite number.</exception>
     /// <remarks>
     /// The value is formatted with an invariant decimal point so the command is locale-independent.
     /// Command: DIO:PORt:STATe channel,value
@@ -558,6 +561,8 @@ public class ScpiMessageProducer
     /// </remarks>
     public static IOutboundMessage<string> SetDioPortState(int channel, double value)
     {
+        ValidateChannel(channel);
+
         RequireFinite(value, nameof(value), "State value");
 
         return new ScpiMessage($"DIO:PORt:STATe {channel},{value.ToString(CultureInfo.InvariantCulture)}");


### PR DESCRIPTION
## What was wrong

`ScpiMessageProducer` has eleven public commands that take a channel number. Nine of them reject a negative channel immediately, with an `ArgumentOutOfRangeException` naming the bad argument. The two digital-I/O commands did not: `SetDioPortDirection(-1, 1)` cheerfully handed back a perfectly well-formed message whose payload was `DIO:PORt:DIRection -1,1`, and `SetDioPortState(-1, 1)` did the same. That frame went out to the device, which has no such channel — so a plain programming mistake surfaced late as a device-side rejection or a silent no-op, instead of at the line that made it. Worse, the library was telling callers two different stories about the same illegal argument depending on which command they happened to be using.

## How it was fixed

Both DIO commands now call the same `ValidateChannel` helper the other nine already share, so all eleven throw the identical exception, with the same `ParamName` and the same message. On `SetDioPortState` the channel check runs ahead of the finite-value check added in #645, so a caller who gets both arguments wrong is told about the first one.

The thing worth pushing back on: **this rejects input that used to be accepted.** Code that passed a negative channel to either DIO command previously got a message object and now gets an exception. That is the point of the change — a negative channel was never valid for the firmware — but it is a behavior change to public API, which is why it is its own commit rather than folded into a refactor. Nothing inside this repo is affected: the only production callers are the device-level DIO wrappers, which pass a channel number resolved from the device's own channel collection and so can never be negative. Channel `0` remains valid and is pinned by a test.

## How it was verified

- A throwaway probe first confirmed both methods really did accept `-1` today, and the pre-existing nine-command uniformity test was confirmed green against unchanged code — so the new assertions are checked against a proven reference rather than a copied literal.
- The four new-behavior assertions were then run against unchanged code and failed, as they must, before the two-line production change was made.
- The existing `EveryChannelAddressedProducer_RejectsNegativeChannelIdentically` test now covers all eleven commands instead of nine, so a twelfth channel command added without the guard fails the suite.
- Clean `--no-incremental` solution build: 0 warnings, 0 errors. Full `dotnet test` green on net9.0 and net10.0 (3832 passed per TFM, plus 217 in Daqifi.Mcp.Tests).
- Bench: smoke-tested against the board over USB with the example CLI built against this branch. The CLI exposes no DIO command, so these two producers cannot be driven on the wire through it; for valid channels the emitted bytes are unchanged either way, so there was nothing hardware could add here.

closes #624

**Not merging — for review.**
