### PR TITLE
chore(firmware): compute a hex record's full address in one place

### DIFF
--- a/src/Daqifi.Core.Tests/Firmware/IntelHexParserTests.cs
+++ b/src/Daqifi.Core.Tests/Firmware/IntelHexParserTests.cs
@@ -358,6 +358,31 @@ public class IntelHexParserTests
     }
 
     [Fact]
+    public void ParseRecords_ProtectionIsDecidedOnTheSameAddressThatIsReported()
+    {
+        // Whether a record is filtered and what address it is reported under are the same
+        // 32-bit value, computed in two different places from the same two inputs. Pin that
+        // they agree, using a protected range whose boundaries fall on the record's OFFSET
+        // half: every existing boundary test varies only the extended-address half, so all of
+        // them would still pass if the two offset decodes disagreed on byte order.
+        var parser = new IntelHexParser(0x00010200, 0x00010300);
+        var lines = new[]
+        {
+            ":020000040001F9",                                   // Extended address 0x0001
+            ":10010000AABBCCDDEEFF00112233445566778899F7",       // 0x00010100 - below the range
+            ":10020000AABBCCDDEEFF00112233445566778899F6",       // 0x00010200 - range start
+            ":10030000AABBCCDDEEFF00112233445566778899F5",       // 0x00010300 - range end (inclusive)
+            ":10040000AABBCCDDEEFF00112233445566778899F4",       // 0x00010400 - above the range
+            ":00000001FF"                                        // EOF
+        };
+
+        var result = parser.ParseRecords(lines);
+
+        var dataAddresses = result.Where(r => r.RecordType == 0x00).Select(r => r.Address).ToArray();
+        Assert.Equal([0x00010100u, 0x00010400u], dataAddresses);
+    }
+
+    [Fact]
     public void ParseRecords_ReturnsCorrectRecordTypes()
     {
         var lines = new[]

--- a/src/Daqifi.Core/Firmware/IntelHexParser.cs
+++ b/src/Daqifi.Core/Firmware/IntelHexParser.cs
@@ -82,12 +82,7 @@ public class IntelHexParser
 
         foreach (var (hexLine, baseAddress) in EnumerateUnprotectedRecords(lines))
         {
-            var offsetAddressArray = hexLine.Skip(1).Take(2).ToArray();
-            if (BitConverter.IsLittleEndian) Array.Reverse(offsetAddressArray);
-            var offsetAddress = BitConverter.ToUInt16(offsetAddressArray, 0);
-            var fullAddress = ((uint)baseAddress << 16) | offsetAddress;
-
-            records.Add(new HexFileRecord(fullAddress, hexLine, hexLine[3]));
+            records.Add(new HexFileRecord(ComputeFullAddress(hexLine, baseAddress), hexLine, hexLine[3]));
         }
 
         return records;
@@ -162,10 +157,10 @@ public class IntelHexParser
         // where N is the value of the byte-count field (record[0]). ValidateLine already guarantees at
         // least 5 decoded bytes, so record[0] is safely accessible. A declared count that disagrees with
         // the actual data length means the record is truncated, padded, or corrupt. Rejecting it here as
-        // the documented InvalidDataException prevents the downstream BitConverter.ToUInt16 calls (in
-        // UpdateBaseAddress / IsProtectedHexRecord / ParseRecords) from reading a wrong-sized slice and
-        // throwing a raw ArgumentException — e.g. a type-04 record with a zero byte count would otherwise
-        // hand ToUInt16 a zero-length array and crash the whole parse.
+        // the documented InvalidDataException prevents the downstream ReadBigEndianUInt16 reads (from
+        // UpdateBaseAddress and ComputeFullAddress) from taking a wrong-sized slice and throwing a raw
+        // ArgumentException — e.g. a type-04 record with a zero byte count would otherwise hand
+        // BitConverter.ToUInt16 a zero-length array and crash the whole parse.
         int declaredDataLength = record[0];
         int actualDataLength = record.Length - 5;
         if (actualDataLength != declaredDataLength)
@@ -233,9 +228,34 @@ public class IntelHexParser
                 $"The hex record \"{line}\" is a type-04 extended-address record but does not carry exactly 2 data bytes");
         }
 
-        var dataArray = hexRecord.Skip(4).Take(2).ToArray();
-        if (BitConverter.IsLittleEndian) Array.Reverse(dataArray);
-        return BitConverter.ToUInt16(dataArray, 0);
+        return ReadBigEndianUInt16(hexRecord, 4);
+    }
+
+    /// <summary>
+    /// Computes the record's full 32-bit address: the running extended-linear base address in
+    /// the high 16 bits, and the record's own offset address - bytes 1-2 of every Intel HEX
+    /// record - in the low 16 bits.
+    /// </summary>
+    /// <remarks>
+    /// Both the protected-range test and the address reported on a parsed
+    /// <see cref="HexFileRecord"/> are this same value, so they must be computed the same way:
+    /// if they disagreed, a record could be filtered on one address and reported under another.
+    /// </remarks>
+    private static uint ComputeFullAddress(byte[] hexRecord, ushort baseAddress)
+    {
+        return ((uint)baseAddress << 16) | ReadBigEndianUInt16(hexRecord, 1);
+    }
+
+    /// <summary>
+    /// Reads the two bytes at <paramref name="offset"/> as a big-endian <see cref="ushort"/>,
+    /// which is the byte order Intel HEX uses for both the offset address and the type-04
+    /// extended-address payload.
+    /// </summary>
+    private static ushort ReadBigEndianUInt16(byte[] record, int offset)
+    {
+        var bytes = record.Skip(offset).Take(2).ToArray();
+        if (BitConverter.IsLittleEndian) Array.Reverse(bytes);
+        return BitConverter.ToUInt16(bytes, 0);
     }
 
     private bool IsProtectedHexRecord(byte[] hexRecord, ushort baseAddress)
@@ -246,10 +266,7 @@ public class IntelHexParser
             return false;
         }
 
-        var offsetAddressArray = hexRecord.Skip(1).Take(2).ToArray();
-        if (BitConverter.IsLittleEndian) Array.Reverse(offsetAddressArray);
-        var offsetAddress = BitConverter.ToUInt16(offsetAddressArray, 0);
-        var hexRecordAddress = ((uint)baseAddress << 16) | offsetAddress;
+        var hexRecordAddress = ComputeFullAddress(hexRecord, baseAddress);
 
         return hexRecordAddress >= _beginProtectedAddress && hexRecordAddress <= _endProtectedAddress;
     }

--- a/src/Daqifi.Core/Firmware/IntelHexParser.cs
+++ b/src/Daqifi.Core/Firmware/IntelHexParser.cs
@@ -157,10 +157,12 @@ public class IntelHexParser
         // where N is the value of the byte-count field (record[0]). ValidateLine already guarantees at
         // least 5 decoded bytes, so record[0] is safely accessible. A declared count that disagrees with
         // the actual data length means the record is truncated, padded, or corrupt. Rejecting it here as
-        // the documented InvalidDataException prevents the downstream ReadBigEndianUInt16 reads (from
-        // UpdateBaseAddress and ComputeFullAddress) from taking a wrong-sized slice and throwing a raw
-        // ArgumentException — e.g. a type-04 record with a zero byte count would otherwise hand
-        // BitConverter.ToUInt16 a zero-length array and crash the whole parse.
+        // the documented InvalidDataException, rather than being parsed as if it were intact.
+        //
+        // This check is NOT what keeps the ReadBigEndianUInt16 reads in range. ComputeFullAddress reads
+        // bytes 1-2, which ValidateLine's 11-character minimum already guarantees; and a zero-count
+        // type-04 record passes right through here, because its declared count does equal its (zero)
+        // data length — that case is caught by UpdateBaseAddress's own explicit type-04 guard below.
         int declaredDataLength = record[0];
         int actualDataLength = record.Length - 5;
         if (actualDataLength != declaredDataLength)


### PR DESCRIPTION
Produced by the **duplicate-unifier** maintenance routine. It is safe because the two copies it merges were already the identical expression, and the decode sequence is preserved byte for byte rather than modernised.

## What was wrong

`IntelHexParser` worked out a hex record's full 32-bit address in two different places from the same two inputs: `ParseRecords` computed it to report on the `HexFileRecord`, and `IsProtectedHexRecord` computed it to decide whether the record falls in the protected calibration range and should be dropped from a firmware upload. These are the same number and have to stay the same number — if they ever drifted, a record would be filtered on one address and reported under another, which is exactly the kind of disagreement you would only notice as a firmware image that is subtly wrong. The five-line big-endian decode underneath (`Skip/Take/ToArray` → conditional `Array.Reverse` → `BitConverter.ToUInt16`) additionally appeared a third time in `UpdateBaseAddress`.

## How it was fixed

One private `ComputeFullAddress(hexRecord, baseAddress)`, used by both sites, over a shared `ReadBigEndianUInt16(record, offset)` that `UpdateBaseAddress` also uses for its type-04 payload.

The evidence it is behavior-free: the two copies were verbatim identical modulo the local variable names, so there was no version to choose between; and the decode is lifted unchanged rather than rewritten, so the offsets, the endianness check and the exception a short slice would raise are all exactly what they were.

The thing worth pushing back on is that lift. `BinaryPrimitives.ReadUInt16BigEndian(record.AsSpan(offset, 2))` is the obvious modern spelling and would drop three allocations per record. It is deliberately not done here: `AsSpan` throws `ArgumentOutOfRangeException` where `BitConverter.ToUInt16` throws `ArgumentException`, and although both look unreachable behind the existing length guards, "looks unreachable" is not the standard a no-behavior-change PR should be held to. That swap is a separate, easily reviewed change.

## Verification

The guarding test came first. Every existing protected-range test varies only the extended-address half of the address, so all of them would still have passed if the two offset decodes had disagreed on byte order — the agreement the extraction exists to guarantee was not actually pinned. `ParseRecords_ProtectionIsDecidedOnTheSameAddressThatIsReported` puts the range boundaries on the offset half instead, and it was confirmed green against the **unchanged** code before any refactoring.

Build clean (0 warnings, `TreatWarningsAsErrors`); full suite green on net9.0 and net10.0 (3834 passed, 2 pre-existing skips per TFM) plus Daqifi.Mcp 217. No board run: this changes no bytes, no ordering and no timing on the wire.

Checked for the usual adjacent asymmetry and found none — the two copies agreed, and the offset read's length guarantee (`ValidateLine`'s 11-character minimum) is airtight, so no separate issue is filed.

*Not merging — for review.*
