### PR TITLE
chore(tests): drop a write-timeout assertion that the line above already decides

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/SerialStreamTransportTests.cs
@@ -70,7 +70,6 @@ public class SerialStreamTransportTests
 
         Assert.Equal(500, port.ReadTimeout);
         Assert.Equal(2000, port.WriteTimeout);
-        Assert.NotEqual(SerialPort.InfiniteTimeout, port.WriteTimeout);
     }
 
     [Fact]


### PR DESCRIPTION
Produced by the **useless-test-pruner** maintenance routine, which looks for tests asserting something that structurally cannot fail. This one is a single deleted line, and it is safe because the assertion it removes was already decided by the assertion immediately above it.

## What was wrong

`SerialStreamTransport_ApplyOperationalTimeouts_BoundsBothDirections` checked the serial write timeout twice. It first pinned it to exactly `2000`, then asserted it was not `SerialPort.InfiniteTimeout`. `InfiniteTimeout` is the compile-time constant `-1`, so by the time the second assertion runs, the first one has already established the value is 2000 — the "not infinite" check can never be the thing that fails. It reads like a second, independent guarantee about the write path being bounded, but it contributes nothing, and that is worse than not being there at all: it makes the test look like it covers more than it does.

## How it was fixed

Deleted that one line. `Assert.Equal(2000, port.WriteTimeout)` directly above is untouched and is what actually covers the behavior — it is strictly stronger, since pinning the exact value rules out infinity along with every other wrong value. The `ReadTimeout` assertion and the explanatory comment above the test are also untouched.

The one thing a reviewer might reasonably push back on is whether the deleted line documented the intent of #399. I do not think it did: the regression #399 describes is `WriteTimeout` keeping the 30-second *connect* timeout for the life of the port, not it going infinite. The test arranges exactly that scenario (`WriteTimeout = 30000`) and `Assert.Equal(2000, ...)` is the assertion that catches it. The prose comment above the test already states the "both directions must end up bounded and short" intent for a future reader.

## Verification

Build clean, 0 warnings. Full suite green on both target frameworks (run under a `tests.N` lock): net9.0 3827 passed / 0 failed / 2 skipped, net10.0 3827 passed / 0 failed / 2 skipped, plus `Daqifi.Mcp.Tests` 217 passed. Coverage is unchanged — the removed line exercised no production code the surviving assertion does not.

Bench validation does not apply here: this is a test-only change that touches no production code and needs no device, so the board was never used.

**Not merging — for review.**