### PR TITLE
chore(build): give the published Daqifi.Mcp package its license, URLs, tags and symbols

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,10 @@
 
     Only settings that every project in the repo should share belong here.
     Anything a project legitimately decides for itself - PackageId, OutputType,
-    PackAsTool, IsPackable, coverlet output, package metadata - stays in that
-    project's .csproj.
+    PackAsTool, IsPackable, coverlet output, per-package metadata - stays in
+    that project's .csproj. Package metadata shared by the two published
+    packages lives in the repo-root Directory.Build.targets (issue #644), which
+    is imported late enough to see $(IsPackable) and skip the test projects.
 
     TargetFramework(s) is deliberately NOT centralized: the projects genuinely
     differ (Daqifi.Core and Daqifi.Core.Tests multi-target net9.0;net10.0, while

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,6 +43,11 @@
          evaluate EnableSourceLink=true without one. -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- EmbedUntrackedSources is already the SDK default (a bare `dotnet new
+         classlib` evaluates it as true), so this changes nothing for any project
+         here - every project in this repo, packable or not, evaluated it as true
+         before this file existed. It is restated only so a future change to that
+         SDK default cannot quietly alter what ships in the symbol packages. -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,51 @@
+<Project>
+
+  <!--
+    Package metadata that is a fact about this repository rather than about any
+    one package: the license it ships under, where it lives, and how its symbols
+    are published. Both published packages - Daqifi.Core and the Daqifi.Mcp
+    dotnet tool - want the same answers, and Daqifi.Mcp was shipping to nuget.org
+    with none of them (issue #644).
+
+    What identifies an individual package - PackageId, Description, PackageTags,
+    PackageReadmeFile - stays in that project's .csproj.
+
+    Why .targets and not Directory.Build.props: the guard below has to see
+    $(IsPackable), and the test projects set it in their own .csproj. MSBuild
+    imports Directory.Build.props *before* the project body and
+    Directory.Build.targets *after* it, so in Directory.Build.props the guard
+    would read an empty $(IsPackable) and apply to everything. Verified with
+    `dotnet msbuild <csproj> -getProperty:...`: the same condition in
+    Directory.Build.props matches Daqifi.Core.Tests, in Directory.Build.targets
+    it does not.
+
+    Keeping the test projects out is not cosmetic. ContinuousIntegrationBuild
+    turns on DeterministicSourcePaths, which rewrites source paths in the PDB and
+    would break the coverlet line-coverage mapping Daqifi.Core.Tests collects.
+  -->
+  <PropertyGroup Condition="'$(IsPackable)' != 'false'">
+    <Authors>DAQiFi</Authors>
+    <!-- The SDK defaults Company to $(Authors), but it resolves that default
+         before this file is imported, so an Authors set here alone would leave
+         AssemblyCompanyAttribute as the assembly name. Both assemblies already
+         carry Company=DAQiFi; stating it explicitly keeps
+         AssemblyCompanyAttribute exactly as it is today. Verified by diffing
+         the evaluated Company property before and after. -->
+    <Company>DAQiFi</Company>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/daqifi/daqifi-core</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/daqifi/daqifi-core</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <!-- Symbols and SourceLink, so a consumer can step into either package.
+         SourceLink itself needs no PackageReference: the .NET SDK has bundled
+         Microsoft.SourceLink.GitHub since .NET 8, and both projects already
+         evaluate EnableSourceLink=true without one. -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+</Project>

--- a/src/Daqifi.Core.Tests/Build/DirectoryBuildPropsTests.cs
+++ b/src/Daqifi.Core.Tests/Build/DirectoryBuildPropsTests.cs
@@ -4,9 +4,9 @@ using System.Xml.Linq;
 namespace Daqifi.Core.Tests.Build;
 
 /// <summary>
-/// Guards the repo-wide build configuration added for issue #638: the properties that live in
-/// the root <c>Directory.Build.props</c> must not also be declared in an individual
-/// <c>.csproj</c>.
+/// Guards the repo-wide build configuration: the properties that live in the root
+/// <c>Directory.Build.props</c> (issue #638) or the root <c>Directory.Build.targets</c>
+/// (issue #644) must not also be declared in an individual <c>.csproj</c>.
 /// </summary>
 /// <remarks>
 /// The drift these tests exist to prevent is not hypothetical. Before #638 the same three
@@ -30,21 +30,33 @@ public class DirectoryBuildPropsTests
 
     private static string DirectoryBuildPropsPath => Path.Combine(RepositoryRoot, "Directory.Build.props");
 
+    private static string DirectoryBuildTargetsPath => Path.Combine(RepositoryRoot, "Directory.Build.targets");
+
     /// <summary>
-    /// Property names declared in the root <c>Directory.Build.props</c>, read from the file itself
-    /// so that adding a property there automatically extends the coverage below.
+    /// Property names declared in one of the repo-root build files, read from the file itself so
+    /// that adding a property there automatically extends the coverage below.
     /// </summary>
     /// <remarks>
     /// Compared case-insensitively because MSBuild property names are: <c>&lt;Nullable&gt;</c> and
     /// <c>&lt;nullable&gt;</c> set the same property, so a redeclaration that differs only in casing
     /// still overrides the centralized value and still has to be caught.
     /// </remarks>
-    private static HashSet<string> CentralizedPropertyNames() =>
-        XDocument.Load(DirectoryBuildPropsPath)
+    private static HashSet<string> PropertyNamesIn(string buildFile) =>
+        XDocument.Load(buildFile)
             .Descendants("PropertyGroup")
             .Elements()
             .Select(e => e.Name.LocalName)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Every property name centralized at the repo root, across both build files.
+    /// </summary>
+    private static HashSet<string> CentralizedPropertyNames()
+    {
+        var names = PropertyNamesIn(DirectoryBuildPropsPath);
+        names.UnionWith(PropertyNamesIn(DirectoryBuildTargetsPath));
+        return names;
+    }
 
     private static IReadOnlyList<string> ProjectFiles() =>
         Directory.GetFiles(Path.Combine(RepositoryRoot, "src"), "*.csproj", SearchOption.AllDirectories)
@@ -59,13 +71,65 @@ public class DirectoryBuildPropsTests
     }
 
     [Fact]
+    public void DirectoryBuildTargets_ExistsAtRepositoryRoot()
+    {
+        Assert.True(File.Exists(DirectoryBuildTargetsPath),
+            $"Expected a repo-wide Directory.Build.targets at {DirectoryBuildTargetsPath}.");
+    }
+
+    [Fact]
     public void DirectoryBuildProps_CentralizesTheSharedProperties()
     {
-        var centralized = CentralizedPropertyNames();
+        var centralized = PropertyNamesIn(DirectoryBuildPropsPath);
 
         Assert.Contains("ImplicitUsings", centralized);
         Assert.Contains("Nullable", centralized);
         Assert.Contains("TreatWarningsAsErrors", centralized);
+    }
+
+    [Fact]
+    public void DirectoryBuildTargets_CentralizesTheSharedPackageMetadata()
+    {
+        // Issue #644: Daqifi.Mcp shipped to nuget.org with no license, project URL, repository
+        // URL, tags or symbol package because these lived only in Daqifi.Core.csproj.
+        var centralized = PropertyNamesIn(DirectoryBuildTargetsPath);
+
+        Assert.Contains("Authors", centralized);
+        Assert.Contains("PackageLicenseExpression", centralized);
+        Assert.Contains("PackageProjectUrl", centralized);
+        Assert.Contains("RepositoryUrl", centralized);
+        Assert.Contains("RepositoryType", centralized);
+        Assert.Contains("IncludeSymbols", centralized);
+        Assert.Contains("PublishRepositoryUrl", centralized);
+    }
+
+    [Fact]
+    public void DirectoryBuildTargets_LeavesPerPackageIdentityToTheProjects()
+    {
+        // PackageId, Description and PackageTags say which package this is; centralizing them
+        // would give both packages the same identity.
+        var centralized = PropertyNamesIn(DirectoryBuildTargetsPath);
+
+        Assert.DoesNotContain("PackageId", centralized);
+        Assert.DoesNotContain("Description", centralized);
+        Assert.DoesNotContain("PackageTags", centralized);
+    }
+
+    [Fact]
+    public void BothPackableProjects_DeclareTheirOwnPackageTags()
+    {
+        // The per-package half of #644: the tags are what a nuget.org search matches on, and
+        // Daqifi.Mcp had none at all.
+        foreach (var project in new[] { "Daqifi.Core", "Daqifi.Mcp" })
+        {
+            var path = Path.Combine(RepositoryRoot, "src", project, $"{project}.csproj");
+            var tags = XDocument.Load(path)
+                .Descendants("PackageTags")
+                .Select(e => e.Value)
+                .SingleOrDefault();
+
+            Assert.False(string.IsNullOrWhiteSpace(tags), $"{project}.csproj declares no <PackageTags>.");
+        }
     }
 
     [Fact]
@@ -111,8 +175,9 @@ public class DirectoryBuildPropsTests
         }
 
         Assert.True(offenders.Count == 0,
-            "A property centralized in Directory.Build.props is redeclared per-project, which " +
-            "silently overrides the shared value: " + string.Join("; ", offenders));
+            "A property centralized in Directory.Build.props or Directory.Build.targets is " +
+            "redeclared per-project, which silently overrides the shared value (props) or is " +
+            "silently overridden by it (targets): " + string.Join("; ", offenders));
     }
 
     [Fact]

--- a/src/Daqifi.Core/Daqifi.Core.csproj
+++ b/src/Daqifi.Core/Daqifi.Core.csproj
@@ -5,24 +5,15 @@
 
     <!-- ImplicitUsings, Nullable and TreatWarningsAsErrors come from the repo-root Directory.Build.props. -->
 
-    <!-- Package Metadata -->
+    <!-- Package Metadata. Authors, license, URLs and the symbol/SourceLink
+         settings are repo-wide and come from the root Directory.Build.targets. -->
     <PackageId>Daqifi.Core</PackageId>
-    <Authors>DAQiFi</Authors>
     <Description>Core library for interacting with DAQiFi devices</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/daqifi/daqifi-core</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>daqifi;daq;data-acquisition;measurement;instrumentation</PackageTags>
-    <RepositoryUrl>https://github.com/daqifi/daqifi-core</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
 
     <!-- Build Configuration -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Daqifi.Mcp/Daqifi.Mcp.csproj
+++ b/src/Daqifi.Mcp/Daqifi.Mcp.csproj
@@ -12,10 +12,13 @@
     <!-- Distribution: `dotnet tool install -g Daqifi.Mcp` exposes the `daqifi-mcp` command. -->
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>daqifi-mcp</ToolCommandName>
+
+    <!-- Package Metadata. Authors, license, URLs and the symbol/SourceLink
+         settings are repo-wide and come from the root Directory.Build.targets. -->
     <PackageId>Daqifi.Mcp</PackageId>
-    <Authors>DAQiFi</Authors>
     <Description>Model Context Protocol (MCP) server for DAQiFi Nyquist data-acquisition devices. Lets an AI agent discover, connect, configure channels, read live measurements, and run on-device SD-card logging.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>daqifi;daq;data-acquisition;mcp;model-context-protocol;ai;dotnet-tool</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What was wrong

`Daqifi.Mcp` is a package we publish — `dotnet tool install -g Daqifi.Mcp` — and its nuget.org listing has no license, no link back to the project, no link to the source repository, and no tags, so it does not turn up in a search for "daqifi" or "mcp". It also ships no symbol package, so nobody can step into it in a debugger. All of that metadata existed, but only in `Daqifi.Core.csproj`, so only the `Daqifi.Core` package got it. Nothing was broken; the tool has simply been going out looking anonymous.

## How it was fixed

The half of that metadata that is a fact about *this repository* rather than about one package — authors, the MIT license, the project and repository URLs, and the symbol/SourceLink settings — now lives once in a new repo-root `Directory.Build.targets`, applied to any project that is packable. The half that says *which package this is* — `PackageId`, `Description`, `PackageReadmeFile`, `PackageTags` — stays in each `.csproj`, and `Daqifi.Mcp` gets tags of its own. The `Daqifi.Core` package comes out byte-for-byte the same; only `Daqifi.Mcp` changes.

Two things a reviewer may want to push back on:

- **Why `Directory.Build.targets` and not the `Directory.Build.props` #647 just added?** The guard has to read `$(IsPackable)`, and the test projects set it in their own `.csproj`. MSBuild imports `.props` *before* the project body and `.targets` *after* it, so the same condition in `.props` matches `Daqifi.Core.Tests` and in `.targets` does not — measured, not assumed. That is not cosmetic: `ContinuousIntegrationBuild` turns on `DeterministicSourcePaths`, which rewrites PDB source paths and would break the coverlet line-coverage mapping `Daqifi.Core.Tests` collects.
- **`Daqifi.Mcp` now produces a `.snupkg`, which the release workflow will push.** That is the intended fix for "no symbols", but it is the one thing here that changes what `release.yml` uploads. The symbol package contains exactly the two first-party PDBs (`daqifi-mcp.pdb`, `Daqifi.Core.pdb`), both with matching assemblies in the main package.

No SourceLink `PackageReference` was added to `Daqifi.Mcp`: the .NET SDK has bundled `Microsoft.SourceLink.GitHub` since .NET 8, and the build already emits a correct `Daqifi.Mcp.sourcelink.json` mapping to `raw.githubusercontent.com` without one.

<details>
<summary>Evidence: evaluated MSBuild properties, before vs after</summary>

~65 properties dumped with `dotnet msbuild <csproj> -getProperty:<Name>` for all six (project, TFM) pairs, restore warm on both sides. The complete set of differences:

```
=== core-net9 ===      (no property changes)
=== core-net10 ===     (no property changes)
=== coretests-net9 === (no property changes)
=== coretests-net10 ===(no property changes)
=== mcptests-net9 ===  (no property changes)
=== mcp-net9 ===
  PackageLicenseExpression: '' -> 'MIT'
  PackageProjectUrl:        '' -> 'https://github.com/daqifi/daqifi-core'
  PackageTags:              '' -> 'daqifi;daq;data-acquisition;mcp;model-context-protocol;ai;dotnet-tool'
  RepositoryUrl:            '' -> 'https://github.com/daqifi/daqifi-core'
  RepositoryType:           '' -> 'git'
  IncludeSymbols:           '' -> 'true'
  SymbolPackageFormat:      'symbols.nupkg' -> 'snupkg'
  PublishRepositoryUrl:     '' -> 'true'
```

A first attempt without the explicit `<Company>` also showed `Company: 'DAQiFi' -> 'Daqifi.Core'` / `-> 'daqifi-mcp'`, i.e. a silently changed `AssemblyCompanyAttribute`. Pinning `Company` next to `Authors` removes that diff; the generated `AssemblyInfo.cs` for both packable projects still reads `AssemblyCompanyAttribute("DAQiFi")`.

</details>

<details>
<summary>Evidence: <code>dotnet pack</code>, before vs after</summary>

`Daqifi.Core.0.0.0-local.nupkg` and `.snupkg`: nuspec **identical**, file list identical (only the random OPC `.psmdcp` filename differs).

`Daqifi.Mcp` nuspec before:

```xml
<id>Daqifi.Mcp</id>
<authors>DAQiFi</authors>
<readme>README.md</readme>
<description>Model Context Protocol (MCP) server for DAQiFi ...</description>
<packageTypes><packageType name="DotnetTool" /></packageTypes>
<repository type="git" commit="f015149..." />
```

after:

```xml
<id>Daqifi.Mcp</id>
<authors>DAQiFi</authors>
<license type="expression">MIT</license>
<licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
<readme>README.md</readme>
<projectUrl>https://github.com/daqifi/daqifi-core</projectUrl>
<description>Model Context Protocol (MCP) server for DAQiFi ...</description>
<tags>daqifi daq data-acquisition mcp model-context-protocol ai dotnet-tool</tags>
<packageTypes><packageType name="DotnetTool" /></packageTypes>
<repository type="git" url="https://github.com/daqifi/daqifi-core" branch="..." commit="f015149..." />
```

So the nupkg now carries: a `<license>` + `<licenseUrl>`, a `<projectUrl>`, `<tags>`, and a `url` on `<repository>` (before, `<repository>` had a commit but no URL, which is why nuget.org showed no source link). And `Daqifi.Mcp.0.0.0-local.snupkg` is produced where **no symbol package existed before** — it contains `tools/net9.0/any/daqifi-mcp.pdb` and `tools/net9.0/any/Daqifi.Core.pdb`.

</details>

## Verification

- Release solution build: 0 warnings, 0 errors.
- Full suite green: net9.0 — 3837 Core (2 skipped, hardware-gated) + 217 MCP; net10.0 — 3837 Core.
- `DirectoryBuildPropsTests` extended to cover the new targets file (10 tests, all green): it must exist, it must centralize the shared package metadata, it must *not* centralize per-package identity, both packable projects must declare their own `PackageTags`, and no `.csproj` may redeclare anything centralized in either root build file.
- Downstream consumer check: the example CLI at `Daqifi.Core.Cli.csproj` builds clean against this branch's core (`-p:DaqifiCoreProjectPath=...`), which is the failure mode a packaging change would cause.
- **Bench validation does not apply** — this changes nothing that executes on a device; no board interaction was performed.

`closes #644`

**Not merging — for review.**
