### PR TITLE
fix(hid): an all-NUL HID descriptor field is 'not reported', not an empty string

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/HidStringNormalizationTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/HidStringNormalizationTests.cs
@@ -1,0 +1,53 @@
+using Daqifi.Core.Communication.Transport;
+
+namespace Daqifi.Core.Tests.Communication.Transport;
+
+public class HidStringNormalizationTests
+{
+    [Theory]
+    // The case from #670: a fixed-width HID descriptor field that is nothing but NUL padding.
+    [InlineData("\0")]
+    [InlineData("\0\0\0\0\0\0\0\0")]
+    // Padding mixed with whitespace, in either order.
+    [InlineData(" \0 ")]
+    [InlineData("\0 \0")]
+    [InlineData("\0\t\0\r\n")]
+    public void Normalize_FieldThatIsOnlyPadding_IsReportedAsNoValue(string value)
+    {
+        Assert.Null(HidStringNormalization.Normalize(value));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\r\n")]
+    public void Normalize_NullEmptyOrWhitespace_IsReportedAsNoValue(string? value)
+    {
+        Assert.Null(HidStringNormalization.Normalize(value));
+    }
+
+    [Theory]
+    // Trailing NUL padding is the normal shape of a populated fixed-width descriptor field.
+    [InlineData("SN-0042\0\0\0\0\0", "SN-0042")]
+    // Padding on the leading edge, and whitespace on the far side of the padding, are stripped too.
+    [InlineData("\0\0SN-0042", "SN-0042")]
+    [InlineData("  SN-0042  ", "SN-0042")]
+    [InlineData(" SN-0042 \0\0", "SN-0042")]
+    [InlineData("\0 SN-0042 \0", "SN-0042")]
+    [InlineData("\0\0DAQiFi Nyquist 1\0\0", "DAQiFi Nyquist 1")]
+    public void Normalize_PaddedField_KeepsOnlyTheValue(string value, string expected)
+    {
+        Assert.Equal(expected, HidStringNormalization.Normalize(value));
+    }
+
+    [Fact]
+    public void Normalize_LeavesTheInteriorOfTheValueAlone()
+    {
+        // Only the padded edges are trimmed. A descriptor whose value legitimately contains
+        // interior spacing (a product name) must survive intact, and an interior NUL is not
+        // padding either -- silently splicing it out would change the reported identity.
+        Assert.Equal("DAQiFi  Nyquist 1", HidStringNormalization.Normalize("\0DAQiFi  Nyquist 1\0"));
+        Assert.Equal("SN-1\0SN-2", HidStringNormalization.Normalize("  SN-1\0SN-2  "));
+    }
+}

--- a/src/Daqifi.Core/Communication/Transport/HidStringNormalization.cs
+++ b/src/Daqifi.Core/Communication/Transport/HidStringNormalization.cs
@@ -13,18 +13,42 @@ namespace Daqifi.Core.Communication.Transport;
 internal static class HidStringNormalization
 {
     /// <summary>
-    /// Trims a raw HID string field and strips trailing NUL padding, returning
-    /// <see langword="null"/> for a null, empty, or whitespace-only value.
+    /// Trims whitespace and NUL padding from both ends of a raw HID string field, returning
+    /// <see langword="null"/> when nothing is left.
     /// </summary>
+    /// <remarks>
+    /// HID string descriptors are fixed-width and NUL-padded, so a field carrying no value can
+    /// arrive as NUL padding just as easily as it can arrive empty or blank. All of those
+    /// spellings of "not reported" collapse onto <see langword="null"/>, so a caller only has to
+    /// check for <see langword="null"/> to know whether the device told it anything. NUL is not
+    /// whitespace as far as .NET is concerned (<c>char.IsWhiteSpace('\0')</c> is
+    /// <see langword="false"/>), so the padding has to be trimmed explicitly rather than left to
+    /// <see cref="string.Trim()"/>.
+    /// </remarks>
     /// <param name="value">The raw string read from the native HID descriptor.</param>
     /// <returns>The normalized string, or <see langword="null"/> if there was no usable value.</returns>
     public static string? Normalize(string? value)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (value == null)
         {
             return null;
         }
 
-        return value.Trim().TrimEnd('\0');
+        var start = 0;
+        var end = value.Length - 1;
+
+        while (start <= end && IsPadding(value[start]))
+        {
+            start++;
+        }
+
+        while (end >= start && IsPadding(value[end]))
+        {
+            end--;
+        }
+
+        return end < start ? null : value.Substring(start, end - start + 1);
     }
+
+    private static bool IsPadding(char c) => c == '\0' || char.IsWhiteSpace(c);
 }


### PR DESCRIPTION
A USB HID string descriptor is a fixed-width field, and a device that has no serial number or product name to report fills that field with NUL padding rather than leaving it blank. `HidStringNormalization.Normalize` is the one place both HID backends funnel those raw fields through, and its rule is "anything that isn't a real value comes back as `null`, so a caller only has to check one thing". It got that rule right for `null`, `""` and whitespace — and wrong for the padding case that HID actually produces. `char.IsWhiteSpace('\0')` is `false`, so `"\0"` sailed past the `IsNullOrWhiteSpace` guard, survived `Trim()` untouched, and was then hollowed out to `""` by the `TrimEnd('\0')` on the next line. The function handed back a non-null string carrying no information — precisely the case the guard exists to catch.

The fix trims NUL and whitespace from both ends in a single pass and returns `null` when nothing survives, so `"\0"`, `" \0 "`, `""` and `"   "` all mean the same thing. Two smaller behavior changes come with it, both deliberate: a **leading** NUL is now stripped (`"\0SN-1"` used to come back with the NUL still attached, since `TrimEnd` only looked at the far end), and whitespace sitting on the inside of trailing padding is now removed (`"SN-1 \0"` was previously `"SN-1 "`). The interior of a value is untouched — an interior NUL is not padding, and splicing it out would silently change a reported identity.

**What a reviewer should push back on:** nothing in this repo behaves differently today because of the bug, and the issue's stated impact is wrong. #670 claims two devices with all-padding serials would "look like they share an identity"; they would not. `DeviceIdentity` runs its own `Normalize`, which is `IsNullOrWhiteSpace ? null : ...`, so an empty serial already becomes `null` there, and an identity with no discriminators never matches anything — including itself. Every other consumer is equally immune: `HidDeviceFinder` does `?? string.Empty`, `HidDeviceInfo.ToString()` and `HidLibraryTransport.NormalizeSerialFilter` both test with `IsNullOrWhiteSpace`. So this is a latent contract violation, not a live failure, and that same fact is what makes the change safe: no in-repo caller can tell the difference.

It is still worth fixing rather than documenting-as-intended, because the alternative is pinning a rule nobody can explain — that `" "` returns `null` but `"\0"` returns `""`, when both mean "the device told us nothing". The function already decided that a blank field is an absent field; NUL padding is just how HID spells blank. `HidDeviceInfo.SerialNumber` and `.ProductName` are public nullable properties, so an out-of-repo consumer doing a plain null check is the one who would actually be misled. #618/#627 settled the same question the same way for the SD-card config merge: a blank string is a gap, not an answer.

`HidStringNormalization` is `internal`, so no public signature moves; only the value flowing through two public nullable properties changes, and only in the all-padding case.

**Tests.** The type had none. There are now 16 cases covering NUL-only, NUL-padded-with-content (leading, trailing and both), whitespace-plus-NUL, empty, whitespace-only, `null`, and interior preservation. Each was verified to fail against a mutation of the production code:

- reverting to the old `IsNullOrWhiteSpace` + `TrimEnd('\0')` body — 10 fail
- dropping `'\0'` from the padding predicate — 11 fail, including plain trailing padding
- dropping `char.IsWhiteSpace` from it — 9 fail, including the whitespace-only and `"  SN-0042  "` cases
- deleting the leading-edge trim loop — 6 fail
- returning `string.Empty` instead of `null` when nothing survives — 8 fail, including `""`
- stripping NULs from the whole string rather than the edges — the interior-preservation test fails
- making the `null` guard return `string.Empty` — the `null` case fails

Full suite green on net9.0 and net10.0 under `-warnaserror`: 3918 passed, 2 skipped (Core, each TFM) and 217 passed (Mcp). Bench validation does not apply — this is pure string normalization with no device interaction, and the two HID call sites are unchanged.

closes #670

Not merging — for review.
