### PR TITLE
fix(tests): ask the exchange whether it recognised the reply, not the clock

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -189,5 +189,6 @@ public class ConnectionGuardTests
         public IDisposable SubscribeConsumerErrors(IMessageConsumer<string> consumer) => throw new NotSupportedException();
         public void OnStaleLineBoundaryCaptured() => throw new NotSupportedException();
         public void OnSendBoundaryCaptured() => throw new NotSupportedException();
+        public void OnReplyWaitCompleted(bool sawResponse) => throw new NotSupportedException();
     }
 }

--- a/src/Daqifi.Core.Tests/Device/TextExchangeLineFramingTests.cs
+++ b/src/Daqifi.Core.Tests/Device/TextExchangeLineFramingTests.cs
@@ -55,12 +55,10 @@ public class TextExchangeLineFramingTests
 
         device.Connect();
 
-        var stopwatch = Stopwatch.StartNew();
         var lines = await device.CallAsync(() => transport.Release());
-        stopwatch.Stop();
 
         Assert.Equal(new[] { "Added test log messages" }, lines);
-        AssertAnsweredPromptly(stopwatch);
+        AssertRecognisedTheReply(device);
 
         device.Disconnect();
     }
@@ -77,11 +75,9 @@ public class TextExchangeLineFramingTests
 
         device.Connect();
 
-        var stopwatch = Stopwatch.StartNew();
         var lines = await device.CallAsync(() => transport.Release());
-        stopwatch.Stop();
 
-        AssertAnsweredPromptly(stopwatch);
+        AssertRecognisedTheReply(device);
 
         // ...and the blank line stays out of the caller's result. It is evidence for the wait
         // loop, not content: every caller of this seam parses lines, and none of them ever saw a
@@ -107,6 +103,15 @@ public class TextExchangeLineFramingTests
         stopwatch.Stop();
 
         Assert.Empty(lines);
+
+        // The mirror of AssertRecognisedTheReply, and the half of this control that no longer
+        // depends on the clock: silence must leave the exchange with nothing it would keep as an
+        // answer. If counting blank lines ever started counting a device that sent none, this
+        // flips to true here while the elapsed-time check below stays happily green.
+        Assert.False(
+            device.RecognisedTheReply,
+            "A silent device left the exchange believing it had been answered.");
+
         Assert.True(
             stopwatch.ElapsedMilliseconds >= ResponseTimeoutMs - 500,
             $"A silent device should have used the whole {ResponseTimeoutMs}ms response window, "
@@ -153,15 +158,30 @@ public class TextExchangeLineFramingTests
         device.Disconnect();
     }
 
-    private static void AssertAnsweredPromptly(Stopwatch stopwatch)
+    private static void AssertRecognisedTheReply(LineFramingTestableDevice device)
     {
-        // Generously bounded: a recognised reply finishes in about the completion timeout, and an
-        // unrecognised one takes at least ResponseTimeoutMs. Anything below this bound can only be
-        // the former, with room to spare for a slow build agent.
+        // The exchange reports which branch its reply wait loop left by, so this asks it rather
+        // than inferring the answer from a stopwatch.
+        //
+        // The bound this replaces was `elapsed < ResponseTimeoutMs - 1000`, i.e. "it finished well
+        // inside the response timeout, so it must have recognised the reply". That inference
+        // measures the runner as much as the exchange: the wait loop polls with
+        // `await Task.Delay(50)`, and on a thread-pool-starved CI agent each of those continuations
+        // can take a second to be scheduled — so an exchange that recognised the reply on its very
+        // first poll still returns seconds later, and the stopwatch calls a fast path a timed-out
+        // one. That is issue #634: 2129ms observed against a 2000ms bound, on a run where the
+        // reply was recognised correctly the whole time, and green again on a re-run of the same
+        // SHA. Reproduced here 10/10 under a starved pool, at 2.1-2.7s.
+        //
+        // Nothing is weakened by asking instead. The failure this guards against — a reply shape
+        // the line framing cannot see, which is the whole of #538 — leaves the loop in its
+        // first-response phase, so it still lands here as false. So does the #592 regression of a
+        // reply that arrived before the loop's first poll going unnoticed. What the stopwatch
+        // added on top of that was the machine's load, and that is all this drops.
         Assert.True(
-            stopwatch.ElapsedMilliseconds < ResponseTimeoutMs - 1000,
-            $"The exchange took {stopwatch.ElapsedMilliseconds}ms, which means it waited out its "
-            + $"{ResponseTimeoutMs}ms response timeout instead of recognising the reply.");
+            device.RecognisedTheReply,
+            "The exchange never saw the reply as an answer, so it waited out its "
+            + $"{ResponseTimeoutMs}ms first-response timeout instead of recognising it.");
     }
 
     /// <summary>Exposes the protected text-exchange entry point with the timeouts these tests need.</summary>
@@ -171,6 +191,21 @@ public class TextExchangeLineFramingTests
             : base(name, transport)
         {
         }
+
+        /// <summary>
+        /// What the last exchange's reply wait loop concluded: <c>true</c> if it found evidence the
+        /// device answered, <c>false</c> if it sat out its whole first-response timeout, and
+        /// <c>null</c> if no exchange has finished waiting yet — which is itself a failure for
+        /// every caller of it here, and reads as one.
+        /// </summary>
+        public bool? RecognisedTheReply { get; private set; }
+
+        /// <summary>
+        /// Records <see cref="DaqifiDevice.OnReplyWaitCompleted"/> so a test can assert on the
+        /// branch the exchange took rather than on how long it took to get there. Written on the
+        /// exchange's own task and read only after awaiting it, so the await orders the two.
+        /// </summary>
+        internal override void OnReplyWaitCompleted(bool sawResponse) => RecognisedTheReply = sawResponse;
 
         public Task<IReadOnlyList<string>> CallAsync(Action setupAction)
         {

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -2032,6 +2032,18 @@ namespace Daqifi.Core.Device
         {
         }
 
+        /// <inheritdoc />
+        void ITextExchangeHost.OnReplyWaitCompleted(bool sawResponse) => OnReplyWaitCompleted(sawResponse);
+
+        /// <summary>
+        /// A no-op on the real device. Overridable for tests, mirroring
+        /// <see cref="OnSendBoundaryCaptured"/> — see
+        /// <see cref="ITextExchangeHost.OnReplyWaitCompleted"/> for why this seam exists.
+        /// </summary>
+        internal virtual void OnReplyWaitCompleted(bool sawResponse)
+        {
+        }
+
         #endregion
 
         #region IOperationSerializationHost — the serializer's view of this device

--- a/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
+++ b/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
@@ -185,5 +185,27 @@ namespace Daqifi.Core.Device.Internal
         /// the guess with an ordering the runtime guarantees.
         /// </remarks>
         void OnSendBoundaryCaptured();
+
+        /// <summary>
+        /// Called once the reply wait loop has finished, reporting whether the exchange ever found
+        /// evidence that the device answered — <c>true</c> when it left the loop on the short
+        /// completion timeout, <c>false</c> when it sat out the whole first-response timeout in
+        /// silence. A no-op on the real device, like the two seams above.
+        /// </summary>
+        /// <remarks>
+        /// This is the fact the #538 timing tests were really asserting. They inferred it from a
+        /// stopwatch — "finished well inside the response timeout, so it must have recognised the
+        /// reply" — and that inference is only as good as the machine's scheduling: the wait loop
+        /// polls with <c>await Task.Delay(50)</c>, so on a thread-pool-starved runner an exchange
+        /// that recognised the reply on its first poll can still take seconds of wall clock to
+        /// return, and the stopwatch then reports a fast path as a timed-out one (issue #634).
+        /// Reporting the branch the loop actually took removes the inference, and with it the
+        /// machine's load as an input to the assertion.
+        /// </remarks>
+        /// <param name="sawResponse">
+        /// Whether anything the exchange would keep as an answer arrived before the first-response
+        /// timeout expired.
+        /// </param>
+        void OnReplyWaitCompleted(bool sawResponse);
     }
 }

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -667,6 +667,13 @@ namespace Daqifi.Core.Device.Internal
                         }
                     }
 
+                    // Test-only seam (issue #634), the third of these and a no-op on the real
+                    // device. It publishes which branch the loop above just left by: a test that
+                    // cares whether the exchange recognised the reply can then ask, instead of
+                    // inferring it from how long the whole call took on a machine whose scheduler
+                    // it does not control.
+                    _host.OnReplyWaitCompleted(hasReceivedAny);
+
                     var collectedLineCount = CollectedLineCount();
                     Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Collection complete at {ElapsedMs}ms, {LineCount} lines", sw.ElapsedMilliseconds, collectedLineCount));
 


### PR DESCRIPTION
## What was wrong

Two tests in `TextExchangeLineFramingTests` — the ones that check the SCPI text exchange
recognises a blank-line or bare-LF reply instead of sitting out its response timeout — were
failing intermittently on CI. The most recent one reported "the exchange took 2129ms" against a
2000 ms bound: net9.0 red, net10.0 green on the same commit, and green again on a re-run of the
same SHA. Nothing was actually wrong with the exchange on those runs. The tests were deciding
whether the reply had been recognised by timing the whole call, and the exchange's reply wait
loop polls with `await Task.Delay(50)` — so on a thread-pool-starved build agent an exchange that
recognised the reply on its very first poll still takes seconds of wall clock to return, and the
stopwatch reports a fast path as a timed-out one. The bound was measuring the runner, not the
code under test.

## How it was fixed

The exchange now says which branch its wait loop left by, through a test-only host seam
(`OnReplyWaitCompleted(bool sawResponse)`, a no-op on the real device and the third of these
after the two added for #553 and #632), and the tests assert on that instead of on elapsed time.

The thing worth pushing back on is that this removes a timing assertion, so it is worth being
explicit that the guard is not weakened. The failure these tests exist to catch — a reply shape
the line framing cannot see (#538) — leaves the wait loop in its first-response phase, which now
lands as `false` here; so does the #592 regression of a reply that arrived before the loop's
first poll going unnoticed. Both were previously caught only by inference from the clock. What
the stopwatch added on top of that was the machine's load, and that is the only thing dropped.
The silent-device control test gains the mirror assertion (silence must leave the exchange
believing nothing answered) and keeps its existing elapsed-time check, which can only fail late
and so cannot flake this way.

## Verification

Reproduced with a temporary in-process harness that blocks the thread pool with
`ProcessorCount * 8` non-CPU-burning work items — external CPU spinners do not starve the .NET
pool, which is the actual CI mechanism. Harness removed before committing; no external spinners
were needed, so peak extra CPU load was zero.

| | net9.0 | net10.0 |
|---|---|---|
| before | 10 / 10 runs failed | 10 / 10 runs failed |
| after | 0 / 10 | 0 / 10 |

Observed failure times before the fix were 2.1–2.7 s against the 2000 ms bound — the same range
as the CI failure in the issue. In every one of those runs the exchange returned the correct
result; only the stopwatch disagreed. This is a test-side timing sensitivity, not a product bug.

Full suite green on both target frameworks: Core 3827 passed / 0 failed / 2 skipped on net9.0 and
net10.0, Mcp 217 passed. Build clean, 0 warnings.

closes #634

Not merging — for review.
