### PR TITLE
ci: build and test on Windows and macOS, not just Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,26 +18,56 @@ on:
   push:
     branches: [ main ]
 
+# Superseded pushes to a PR branch used to keep running to completion; with three
+# runners per run that waste is now tripled, so cancel them. Only pull_request runs
+# are cancelled: a merge_group run is the gate for a commit that is about to land,
+# and a push run on main is the backstop above — neither is ever redundant.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    
+  # One leg per supported OS (#635). The library branches on the host OS in a dozen
+  # files — the macOS IOKit HID transport, the Windows PnP/WMI discovery providers —
+  # and until now the first machine to compile any of that was a user's.
+  # fail-fast is off so one platform's failure still leaves the other two's results
+  # readable, which is the whole point of having them.
+  test:
+    name: test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
     steps:
     - uses: actions/checkout@v7
-        
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v6
       with:
         dotnet-version: |
           9.0.x
           10.0.x
-        
+
+    # setup-dotnet's own `cache: true` keys off packages.lock.json, which this repo
+    # does not use, so cache the package folder directly. Keyed by OS because the
+    # restored graph differs per platform, and by the project files because that is
+    # what decides which packages get pulled.
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
+
     - name: Restore dependencies
       run: dotnet restore Daqifi.Core.sln
-      
+
     - name: Build
       run: dotnet build --no-restore Daqifi.Core.sln
-      
+
     - name: Test
       run: dotnet test Daqifi.Core.sln
 
@@ -60,8 +90,9 @@ jobs:
         command -v python3 >/dev/null 2>&1 || python_bin=python
         "$python_bin" .github/scripts/coverage-summary.py "${reports[@]}"
 
-    # Keyed by runner.os so the artifact names stay unique if the job ever becomes
-    # a multi-OS matrix (#635).
+    # Keyed by runner.os so the three legs upload three artifacts instead of
+    # colliding on one name. Each leg's numbers differ: the OS-specific transports
+    # only execute on the platform they are written for.
     - name: Upload coverage report
       if: always()
       uses: actions/upload-artifact@v7
@@ -69,3 +100,22 @@ jobs:
         name: coverage-${{ runner.os }}
         path: src/coverage/*.cobertura.xml
         if-no-files-found: warn
+
+  # The matrix legs report as "test (ubuntu-latest)" and friends, so branch
+  # protection and the merge queue would lose the check they require. This job keeps
+  # the old "build" name and passes only when every leg passed, so the required
+  # check keeps reporting and automatically covers any OS added to the matrix later.
+  build:
+    name: build
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check matrix result
+      env:
+        RESULT: ${{ needs.test.result }}
+      run: |
+        echo "Matrix result: $RESULT"
+        # Anything other than success — a failed leg, a cancelled leg, or a leg
+        # skipped by a bad `if` — must not report green.
+        [ "$RESULT" = "success" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,12 @@ jobs:
     - name: Build
       run: dotnet build --no-restore Daqifi.Core.sln
 
+    # --no-build because the step above already built it. Without that flag every
+    # leg compiled the solution a second time, which the matrix would have tripled.
+    # Verified locally that coverlet still writes both cobertura reports under
+    # --no-build: it instruments through its own no-build target.
     - name: Test
-      run: dotnet test Daqifi.Core.sln
+      run: dotnet test --no-build --no-restore Daqifi.Core.sln
 
     # Daqifi.Core.Tests.csproj collects coverage on every run, so the cobertura
     # report already exists by this point; the next two steps are only about not


### PR DESCRIPTION
## What was wrong

Every CI run this repo has ever done was Linux-only. Meanwhile the library advertises Windows, macOS and Linux support and branches on the host OS in a dozen files — the 377-line macOS IOKit HID transport that exists purely because HidSharp finds nothing on macOS (#262), and the Windows PnP/WMI discovery providers behind #487. None of that had ever been compiled by CI, let alone run. The first machine to build the Windows and macOS branches was a user's, so a `System.Management` reference that fails to resolve, an IOKit entry point that does not exist, or an analyzer that only fires on one host would have shipped to them rather than shown up here.

## How it was fixed

The single `build` job becomes a three-OS matrix — `ubuntu-latest`, `windows-latest`, `macos-latest` — with `fail-fast: false` so one platform breaking still leaves the other two's results readable.

Things worth pushing back on:

- **Check names.** Matrix legs report as `test (ubuntu-latest)` and friends, which would strand branch protection and the merge queue waiting on a `build` check that no longer exists — every queued PR would hang. A `needs: test` aggregate job keeps the name `build` and passes only when the whole matrix succeeded, so the required check keeps reporting and automatically covers any OS added later. No branch-protection change is needed as part of this.
- **CI cost.** This repo is public, so the runners are free, but three legs is still three times the wall clock. Two mitigations ride along: a `concurrency` group that cancels superseded `pull_request` runs (never `merge_group` or push-to-main — those are gates, not redundant work), and a NuGet package cache. `setup-dotnet`'s own `cache: true` keys off `packages.lock.json`, which this repo does not use, so the cache is an explicit `actions/cache` on `~/.nuget/packages`.
- **No test was excluded, skipped, loosened, or gated to get a green matrix.** Nothing needed it — see below.
- Coverage from #648 survives unchanged: it already named its artifact `coverage-${{ runner.os }}` in anticipation of exactly this, so the three legs upload `coverage-Linux`, `coverage-Windows` and `coverage-macOS` instead of colliding, and each leg's job summary renders its own table.

**Deliberately not done:** no target-framework changes, no coverage threshold (#641 settled that), nothing requiring a secret this repo lacks.

**One item from the issue is deferred, not forgotten.** #635 also asks that the four OS-branching tests skip explicitly off-platform instead of passing vacuously. I tried it and backed it out: xUnit 2.9.3 has no `Assert.Skip`/`Assert.SkipWhen` — `Xunit.Sdk.SkipException` and the `$XunitDynamicSkip$` token exist in `xunit.assert`, but v2's execution engine does not honour them, and a locally-verified run turned the skip into a **failure** rather than a skip. Making it work means either a package addition or a custom `FactAttribute`, both of which are outside a CI change and would collide with the csproj work in flight. The matrix removes most of the harm anyway: `UsbProviderFactoryTests` and `HidPlatformFactoryTests` now genuinely take their Windows and macOS arms on the runners that have those platforms, so their green is no longer standing in for two untested branches. Filed as #663 with the three options and the failing output.

## What the runs reported

First CI run [32758509179](https://github.com/daqifi/daqifi-core/actions/runs/32758509179) — all three legs inspected in their logs, not just by their check marks:

| Leg | Result | Daqifi.Core.Tests (each TFM) | Coverage artifact |
| --- | --- | --- | --- |
| `test (ubuntu-latest)` | pass, 2m18s | 3838 passed, 2 skipped, 0 failed | `coverage-Linux` |
| `test (windows-latest)` | pass, 3m26s | 3838 passed, 2 skipped, 0 failed | `coverage-Windows` |
| `test (macos-latest)` | pass, 3m7s | 3838 passed, 2 skipped, 0 failed | `coverage-macOS` |
| `build` (aggregate) | pass, 3s | — | — |

Second run [32759801262](https://github.com/daqifi/daqifi-core/actions/runs/32759801262), after dropping the duplicate compile: all four checks pass again with identical test counts and all three coverage artifacts, and each leg got faster — Windows 3m26s → 2m40s, ubuntu 2m18s → 2m0s.

The 2 skips are the pre-existing hardware-gated `[Fact(Skip=…)]` transport tests, identical on all three. `Daqifi.Mcp.Tests` is 217/217 everywhere. The Windows leg's coverage step confirmed the `python3`→`python` fallback works under Git Bash and rendered its table.

**No cross-platform product bug surfaced.** That is the honest headline: the suite is clean on all three OSes for both `net9.0` and `net10.0`, including the serial/transport code that was the obvious risk. I ran the full suite locally on macOS first as an early signal (same result) before CI confirmed it on all three.

closes #635

**Not merging — for review.**
