### PR TITLE
fix(scpi): reject an out-of-range direction on SetDioPortDirection

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -196,6 +196,47 @@ public class ScpiMessageProducerTests
         AssertMessageFormat(message);
     }
 
+    // `direction` is documented as a two-value enumeration (0 = input, 1 = output) and the
+    // firmware understands nothing else, so anything outside that is caller error rather
+    // than a frame to put on the wire.
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    [InlineData(7)]
+    [InlineData(int.MaxValue)]
+    public void SetDioPortDirection_WithOutOfRangeDirection_Throws(int direction)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ScpiMessageProducer.SetDioPortDirection(0, direction));
+
+        Assert.Equal("direction", ex.ParamName);
+        Assert.Equal(direction, ex.ActualValue);
+        Assert.StartsWith("Direction must be 0 (input) or 1 (output).", ex.Message, StringComparison.Ordinal);
+    }
+
+    // Both documented values must survive the guard unchanged, byte for byte.
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void SetDioPortDirection_WithDocumentedDirection_StillReturnsCommand(int direction)
+    {
+        var message = ScpiMessageProducer.SetDioPortDirection(3, direction);
+        Assert.Equal($"DIO:PORt:DIRection 3,{direction}", message.Data);
+        AssertMessageFormat(message);
+    }
+
+    [Fact]
+    public void SetDioPortDirection_WithNegativeChannel_ThrowsBeforeCheckingTheDirection()
+    {
+        // Both arguments are invalid here. The channel guard runs first, so the caller is
+        // told about `channel` rather than about `direction`, matching SetDioPortState and
+        // the PWM setters, which all validate the channel before the value.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ScpiMessageProducer.SetDioPortDirection(-1, 7));
+
+        Assert.Equal("channel", ex.ParamName);
+    }
+
     [Fact]
     public void SetDioPortState_ReturnsCorrectCommand()
     {
@@ -1201,6 +1242,37 @@ public class ScpiMessageProducerTests
             Assert.Equal(-1, o.ActualValue);
             Assert.StartsWith("Channel number cannot be negative.", o.Message, StringComparison.Ordinal);
         });
+    }
+
+    // The companion to EveryChannelAddressedProducer_RejectsNegativeChannelIdentically, for
+    // the other axis: the producers whose *second* argument has a documented range. Each
+    // guard is written out at its own call site (the ranges differ, so there is no shared
+    // helper to hold the rule), which is exactly why the observable shape needs pinning in
+    // one place — SetDioPortDirection was the one that had drifted, emitting a frame for
+    // any int at all. Anything the caller can see about the throw is compared across all
+    // three rather than against a literal copied out of the source.
+    [Fact]
+    public void EveryValueRangedProducer_RejectsOutOfRangeArgumentIdentically()
+    {
+        var producers = new (string Name, string ParamName, object ActualValue, string MessagePrefix, Action Act)[]
+        {
+            (nameof(ScpiMessageProducer.SetPwmChannelFrequency), "frequencyHz", 0, "Frequency must be positive.",
+                () => ScpiMessageProducer.SetPwmChannelFrequency(0, 0)),
+            (nameof(ScpiMessageProducer.SetPwmChannelDutyCycle), "dutyCyclePercent", 101, "Duty cycle must be 0-100 percent.",
+                () => ScpiMessageProducer.SetPwmChannelDutyCycle(0, 101)),
+            (nameof(ScpiMessageProducer.SetDioPortDirection), "direction", 2, "Direction must be 0 (input) or 1 (output).",
+                () => ScpiMessageProducer.SetDioPortDirection(0, 2)),
+        };
+
+        Assert.Equal(3, producers.Length);
+        foreach (var (name, paramName, actualValue, messagePrefix, act) in producers)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(act);
+
+            // Compared as one tuple so a failure names the producer that drifted.
+            Assert.Equal((name, paramName, (object?)actualValue), (name, ex.ParamName, ex.ActualValue));
+            Assert.StartsWith(messagePrefix, ex.Message, StringComparison.Ordinal);
+        }
     }
 
     private static void AssertMessageFormat(IOutboundMessage<string> message)

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -1254,9 +1254,11 @@ public class ScpiMessageProducerTests
     //
     // This list is the COMPLETE set of inline value-range guards in ScpiMessageProducer, not
     // a sample: it is the whole population of `throw new ArgumentOutOfRangeException` sites
-    // outside the shared ValidateChannel/RequireFinite helpers. A producer that gains a
-    // ranged value argument must be added here — the count assertion below is the reminder,
-    // since nothing else structurally forces it.
+    // outside the shared ValidateChannel/RequireFinite helpers — verified by grepping that
+    // throw against this table. A producer that gains a ranged value argument must be added
+    // here. The count assertion below is a deliberate tripwire, not a proof of completeness:
+    // it fails the moment someone edits the table without reading this note, which is the
+    // same mechanism EveryChannelAddressedProducer_RejectsNegativeChannelIdentically uses.
     [Fact]
     public void EveryValueRangedProducer_RejectsOutOfRangeArgumentIdentically()
     {
@@ -1278,9 +1280,13 @@ public class ScpiMessageProducerTests
                 () => ScpiMessageProducer.SetSdMinFreeSpace(-1)),
             (nameof(ScpiMessageProducer.RunSdBenchmark), "size", 0L, "Benchmark size must be positive.",
                 () => ScpiMessageProducer.RunSdBenchmark(0)),
+            // An undefined enum value is the same rule expressed over an enum's range, and it
+            // throws the same exception in the same shape, so it belongs in the census too.
+            (nameof(ScpiMessageProducer.SetStreamInterface), "streamInterface", (StreamInterface)999, "Unknown stream interface.",
+                () => ScpiMessageProducer.SetStreamInterface((StreamInterface)999)),
         };
 
-        Assert.Equal(8, producers.Length);
+        Assert.Equal(9, producers.Length);
         foreach (var (name, paramName, actualValue, messagePrefix, act) in producers)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(act);

--- a/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Producers/ScpiMessageProducerTests.cs
@@ -1245,12 +1245,18 @@ public class ScpiMessageProducerTests
     }
 
     // The companion to EveryChannelAddressedProducer_RejectsNegativeChannelIdentically, for
-    // the other axis: the producers whose *second* argument has a documented range. Each
-    // guard is written out at its own call site (the ranges differ, so there is no shared
-    // helper to hold the rule), which is exactly why the observable shape needs pinning in
-    // one place — SetDioPortDirection was the one that had drifted, emitting a frame for
-    // any int at all. Anything the caller can see about the throw is compared across all
-    // three rather than against a literal copied out of the source.
+    // the other axis: every producer in this class whose *value* argument has a documented
+    // range. Each guard is written out at its own call site (the ranges differ, so there is
+    // no shared helper to hold the rule), which is exactly why the observable shape needs
+    // pinning in one place — SetDioPortDirection was the one that had drifted, emitting a
+    // frame for any int at all. Anything the caller can see about the throw is compared
+    // across all of them rather than against a literal copied out of the source.
+    //
+    // This list is the COMPLETE set of inline value-range guards in ScpiMessageProducer, not
+    // a sample: it is the whole population of `throw new ArgumentOutOfRangeException` sites
+    // outside the shared ValidateChannel/RequireFinite helpers. A producer that gains a
+    // ranged value argument must be added here — the count assertion below is the reminder,
+    // since nothing else structurally forces it.
     [Fact]
     public void EveryValueRangedProducer_RejectsOutOfRangeArgumentIdentically()
     {
@@ -1262,9 +1268,19 @@ public class ScpiMessageProducerTests
                 () => ScpiMessageProducer.SetPwmChannelDutyCycle(0, 101)),
             (nameof(ScpiMessageProducer.SetDioPortDirection), "direction", 2, "Direction must be 0 (input) or 1 (output).",
                 () => ScpiMessageProducer.SetDioPortDirection(0, 2)),
+            (nameof(ScpiMessageProducer.UseAdcCalibration), "bank", 2, "Calibration bank must be 0 (factory) or 1 (user).",
+                () => ScpiMessageProducer.UseAdcCalibration(2)),
+            (nameof(ScpiMessageProducer.SetLogLevel), "level", 4, "Log level must be between 0 (None) and 3 (Debug).",
+                () => ScpiMessageProducer.SetLogLevel("ADC", 4)),
+            (nameof(ScpiMessageProducer.SetSdMaxFileSize), "bytes", -1L, "Max file size cannot be negative.",
+                () => ScpiMessageProducer.SetSdMaxFileSize(-1)),
+            (nameof(ScpiMessageProducer.SetSdMinFreeSpace), "bytes", -1L, "Minimum free space cannot be negative.",
+                () => ScpiMessageProducer.SetSdMinFreeSpace(-1)),
+            (nameof(ScpiMessageProducer.RunSdBenchmark), "size", 0L, "Benchmark size must be positive.",
+                () => ScpiMessageProducer.RunSdBenchmark(0)),
         };
 
-        Assert.Equal(3, producers.Length);
+        Assert.Equal(8, producers.Length);
         foreach (var (name, paramName, actualValue, messagePrefix, act) in producers)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(act);

--- a/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
+++ b/src/Daqifi.Core/Communication/Producers/ScpiMessageProducer.cs
@@ -540,10 +540,15 @@ public class ScpiMessageProducer
     /// Command: DIO:PORt:DIRection channel,direction
     /// Example: messageProducer.Send(ScpiMessageProducer.SetDioPortDirection(1, 1)); // Set channel 1 as output
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="channel"/> is negative.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="channel"/> is negative, or <paramref name="direction"/> is not 0 or 1.</exception>
     public static IOutboundMessage<string> SetDioPortDirection(int channel, int direction)
     {
         ValidateChannel(channel);
+
+        if (direction is < 0 or > 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(direction), direction, "Direction must be 0 (input) or 1 (output).");
+        }
 
         return new ScpiMessage($"DIO:PORt:DIRection {channel},{direction}");
     }


### PR DESCRIPTION
## What was wrong

`ScpiMessageProducer.SetDioPortDirection(int channel, int direction)` documents its second argument as a two-value enumeration — "0 = input, 1 = output" — but accepted any `int` at all. `SetDioPortDirection(0, 7)` handed back a perfectly well-formed message whose payload was `DIO:PORt:DIRection 0,7`, and that frame went out on the wire to firmware that understands only 0 and 1. A caller who got the argument order wrong, or passed a raw pin bitmask, got no complaint from the library — just a nonsense command sent to the board.

The class was also inconsistent with itself: the two PWM setters right beside it do enforce their documented ranges (`SetPwmChannelFrequency` rejects `<= 0`, `SetPwmChannelDutyCycle` rejects outside `0..100`), and `#649` just brought both DIO producers in line on the *channel* argument. `direction` was the remaining hole.

## How it was fixed

`SetDioPortDirection` now range-checks `direction` the same way its PWM neighbours check theirs — an inline `is < 0 or > 1` test right after the channel guard, throwing `ArgumentOutOfRangeException` named for the parameter and carrying the offending value. **This is a behavior change: input that used to produce a message now throws.** That is the point of the ticket, but it is the thing to weigh — anything outside 0/1 was previously accepted silently.

Nothing in the repo is affected. The only production caller, `ChannelControlOperations.SetDioDirection`, already rejects anything that is not `ChannelDirection.Input`/`Output` and passes a bool-derived `0` or `1`. So the change is only reachable by an external caller using the public producer directly — exactly the misuse it is meant to catch. The sibling `SetDioPortState(int, double)` value range is deliberately **not** touched here; its `double`-typed two-state argument is a breaking-API question tracked on #629, and #651 asks for these to stay separate.

## How it was verified

Before changing anything, a throwaway probe recorded what the method actually did on unchanged code. `SetDioPortDirection(0, direction)` for `direction` of `-1`, `2`, `7`, and `int.MaxValue` each returned a message rather than throwing, with payloads `DIO:PORt:DIRection 0,-1`, `0,2`, `0,7`, `0,2147483647`. The same probe pinned the reference shape of the two already-guarded PWM siblings (`ParamName`/`ActualValue`/message) so the new assertions compare against proven behavior rather than a literal copied out of the source.

The five new/changed assertions were then confirmed to **fail against unchanged code** and pass after the fix. The no-regression tests — both documented directions `0` and `1`, and channel `0` — passed in both states, so valid input is byte-identical before and after.

A new `EveryValueRangedProducer_RejectsOutOfRangeArgumentIdentically` test is the companion to the existing channel-uniformity test, on the other axis: it pins the observable throw shape across all three range-checked value arguments, so a fourth added without a guard fails the suite instead of shipping.

Clean `dotnet build --no-incremental`: 0 warnings, 0 errors under repo-wide `TreatWarningsAsErrors`. Full suite green on **net9.0 and net10.0** (3846 passed / 0 failed / 2 pre-existing skips per TFM; Daqifi.Mcp.Tests 217 passed).

closes #651

**Not merging — for review.**
