### PR TITLE
test(consumers): make the parser routing tests actually test the routing

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/CompositeMessageParserTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/CompositeMessageParserTests.cs
@@ -1,5 +1,6 @@
 using Daqifi.Core.Communication.Consumers;
 using Daqifi.Core.Communication.Messages;
+using Google.Protobuf;
 using System.Text;
 
 namespace Daqifi.Core.Tests.Communication.Consumers;
@@ -12,10 +13,10 @@ public class CompositeMessageParserTests
         // Arrange
         var parser = new CompositeMessageParser();
         var textData = Encoding.UTF8.GetBytes("*IDN?\r\nDAQiFi Device v1.0\r\n");
-        
+
         // Act
         var messages = parser.ParseMessages(textData, out var consumedBytes);
-        
+
         // Assert
         Assert.Equal(2, messages.Count());
         Assert.All(messages, msg => Assert.IsType<string>(msg.Data));
@@ -27,32 +28,57 @@ public class CompositeMessageParserTests
     [Fact]
     public void CompositeMessageParser_ParseMessages_WithBinaryData_ShouldUseProtobufParser()
     {
-        // Arrange
-        var parser = new CompositeMessageParser();
-        // Binary data with null bytes should trigger protobuf parsing attempt
+        // Arrange - 50% null bytes, well past the 10% null-ratio threshold, so the
+        // classifier must hand this to the protobuf parser FIRST. Both parsers are
+        // recorded into one shared log so the assertion below sees the real call
+        // ORDER, not just which parsers were touched.
+        var log = new RoutingLog();
+        var protobufResult = new DaqifiOutMessage { MsgTimeStamp = 1234 };
+        var parser = new CompositeMessageParser(
+            new RecordingTextParser(log, result: "should not be reached", consumed: 4),
+            new RecordingProtobufParser(log, result: protobufResult, consumed: 4));
         var binaryDataWithNulls = new byte[] { 0x00, 0x01, 0x00, 0x02 };
-        
+
         // Act
-        var messages = parser.ParseMessages(binaryDataWithNulls, out var consumedBytes);
-        
-        // Assert - Should attempt protobuf parsing due to null bytes
-        // Even if parsing fails, should not throw exceptions
-        Assert.True(consumedBytes >= 0);
+        var messages = parser.ParseMessages(binaryDataWithNulls, out var consumedBytes).ToList();
+
+        // Assert - the protobuf parser ran, it ran first, and because it produced a
+        // message the text parser was never consulted at all. Routing the other way
+        // would put "text" in the log and would surface the text parser's string here.
+        Assert.Equal(new[] { "protobuf" }, log.Calls);
+        Assert.Equal(binaryDataWithNulls, log.Buffers.Single());
+        var message = Assert.Single(messages);
+        Assert.Same(protobufResult, Assert.IsType<DaqifiOutMessage>(message.Data));
+        Assert.Equal(4, consumedBytes);
     }
 
     [Fact]
-    public void CompositeMessageParser_ParseMessages_WithNullBytes_ShouldDetectAsBinary()
+    public void CompositeMessageParser_ParseMessages_WithOneNullByteInPrintableData_ShouldDetectAsText()
     {
-        // Arrange
-        var parser = new CompositeMessageParser();
-        var dataWithNulls = new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00, 0x57, 0x6F, 0x72, 0x6C, 0x64 }; // "Hello\0World"
-        
+        // Arrange - "Hello\0World": 10 of 11 bytes are printable ASCII (90.9%) and only
+        // one is a null (9.1%).
+        //
+        // This test used to be called "...WithNullBytes_ShouldDetectAsBinary" and asserted
+        // nothing, so nobody noticed it was named for the opposite of what the classifier
+        // does. Printable ratio is weighed BEFORE null ratio on purpose (heuristic 1 in
+        // DetectMessageType): a buffer that is over 80% printable is text even with a
+        // stray null in it, and a lone null in eleven bytes is below the 10% null-density
+        // threshold anyway. The genuinely binary case — 40% nulls, 24% printable — is
+        // covered by WithBinaryData_ShouldUseProtobufParser above.
+        var log = new RoutingLog();
+        var parser = new CompositeMessageParser(
+            new RecordingTextParser(log, result: "Hello\0World", consumed: 11),
+            new RecordingProtobufParser(log, result: new DaqifiOutMessage(), consumed: 11));
+        var dataWithOneNull = new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00, 0x57, 0x6F, 0x72, 0x6C, 0x64 };
+
         // Act
-        var messages = parser.ParseMessages(dataWithNulls, out var consumedBytes);
-        
-        // Assert - Should try protobuf parser first due to null bytes
-        // May return empty if not valid protobuf, but should have attempted protobuf parsing
-        Assert.True(consumedBytes >= 0);
+        var messages = parser.ParseMessages(dataWithOneNull, out var consumedBytes).ToList();
+
+        // Assert - text parser first, and it answered, so protobuf was never consulted.
+        Assert.Equal(new[] { "text" }, log.Calls);
+        var message = Assert.Single(messages);
+        Assert.Equal("Hello\0World", Assert.IsType<string>(message.Data));
+        Assert.Equal(11, consumedBytes);
     }
 
     [Fact]
@@ -61,10 +87,10 @@ public class CompositeMessageParserTests
         // Arrange
         var parser = new CompositeMessageParser();
         var textOnlyData = Encoding.UTF8.GetBytes("Hello World\r\n");
-        
+
         // Act
         var messages = parser.ParseMessages(textOnlyData, out var consumedBytes);
-        
+
         // Assert
         Assert.Single(messages);
         Assert.IsType<string>(messages.First().Data);
@@ -78,10 +104,10 @@ public class CompositeMessageParserTests
         // Arrange
         var parser = new CompositeMessageParser();
         var emptyData = new byte[0];
-        
+
         // Act
         var messages = parser.ParseMessages(emptyData, out var consumedBytes);
-        
+
         // Assert
         Assert.Empty(messages);
         Assert.Equal(0, consumedBytes);
@@ -94,12 +120,12 @@ public class CompositeMessageParserTests
         var mockTextParser = new LineBasedMessageParser("\n"); // Custom line ending
         var mockProtobufParser = new ProtobufMessageParser();
         var parser = new CompositeMessageParser(mockTextParser, mockProtobufParser);
-        
+
         var textData = Encoding.UTF8.GetBytes("Line 1\nLine 2\n");
-        
+
         // Act
         var messages = parser.ParseMessages(textData, out var consumedBytes);
-        
+
         // Assert
         Assert.Equal(2, messages.Count());
         Assert.All(messages, msg => Assert.IsType<string>(msg.Data));
@@ -108,85 +134,204 @@ public class CompositeMessageParserTests
     }
 
     [Fact]
-    public void CompositeMessageParser_ParseMessages_WithNullTextParser_ShouldStillWork()
+    public void CompositeMessageParser_ParseMessages_WithNullTextParser_UsesDefaultLineParser()
     {
-        // Arrange
-        var parser = new CompositeMessageParser(null, new ProtobufMessageParser());
+        // Arrange - a null text parser means "use the default", not "skip text routing".
+        // The old version of this test asserted only consumedBytes >= 0 and carried a
+        // comment claiming the call would fall back to the protobuf parser; it does not.
+        var log = new RoutingLog();
+        var protobufSpy = new RecordingProtobufParser(log, result: new DaqifiOutMessage(), consumed: 13);
+        var parser = new CompositeMessageParser(null, protobufSpy);
         var textData = Encoding.UTF8.GetBytes("Hello World\r\n");
-        
+
         // Act
-        var messages = parser.ParseMessages(textData, out var consumedBytes);
-        
-        // Assert - Should fallback to protobuf parser, which likely won't parse text successfully
-        // But should not throw an exception
-        Assert.True(consumedBytes >= 0);
+        var messages = parser.ParseMessages(textData, out var consumedBytes).ToList();
+
+        // Assert - the substituted LineBasedMessageParser handled the buffer end to end,
+        // so the supplied protobuf parser was never reached.
+        var message = Assert.Single(messages);
+        Assert.Equal("Hello World", Assert.IsType<string>(message.Data));
+        Assert.Equal(textData.Length, consumedBytes);
+        Assert.Empty(log.Calls);
     }
 
     [Fact]
-    public void CompositeMessageParser_ParseMessages_WithNullProtobufParser_ShouldStillWork()
+    public void CompositeMessageParser_ParseMessages_WithNullProtobufParser_UsesDefaultProtobufParser()
     {
-        // Arrange
-        var parser = new CompositeMessageParser(new LineBasedMessageParser(), null);
-        var binaryData = new byte[] { 0x00, 0x01, 0x02, 0x03 }; // Binary data with null bytes
-        
+        // Arrange - a null protobuf parser also means "use the default", and the old
+        // version of this test (consumedBytes >= 0 on four junk bytes) could not tell
+        // whether the substitution happened. Feed a real length-delimited frame instead:
+        // only a working ProtobufMessageParser decodes it, and the supplied text parser
+        // is rigged to answer, so if routing ever reached it the answer here would be a
+        // string instead of a DaqifiOutMessage.
+        var log = new RoutingLog();
+        var textSpy = new RecordingTextParser(log, result: "text parser must not win", consumed: 3);
+        var parser = new CompositeMessageParser(textSpy, null);
+
+        using var stream = new MemoryStream();
+        new DaqifiOutMessage { MsgTimeStamp = 99 }.WriteDelimitedTo(stream);
+        var protobufFrame = stream.ToArray();
+
         // Act
-        var messages = parser.ParseMessages(binaryData, out var consumedBytes);
-        
-        // Assert - Should try text parser even for binary data
-        Assert.True(consumedBytes >= 0);
+        var messages = parser.ParseMessages(protobufFrame, out var consumedBytes).ToList();
+
+        // Assert
+        Assert.Empty(log.Calls);
+        var message = Assert.Single(messages);
+        Assert.Equal(99u, Assert.IsType<DaqifiOutMessage>(message.Data).MsgTimeStamp);
+        Assert.Equal(protobufFrame.Length, consumedBytes);
+    }
+
+    [Fact]
+    public void CompositeMessageParser_ParseMessages_WhenPreferredParserFindsNothing_FallsBackWithFullBuffer()
+    {
+        // Arrange - 25% null bytes, so the protobuf parser is preferred; it is rigged to
+        // find nothing while reporting that it consumed 3 bytes resyncing over the junk.
+        var log = new RoutingLog();
+        var textSpy = new RecordingTextParser(log, result: "fallback line", consumed: 4);
+        var protobufSpy = new RecordingProtobufParser(log, result: null, consumed: 3);
+        var parser = new CompositeMessageParser(textSpy, protobufSpy);
+        var binaryData = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+
+        // Act
+        var messages = parser.ParseMessages(binaryData, out var consumedBytes).ToList();
+
+        // Assert - the preferred parser runs first, the other runs second, and the second
+        // one is handed the WHOLE buffer. That last point is the invariant CompositeMessageParser
+        // documents on TryParse: a parser that consumed bytes without producing a message
+        // does not get to hide those bytes from the fallback, and its consumedBytes is not
+        // adopted (4, from the text parser that actually answered, not 3).
+        Assert.Equal(new[] { "protobuf", "text" }, log.Calls);
+        Assert.All(log.Buffers, buffer => Assert.Equal(binaryData, buffer));
+        var message = Assert.Single(messages);
+        Assert.Equal("fallback line", Assert.IsType<string>(message.Data));
+        Assert.Equal(4, consumedBytes);
     }
 
     [Fact]
     public void CompositeMessageParser_ParseMessages_ReturnsDifferentMessageTypes()
     {
-        // Arrange
+        // Arrange - the point of the composite is that one call site can receive both
+        // formats, so the two routings must yield genuinely different Data types. The
+        // old version of this test ended in Assert.True(binaryMessages.Count() >= 0),
+        // which Enumerable.Count() can never violate.
         var parser = new CompositeMessageParser();
-        
-        // Test text message
         var textData = Encoding.UTF8.GetBytes("Text Message\r\n");
-        var textMessages = parser.ParseMessages(textData, out _);
-        
-        // Test binary message (mock binary data)
-        var binaryData = new byte[] { 0x00, 0x08, 0x01 }; // Mock binary with null bytes
-        var binaryMessages = parser.ParseMessages(binaryData, out _);
-        
+
+        using var stream = new MemoryStream();
+        new DaqifiOutMessage { MsgTimeStamp = 42 }.WriteDelimitedTo(stream);
+        var protobufFrame = stream.ToArray();
+
+        // Act
+        var textMessages = parser.ParseMessages(textData, out var textConsumed).ToList();
+        var binaryMessages = parser.ParseMessages(protobufFrame, out var binaryConsumed).ToList();
+
         // Assert
-        if (textMessages.Any())
-        {
-            Assert.IsType<string>(textMessages.First().Data);
-        }
-        
-        // Binary messages might not parse successfully, but should not throw
-        Assert.True(binaryMessages.Count() >= 0);
+        var textMessage = Assert.Single(textMessages);
+        Assert.Equal("Text Message", Assert.IsType<string>(textMessage.Data));
+        Assert.Equal(textData.Length, textConsumed);
+
+        var binaryMessage = Assert.Single(binaryMessages);
+        var decoded = Assert.IsType<DaqifiOutMessage>(binaryMessage.Data);
+        Assert.Equal(42u, decoded.MsgTimeStamp);
+        Assert.Equal(protobufFrame.Length, binaryConsumed);
     }
 
-    [Fact]
-    public void CompositeMessageParser_ParseMessages_WithMixedScenarios_ShouldHandleGracefully()
+    public static TheoryData<string, byte[], string[], int> MixedScenarios() => new()
+    {
+        // SCPI command echo: >80% printable, routed to text, one complete line.
+        { "SCPI command", Encoding.UTF8.GetBytes("*IDN?\r\n"), new[] { "*IDN?" }, 7 },
+        { "SCPI query", Encoding.UTF8.GetBytes("SYST:ERR?\r\n"), new[] { "SYST:ERR?" }, 11 },
+
+        // A truncated protobuf-shaped buffer: the 0x0A length prefix declares 10 body
+        // bytes but only 4 are present, and there is no CRLF for the text parser either.
+        // Neither parser produces a message, so neither parser's consumedBytes is
+        // adopted and the caller keeps every byte for the next read.
+        { "truncated protobuf frame", new byte[] { 0x0A, 0x04, 0x74, 0x65, 0x73, 0x74 }, Array.Empty<string>(), 0 },
+
+        // 75% nulls: protobuf first, no valid frame, text fallback finds no line.
+        { "binary with nulls", new byte[] { 0x00, 0x00, 0x00, 0x01 }, Array.Empty<string>(), 0 },
+
+        // (The empty buffer is not a row here: WithEmptyData_ShouldReturnEmpty above
+        // already pins that contract, and it is the one input whose expected result
+        // cannot be driven red by mutating either parser, since CompositeMessageParser
+        // returns before routing.)
+
+        // A single non-printable byte must NOT be swallowed as a text line.
+        { "lone non-printable byte", new byte[] { 0xFF }, Array.Empty<string>(), 0 },
+    };
+
+    /// <remarks>
+    /// <paramref name="scenario"/> names the row in the runner output and in the failure
+    /// messages below; a raw byte[] renders as "Byte[]", which tells a reviewer nothing
+    /// about which case broke.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(MixedScenarios))]
+    public void CompositeMessageParser_ParseMessages_WithMixedScenarios_ProducesExactMessagesAndConsumedBytes(
+        string scenario, byte[] data, string[] expectedText, int expectedConsumed)
     {
         // Arrange
         var parser = new CompositeMessageParser();
-        
-        // Test various data patterns that might come from real DAQiFi devices
-        var scenarios = new[]
+
+        // Act
+        var messages = parser.ParseMessages(data, out var consumedBytes).ToList();
+
+        // Assert - the old version of this test only checked that nothing threw and that
+        // consumed >= 0, which held no matter where the bytes went. Pinning the exact
+        // output and the exact consumedBytes is what makes a misroute visible: a buffer
+        // routed to the wrong parser either loses its message or reports the wrong
+        // number of bytes consumed, and a caller that trims the wrong count corrupts
+        // the stream.
+        var actualText = messages.Select(m => Assert.IsType<string>(m.Data)).ToArray();
+        Assert.True(
+            expectedText.SequenceEqual(actualText),
+            $"{scenario}: expected [{string.Join(", ", expectedText)}] but got [{string.Join(", ", actualText)}]");
+        Assert.True(
+            expectedConsumed == consumedBytes,
+            $"{scenario}: expected consumedBytes {expectedConsumed} but got {consumedBytes}");
+    }
+
+    /// <summary>
+    /// Shared, ordered record of which parser <see cref="CompositeMessageParser"/> invoked
+    /// and with what bytes. One log is handed to both recording parsers so a test can assert
+    /// the routing ORDER, not merely that a parser was reached.
+    /// </summary>
+    private sealed class RoutingLog
+    {
+        public List<string> Calls { get; } = [];
+        public List<byte[]> Buffers { get; } = [];
+
+        public void Record(string parserName, byte[] data)
         {
-            Encoding.UTF8.GetBytes("*IDN?\r\n"),                    // SCPI command
-            Encoding.UTF8.GetBytes("SYST:ERR?\r\n"),               // SCPI query
-            new byte[] { 0x0A, 0x04, 0x74, 0x65, 0x73, 0x74 },   // Mock protobuf-like
-            new byte[] { 0x00, 0x00, 0x00, 0x01 },                // Binary with nulls
-            Encoding.UTF8.GetBytes(""),                             // Empty
-            new byte[] { 0xFF }                                     // Single byte
-        };
-        
-        // Act & Assert - Should not throw exceptions for any scenario
-        foreach (var scenario in scenarios)
+            Calls.Add(parserName);
+            Buffers.Add(data.ToArray());
+        }
+    }
+
+    private sealed class RecordingTextParser(RoutingLog log, string? result = null, int consumed = 0)
+        : IMessageParser<string>
+    {
+        public IEnumerable<IInboundMessage<string>> ParseMessages(byte[] data, out int consumedBytes)
         {
-            var exception = Record.Exception(() => 
-            {
-                var messages = parser.ParseMessages(scenario, out var consumed);
-                Assert.True(consumed >= 0);
-            });
-            
-            Assert.Null(exception);
+            log.Record("text", data);
+            consumedBytes = consumed;
+            return result is null
+                ? []
+                : [new TextInboundMessage(result)];
+        }
+    }
+
+    private sealed class RecordingProtobufParser(RoutingLog log, DaqifiOutMessage? result = null, int consumed = 0)
+        : IMessageParser<DaqifiOutMessage>
+    {
+        public IEnumerable<IInboundMessage<DaqifiOutMessage>> ParseMessages(byte[] data, out int consumedBytes)
+        {
+            log.Record("protobuf", data);
+            consumedBytes = consumed;
+            return result is null
+                ? []
+                : [new ProtobufMessage(result)];
         }
     }
 }

--- a/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserTests.cs
@@ -11,20 +11,22 @@ public class ProtobufMessageParserTests
     [Fact]
     public void ProtobufMessageParser_ParseMessages_WithValidProtobuf_ShouldReturnMessage()
     {
-        // Arrange
+        // Arrange - a real length-delimited frame. This test used to pass an EMPTY buffer
+        // (duplicating WithEmptyData_ShouldReturnEmpty) and hid its only type assertion
+        // behind `if (messages.Any())`, which was never true, so it asserted nothing.
         var parser = new ProtobufMessageParser();
-        // Create minimal valid protobuf data (empty message)
-        var data = new byte[] { }; // Empty protobuf message
-        
+        using var stream = new MemoryStream();
+        new DaqifiOutMessage { MsgTimeStamp = 42 }.WriteDelimitedTo(stream);
+        var data = stream.ToArray();
+
         // Act
-        var messages = parser.ParseMessages(data, out var consumedBytes);
-        
-        // Assert - Empty message should parse successfully
-        if (messages.Any())
-        {
-            Assert.IsType<ProtobufMessage>(messages.First());
-        }
-        Assert.True(consumedBytes >= 0);
+        var messages = parser.ParseMessages(data, out var consumedBytes).ToList();
+
+        // Assert - one decoded message, and the length prefix is consumed along with the
+        // body so the caller trims the whole frame off its buffer.
+        var message = Assert.IsType<ProtobufMessage>(Assert.Single(messages));
+        Assert.Equal(42u, message.Data.MsgTimeStamp);
+        Assert.Equal(data.Length, consumedBytes);
     }
 
     [Fact]
@@ -58,18 +60,25 @@ public class ProtobufMessageParserTests
     }
 
     [Fact]
-    public void ProtobufMessageParser_ParseMessages_WithNullBytes_ShouldHandleCorrectly()
+    public void ProtobufMessageParser_ParseMessages_WithNullBytes_ResyncsAndPreservesTrailingPrefix()
     {
-        // Arrange - This simulates the actual issue with binary protobuf containing null bytes
+        // Arrange - null bytes that would break LineBasedMessageParser. None of these five
+        // bytes begins a valid frame, so what matters is exactly how far the parser
+        // resyncs. The old assertion was `consumedBytes >= 0`, which any behaviour
+        // satisfies, including silently eating the whole buffer.
         var parser = new ProtobufMessageParser();
-        // Create data with null bytes that would break LineBasedMessageParser
         var dataWithNulls = new byte[] { 0x00, 0x01, 0x02, 0x00, 0x03 };
-        
-        // Act - Parser should handle the null bytes gracefully
+
+        // Act
         var messages = parser.ParseMessages(dataWithNulls, out var consumedBytes);
-        
-        // Assert - Should not throw exceptions, even if parsing fails
-        Assert.True(consumedBytes >= 0);
+
+        // Assert - nothing parses, and the parser advances one byte at a time over the
+        // four unusable leading bytes. It stops at the trailing 0x03: that byte is a
+        // varint prefix declaring a 3-byte body that has not arrived yet, and consuming a
+        // possible frame start would destroy it for the caller, which trims consumedBytes
+        // from its buffer. So consumedBytes is 4, not 5 and not 0.
+        Assert.Empty(messages);
+        Assert.Equal(4, consumedBytes);
     }
 
     [Fact]
@@ -90,20 +99,27 @@ public class ProtobufMessageParserTests
     }
 
     [Fact]
-    public void ProtobufMessageParser_ParseMessages_WithMultipleMessages_ShouldParseFirst()
+    public void ProtobufMessageParser_ParseMessages_WithMultipleMessages_ShouldParseAll()
     {
-        // Arrange
+        // Arrange - two real length-delimited frames back to back, the shape a streaming
+        // device produces when several samples land in one read. The old version of this
+        // test used hand-written "mock protobuf" bytes that are not valid delimited frames
+        // at all, so it parsed nothing; its `consumedBytes >= 0` assertion hid that, and
+        // the name's claim about parsing the first message was never checked.
         var parser = new ProtobufMessageParser();
-        // Create combined mock protobuf data
-        var data1 = new byte[] { 0x08, 0x01 }; // Mock protobuf message 1
-        var data2 = new byte[] { 0x08, 0x02 }; // Mock protobuf message 2
-        var combinedData = data1.Concat(data2).ToArray();
-        
+        using var stream = new MemoryStream();
+        new DaqifiOutMessage { MsgTimeStamp = 7 }.WriteDelimitedTo(stream);
+        new DaqifiOutMessage { MsgTimeStamp = 9 }.WriteDelimitedTo(stream);
+        var combinedData = stream.ToArray();
+
         // Act
-        var messages = parser.ParseMessages(combinedData, out var consumedBytes);
-        
-        // Assert - Should attempt to parse and consume some data
-        Assert.True(consumedBytes >= 0);
+        var messages = parser.ParseMessages(combinedData, out var consumedBytes).ToList();
+
+        // Assert - both frames come out, in wire order, and the whole buffer is consumed.
+        Assert.Equal(2, messages.Count);
+        Assert.Equal(new uint[] { 7, 9 }, messages.Select(m => m.Data.MsgTimeStamp));
+        Assert.All(messages, m => Assert.IsType<ProtobufMessage>(m));
+        Assert.Equal(combinedData.Length, consumedBytes);
     }
 
     [Fact]
@@ -556,20 +572,27 @@ public class ProtobufMessageParserTests
     [Fact]
     public void ProtobufMessageParser_ParseMessages_ReturnsCorrectMessageType()
     {
-        // Arrange
+        // Arrange - a streaming-shaped frame with a repeated payload field, so this checks
+        // that the wrapper hands back the fully decoded generated message and not just
+        // something that happens to be a DaqifiOutMessage. Like the two tests above, this
+        // one previously ran on an EMPTY buffer and guarded its assertions behind
+        // `if (messages.Any())`, so neither assertion ever executed.
         var parser = new ProtobufMessageParser();
-        var data = new byte[] { }; // Empty protobuf
-        
+        using var stream = new MemoryStream();
+        var original = new DaqifiOutMessage { MsgTimeStamp = 100 };
+        original.AnalogInData.Add(11);
+        original.AnalogInData.Add(22);
+        original.WriteDelimitedTo(stream);
+        var data = stream.ToArray();
+
         // Act
-        var messages = parser.ParseMessages(data, out var consumedBytes);
-        
-        // Assert - If parsing succeeds, should return correct types
-        if (messages.Any())
-        {
-            var message = messages.First();
-            Assert.IsType<ProtobufMessage>(message);
-            Assert.IsType<DaqifiOutMessage>(message.Data);
-        }
-        Assert.True(consumedBytes >= 0);
+        var messages = parser.ParseMessages(data, out var consumedBytes).ToList();
+
+        // Assert
+        var message = Assert.IsType<ProtobufMessage>(Assert.Single(messages));
+        var decoded = Assert.IsType<DaqifiOutMessage>(message.Data);
+        Assert.Equal(100u, decoded.MsgTimeStamp);
+        Assert.Equal(new[] { 11, 22 }, decoded.AnalogInData);
+        Assert.Equal(data.Length, consumedBytes);
     }
 }


### PR DESCRIPTION
## What was wrong

Ten tests across `CompositeMessageParserTests` and `ProtobufMessageParserTests` carried the names of routing tests — `ShouldUseProtobufParser`, `ShouldDetectAsBinary`, `WithMultipleMessages_ShouldParseFirst` — but their only assertion was `Assert.True(consumedBytes >= 0)`. Nothing in them said which parser had run, which is the entire behaviour they were named for. A change that routed every buffer to the wrong parser would have left all ten green. One was a strict tautology (`Assert.True(binaryMessages.Count() >= 0)` — `Enumerable.Count()` cannot be negative), and five hid their only real assertion behind `if (messages.Any())`, so they asserted nothing whenever the parser returned empty — which, for the buffers they used, was always. Three of them ran on an **empty** byte array despite being named for valid protobuf. The suite was reporting coverage of the parser routing that the project did not actually have.

## How it was fixed

Each test now pins the real behaviour: which parser was consulted and in what order, how many messages came out, of what concrete type and with what decoded field values, and what `consumedBytes` exactly equals. Two recording parsers write into one shared ordered call log, so a test can assert the routing **order** (`["protobuf", "text"]`) rather than merely that a parser was reached — and can prove the negative, that the second parser was never consulted when the first answered. Every `if (messages.Any())` guard is gone. The buffers that were fake "mock protobuf" bytes (not valid length-delimited frames at all, which is why nothing ever parsed) are now real frames built with `WriteDelimitedTo`.

**Two things a reviewer should push back on if they disagree:**

1. **`WithNullBytes_ShouldDetectAsBinary` was named for the opposite of what the code does.** `"Hello\0World"` is 90.9% printable ASCII and 9.1% null, and `DetectMessageType` weighs printable ratio *before* null density on purpose (the 10% null threshold isn't even met). It routes to **text**. That is deliberate and documented in the classifier — the genuinely binary case it guards against is the 40%-null / 24%-printable `SYSInfoPB?` reply from issue #268 — so I renamed the test to `WithOneNullByteInPrintableData_ShouldDetectAsText` rather than pin a behaviour the code doesn't have. **This is not a bug report**; no parser bug was found. If you'd rather the classifier *did* treat any null byte as binary, that's a separate design change and this test would need to move with it.

2. **`ReturnsCorrectMessageType` is a tenth test, not in issue #653's list of nine.** It sits in the same file with the identical defect (empty buffer, `if (messages.Any())`, `consumedBytes >= 0`). Leaving it would have shipped a file that still contained the exact pattern this PR claims to remove.

### Mutation evidence — every rewritten test was confirmed able to fail

Each mutation was applied to production code, the tests run, then reverted. Verified red:

| Mutation | Tests it turns red |
|---|---|
| M1 — swap the two routing branches in `CompositeMessageParser.ParseMessages` | `WithBinaryData_ShouldUseProtobufParser`, `WithOneNullByteInPrintableData_ShouldDetectAsText`, `WithNullTextParser_UsesDefaultLineParser`, `WithNullProtobufParser_UsesDefaultProtobufParser`, `WhenPreferredParserFindsNothing_FallsBackWithFullBuffer` |
| M2 — `TryParse` adopts `Math.Max(consumedBytes, parserConsumed)` instead of only adopting on a produced message | `WithMixedScenarios` rows *truncated protobuf frame*, *binary with nulls* |
| M3 — `currentIndex += messageLength` (drop the length prefix from the advance) | `WithValidProtobuf_ShouldReturnMessage`, `WithMultipleMessages_ShouldParseAll`, `ReturnsCorrectMessageType`, `ReturnsDifferentMessageTypes`, `WithNullProtobufParser_UsesDefaultProtobufParser` |
| M4 — resync advances by 2 instead of 1 in the invalid-length branch | `WithNullBytes_ResyncsAndPreservesTrailingPrefix` (and only that one) |
| M5 — `break` after the first parsed frame | `WithMultipleMessages_ShouldParseAll` |
| M6 — `TextPrintableRatio` 0.8 → 0.95 | `WithOneNullByteInPrintableData_ShouldDetectAsText` |
| M7 — `LineBasedMessageParser` reports `consumedBytes` without the line ending | `ReturnsDifferentMessageTypes`, `WithNullTextParser_UsesDefaultLineParser`, `WithMixedScenarios` rows *SCPI command*, *SCPI query* |
| M8 — `LineBasedMessageParser` swallows an unterminated tail as a line | `WithMixedScenarios` rows *lone non-printable byte*, *truncated protobuf frame*, *binary with nulls* |

The one input I could **not** make failable is the empty buffer, because `CompositeMessageParser` returns before routing — so I dropped it from the theory rather than keep a row no mutation can kill; the existing `WithEmptyData_ShouldReturnEmpty` already pins that contract exactly. There is a comment in the theory data saying so.

## Verification

Test-only change; no production code is modified. Full suite green on both frameworks: net9.0 Core 3838 passed / 2 skipped, net10.0 Core 3838 passed / 2 skipped, Mcp 217 passed, 0 failed, 0 warnings. Line coverage 88.48%. Bench validation does not apply — nothing here touches the device, and the board was never acquired.

The diff also drops trailing whitespace from four adjacent tests I did not otherwise change, a side effect of rewriting the file.

closes #653

**Not merging — for review.**
