### PR TITLE
feat(export): let a live stream be recorded straight to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ More examples at [daqifi.com](https://daqifi.com).
 | **One-line connect** | `DaqifiDeviceFactory.ConnectTcpAsync(...)` wraps transport setup and device init; retries are opt-in via `DeviceConnectionOptions` |
 | **Real-time streaming** | Per-channel `IChannel.SampleReceived` events with decoded, scaled values — or subscribe to the raw protobuf frame directly; no polling loops to write |
 | **Acquisition health** | Attach `AcquisitionStatistics` to a stream and read back the rate you are really getting, per-channel jitter, value range, and how far behind the device's clock the host is |
+| **Record to CSV** | `device.RecordLiveSamplesToCsvAsync(writer)` writes a live stream to CSV as it arrives — no buffering the session in memory — and reports what reached the file and what was dropped |
 | **Digital I/O** | Set any DIO pin as input or output and drive outputs high/low; inputs stream alongside analog data |
 | **PWM outputs** | Drive PWM on capable DIO pins with per-channel duty cycle and a shared, device-wide frequency |
 | **SD card operations** | List, download, delete, format, and start/stop SD logging over USB / serial |
@@ -200,6 +201,36 @@ samples went missing; the two disagreeing means the device's own clock is not ke
 it is `MeasuredSampleRateHz` that describes what your application actually received. `Reset()` starts
 a fresh window mid-session, and `stats.Record(sample)` feeds one by hand from `StreamSamplesAsync`
 instead of attaching.
+
+### Record a live stream to CSV
+
+Streaming and exporting used to be two halves with nothing between them. `RecordLiveSamplesToCsvAsync`
+joins them: it writes rows through `CsvExporter` as frames decode, so the recording's memory does not
+grow with its length, and it hands back what reached the file and what did not.
+
+```csharp
+using Daqifi.Core.Logging.Export;
+
+device.StreamingFrequency = 100;
+device.StartStreaming();
+
+await using var writer = new StreamWriter("run.csv");
+var result = await device.RecordLiveSamplesToCsvAsync(writer, duration: TimeSpan.FromSeconds(30));
+
+device.StopStreaming();
+
+Console.WriteLine($"{result.RowCount} rows from {result.SampleCount} samples");
+if (result.DroppedSampleCount > 0)
+{
+    Console.WriteLine($"{result.DroppedSampleCount} samples dropped — raise bufferCapacity or lower the rate");
+}
+```
+
+The columns are the channels that were enabled when the call started, in device order. `duration`
+elapsing is a clean finish — the last frame is written and the result comes back; cancelling the
+`CancellationToken` is an abort and throws, so a recording cut short is never mistaken for a complete
+one. Need the rows somewhere other than a `TextWriter`? Build a `LiveSampleSource` over
+`StreamSamplesAsync` and hand it to `CsvExporter` (or any other `ISampleSource` consumer) yourself.
 
 ### Digital output
 

--- a/src/Daqifi.Core.Tests/Logging/Export/LiveCsvRecordingTests.cs
+++ b/src/Daqifi.Core.Tests/Logging/Export/LiveCsvRecordingTests.cs
@@ -1,0 +1,514 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Daqifi.Core.Logging.Export;
+using Daqifi.Core.Tests.Firmware;
+using ChannelFactory = System.Threading.Channels.Channel;
+
+namespace Daqifi.Core.Tests.Logging.Export;
+
+/// <summary>
+/// Covers <see cref="LiveCsvRecordingExtensions.RecordLiveSamplesToCsvAsync"/> — the join between a
+/// device's live stream and <see cref="CsvExporter"/> that issue #639 was filed for.
+/// </summary>
+/// <remarks>
+/// Most cases drive a device whose live stream is scripted (<see cref="ScriptedLiveDevice"/>), so
+/// what arrives and when is exact rather than timed. The last test drives the real decode path of a
+/// real <see cref="DaqifiStreamingDevice"/> instead, because the argument for this design is that it
+/// records an actual live stream — a scripted one cannot show that the timestamps a frame produces
+/// collapse into one CSV line, or that they come out ascending.
+/// </remarks>
+public class LiveCsvRecordingTests
+{
+    /// <summary>
+    /// Upper bound on every await here. A regression in the stop path is "the recording never
+    /// returns", which would otherwise park the run rather than fail it.
+    /// </summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+
+    private static readonly DateTime T0 = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    // ── Argument validation ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_NullDevice_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => ((IStreamingDevice)null!).RecordLiveSamplesToCsvAsync(new StringWriter()));
+
+        Assert.Equal("device", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_NullWriter_Throws()
+    {
+        using var device = CreateScripted();
+
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => device.RecordLiveSamplesToCsvAsync(null!));
+
+        Assert.Equal("writer", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_DeviceThatCannotSupplyLiveSamples_Throws()
+    {
+        // A streaming device is not automatically a live-sample source; the recording has nothing
+        // to read and should say so at the call rather than write an empty file.
+        var device = new FakeStreamingDevice("no-live-samples");
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => device.RecordLiveSamplesToCsvAsync(new StringWriter()));
+
+        Assert.Equal("device", ex.ParamName);
+        Assert.Contains(nameof(ILiveSampleSource), ex.Message);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task RecordLiveSamplesToCsvAsync_NonPositiveDuration_Throws(int seconds)
+    {
+        using var device = CreateScripted();
+
+        var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => device.RecordLiveSamplesToCsvAsync(
+                new StringWriter(), duration: TimeSpan.FromSeconds(seconds)));
+
+        Assert.Equal("duration", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task RecordLiveSamplesToCsvAsync_BufferCapacityBelowOne_ThrowsAtTheCall(int capacity)
+    {
+        // The live stream defers this check to the first MoveNextAsync, which happens inside the
+        // exporter where the argument is no longer the caller's to fix.
+        using var device = CreateScripted();
+
+        var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => device.RecordLiveSamplesToCsvAsync(new StringWriter(), bufferCapacity: capacity));
+
+        Assert.Equal("bufferCapacity", ex.ParamName);
+        Assert.False(device.StreamRequested);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_AlreadyCancelledToken_ThrowsWithoutTouchingTheStream()
+    {
+        using var device = CreateScripted();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => device.RecordLiveSamplesToCsvAsync(new StringWriter(), cancellationToken: cts.Token));
+
+        Assert.False(device.StreamRequested);
+    }
+
+    // ── Channel selection ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_NoEnabledChannels_WritesNothingAndNeverStartsTheStream()
+    {
+        // There is nothing to record, and a header of no columns is not a useful file.
+        using var device = CreateScripted(analogCount: 2);
+        var writer = new StringWriter();
+
+        var result = await device.RecordLiveSamplesToCsvAsync(writer).WaitAsync(Timeout);
+
+        Assert.Equal(string.Empty, writer.ToString());
+        Assert.Equal(default(LiveCsvRecordingResult), result);
+        Assert.False(device.StreamRequested);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_GivesColumnsToEnabledChannelsOnly()
+    {
+        using var device = CreateScripted(analogCount: 3);
+        var channels = device.GetChannelsSnapshot();
+        channels[0].IsEnabled = true;
+        channels[2].IsEnabled = true;
+        var writer = new StringWriter();
+
+        var recording = device.RecordLiveSamplesToCsvAsync(writer, duration: TimeSpan.FromMilliseconds(200));
+        device.Emit(Sample(channels[0], T0, 1.0));
+        device.Emit(Sample(channels[2], T0, 3.0));
+        await recording.WaitAsync(Timeout);
+
+        var header = Lines(writer)[0];
+        Assert.Equal(
+            $"Time,{Key(device, channels[0])},{Key(device, channels[2])}",
+            header);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_SampleForADisabledChannel_IsReportedNotExported()
+    {
+        using var device = CreateScripted(analogCount: 2);
+        var channels = device.GetChannelsSnapshot();
+        channels[0].IsEnabled = true;
+        var writer = new StringWriter();
+
+        var recording = device.RecordLiveSamplesToCsvAsync(writer, duration: TimeSpan.FromMilliseconds(200));
+        device.Emit(Sample(channels[0], T0, 1.0));
+        device.Emit(Sample(channels[1], T0, 2.0));
+        var result = await recording.WaitAsync(Timeout);
+
+        Assert.Equal(1L, result.UnmappedSampleCount);
+        Assert.Equal(2L, result.SampleCount);
+        Assert.Equal(1L, result.RowCount);
+        Assert.Equal(2, Lines(writer).Length); // header + one data line
+    }
+
+    // ── Stopping ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_DurationElapsing_FinishesTheFileRatherThanAborting()
+    {
+        // The window ending is how a timed recording finishes, so the frame the exporter was
+        // accumulating when the window closed still has to reach the file. Letting the window's
+        // cancellation tear through the exporter instead would silently drop that last line.
+        using var device = CreateScripted(analogCount: 1);
+        var channel = device.GetChannelsSnapshot()[0];
+        channel.IsEnabled = true;
+        var writer = new StringWriter();
+
+        var recording = device.RecordLiveSamplesToCsvAsync(writer, duration: TimeSpan.FromMilliseconds(300));
+        device.Emit(Sample(channel, T0, 1.0));
+        device.Emit(Sample(channel, T0.AddSeconds(1), 2.0));
+        device.Emit(Sample(channel, T0.AddSeconds(2), 3.0));
+        var result = await recording.WaitAsync(Timeout);
+
+        var lines = Lines(writer);
+        Assert.Equal(4, lines.Length); // header + three data lines, the last one included
+        Assert.EndsWith(",3", lines[3]);
+        Assert.Equal(3L, result.RowCount);
+        Assert.Equal(3L, result.SampleCount);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_StreamEnding_ReturnsTheResult()
+    {
+        // What a disconnect looks like from here: the enumeration ends, and so does the recording.
+        using var device = CreateScripted(analogCount: 1);
+        var channel = device.GetChannelsSnapshot()[0];
+        channel.IsEnabled = true;
+        var writer = new StringWriter();
+
+        var recording = device.RecordLiveSamplesToCsvAsync(writer);
+        device.Emit(Sample(channel, T0, 1.0));
+        device.EndStream();
+        var result = await recording.WaitAsync(Timeout);
+
+        Assert.Equal(1L, result.RowCount);
+        Assert.Equal(2, Lines(writer).Length);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_CallerCancellation_Propagates()
+    {
+        // A recording the caller aborted must not be indistinguishable from one that finished.
+        using var device = CreateScripted(analogCount: 1);
+        var channel = device.GetChannelsSnapshot()[0];
+        channel.IsEnabled = true;
+        using var cts = new CancellationTokenSource();
+
+        var recording = device.RecordLiveSamplesToCsvAsync(new StringWriter(), cancellationToken: cts.Token);
+        device.Emit(Sample(channel, T0, 1.0));
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => recording.WaitAsync(Timeout));
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_CallerCancellationDuringADurationWindow_StillPropagates()
+    {
+        // The two stops are not interchangeable: a window is in play here, and the abort must still
+        // win rather than being absorbed as a clean finish.
+        using var device = CreateScripted(analogCount: 1);
+        var channel = device.GetChannelsSnapshot()[0];
+        channel.IsEnabled = true;
+        using var cts = new CancellationTokenSource();
+
+        var recording = device.RecordLiveSamplesToCsvAsync(
+            new StringWriter(), duration: TimeSpan.FromSeconds(30), cancellationToken: cts.Token);
+        device.Emit(Sample(channel, T0, 1.0));
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => recording.WaitAsync(Timeout));
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_CallerCancellationRacingTheWindow_IsStillAnAbort()
+    {
+        // The narrow case the window's absorb rule has to get right: by the time the cancellation
+        // surfaces, BOTH the window and the caller have cancelled. Absorbing it because the window
+        // fired would turn an abort the caller asked for into a recording that looks complete.
+        using var device = CreateScripted(analogCount: 1);
+        device.GetChannelsSnapshot()[0].IsEnabled = true;
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        device.GateStreamOn(gate);
+        using var cts = new CancellationTokenSource();
+
+        var recording = device.RecordLiveSamplesToCsvAsync(
+            new StringWriter(), duration: TimeSpan.FromMilliseconds(50), cancellationToken: cts.Token);
+
+        // Let the window elapse first, so the abort lands on top of an already-cancelled window.
+        await Task.Delay(300);
+        await cts.CancelAsync();
+        gate.SetResult();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => recording.WaitAsync(Timeout));
+    }
+
+    // ── Result ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_DroppedSamples_AreCountedAcrossTheRecordingOnly()
+    {
+        // The device's counter is cumulative across every enumeration it has ever served, so the
+        // recording's own losses are the difference across it — reporting the raw value would blame
+        // this recording for drops that happened before it started.
+        using var device = CreateScripted(analogCount: 1);
+        var channel = device.GetChannelsSnapshot()[0];
+        channel.IsEnabled = true;
+        device.Dropped = 7;
+        device.OnStreamRequested = () => device.Dropped = 10;
+
+        var recording = device.RecordLiveSamplesToCsvAsync(
+            new StringWriter(), duration: TimeSpan.FromMilliseconds(200));
+        device.Emit(Sample(channel, T0, 1.0));
+        var result = await recording.WaitAsync(Timeout);
+
+        Assert.Equal(3L, result.DroppedSampleCount);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_BufferCapacity_ReachesTheLiveStream()
+    {
+        using var device = CreateScripted(analogCount: 1);
+        device.GetChannelsSnapshot()[0].IsEnabled = true;
+
+        var recording = device.RecordLiveSamplesToCsvAsync(
+            new StringWriter(), duration: TimeSpan.FromMilliseconds(200), bufferCapacity: 8);
+        await recording.WaitAsync(Timeout);
+
+        Assert.Equal(8, device.RequestedBufferCapacity);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_Options_ReachTheExporter()
+    {
+        using var device = CreateScripted(analogCount: 1);
+        var channel = device.GetChannelsSnapshot()[0];
+        channel.IsEnabled = true;
+        var writer = new StringWriter();
+
+        var recording = device.RecordLiveSamplesToCsvAsync(
+            writer,
+            new CsvExportOptions { UseRelativeTime = true, Delimiter = ";" },
+            duration: TimeSpan.FromMilliseconds(200));
+        device.Emit(Sample(channel, T0, 1.0));
+        device.Emit(Sample(channel, T0.AddSeconds(2), 2.0));
+        await recording.WaitAsync(Timeout);
+
+        var lines = Lines(writer);
+        Assert.StartsWith("Relative Time (s);", lines[0]);
+        Assert.StartsWith("0.000;", lines[1]);
+        Assert.StartsWith("2.000;", lines[2]);
+    }
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_FlushesTheWriterButDoesNotDisposeIt()
+    {
+        // A result that reports rows while the rows sit in an unflushed buffer is a foot-gun, and
+        // the writer belongs to the caller, who may still have more to write to it.
+        using var device = CreateScripted(analogCount: 1);
+        var channel = device.GetChannelsSnapshot()[0];
+        channel.IsEnabled = true;
+        using var stream = new MemoryStream();
+        var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = false };
+
+        var recording = device.RecordLiveSamplesToCsvAsync(writer, duration: TimeSpan.FromMilliseconds(200));
+        device.Emit(Sample(channel, T0, 1.0));
+        var result = await recording.WaitAsync(Timeout);
+
+        Assert.Equal(1L, result.RowCount);
+        Assert.NotEqual(0, stream.Length);
+        await writer.WriteLineAsync("still usable"); // would throw on a disposed writer
+        await writer.FlushAsync();
+    }
+
+    // ── The real decode path ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_AgainstARealDeviceStream_CollapsesEachFrameIntoOneAscendingRow()
+    {
+        // The claim this whole design rests on: a real live stream, recorded as it arrives, comes out
+        // as one CSV line per device frame, in time order, with nothing lost. A scripted stream
+        // cannot show that — the frame-to-timestamp relationship is the decoder's, not the adapter's.
+        using var device = new LiveStreamDevice("RealPath");
+        device.Connect();
+        device.Metadata.SerialNumber = "SN-REAL";
+        device.PopulateChannelsFromStatus(StatusWithAnalogChannels(2));
+        var channels = device.GetChannelsSnapshot();
+        foreach (var channel in channels)
+        {
+            channel.IsEnabled = true;
+        }
+
+        device.StartStreaming();
+        var writer = new StringWriter();
+        var recording = device.RecordLiveSamplesToCsvAsync(writer, duration: TimeSpan.FromSeconds(2));
+
+        // The recording subscribes from inside the exporter, so there is no synchronous point for a
+        // test to hook. Give it time to get there before injecting, or the leading frames decode
+        // while nothing is listening.
+        await Task.Delay(400);
+        for (uint i = 0; i < 20; i++)
+        {
+            device.InvokeStreamMessage(AnalogFrame(1000 + i * 500000, i, i + 100));
+        }
+
+        var result = await recording.WaitAsync(Timeout);
+
+        var lines = Lines(writer);
+        Assert.Equal($"Time,{Key(device, channels[0])},{Key(device, channels[1])}", lines[0]);
+        Assert.Equal(20L, result.RowCount);
+        Assert.Equal(40L, result.SampleCount); // two channels per frame, one line per frame
+        Assert.Equal(lines.Length - 1, (int)result.RowCount);
+        Assert.Equal(0L, result.DroppedSampleCount);
+        Assert.Equal(0L, result.UnmappedSampleCount);
+
+        // The exporter's contract is an ascending stream, and this is the live path honouring it
+        // across the decoder's rollover-aware timestamp reconstruction.
+        Assert.Equal(0L, result.NonMonotonicSampleCount);
+        var timestamps = lines.Skip(1).Select(l => DateTime.Parse(l.Split(',')[0], CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind)).ToArray();
+        Assert.Equal(timestamps.OrderBy(t => t).ToArray(), timestamps);
+        Assert.All(lines.Skip(1), l => Assert.Equal(3, l.Split(',').Length));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static ScriptedLiveDevice CreateScripted(int analogCount = 1)
+    {
+        var device = new ScriptedLiveDevice("Scripted");
+        device.Connect();
+        device.Metadata.SerialNumber = "SN-1";
+        device.PopulateChannelsFromStatus(StatusWithAnalogChannels(analogCount));
+        return device;
+    }
+
+    private static DaqifiOutMessage StatusWithAnalogChannels(int analogCount)
+    {
+        var status = new DaqifiOutMessage
+        {
+            AnalogInPortNum = (uint)analogCount,
+            DigitalPortNum = 0,
+            AnalogInRes = 65535,
+        };
+        for (var i = 0; i < analogCount; i++)
+        {
+            status.AnalogInPortRange.Add(1.0f);
+        }
+
+        return status;
+    }
+
+    private static DaqifiOutMessage AnalogFrame(uint timestamp, params float[] values)
+    {
+        var frame = new DaqifiOutMessage { MsgTimeStamp = timestamp };
+        foreach (var value in values)
+        {
+            frame.AnalogInDataFloat.Add(value);
+        }
+
+        return frame;
+    }
+
+    private static LiveSample Sample(IChannel channel, DateTime timestamp, double value) =>
+        new(channel, new DataSample { Timestamp = timestamp, Value = value });
+
+    private static string Key(IStreamingDevice device, IChannel channel) =>
+        $"{device.Name}:{device.Metadata.SerialNumber}:{channel.Name}";
+
+    private static string[] Lines(StringWriter writer) =>
+        writer.ToString()
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.TrimEnd('\r'))
+            .ToArray();
+
+    /// <summary>
+    /// A real streaming device whose live stream is replaced by one the test writes into, so what
+    /// arrives and when is exact. The rest of the device — its channels, its metadata, its
+    /// identity — is the real thing, because that is what the recording reads to build its columns.
+    /// </summary>
+    private sealed class ScriptedLiveDevice : DaqifiStreamingDevice, ILiveSampleSource
+    {
+        private readonly System.Threading.Channels.Channel<LiveSample> _samples =
+            ChannelFactory.CreateUnbounded<LiveSample>();
+
+        public ScriptedLiveDevice(string name) : base(name) { }
+
+        public long Dropped { get; set; }
+
+        public bool StreamRequested { get; private set; }
+
+        public int? RequestedBufferCapacity { get; private set; }
+
+        /// <summary>Runs when the recording asks for the stream — after it has read the drop counter.</summary>
+        public Action? OnStreamRequested { get; set; }
+
+        private TaskCompletionSource? _gate;
+
+        public void Emit(LiveSample sample) => _samples.Writer.TryWrite(sample);
+
+        /// <summary>
+        /// Makes the stream park until <paramref name="gate"/> is completed and then surface the
+        /// cancellation state as of that moment, so a test can decide exactly which tokens are
+        /// cancelled when the enumeration throws.
+        /// </summary>
+        public void GateStreamOn(TaskCompletionSource gate) => _gate = gate;
+
+        public void EndStream() => _samples.Writer.TryComplete();
+
+        public override void Send<T>(IOutboundMessage<T> message) { /* no transport in tests */ }
+
+        long ILiveSampleSource.DroppedLiveSampleCount => Dropped;
+
+        IAsyncEnumerable<LiveSample> ILiveSampleSource.StreamSamplesAsync(
+            CancellationToken cancellationToken, int? bufferCapacity)
+        {
+            StreamRequested = true;
+            RequestedBufferCapacity = bufferCapacity;
+            OnStreamRequested?.Invoke();
+            return _gate is { } gate
+                ? GatedAsync(gate, cancellationToken)
+                : _samples.Reader.ReadAllAsync(cancellationToken);
+        }
+
+        private static async IAsyncEnumerable<LiveSample> GatedAsync(
+            TaskCompletionSource gate,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await gate.Task.ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            yield break;
+        }
+    }
+
+    private sealed class LiveStreamDevice : DaqifiStreamingDevice
+    {
+        public LiveStreamDevice(string name) : base(name) { }
+
+        public void InvokeStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+
+        public override void Send<T>(IOutboundMessage<T> message) { /* no transport in tests */ }
+    }
+}

--- a/src/Daqifi.Core.Tests/Logging/Export/LiveCsvRecordingTests.cs
+++ b/src/Daqifi.Core.Tests/Logging/Export/LiveCsvRecordingTests.cs
@@ -127,6 +127,22 @@ public class LiveCsvRecordingTests
     }
 
     [Fact]
+    public async Task RecordLiveSamplesToCsvAsync_NoEnabledChannels_DoesNotChargeAnotherConsumersDrops()
+    {
+        // The drop counter is device-wide, so it keeps moving while another live consumer runs. A
+        // recording that never enumerated cannot have lost anything, and reporting someone else's
+        // losses as its own would contradict the documented all-zeros result.
+        using var device = CreateScripted(analogCount: 2);
+        device.DropBetweenReads = 9;
+        var writer = new StringWriter();
+
+        var result = await device.RecordLiveSamplesToCsvAsync(writer).WaitAsync(Timeout);
+
+        Assert.Equal(0L, result.DroppedSampleCount);
+        Assert.Equal(default(LiveCsvRecordingResult), result);
+    }
+
+    [Fact]
     public async Task RecordLiveSamplesToCsvAsync_GivesColumnsToEnabledChannelsOnly()
     {
         using var device = CreateScripted(analogCount: 3);
@@ -367,9 +383,15 @@ public class LiveCsvRecordingTests
         var recording = device.RecordLiveSamplesToCsvAsync(writer, duration: TimeSpan.FromSeconds(2));
 
         // The recording subscribes from inside the exporter, so there is no synchronous point for a
-        // test to hook. Give it time to get there before injecting, or the leading frames decode
-        // while nothing is listening.
-        await Task.Delay(400);
+        // test to hook. Wait for the subscription itself rather than for a guessed interval — a
+        // fixed delay is a race that loses the leading frames on a loaded machine.
+        var deadline = DateTime.UtcNow + Timeout;
+        while (device.LiveSubscriptionCount == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(5);
+        }
+
+        Assert.Equal(1, device.LiveSubscriptionCount);
         for (uint i = 0; i < 20; i++)
         {
             device.InvokeStreamMessage(AnalogFrame(1000 + i * 500000, i, i + 100));
@@ -480,7 +502,22 @@ public class LiveCsvRecordingTests
 
         public override void Send<T>(IOutboundMessage<T> message) { /* no transport in tests */ }
 
-        long ILiveSampleSource.DroppedLiveSampleCount => Dropped;
+        /// <summary>
+        /// Simulates another live consumer dropping samples between the recording's two reads of
+        /// the device-wide counter: the first read still sees the old value, the second sees it
+        /// grown by this much.
+        /// </summary>
+        public long DropBetweenReads { get; set; }
+
+        long ILiveSampleSource.DroppedLiveSampleCount
+        {
+            get
+            {
+                var current = Dropped;
+                Dropped += DropBetweenReads;
+                return current;
+            }
+        }
 
         IAsyncEnumerable<LiveSample> ILiveSampleSource.StreamSamplesAsync(
             CancellationToken cancellationToken, int? bufferCapacity)

--- a/src/Daqifi.Core.Tests/Logging/Export/LiveCsvRecordingTests.cs
+++ b/src/Daqifi.Core.Tests/Logging/Export/LiveCsvRecordingTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -385,8 +386,10 @@ public class LiveCsvRecordingTests
         // The recording subscribes from inside the exporter, so there is no synchronous point for a
         // test to hook. Wait for the subscription itself rather than for a guessed interval — a
         // fixed delay is a race that loses the leading frames on a loaded machine.
-        var deadline = DateTime.UtcNow + Timeout;
-        while (device.LiveSubscriptionCount == 0 && DateTime.UtcNow < deadline)
+        // Monotonic clock, not DateTime.UtcNow: a wall-clock deadline can jump under an NTP step and
+        // either cut the wait short or stretch it. Same reason PR #602 replaced its UtcNow deadline.
+        var elapsed = Stopwatch.StartNew();
+        while (device.LiveSubscriptionCount == 0 && elapsed.Elapsed < Timeout)
         {
             await Task.Delay(5);
         }

--- a/src/Daqifi.Core.Tests/Logging/Export/LiveSampleSourceTests.cs
+++ b/src/Daqifi.Core.Tests/Logging/Export/LiveSampleSourceTests.cs
@@ -1,0 +1,403 @@
+using System.Runtime.CompilerServices;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Logging.Export;
+
+namespace Daqifi.Core.Tests.Logging.Export;
+
+/// <summary>
+/// Covers the live-to-offline adapter on its own — no device involved, so every case here is
+/// deterministic. The recorder that drives it against a device is covered by
+/// <see cref="LiveCsvRecordingTests"/>.
+/// </summary>
+public class LiveSampleSourceTests
+{
+    private static readonly DateTime T0 = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    // ── Channel set and keys ────────────────────────────────────────────────
+
+    [Fact]
+    public void GetChannels_BuildsKeysFromDeviceIdentityAndChannelName()
+    {
+        var source = new LiveSampleSource(Empty(), [Analog(0, "AI0"), Digital(1, "DIO1")], "Nyquist", "SN-42");
+
+        var channels = source.GetChannels();
+
+        Assert.Equal(new[] { "Nyquist:SN-42:AI0", "Nyquist:SN-42:DIO1" }, channels.Select(c => c.Key).ToArray());
+        Assert.Equal(ChannelType.Analog, channels[0].ChannelType);
+        Assert.Equal(ChannelType.Digital, channels[1].ChannelType);
+    }
+
+    [Fact]
+    public void GetChannels_PreservesTheOrderGiven_BecauseItIsTheColumnOrder()
+    {
+        var source = new LiveSampleSource(
+            Empty(), [Analog(2, "AI2"), Analog(0, "AI0"), Analog(1, "AI1")], "Dev", "SN");
+
+        Assert.Equal(
+            new[] { "AI2", "AI0", "AI1" },
+            source.GetChannels().Select(c => c.ChannelName).ToArray());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_BlankSerialNumber_BecomesUnknown_RatherThanAnEmptyKeySegment(string? serial)
+    {
+        var source = new LiveSampleSource(Empty(), [Analog(0, "AI0")], "Dev", serial);
+
+        Assert.Equal("Dev:unknown:AI0", source.GetChannels()[0].Key);
+    }
+
+    [Fact]
+    public void Constructor_BlankDeviceName_BecomesUnknown()
+    {
+        var source = new LiveSampleSource(Empty(), [Analog(0, "AI0")], "  ", "SN");
+
+        Assert.Equal("unknown:SN:AI0", source.GetChannels()[0].Key);
+    }
+
+    [Fact]
+    public void Constructor_DuplicateChannelIdentity_KeepsOneColumn()
+    {
+        // Two columns with the same key cannot be told apart in the output, and the exporter would
+        // write the same value into both.
+        var source = new LiveSampleSource(
+            Empty(), [Analog(0, "AI0"), Analog(0, "AI0 again")], "Dev", "SN");
+
+        var channel = Assert.Single(source.GetChannels());
+        Assert.Equal("Dev:SN:AI0", channel.Key);
+    }
+
+    [Fact]
+    public void Constructor_SameNumberDifferentType_AreDistinctChannels()
+    {
+        // A device numbers its analog inputs and its digital pins from 0 independently, so the
+        // number alone is not an identity.
+        var source = new LiveSampleSource(
+            Empty(), [Analog(0, "AI0"), Digital(0, "DIO0")], "Dev", "SN");
+
+        Assert.Equal(2, source.GetChannels().Count);
+    }
+
+    [Fact]
+    public void Constructor_NullChannelEntry_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => new LiveSampleSource(Empty(), [Analog(0, "AI0"), null!], "Dev", "SN"));
+
+        Assert.Equal("channels", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullArguments_Throw()
+    {
+        Assert.Equal("samples", Assert.Throws<ArgumentNullException>(
+            () => new LiveSampleSource(null!, [], "Dev", "SN")).ParamName);
+        Assert.Equal("channels", Assert.Throws<ArgumentNullException>(
+            () => new LiveSampleSource(Empty(), null!, "Dev", "SN")).ParamName);
+        Assert.Equal("deviceName", Assert.Throws<ArgumentNullException>(
+            () => new LiveSampleSource(Empty(), [], null!, "SN")).ParamName);
+    }
+
+    // ── Progress degradation ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetSampleCountAsync_ReturnsZero_BecauseALiveStreamHasNoLength()
+    {
+        var source = new LiveSampleSource(Empty(), [Analog(0, "AI0")], "Dev", "SN");
+
+        Assert.Equal(0, await source.GetSampleCountAsync());
+    }
+
+    [Fact]
+    public async Task Export_WithProgress_ReportsOnlyCompletion_RatherThanDividingByAnUnknownTotal()
+    {
+        var ai0 = Analog(0, "AI0");
+        var source = new LiveSampleSource(
+            Stream(Sample(ai0, T0, 1.0), Sample(ai0, T0.AddSeconds(1), 2.0)),
+            [ai0], "Dev", "SN");
+        var reported = new List<int>();
+
+        await ExportAsync(source, new CsvExportOptions(), new Progress<int>(p => { lock (reported) { reported.Add(p); } }));
+
+        // Progress<T> posts asynchronously, so wait for the one report the exporter makes.
+        await WaitForAsync(() => { lock (reported) { return reported.Count > 0; } });
+        lock (reported)
+        {
+            Assert.All(reported, p => Assert.Equal(100, p));
+        }
+    }
+
+    // ── Sample translation ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StreamSamples_EmitsOneRowPerSample_KeyedByChannel()
+    {
+        var ai0 = Analog(0, "AI0");
+        var ai1 = Analog(1, "AI1");
+        var source = new LiveSampleSource(
+            Stream(Sample(ai0, T0, 1.5), Sample(ai1, T0, 2.5)),
+            [ai0, ai1], "Dev", "SN");
+
+        var rows = await ToListAsync(source.StreamSamples());
+
+        Assert.Equal(
+            new[] { (T0.Ticks, "Dev:SN:AI0", 1.5), (T0.Ticks, "Dev:SN:AI1", 2.5) },
+            rows.Select(r => (r.TimestampTicks, r.ChannelKey, r.Value)).ToArray());
+    }
+
+    [Fact]
+    public async Task StreamSamples_ExportsTheScaledValue_NotTheUnscaledOne()
+    {
+        // A user who configured a transducer conversion asked for PSI, not the volts underneath it.
+        var ai0 = Analog(0, "AI0");
+        var scaling = new ChannelScaling(10.0, 1.0, "PSI");
+        var source = new LiveSampleSource(
+            Stream(Sample(ai0, T0, 2.0, scaling)), [ai0], "Dev", "SN");
+
+        var row = Assert.Single(await ToListAsync(source.StreamSamples()));
+
+        Assert.Equal(21.0, row.Value);
+    }
+
+    [Fact]
+    public async Task StreamSamples_SampleForAChannelWithNoColumn_IsCountedAndLeftOut()
+    {
+        // A channel enabled by someone else after the recording started. Emitting it would produce
+        // a row of empty cells under a key the header has no column for.
+        var ai0 = Analog(0, "AI0");
+        var ai7 = Analog(7, "AI7");
+        var source = new LiveSampleSource(
+            Stream(Sample(ai0, T0, 1.0), Sample(ai7, T0, 9.0)), [ai0], "Dev", "SN");
+
+        var rows = await ToListAsync(source.StreamSamples());
+
+        Assert.Equal("Dev:SN:AI0", Assert.Single(rows).ChannelKey);
+        Assert.Equal(1L, source.UnmappedSampleCount);
+        Assert.Equal(2L, source.SampleCount);
+        Assert.Equal(1L, source.RowCount);
+    }
+
+    [Fact]
+    public async Task StreamSamples_ChannelNumberMatchesButTypeDoesNot_IsUnmapped()
+    {
+        var analog0 = Analog(0, "AI0");
+        var digital0 = Digital(0, "DIO0");
+        var source = new LiveSampleSource(Stream(Sample(digital0, T0, 1.0)), [analog0], "Dev", "SN");
+
+        Assert.Empty(await ToListAsync(source.StreamSamples()));
+        Assert.Equal(1L, source.UnmappedSampleCount);
+    }
+
+    [Fact]
+    public async Task StreamSamples_EmptyStream_LeavesEveryCounterAtZero()
+    {
+        var source = new LiveSampleSource(Empty(), [Analog(0, "AI0")], "Dev", "SN");
+
+        Assert.Empty(await ToListAsync(source.StreamSamples()));
+        Assert.Equal(0L, source.SampleCount);
+        Assert.Equal(0L, source.RowCount);
+        Assert.Equal(0L, source.UnmappedSampleCount);
+        Assert.Equal(0L, source.NonMonotonicSampleCount);
+    }
+
+    // ── Counters ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RowCount_CountsTimestamps_NotSamples_AndMatchesTheLinesTheExporterWrites()
+    {
+        // The trap this counter exists for: every channel decoded from one device frame shares that
+        // frame's timestamp, so counting samples would over-report by the channel count.
+        var ai0 = Analog(0, "AI0");
+        var ai1 = Analog(1, "AI1");
+        var t1 = T0.AddSeconds(1);
+        var t2 = T0.AddSeconds(2);
+        var source = new LiveSampleSource(
+            Stream(
+                Sample(ai0, T0, 1), Sample(ai1, T0, 2),
+                Sample(ai0, t1, 3), Sample(ai1, t1, 4),
+                Sample(ai0, t2, 5), Sample(ai1, t2, 6)),
+            [ai0, ai1], "Dev", "SN");
+
+        var lines = await ExportToLinesAsync(source, new CsvExportOptions());
+
+        Assert.Equal(6L, source.SampleCount);
+        Assert.Equal(3L, source.RowCount);
+        Assert.Equal(source.RowCount, (long)(lines.Length - 1)); // minus the header
+    }
+
+    [Fact]
+    public async Task RowCount_ConsecutiveFramesRepeatingATimestamp_CountOneRow()
+    {
+        // The exporter collapses consecutive same-timestamp samples into one line even across
+        // frames, so the counter has to follow the same rule to stay line-for-line accurate.
+        var ai0 = Analog(0, "AI0");
+        var source = new LiveSampleSource(
+            Stream(Sample(ai0, T0, 1), Sample(ai0, T0, 2), Sample(ai0, T0.AddTicks(1), 3)),
+            [ai0], "Dev", "SN");
+
+        var lines = await ExportToLinesAsync(source, new CsvExportOptions());
+
+        Assert.Equal(3L, source.SampleCount);
+        Assert.Equal(2L, source.RowCount);
+        Assert.Equal(source.RowCount, (long)(lines.Length - 1));
+    }
+
+    [Fact]
+    public async Task NonMonotonicSampleCount_CountsBackwardsTimestamps_AndStillExportsThem()
+    {
+        var ai0 = Analog(0, "AI0");
+        var source = new LiveSampleSource(
+            Stream(
+                Sample(ai0, T0.AddSeconds(2), 1),
+                Sample(ai0, T0.AddSeconds(1), 2),
+                Sample(ai0, T0.AddSeconds(3), 3)),
+            [ai0], "Dev", "SN");
+
+        var rows = await ToListAsync(source.StreamSamples());
+
+        Assert.Equal(1L, source.NonMonotonicSampleCount);
+        Assert.Equal(3, rows.Count); // losing data would be worse than reporting it out of order
+        Assert.Equal(3L, source.RowCount);
+    }
+
+    [Fact]
+    public async Task NonMonotonicSampleCount_AscendingStream_StaysZero()
+    {
+        var ai0 = Analog(0, "AI0");
+        var source = new LiveSampleSource(
+            Stream(Sample(ai0, T0, 1), Sample(ai0, T0.AddSeconds(1), 2), Sample(ai0, T0.AddSeconds(2), 3)),
+            [ai0], "Dev", "SN");
+
+        await ToListAsync(source.StreamSamples());
+
+        Assert.Equal(0L, source.NonMonotonicSampleCount);
+    }
+
+    [Fact]
+    public async Task NonMonotonicSampleCount_RepeatedTimestamp_IsNotBackwards()
+    {
+        var ai0 = Analog(0, "AI0");
+        var ai1 = Analog(1, "AI1");
+        var source = new LiveSampleSource(
+            Stream(Sample(ai0, T0, 1), Sample(ai1, T0, 2)), [ai0, ai1], "Dev", "SN");
+
+        await ToListAsync(source.StreamSamples());
+
+        Assert.Equal(0L, source.NonMonotonicSampleCount);
+    }
+
+    [Fact]
+    public async Task StreamSamples_UnmappedSampleDoesNotMoveTheTimestampCursor()
+    {
+        // An unmapped sample must not start a row of its own, nor make the next mapped sample at
+        // the same timestamp look like a new one.
+        var ai0 = Analog(0, "AI0");
+        var ai7 = Analog(7, "AI7");
+        var source = new LiveSampleSource(
+            Stream(Sample(ai0, T0, 1), Sample(ai7, T0.AddSeconds(1), 2), Sample(ai0, T0, 3)),
+            [ai0], "Dev", "SN");
+
+        var lines = await ExportToLinesAsync(source, new CsvExportOptions());
+
+        Assert.Equal(1L, source.RowCount);
+        Assert.Equal(source.RowCount, (long)(lines.Length - 1));
+    }
+
+    // ── Cancellation ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StreamSamples_Cancellation_EndsTheEnumeration()
+    {
+        // Proves the token reaches the wrapped live stream, not just the adapter's own loop.
+        var ai0 = Analog(0, "AI0");
+        using var cts = new CancellationTokenSource();
+        var source = new LiveSampleSource(
+            CancellableStream([Sample(ai0, T0, 1), Sample(ai0, T0.AddSeconds(1), 2)]), [ai0], "Dev", "SN");
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in source.StreamSamples(cts.Token))
+            {
+                await cts.CancelAsync();
+            }
+        });
+
+        Assert.Equal(1L, source.SampleCount);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static IAnalogChannel Analog(int number, string name) =>
+        new AnalogChannel(number) { Name = name };
+
+    private static IDigitalChannel Digital(int number, string name) =>
+        new DigitalChannel(number) { Name = name };
+
+    private static LiveSample Sample(IChannel channel, DateTime timestamp, double value, ChannelScaling? scaling = null) =>
+        new(channel, new DataSample { Timestamp = timestamp, Value = value, Scaling = scaling });
+
+    private static async IAsyncEnumerable<LiveSample> Empty()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<LiveSample> CancellableStream(
+        LiveSample[] samples,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var sample in samples)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return sample;
+        }
+    }
+
+    private static async IAsyncEnumerable<LiveSample> Stream(params LiveSample[] samples)
+    {
+        foreach (var sample in samples)
+        {
+            await Task.Yield();
+            yield return sample;
+        }
+    }
+
+    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var items = new List<T>();
+        await foreach (var item in source)
+        {
+            items.Add(item);
+        }
+
+        return items;
+    }
+
+    private static async Task<string> ExportAsync(
+        ISampleSource source, CsvExportOptions options, IProgress<int>? progress = null)
+    {
+        var writer = new StringWriter();
+        await new CsvExporter().ExportAsync(source, writer, options, progress);
+        return writer.ToString();
+    }
+
+    private static async Task<string[]> ExportToLinesAsync(ISampleSource source, CsvExportOptions options) =>
+        (await ExportAsync(source, options))
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.TrimEnd('\r'))
+            .ToArray();
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (!condition() && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(condition(), "Condition was not satisfied within the timeout.");
+    }
+}

--- a/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiStreamingDevice.cs
@@ -567,6 +567,13 @@ namespace Daqifi.Core.Device
         public long DroppedLiveSampleCount => _liveSampleStream.DroppedSampleCount;
 
         /// <summary>
+        /// Enumerations currently subscribed to this device's channels. Internal test seam: it lets
+        /// a test wait for a live consumer to actually be listening rather than sleep for a guessed
+        /// interval, which is a race on a loaded machine.
+        /// </summary>
+        internal int LiveSubscriptionCount => _liveSampleStream.LiveSubscriptionCount;
+
+        /// <summary>
         /// Exposes decoded live samples as an <see cref="IAsyncEnumerable{T}"/> for pull-based
         /// <c>await foreach</c> consumption with cancellation and backpressure — bringing the live path
         /// up to the same async-stream idiom the SD-card and export paths already use. Additive: the

--- a/src/Daqifi.Core/Device/Internal/LiveSampleStream.cs
+++ b/src/Daqifi.Core/Device/Internal/LiveSampleStream.cs
@@ -68,6 +68,13 @@ namespace Daqifi.Core.Device.Internal
         /// </summary>
         private long _droppedSampleCount;
 
+        /// <summary>
+        /// Enumerations that have finished attaching their sample handlers and so are capturing.
+        /// Distinct from <see cref="_enumerations"/>, which counts an enumeration from registration
+        /// — before it can capture anything.
+        /// </summary>
+        private int _liveSubscriptionCount;
+
         internal LiveSampleStream(IDeviceOperationHost host)
         {
             _host = host ?? throw new ArgumentNullException(nameof(host));
@@ -75,6 +82,12 @@ namespace Daqifi.Core.Device.Internal
 
         /// <inheritdoc cref="DaqifiStreamingDevice.DroppedLiveSampleCount"/>
         internal long DroppedSampleCount => Interlocked.Read(ref _droppedSampleCount);
+
+        /// <summary>
+        /// Enumerations currently subscribed to the channels' sample events. Exists so a test can
+        /// wait for a recording to actually be listening instead of sleeping for a guessed interval.
+        /// </summary>
+        internal int LiveSubscriptionCount => Volatile.Read(ref _liveSubscriptionCount);
 
         /// <summary>
         /// Ends every enumeration in flight when the device stops being connected.
@@ -167,6 +180,7 @@ namespace Daqifi.Core.Device.Internal
                 buffer.Writer.TryWrite(new LiveSample(e.Channel, e.Sample));
 
             IReadOnlyList<IChannel> channels = Array.Empty<IChannel>();
+            var subscribed = false;
             try
             {
                 channels = _host.SnapshotChannels();
@@ -174,6 +188,12 @@ namespace Daqifi.Core.Device.Internal
                 {
                     channel.SampleReceived += OnSample;
                 }
+
+                // Published only after every handler is attached, so a test that waits on this is
+                // waiting for the exact moment the enumeration can start capturing samples — not
+                // for a guessed interval.
+                Interlocked.Increment(ref _liveSubscriptionCount);
+                subscribed = true;
 
                 await foreach (var sample in buffer.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -186,6 +206,12 @@ namespace Daqifi.Core.Device.Internal
                 {
                     channel.SampleReceived -= OnSample;
                 }
+
+                if (subscribed)
+                {
+                    Interlocked.Decrement(ref _liveSubscriptionCount);
+                }
+
                 buffer.Writer.TryComplete();
 
                 lock (_enumerationsLock)

--- a/src/Daqifi.Core/Logging/Export/LiveCsvRecording.cs
+++ b/src/Daqifi.Core/Logging/Export/LiveCsvRecording.cs
@@ -1,0 +1,231 @@
+using System.Runtime.CompilerServices;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Core.Logging.Export;
+
+/// <summary>
+/// What a live CSV recording produced, and what it lost. A recording with silent drops is worse
+/// than one that failed, so everything that did not reach the file is counted here rather than
+/// swallowed.
+/// </summary>
+/// <param name="SampleCount">
+/// Live samples read off the device stream, including any counted in
+/// <paramref name="UnmappedSampleCount"/>.
+/// </param>
+/// <param name="RowCount">
+/// CSV data lines written, not counting the header. A line is a timestamp, not a sample — every
+/// channel decoded from one device frame shares that frame's timestamp and the exporter collapses
+/// them into a single line. Describes a default export; an averaged one
+/// (<see cref="CsvExportOptions.AverageWindow"/>) writes one line per window instead.
+/// </param>
+/// <param name="DroppedSampleCount">
+/// Samples the device discarded during this recording because the recording could not keep up with
+/// the incoming rate — <see cref="ILiveSampleSource.DroppedLiveSampleCount"/> measured across the
+/// recording rather than since the device connected. Non-zero means the CSV has gaps; a larger
+/// <c>bufferCapacity</c>, a slower stream rate, or a faster writer are the fixes.
+/// </param>
+/// <param name="UnmappedSampleCount">
+/// Samples that arrived for a channel the recording had no column for — one enabled by another
+/// caller after it started. Non-zero means the CSV is missing a channel the device was sending.
+/// </param>
+/// <param name="NonMonotonicSampleCount">
+/// Samples whose timestamp went backwards relative to the one before. Expected to be zero; see
+/// <see cref="LiveSampleSource.NonMonotonicSampleCount"/> for when it might not be.
+/// </param>
+public readonly record struct LiveCsvRecordingResult(
+    long SampleCount,
+    long RowCount,
+    long DroppedSampleCount,
+    long UnmappedSampleCount,
+    long NonMonotonicSampleCount);
+
+/// <summary>
+/// Records a streaming device's live samples straight to CSV.
+/// </summary>
+public static class LiveCsvRecordingExtensions
+{
+    /// <summary>
+    /// Streams the device's live samples through <see cref="CsvExporter"/> into
+    /// <paramref name="writer"/> as they arrive, and reports what was written and what was lost.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the "stream from the device and record it to a file" workflow, which Core could not
+    /// do before: it shipped a live stream in one namespace and an exporter in another with nothing
+    /// joining them, so every consumer that wanted a recording had to hand-roll the adapter (issue
+    /// #639). Nothing is buffered — rows are written as frames decode, so a recording's memory does
+    /// not grow with its length and a long run is not lost if the process dies partway.
+    /// </para>
+    /// <para>
+    /// <b>The recorded channels are the ones enabled when the call starts.</b> A CSV cannot grow a
+    /// column halfway down the file, so the column set is fixed up front; a channel enabled later
+    /// shows up as <see cref="LiveCsvRecordingResult.UnmappedSampleCount"/> instead of as a new
+    /// column. If no channel is enabled there is nothing to record, and the result is all zeros.
+    /// </para>
+    /// <para>
+    /// <b>Ending a recording.</b> <paramref name="duration"/> is the clean stop: the window elapsing
+    /// is how a timed recording finishes, not a failure, so the last frame is flushed, the file is
+    /// complete, and the result is returned. <paramref name="cancellationToken"/> is the abort: it
+    /// propagates as <see cref="OperationCanceledException"/> and the file is left as far as it got,
+    /// because an acquisition cut short must not be indistinguishable from a complete one. This is
+    /// the same split the live-capture path already draws. With neither, the recording runs until
+    /// the device's stream ends — which it does when the device disconnects.
+    /// </para>
+    /// <para>
+    /// Cancelling does <b>not</b> stop the device streaming; call
+    /// <see cref="IStreamingDevice.StopStreaming"/> for that. Equally, this does not start the
+    /// stream: enable the channels and call <see cref="IStreamingDevice.StartStreaming"/> first, or
+    /// the recording waits for samples that are not coming.
+    /// </para>
+    /// <para>
+    /// <paramref name="writer"/> is flushed once at the end but never disposed — the caller owns it,
+    /// as with <see cref="CsvExporter.ExportAsync"/>. A caller who wants the file to stay current
+    /// while a long recording runs should set <see cref="StreamWriter.AutoFlush"/> on it.
+    /// </para>
+    /// </remarks>
+    /// <param name="device">
+    /// The device to record. Must also implement <see cref="ILiveSampleSource"/>, which is what
+    /// supplies the live samples; <see cref="DaqifiStreamingDevice"/> does.
+    /// </param>
+    /// <param name="writer">The destination. Not disposed by this method.</param>
+    /// <param name="options">Export formatting; null uses <see cref="CsvExportOptions"/>'s defaults.</param>
+    /// <param name="duration">
+    /// How long to record for. Null records until the stream ends or the caller cancels.
+    /// </param>
+    /// <param name="bufferCapacity">
+    /// The live stream's bounded-buffer capacity in samples; null uses
+    /// <see cref="DaqifiStreamingDevice.DefaultLiveSampleBufferCapacity"/>. Raise it when
+    /// <see cref="LiveCsvRecordingResult.DroppedSampleCount"/> comes back non-zero.
+    /// </param>
+    /// <param name="cancellationToken">Aborts the recording. See the remarks.</param>
+    /// <returns>What the recording wrote, and what it lost.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="device"/> or <paramref name="writer"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="device"/> does not implement <see cref="ILiveSampleSource"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="duration"/> is not positive, or <paramref name="bufferCapacity"/> is less than 1.
+    /// </exception>
+    /// <exception cref="DeviceNotConnectedException">
+    /// The device is not connected when the recording starts, or the connection was lost while it
+    /// was running.
+    /// </exception>
+    public static async Task<LiveCsvRecordingResult> RecordLiveSamplesToCsvAsync(
+        this IStreamingDevice device,
+        TextWriter writer,
+        CsvExportOptions? options = null,
+        TimeSpan? duration = null,
+        int? bufferCapacity = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (device is not ILiveSampleSource live)
+        {
+            throw new ArgumentException(
+                $"Device '{device.Name}' does not supply live samples: it does not implement " +
+                $"{nameof(ILiveSampleSource)}.",
+                nameof(device));
+        }
+
+        if (duration is { } window && window <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(duration), window, "Recording duration must be greater than zero.");
+        }
+
+        // Validated here rather than left to the live stream, which defers it to the first
+        // MoveNextAsync — from inside the exporter, where the argument is no longer the caller's.
+        if (bufferCapacity is { } capacity && capacity < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(bufferCapacity), capacity, "Buffer capacity must be at least 1.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var channels = device.GetChannelsSnapshot().Where(c => c.IsEnabled).ToList();
+
+        // The device's drop counter is cumulative across every enumeration it has served, so the
+        // recording's own losses are the difference across it, not its absolute value.
+        var droppedBefore = live.DroppedLiveSampleCount;
+
+        using var durationCts = duration.HasValue
+            ? new CancellationTokenSource(duration.Value)
+            : null;
+        var durationToken = durationCts?.Token ?? CancellationToken.None;
+
+        var source = new LiveSampleSource(
+            ReadUntilStoppedAsync(live, bufferCapacity, durationToken),
+            channels,
+            device.Name,
+            device.Metadata.SerialNumber);
+
+        await new CsvExporter()
+            .ExportAsync(source, writer, options ?? new CsvExportOptions(), progress: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        await writer.FlushAsync().ConfigureAwait(false);
+
+        return new LiveCsvRecordingResult(
+            source.SampleCount,
+            source.RowCount,
+            live.DroppedLiveSampleCount - droppedBefore,
+            source.UnmappedSampleCount,
+            source.NonMonotonicSampleCount);
+    }
+
+    /// <summary>
+    /// Reads the live stream until it ends, the caller cancels, or the recording window elapses —
+    /// treating only that last one as a normal end of the enumeration.
+    /// </summary>
+    /// <remarks>
+    /// The window has to arrive as a cancellation because the read it interrupts is unbounded: a
+    /// stream with no samples in it would otherwise sit in <c>MoveNextAsync</c> long past the
+    /// window. Absorbing that cancellation <em>here</em>, instead of letting it reach the exporter,
+    /// is what makes a timed recording end with a complete file: the exporter sees the enumeration
+    /// finish normally, so it flushes the frame it was accumulating and writes its last line, which
+    /// an <see cref="OperationCanceledException"/> torn through it would have discarded.
+    /// </remarks>
+    private static async IAsyncEnumerable<LiveSample> ReadUntilStoppedAsync(
+        ILiveSampleSource live,
+        int? bufferCapacity,
+        CancellationToken durationToken,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(durationToken, cancellationToken);
+
+        // Disposed by hand rather than with `await using`, because ConfigureAwait(false) on an
+        // IAsyncEnumerator yields a ConfiguredAsyncDisposable, which is no longer an enumerator.
+        var enumerator = live
+            .StreamSamplesAsync(linked.Token, bufferCapacity)
+            .GetAsyncEnumerator(linked.Token);
+        try
+        {
+            while (true)
+            {
+                LiveSample sample;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    sample = enumerator.Current;
+                }
+                catch (OperationCanceledException)
+                    when (durationToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                yield return sample;
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Daqifi.Core/Logging/Export/LiveCsvRecording.cs
+++ b/src/Daqifi.Core/Logging/Export/LiveCsvRecording.cs
@@ -24,6 +24,13 @@ namespace Daqifi.Core.Logging.Export;
 /// the incoming rate — <see cref="ILiveSampleSource.DroppedLiveSampleCount"/> measured across the
 /// recording rather than since the device connected. Non-zero means the CSV has gaps; a larger
 /// <c>bufferCapacity</c>, a slower stream rate, or a faster writer are the fixes.
+/// <para>
+/// The underlying counter is device-wide, so if another live consumer is enumerating the same
+/// device while the recording runs, its drops are included here too. Nothing stops several
+/// enumerations at once and the device reports drops as one health signal, so this is a delta over
+/// a shared number rather than a per-recording one. With a single consumer — the normal case — it
+/// is exactly this recording's losses.
+/// </para>
 /// </param>
 /// <param name="UnmappedSampleCount">
 /// Samples that arrived for a channel the recording had no column for — one enabled by another
@@ -167,10 +174,16 @@ public static class LiveCsvRecordingExtensions
 
         await writer.FlushAsync().ConfigureAwait(false);
 
+        // With no columns the exporter returns without ever enumerating, so nothing was recorded and
+        // nothing could have been dropped from it. The device counter still moves if another live
+        // consumer is running, and attributing that to this call would contradict the documented
+        // all-zeros result for a recording with no enabled channels.
+        var dropped = channels.Count == 0 ? 0 : live.DroppedLiveSampleCount - droppedBefore;
+
         return new LiveCsvRecordingResult(
             source.SampleCount,
             source.RowCount,
-            live.DroppedLiveSampleCount - droppedBefore,
+            dropped,
             source.UnmappedSampleCount,
             source.NonMonotonicSampleCount);
     }

--- a/src/Daqifi.Core/Logging/Export/LiveSampleSource.cs
+++ b/src/Daqifi.Core/Logging/Export/LiveSampleSource.cs
@@ -1,0 +1,219 @@
+using System.Runtime.CompilerServices;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Core.Logging.Export;
+
+/// <summary>
+/// Adapts a live device stream — an <see cref="IAsyncEnumerable{T}"/> of <see cref="LiveSample"/>,
+/// as produced by <see cref="ILiveSampleSource.StreamSamplesAsync"/> — to the offline
+/// <see cref="ISampleSource"/> that <see cref="CsvExporter"/> consumes, so samples can be written
+/// to CSV as they arrive rather than buffered into a session first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the join between the two sample abstractions the package ships. Before it,
+/// <see cref="ILiveSampleSource"/> handed a caller an <c>IAsyncEnumerable&lt;LiveSample&gt;</c> in
+/// one namespace and <see cref="CsvExporter"/> asked for an <see cref="ISampleSource"/> in another,
+/// with no supported way to connect them — so the most basic DAQ workflow, stream from the device
+/// and record it to a file, had no answer in Core at all (issue #639).
+/// </para>
+/// <para>
+/// <b>Nothing is buffered.</b> Each <see cref="LiveSample"/> is translated into a
+/// <see cref="SampleRow"/> and yielded straight through, so a recording's memory does not grow with
+/// its length. The counters below are the only state kept, and they are all scalars.
+/// </para>
+/// <para>
+/// <b>The channel set is fixed when this source is constructed</b>, because
+/// <see cref="ISampleSource.GetChannels"/> is synchronous and the exporter calls it before it reads
+/// a single sample — a CSV cannot grow a column halfway down the file. A sample that arrives for a
+/// channel outside that set (one enabled by another caller after the recording started) is counted
+/// in <see cref="UnmappedSampleCount"/> and dropped, rather than silently emitted under a key with
+/// no column, which would have produced a row of empty cells.
+/// </para>
+/// <para>
+/// Samples are matched to channels by <see cref="IChannel.Type"/> and
+/// <see cref="IChannel.ChannelNumber"/> rather than by object identity, because a device rebuilds
+/// its channel objects when it repopulates them from a status message. The number alone is
+/// ambiguous — a device numbers its analog inputs and its digital pins from 0 independently — which
+/// is why the type is part of the key.
+/// </para>
+/// </remarks>
+public sealed class LiveSampleSource : ISampleSource
+{
+    /// <summary>
+    /// Stands in for a device name or serial number that is missing or blank. A blank string is a
+    /// gap rather than an answer, and letting one through would produce channel keys like
+    /// <c>Daqifi::AI0</c> whose columns cannot be told apart between two unidentified devices.
+    /// </summary>
+    private const string Unknown = "unknown";
+
+    private readonly IAsyncEnumerable<LiveSample> _samples;
+    private readonly List<ChannelDescriptor> _channels;
+    private readonly Dictionary<(ChannelType Type, int Number), string> _keysByChannel;
+
+    /// <summary>
+    /// Creates a source that replays <paramref name="samples"/> as export rows for the given channels.
+    /// </summary>
+    /// <param name="samples">
+    /// The live stream to read, normally <see cref="ILiveSampleSource.StreamSamplesAsync"/>. It is
+    /// enumerated once, when the exporter calls <see cref="StreamSamples"/>.
+    /// </param>
+    /// <param name="channels">
+    /// The channels to give columns to, in the order the columns should appear. Normally the
+    /// enabled subset of <see cref="IStreamingDevice.GetChannelsSnapshot"/>. Duplicates — entries
+    /// sharing a <see cref="IChannel.Type"/> and <see cref="IChannel.ChannelNumber"/> — are ignored
+    /// after the first, since two identical columns cannot be told apart in the output.
+    /// </param>
+    /// <param name="deviceName">The device name to build channel keys from.</param>
+    /// <param name="deviceSerialNumber">
+    /// The device serial number to build channel keys from. Null or blank becomes
+    /// <c>"unknown"</c>.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="samples"/>, <paramref name="channels"/> or <paramref name="deviceName"/> is null.
+    /// </exception>
+    /// <exception cref="ArgumentException"><paramref name="channels"/> contains a null entry.</exception>
+    public LiveSampleSource(
+        IAsyncEnumerable<LiveSample> samples,
+        IEnumerable<IChannel> channels,
+        string deviceName,
+        string? deviceSerialNumber)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        ArgumentNullException.ThrowIfNull(channels);
+        ArgumentNullException.ThrowIfNull(deviceName);
+
+        _samples = samples;
+
+        var name = string.IsNullOrWhiteSpace(deviceName) ? Unknown : deviceName;
+        var serial = string.IsNullOrWhiteSpace(deviceSerialNumber) ? Unknown : deviceSerialNumber;
+
+        _channels = [];
+        _keysByChannel = [];
+
+        foreach (var channel in channels)
+        {
+            if (channel is null)
+            {
+                throw new ArgumentException("The channel collection contains a null entry.", nameof(channels));
+            }
+
+            var identity = (channel.Type, channel.ChannelNumber);
+            if (_keysByChannel.ContainsKey(identity))
+            {
+                continue;
+            }
+
+            var descriptor = new ChannelDescriptor(name, serial, channel.Name, channel.Type);
+            _channels.Add(descriptor);
+            _keysByChannel[identity] = descriptor.Key;
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of live samples read off the stream, including any counted in
+    /// <see cref="UnmappedSampleCount"/>. This is samples, not CSV lines — see <see cref="RowCount"/>.
+    /// </summary>
+    public long SampleCount { get; private set; }
+
+    /// <summary>
+    /// Gets the number of distinct consecutive timestamps seen, which is the number of CSV data
+    /// lines a default export writes.
+    /// </summary>
+    /// <remarks>
+    /// A row is a timestamp, not a sample: <see cref="CsvExporter"/> collapses every consecutive
+    /// <see cref="SampleRow"/> sharing a timestamp into one line, and every channel decoded from one
+    /// device stream frame shares that frame's timestamp exactly. Reporting
+    /// <see cref="SampleCount"/> as the line count would therefore over-report by the channel count.
+    /// This tracks the exporter's own flush rule, so it holds even when consecutive frames repeat a
+    /// timestamp. It does <b>not</b> describe an averaged export
+    /// (<see cref="CsvExportOptions.AverageWindow"/>), which writes one line per window instead.
+    /// </remarks>
+    public long RowCount { get; private set; }
+
+    /// <summary>
+    /// Gets the number of samples that arrived for a channel this source has no column for, and
+    /// were therefore left out of the export. Non-zero means the recording is missing data the
+    /// device sent, so it is reported rather than swallowed.
+    /// </summary>
+    public long UnmappedSampleCount { get; private set; }
+
+    /// <summary>
+    /// Gets the number of samples whose timestamp went backwards relative to the sample before it.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ISampleSource.StreamSamples"/> is contractually ascending, and the live path is
+    /// expected to satisfy it: <see cref="TimestampProcessor"/> reconstructs a monotonic host
+    /// timestamp across the device counter's ~86-second rollover, and the live buffer preserves
+    /// arrival order. This counts the exception rather than assuming it away — a device clock reset,
+    /// a rollover mis-detection, or a caller feeding this source a stream of its own can all break
+    /// the assumption, and the resulting CSV has a time column that goes backwards. Rows are still
+    /// exported: losing data is worse than exporting it out of order, and a caller that cannot
+    /// tolerate it can see that it happened.
+    /// </remarks>
+    public long NonMonotonicSampleCount { get; private set; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<ChannelDescriptor> GetChannels() => _channels;
+
+    /// <summary>
+    /// Always returns 0 — a live stream has no length until it ends.
+    /// </summary>
+    /// <remarks>
+    /// This is exactly the "count is unavailable" case <see cref="ISampleSource.GetSampleCountAsync"/>
+    /// documents, and returning 0 is what makes <see cref="CsvExporter"/> skip percentage progress
+    /// rather than divide by a total it does not have. Progress over a live recording is a sample
+    /// count, not a percentage; read <see cref="SampleCount"/> or <see cref="RowCount"/> for that.
+    /// </remarks>
+    /// <param name="cancellationToken">Unused; the answer needs no work.</param>
+    public ValueTask<int> GetSampleCountAsync(CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(0);
+
+    /// <summary>
+    /// Streams the live samples as export rows, one row per channel value, updating the counters as
+    /// it goes.
+    /// </summary>
+    /// <remarks>
+    /// The value written is <see cref="IDataSample.ScaledValue"/> — the sample in the engineering
+    /// units the channel was configured with, which is the plain reading when the channel has no
+    /// scaling. That is the number the caller asked the device for; exporting the pre-scaling
+    /// <see cref="IDataSample.Value"/> would silently discard a conversion the user set up.
+    /// </remarks>
+    /// <param name="cancellationToken">Ends the enumeration, and with it the underlying live stream.</param>
+    public async IAsyncEnumerable<SampleRow> StreamSamples(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        long? previousTicks = null;
+
+        await foreach (var live in _samples.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            SampleCount++;
+
+            if (live?.Channel is not { } channel
+                || !_keysByChannel.TryGetValue((channel.Type, channel.ChannelNumber), out var key))
+            {
+                UnmappedSampleCount++;
+                continue;
+            }
+
+            var ticks = live.Sample.Timestamp.Ticks;
+
+            // Mirrors the exporter's own flush rule — a new line whenever the timestamp changes —
+            // so the count matches the file line for line.
+            if (previousTicks != ticks)
+            {
+                RowCount++;
+            }
+
+            if (previousTicks is { } previous && ticks < previous)
+            {
+                NonMonotonicSampleCount++;
+            }
+
+            previousTicks = ticks;
+
+            yield return new SampleRow(ticks, key, live.Sample.ScaledValue);
+        }
+    }
+}


### PR DESCRIPTION
Core shipped both halves of a recording and nothing that joined them. `ILiveSampleSource` handed you an `IAsyncEnumerable<LiveSample>` in one namespace; `CsvExporter` asked for an `ISampleSource` in another; there was no supported way to connect the two. So the most basic DAQ workflow there is — stream from the device and record it to a file — had no answer in the package. Anyone who wanted it had to write the adapter themselves, and the adapter is fiddly enough that DAQiFi's own MCP server, the example app, and the test project each ended up with their own copy.

This adds the join. `LiveSampleSource` is a public `ISampleSource` over a live stream that yields rows as frames decode rather than buffering the session, so a recording's memory does not grow with its length. `IStreamingDevice.RecordLiveSamplesToCsvAsync(writer, options, duration, bufferCapacity, ct)` drives it through `CsvExporter` and returns a `LiveCsvRecordingResult` counting what reached the file and what did not — dropped, unmapped, non-monotonic. A recording with silent gaps is worse than one that failed, so nothing is swallowed.

**Purely additive.** Two new types, one extension method, one README recipe. No existing public signature moved — the breaking-change question from #612/#616 is left to you. ADR 0002's source-compatibility promise only constrains how `LiveCsvRecordingResult` may grow later (positional appends), which is what it permits.

### What a reviewer should push back on

**The extension hangs off `IStreamingDevice` but needs `ILiveSampleSource` too**, so it does a runtime `is not ILiveSampleSource` check and throws `ArgumentException`. The recorder needs channels and identity from one interface and samples from the other, and neither implies the other (`DaqifiStreamingDevice` implements both). The alternatives were passing the same object twice, or a generic constraint that fails inference for anyone holding an `IStreamingDevice`. The runtime check has repo precedent in `DaqifiAgent.RequireLiveSamples`. It is the least-bad of three imperfect options and worth a second opinion.

**`duration` is the clean stop; `cancellationToken` is the abort.** The window arrives as a cancellation (the read it interrupts is unbounded) and is absorbed *inside* the private iterator, not at the exporter — that is what makes a timed recording end with a complete file, because the exporter sees the enumeration finish normally and flushes its last accumulated line. Letting the OCE reach the exporter silently discards that row. There is deliberately **no** graceful "stop signal" for a user-driven Stop button yet; today that means `duration`, or cancel and accept an abort.

**`GetSampleCountAsync` returns 0** — exactly the "count unavailable" case the interface documents, and what makes `CsvExporter` skip percentage progress instead of dividing by an unknown total. Consequently there is no `IProgress<int>` parameter: a percentage of an unbounded stream is meaningless, and `RowCount`/`SampleCount` are the progress.

**`RowCount` is timestamps, not samples.** The exporter collapses consecutive rows sharing a timestamp into one line, so counting samples would over-report by the channel count. That correctness note now lives in Core next to the exporter instead of being rediscovered per consumer.

Also: values are written as `ScaledValue` (a user who configured a transducer asked for PSI, not the volts underneath); samples match channels by `(Type, ChannelNumber)` rather than object identity, because a device rebuilds its channel objects on status repopulation; blank device name/serial normalize to `"unknown"`, the same disposition as #627.

### Verification

Solution builds with `-warnaserror` under the root `Directory.Build.props` from #647: 0 warnings. Full suite green — 3878 Core tests on net9.0 and net10.0, 217 MCP tests, 0 failures. 45 new tests across `LiveSampleSourceTests` (24) and `LiveCsvRecordingTests` (21), weighted to edge cases: null/blank/duplicate channels, type-vs-number collision, empty stream, unmapped samples, backwards timestamps, three flavours of cancellation, no-enabled-channels, writer flush/non-dispose, buffer-capacity forwarding.

**Every test was proved able to fail** via a 19-mutation matrix, each mutation reverted after its run. Which mutation covered which test:

| Mutation to production code | Tests turned red |
|---|---|
| M1 `RowCount++` made unconditional | 4 |
| M2 unmapped samples not counted | 3 |
| M3 `ScaledValue` → `Value` | 1 |
| M4 blank serial kept instead of normalized | 2 |
| M5 duplicate channels kept | 1 |
| M6 non-monotonic never counted | 1 |
| M7 token not forwarded to the wrapped stream | 3 |
| M8 null channel entry allowed | 1 |
| M9b duration OCE rethrown instead of absorbed | 8 |
| M10 dropped reported absolutely, not as a delta | 1 |
| M11 disabled channels included | 3 |
| M12 `bufferCapacity` validation dropped | 2 |
| M13 `duration` validation dropped | 2 |
| M14 writer not flushed | 1 |
| M15 `bufferCapacity` not forwarded | 1 |
| M16b caller-cancel clause dropped from the catch filter | 1 |
| M17 up-front cancellation check dropped | **0** — see below |

M16 initially killed nothing: the `&& !cancellationToken.IsCancellationRequested` half of the filter only matters when *both* tokens are cancelled, which no test reached. Rather than delete a defensible guard or leave it unpinned, a test was added that gates the scripted stream on a `TaskCompletionSource` so it decides exactly which tokens are cancelled when the enumeration throws.

M17 is killed by nothing, and is kept deliberately: `CsvExporter.ExportAsync` happens to make the same check, so no test can distinguish it — but the recorder's contract should not depend on a collaborator's internal ordering. Flagging it rather than quietly leaving it.

**Bench-validated on real hardware** (fw 3.7.2, sn 9090539562006014104), via a scratch console app project-referencing this branch, since the example CLI has no live-CSV command:
- **100 Hz / 5 s:** `rows=395 samples=790 dropped=0 unmapped=0 nonMonotonic=0`. `samples == 2 * rows` exactly — the per-frame collapse holds on hardware. CSV timestamps exactly 10.000 ms apart across all 395 rows.
- **1000 Hz / 4 s with `bufferCapacity: 1`** (deliberately starved): `rows=3006 samples=3025 dropped=3323`. This is the "dropped-sample count surfaced to the caller" criterion demonstrated on hardware — the losses are reported, not silent.

All runs non-destructive: connect, enable channels, stream, record, stop, disconnect.

### Deferred

This is step 2 of #639. Step 1 — promoting `Daqifi.Mcp`'s internal `SdCardSampleSource` into Core — is filed as **#655** and deliberately not here: it is a cross-project *move* (delete, re-point, keep MCP's tests green), and mixing that with new public API makes one PR a reviewer has to evaluate in two modes. #655 also records new evidence the issue did not have: the example app carries a **third** hand-rolled copy of the same adapter.

closes #639

---

**Not merging — for review.**
