### PR TITLE
fix(export): order channel columns naturally, so AI2 comes before AI10

### DIFF
--- a/src/Daqifi.Core.Tests/Logging/Export/ChannelDescriptorComparerTests.cs
+++ b/src/Daqifi.Core.Tests/Logging/Export/ChannelDescriptorComparerTests.cs
@@ -1,0 +1,108 @@
+using Daqifi.Core.Channel;
+using Daqifi.Core.Logging.Export;
+
+namespace Daqifi.Core.Tests.Logging.Export;
+
+public class ChannelDescriptorComparerTests
+{
+    private static readonly ChannelDescriptorComparer Comparer = ChannelDescriptorComparer.Default;
+
+    private static ChannelDescriptor Channel(string device, string serial, string name)
+        => new(device, serial, name, ChannelType.Analog);
+
+    private static int Sign(int value) => Math.Sign(value);
+
+    [Fact]
+    public void Compare_SameDeviceAndSerial_OrdersChannelNamesNaturally()
+    {
+        var ai2 = Channel("Nq1", "SN001", "AI2");
+        var ai10 = Channel("Nq1", "SN001", "AI10");
+
+        Assert.Equal(-1, Sign(Comparer.Compare(ai2, ai10)));
+    }
+
+    [Fact]
+    public void Compare_DeviceNameDecidesBeforeSerialAndChannel()
+    {
+        var a = Channel("DevA", "SN999", "AI99");
+        var b = Channel("DevB", "SN001", "AI0");
+
+        Assert.Equal(-1, Sign(Comparer.Compare(a, b)));
+    }
+
+    [Fact]
+    public void Compare_SameDevice_SerialDecidesBeforeChannel()
+    {
+        var a = Channel("Nq1", "SN001", "AI99");
+        var b = Channel("Nq1", "SN002", "AI0");
+
+        Assert.Equal(-1, Sign(Comparer.Compare(a, b)));
+    }
+
+    [Theory]
+    [InlineData("DevA", "Deva")]
+    [InlineData("Nq1", "nq1")]
+    public void Compare_DeviceName_IsOrdinalNotCultureSensitive(string upper, string lower)
+    {
+        // Ordinal matches SQLite's BINARY collation, so a source that orders in the database and
+        // one that orders in memory agree byte for byte regardless of the machine's locale.
+        var a = Channel(upper, "SN001", "AI0");
+        var b = Channel(lower, "SN001", "AI0");
+
+        Assert.Equal(Sign(string.CompareOrdinal(upper, lower)), Sign(Comparer.Compare(a, b)));
+    }
+
+    [Fact]
+    public void Compare_SerialNumber_IsOrdinalNotNatural()
+    {
+        // Only the channel name gets natural ordering; serials stay byte-wise so the SQLite
+        // agreement holds for them too.
+        var sn2 = Channel("Nq1", "SN2", "AI0");
+        var sn10 = Channel("Nq1", "SN10", "AI0");
+
+        Assert.Equal(1, Sign(Comparer.Compare(sn2, sn10)));
+    }
+
+    [Fact]
+    public void Compare_IdenticalDescriptors_AreEqual()
+    {
+        Assert.Equal(0, Comparer.Compare(Channel("Nq1", "SN001", "AI0"), Channel("Nq1", "SN001", "AI0")));
+    }
+
+    [Fact]
+    public void Compare_ChannelType_DoesNotAffectOrder()
+    {
+        // Two descriptors that name the same column but disagree on type are the same column.
+        var analog = new ChannelDescriptor("Nq1", "SN001", "AI0", ChannelType.Analog);
+        var digital = new ChannelDescriptor("Nq1", "SN001", "AI0", ChannelType.Digital);
+
+        Assert.Equal(0, Comparer.Compare(analog, digital));
+    }
+
+    [Fact]
+    public void Compare_Nulls_SortBeforeEveryDescriptor()
+    {
+        Assert.Equal(0, Comparer.Compare(null, null));
+        Assert.Equal(-1, Sign(Comparer.Compare(null, Channel("Nq1", "SN001", "AI0"))));
+        Assert.Equal(1, Sign(Comparer.Compare(Channel("Nq1", "SN001", "AI0"), null)));
+    }
+
+    [Fact]
+    public void Sort_TwoDevicesWithTwelveChannelsEach_GroupsByDeviceThenOrdersNaturally()
+    {
+        var channels = new List<ChannelDescriptor>();
+        foreach (var device in new[] { "DevB", "DevA" })
+        {
+            channels.AddRange(Enumerable.Range(0, 12).Select(i => Channel(device, "SN001", $"AI{i}")));
+        }
+
+        var sorted = channels.OrderBy(c => c, Comparer).Select(c => c.Key).ToArray();
+
+        string[] expected =
+        [
+            .. Enumerable.Range(0, 12).Select(i => $"DevA:SN001:AI{i}"),
+            .. Enumerable.Range(0, 12).Select(i => $"DevB:SN001:AI{i}")
+        ];
+        Assert.Equal(expected, sorted);
+    }
+}

--- a/src/Daqifi.Core.Tests/Logging/Export/ChannelNameComparerTests.cs
+++ b/src/Daqifi.Core.Tests/Logging/Export/ChannelNameComparerTests.cs
@@ -1,0 +1,191 @@
+using Daqifi.Core.Logging.Export;
+
+namespace Daqifi.Core.Tests.Logging.Export;
+
+public class ChannelNameComparerTests
+{
+    private static readonly ChannelNameComparer Comparer = ChannelNameComparer.Instance;
+
+    private static int Sign(int value) => Math.Sign(value);
+
+    // ── The defect this type exists for ─────────────────────────────────────
+
+    [Theory]
+    [InlineData("AI2", "AI10")]
+    [InlineData("AI9", "AI10")]
+    [InlineData("AI11", "AI100")]
+    [InlineData("DIO2", "DIO10")]
+    public void Compare_TwoDigitIndex_SortsAfterEverySingleDigitOne(string smaller, string larger)
+    {
+        Assert.Equal(-1, Sign(Comparer.Compare(smaller, larger)));
+        Assert.Equal(1, Sign(Comparer.Compare(larger, smaller)));
+    }
+
+    [Fact]
+    public void Sort_TwelveAnalogChannels_OrdersThemNumericallyNotLexicographically()
+    {
+        // The bug needs a two-digit index to appear at all: with nine channels or fewer,
+        // lexicographic and natural order are identical.
+        string[] names = [.. Enumerable.Range(0, 12).Select(i => $"AI{i}")];
+        var shuffled = names.OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+        // Guard the premise — plain ordinal really does misorder these.
+        Assert.Equal(
+            ["AI0", "AI1", "AI10", "AI11", "AI2", "AI3", "AI4", "AI5", "AI6", "AI7", "AI8", "AI9"],
+            shuffled);
+
+        Assert.Equal(names, shuffled.OrderBy(n => n, Comparer).ToArray());
+    }
+
+    // ── Names without a trailing number behave exactly as before ────────────
+
+    [Theory]
+    [InlineData("Temperature", "Voltage")]
+    [InlineData("AI", "DIO")]
+    [InlineData("Alpha", "alpha")]
+    public void Compare_NoTrailingDigits_IsOrdinal(string first, string second)
+    {
+        Assert.Equal(Sign(string.CompareOrdinal(first, second)), Sign(Comparer.Compare(first, second)));
+    }
+
+    [Fact]
+    public void Compare_DifferentPrefixes_ComparesPrefixBeforeNumber()
+    {
+        // The prefix decides, so a large index on one prefix never overtakes another prefix.
+        Assert.Equal(-1, Sign(Comparer.Compare("AI99", "DIO0")));
+    }
+
+    [Fact]
+    public void Compare_PrefixComparisonIsOrdinal_NotCultureSensitive()
+    {
+        // Ordinal puts every uppercase letter before every lowercase one; a culture-sensitive
+        // comparison interleaves them. Pinning this keeps SQLite's BINARY collation in agreement.
+        Assert.Equal(1, Sign(Comparer.Compare("aI0", "AI0")));
+    }
+
+    // ── Edge cases that have to stay a total order ──────────────────────────
+
+    [Fact]
+    public void Compare_UnnumberedName_SortsBeforeTheNumberedOneSharingItsPrefix()
+    {
+        Assert.Equal(-1, Sign(Comparer.Compare("AI", "AI0")));
+        Assert.Equal(1, Sign(Comparer.Compare("AI0", "AI")));
+    }
+
+    [Fact]
+    public void Compare_LeadingZeros_SameValueStillOrdersDeterministically()
+    {
+        // "AI01" and "AI1" are the same number but different columns, so neither may be
+        // reported as equal to the other.
+        Assert.Equal(-1, Sign(Comparer.Compare("AI01", "AI1")));
+        Assert.Equal(1, Sign(Comparer.Compare("AI1", "AI01")));
+        Assert.Equal(-1, Sign(Comparer.Compare("AI0", "AI00")));
+    }
+
+    [Fact]
+    public void Compare_LeadingZerosDoNotChangeTheValue()
+    {
+        Assert.Equal(-1, Sign(Comparer.Compare("AI002", "AI10")));
+    }
+
+    [Fact]
+    public void Compare_DigitRunTooLongForALong_DoesNotOverflowOrThrow()
+    {
+        // Parsing the trailing digits would throw or wrap here; counting them does not.
+        var huge = "AI" + new string('9', 40);
+        var huger = "AI1" + new string('0', 41);
+
+        Assert.Equal(-1, Sign(Comparer.Compare("AI7", huge)));
+        Assert.Equal(-1, Sign(Comparer.Compare(huge, "AI" + new string('9', 41))));
+        Assert.Equal(1, Sign(Comparer.Compare(huger, "AI0")));
+    }
+
+    [Fact]
+    public void Compare_AllDigitNames_ComparesNumerically()
+    {
+        Assert.Equal(-1, Sign(Comparer.Compare("9", "12")));
+    }
+
+    [Fact]
+    public void Compare_NonAsciiDigits_AreLeftInThePrefixRatherThanParsed()
+    {
+        // Arabic-Indic digits are Unicode decimal digits but cannot be compared as ASCII values.
+        // They stay in the prefix, where they at least sort consistently, and nothing throws.
+        const string arabicTwo = "AI٢";
+        const string arabicThree = "AI٣";
+
+        Assert.Equal(-1, Sign(Comparer.Compare(arabicTwo, arabicThree)));
+        Assert.Equal(0, Comparer.Compare(arabicTwo, "AI٢"));
+    }
+
+    [Fact]
+    public void Compare_IdenticalNames_AreEqual()
+    {
+        Assert.Equal(0, Comparer.Compare("AI10", "AI10"));
+        Assert.Equal(0, Comparer.Compare(string.Empty, string.Empty));
+    }
+
+    [Fact]
+    public void Compare_Nulls_SortBeforeEveryName()
+    {
+        Assert.Equal(0, Comparer.Compare(null, null));
+        Assert.Equal(-1, Sign(Comparer.Compare(null, "AI0")));
+        Assert.Equal(1, Sign(Comparer.Compare("AI0", null)));
+    }
+
+    [Fact]
+    public void Compare_EmptyName_SortsBeforeANumberedOne()
+    {
+        Assert.Equal(-1, Sign(Comparer.Compare(string.Empty, "0")));
+        Assert.Equal(-1, Sign(Comparer.Compare(string.Empty, "AI0")));
+    }
+
+    [Fact]
+    public void Compare_IsAntisymmetricAndTransitiveAcrossAMixedSet()
+    {
+        // A comparer that contradicts itself makes List.Sort's output depend on input order,
+        // so check the three ordering laws directly over an awkward set.
+        string[] names =
+        [
+            "AI0", "AI00", "AI1", "AI01", "AI2", "AI10", "AI11", "AI",
+            "DIO0", "DIO10", "Temperature", "aI0", "", "9", "12"
+        ];
+
+        foreach (var a in names)
+        {
+            Assert.Equal(0, Comparer.Compare(a, a));
+
+            foreach (var b in names)
+            {
+                Assert.Equal(-Sign(Comparer.Compare(b, a)), Sign(Comparer.Compare(a, b)));
+
+                foreach (var c in names)
+                {
+                    if (Comparer.Compare(a, b) < 0 && Comparer.Compare(b, c) < 0)
+                    {
+                        Assert.True(
+                            Comparer.Compare(a, c) < 0,
+                            $"'{a}' < '{b}' < '{c}' but '{a}' does not sort before '{c}'.");
+                    }
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void Compare_DistinctNames_AreNeverReportedEqual()
+    {
+        string[] names = ["AI0", "AI00", "AI1", "AI01", "AI", "AI10", "", "0"];
+
+        foreach (var a in names)
+        {
+            foreach (var b in names)
+            {
+                if (!string.Equals(a, b, StringComparison.Ordinal))
+                {
+                    Assert.NotEqual(0, Comparer.Compare(a, b));
+                }
+            }
+        }
+    }
+}

--- a/src/Daqifi.Core.Tests/Logging/Export/CsvExporterTests.cs
+++ b/src/Daqifi.Core.Tests/Logging/Export/CsvExporterTests.cs
@@ -685,4 +685,75 @@ public class CsvExporterTests
         await Assert.ThrowsAsync<ArgumentException>(async () =>
             await ExportToLinesAsync(source, new CsvExportOptions { Delimiter = bad }));
     }
+
+    // ── #675 natural channel ordering ────────────────────────────────────────
+
+    [Fact]
+    public async Task Export_TwelveChannelsInDescriptorOrder_WritesColumnsInNaturalOrder()
+    {
+        // The bug needs a two-digit channel index to appear at all, so the existing suites — all
+        // of which use one or two channels — could not have caught it. A 12-channel board exported
+        // its columns as AI0, AI1, AI10, AI11, AI2, …, silently misaligning every reading from the
+        // third column on while each value stayed individually correct.
+        var channels = Enumerable.Range(0, 12)
+            .Select(i => new ChannelDescriptor("Nq1", "SN001", $"AI{i}", ChannelType.Analog))
+            .ToList();
+
+        var source = new InMemorySampleSource(
+            channels.OrderBy(c => c, ChannelDescriptorComparer.Default),
+            channels.Select((c, i) => new SampleRow(T0, c.Key, i)));
+
+        var (lines, header) = await ExportToLinesAsync(source, new CsvExportOptions());
+
+        Assert.Equal(
+            "Time," + string.Join(",", channels.Select(c => c.Key)),
+            header);
+
+        // And the values line up with the header they were written under.
+        Assert.Equal(
+            new DateTime(T0).ToString("O") + "," + string.Join(",", Enumerable.Range(0, 12)),
+            lines[1]);
+    }
+
+    [Fact]
+    public async Task Export_ChannelsSortedLexicographically_ShowsTheColumnOrderThisIssueIsAbout()
+    {
+        // Pins the old behaviour as the thing the comparer fixes: the exporter writes whatever
+        // order the source hands it, so ordering the source lexicographically still misplaces
+        // AI10 and AI11 — the fix has to live in the source, not in CsvExporter.
+        var channels = Enumerable.Range(0, 12)
+            .Select(i => new ChannelDescriptor("Nq1", "SN001", $"AI{i}", ChannelType.Analog))
+            .OrderBy(c => c.ChannelName, StringComparer.Ordinal)
+            .ToList();
+
+        var source = new InMemorySampleSource(channels, [new SampleRow(T0, channels[0].Key, 1.0)]);
+
+        var (_, header) = await ExportToLinesAsync(source, new CsvExportOptions());
+
+        Assert.Equal(
+            "Time,Nq1:SN001:AI0,Nq1:SN001:AI1,Nq1:SN001:AI10,Nq1:SN001:AI11,Nq1:SN001:AI2,"
+            + "Nq1:SN001:AI3,Nq1:SN001:AI4,Nq1:SN001:AI5,Nq1:SN001:AI6,Nq1:SN001:AI7,"
+            + "Nq1:SN001:AI8,Nq1:SN001:AI9",
+            header);
+    }
+
+    [Fact]
+    public async Task Export_NineChannels_IsUnaffectedByTheOrderingChange()
+    {
+        // Backward compatibility: with a single digit, lexicographic and natural order are
+        // identical, so no existing export's bytes move.
+        var channels = Enumerable.Range(0, 9)
+            .Select(i => new ChannelDescriptor("Nq1", "SN001", $"AI{i}", ChannelType.Analog))
+            .ToList();
+
+        var lexicographic = channels.OrderBy(c => c.ChannelName, StringComparer.Ordinal).ToList();
+        var natural = channels.OrderBy(c => c, ChannelDescriptorComparer.Default).ToList();
+
+        Assert.Equal(lexicographic, natural);
+
+        var source = new InMemorySampleSource(natural, [new SampleRow(T0, channels[0].Key, 1.0)]);
+        var (_, header) = await ExportToLinesAsync(source, new CsvExportOptions());
+
+        Assert.Equal("Time," + string.Join(",", channels.Select(c => c.Key)), header);
+    }
 }

--- a/src/Daqifi.Core/Logging/Export/ChannelDescriptorComparer.cs
+++ b/src/Daqifi.Core/Logging/Export/ChannelDescriptorComparer.cs
@@ -1,0 +1,71 @@
+namespace Daqifi.Core.Logging.Export;
+
+/// <summary>
+/// The column order <see cref="CsvExporter"/> expects from <see cref="ISampleSource.GetChannels"/>:
+/// by device name, then serial number, then channel name — the first two ordinally, the last with
+/// <see cref="ChannelNameComparer"/> so <c>AI2</c> comes before <c>AI10</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ISampleSource"/> is implemented once per application — desktop, Avalonia, Android —
+/// and each implementation decides the order its channels come back in. Left unstated, that made a
+/// CSV's column order a property of which application exported it, and gave every one of them its
+/// own chance to get the ordering of a two-digit channel index wrong (issue #675). This is the
+/// single answer they can all sort by.
+/// </para>
+/// <para>
+/// Device name and serial number stay <b>ordinal</b>, matching SQLite's BINARY collation, so an
+/// implementation that orders in the database and one that orders in memory produce byte-identical
+/// output. Passing no comparer at all would order by the current culture and quietly break that
+/// agreement on any machine whose locale disagrees with the developer's.
+/// </para>
+/// </remarks>
+public sealed class ChannelDescriptorComparer : IComparer<ChannelDescriptor>
+{
+    /// <summary>
+    /// Gets the shared instance. The comparer holds no state, so one is enough.
+    /// </summary>
+    public static ChannelDescriptorComparer Default { get; } = new();
+
+    private ChannelDescriptorComparer()
+    {
+    }
+
+    /// <summary>
+    /// Compares two channel descriptors by device name, serial number, then channel name.
+    /// </summary>
+    /// <param name="x">The first descriptor. Null sorts before every non-null descriptor.</param>
+    /// <param name="y">The second descriptor.</param>
+    /// <returns>
+    /// A negative number if <paramref name="x"/> sorts first, a positive number if
+    /// <paramref name="y"/> does, and zero when the two name the same column.
+    /// </returns>
+    public int Compare(ChannelDescriptor? x, ChannelDescriptor? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return -1;
+        }
+
+        if (y is null)
+        {
+            return 1;
+        }
+
+        var device = string.CompareOrdinal(x.DeviceName, y.DeviceName);
+        if (device != 0)
+        {
+            return device;
+        }
+
+        var serial = string.CompareOrdinal(x.DeviceSerialNo, y.DeviceSerialNo);
+        return serial != 0
+            ? serial
+            : ChannelNameComparer.Instance.Compare(x.ChannelName, y.ChannelName);
+    }
+}

--- a/src/Daqifi.Core/Logging/Export/ChannelNameComparer.cs
+++ b/src/Daqifi.Core/Logging/Export/ChannelNameComparer.cs
@@ -1,0 +1,131 @@
+namespace Daqifi.Core.Logging.Export;
+
+/// <summary>
+/// Orders channel names the way a person reads them — <c>AI2</c> before <c>AI10</c> — by splitting a
+/// trailing run of digits off the name and comparing it as a number rather than as text.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Plain string ordering is byte-wise, so <c>'1' &lt; '2'</c> puts <c>AI10</c> and <c>AI11</c>
+/// between <c>AI1</c> and <c>AI2</c>. On a device with fewer than ten analog channels that is
+/// invisible, because a single digit sorts the same either way; the moment one has ten or more, the
+/// exported CSV's columns are silently in the wrong order while every value in every column is
+/// individually correct (issue #675).
+/// </para>
+/// <para>
+/// The comparison is <b>ordinal on the prefix, numeric on the trailing digits</b>. Ordinal is
+/// load-bearing rather than incidental: <see cref="ISampleSource"/> implementations backed by SQLite
+/// order their channels in the database using BINARY collation, and only an ordinal prefix
+/// comparison agrees with it — a culture-sensitive one would let the same session export different
+/// bytes depending on the machine's locale.
+/// </para>
+/// <para>
+/// Names with no trailing digits are compared ordinally end to end, so they behave exactly as they
+/// did before this type existed.
+/// </para>
+/// </remarks>
+public sealed class ChannelNameComparer : IComparer<string>
+{
+    /// <summary>
+    /// Gets the shared instance. The comparer holds no state, so one is enough.
+    /// </summary>
+    public static ChannelNameComparer Instance { get; } = new();
+
+    private ChannelNameComparer()
+    {
+    }
+
+    /// <summary>
+    /// Compares two channel names, ordering a shared prefix ordinally and a trailing number
+    /// numerically.
+    /// </summary>
+    /// <param name="x">The first name. Null sorts before every non-null name.</param>
+    /// <param name="y">The second name.</param>
+    /// <returns>
+    /// A negative number if <paramref name="x"/> sorts first, a positive number if
+    /// <paramref name="y"/> does, and zero only when the two names are identical.
+    /// </returns>
+    public int Compare(string? x, string? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return -1;
+        }
+
+        if (y is null)
+        {
+            return 1;
+        }
+
+        var xDigits = TrailingDigitStart(x);
+        var yDigits = TrailingDigitStart(y);
+
+        var prefix = x.AsSpan(0, xDigits).CompareTo(y.AsSpan(0, yDigits), StringComparison.Ordinal);
+        if (prefix != 0)
+        {
+            return prefix;
+        }
+
+        var number = CompareTrailingNumbers(x.AsSpan(xDigits), y.AsSpan(yDigits));
+        if (number != 0)
+        {
+            return number;
+        }
+
+        // Same prefix and the same numeric value, so the names can still differ only by leading
+        // zeros ("AI01" vs "AI1"). Fall back to ordinal over the whole name rather than calling two
+        // distinct columns equal: the order has to be total, or a sort's output depends on the input
+        // order it happened to be given.
+        return string.CompareOrdinal(x, y);
+    }
+
+    /// <summary>
+    /// Returns the index at which <paramref name="value"/>'s trailing run of digits begins, or its
+    /// length when it does not end in a digit.
+    /// </summary>
+    /// <remarks>
+    /// Only ASCII <c>'0'</c>–<c>'9'</c> count. <see cref="char.IsDigit(char)"/> also accepts the
+    /// decimal digits of other scripts, which would be split off here and then compared as text
+    /// anyway — a worse answer than leaving them in the prefix, where they at least sort
+    /// consistently.
+    /// </remarks>
+    private static int TrailingDigitStart(string value)
+    {
+        var start = value.Length;
+        while (start > 0 && value[start - 1] is >= '0' and <= '9')
+        {
+            start--;
+        }
+
+        return start;
+    }
+
+    /// <summary>
+    /// Compares two runs of ASCII digits by value.
+    /// </summary>
+    /// <remarks>
+    /// Compared by significant-digit count and then digit by digit rather than parsed: a channel
+    /// name may carry an arbitrarily long run of digits, and parsing one into a
+    /// <see cref="long"/> would overflow on a name a device is free to report.
+    /// </remarks>
+    private static int CompareTrailingNumbers(ReadOnlySpan<char> x, ReadOnlySpan<char> y)
+    {
+        // An unnumbered name sorts before a numbered one that shares its prefix ("AI" before "AI0").
+        if (x.IsEmpty || y.IsEmpty)
+        {
+            return x.Length.CompareTo(y.Length);
+        }
+
+        x = x.TrimStart('0');
+        y = y.TrimStart('0');
+
+        return x.Length != y.Length
+            ? x.Length.CompareTo(y.Length)
+            : x.CompareTo(y, StringComparison.Ordinal);
+    }
+}

--- a/src/Daqifi.Core/Logging/Export/ISampleSource.cs
+++ b/src/Daqifi.Core/Logging/Export/ISampleSource.cs
@@ -10,6 +10,21 @@ public interface ISampleSource
     /// Returns the ordered list of channels present in this source.
     /// The order determines column order in the exported CSV.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An implementation that discovers its channels — from a database, a file, a set of samples —
+    /// rather than being handed them in a caller-chosen order should return them in
+    /// <see cref="ChannelDescriptorComparer.Default"/> order: device name, then serial number, then
+    /// channel name, with the channel name compared so that <c>AI2</c> precedes <c>AI10</c>. Saying
+    /// only "ordered" left the rule to each implementation, and plain string ordering puts a
+    /// device's <c>AI10</c> and <c>AI11</c> columns between <c>AI1</c> and <c>AI2</c> (issue #675).
+    /// </para>
+    /// <para>
+    /// An implementation whose channels are supplied by the caller — <see cref="LiveSampleSource"/>,
+    /// for one — keeps the caller's order instead, since choosing the columns is the point of
+    /// passing them in.
+    /// </para>
+    /// </remarks>
     IReadOnlyList<ChannelDescriptor> GetChannels();
 
     /// <summary>


### PR DESCRIPTION
## What was wrong

A device with ten or more channels exported a CSV whose columns were in the **wrong order**, and the header gave no clue that they were:

```
Time, ...:AI0, ...:AI1, ...:AI10, ...:AI11, ...:AI2, ...:AI3, ...
```

`AI10` and `AI11` sit third and fourth. On the 12-channel IAQ board this was found on, those are NOx index and CO2 ppm, so the file reads CO, ADC-short, NOx, CO2, VDD, PM1.0… Anyone charting a column positionally, or eyeballing "the last column is CO2", got the wrong signal — silently, because every value in every column was individually valid.

## Why

Nothing was malfunctioning. `ISampleSource.GetChannels()` documented itself as returning an *"ordered"* list without saying what the order is, so each implementation picked its own — and plain string ordering is byte-wise: `'1' < '2'`, therefore `AI10` sorts before `AI2`.

It stayed invisible while devices had fewer than ten channels. With a single digit, lexicographic and natural order are identical. It appears the moment a device has ten or more.

## The fix

Core owns the exporter and the interface contract, so it now owns the ordering rule too — rather than leaving daqifi-desktop, -avalonia and -android each to reinvent it, which would make a CSV's column order a property of which app exported it.

- **`ChannelNameComparer`** — splits a trailing run of digits off the name and compares it as a number. Ordinal on the prefix, numeric on the digits; names that don't end in a digit are compared ordinally end to end, exactly as before.
- **`ChannelDescriptorComparer.Default`** — the whole rule in one comparer: device name and serial ordinal, channel name natural. A discovering `ISampleSource` sorts with `.OrderBy(c => c, ChannelDescriptorComparer.Default)` and is done.
- **`GetChannels()`'s doc comment** now states the expected order, and says which implementations are exempt — the ones handed their channels by the caller (`LiveSampleSource`), where choosing the columns is the point.

### Two constraints the issue called out, both honoured

**Ordinal is load-bearing on device name and serial.** It matches SQLite's BINARY collation, so a source that orders in the database and one that orders in memory produce byte-identical output regardless of the machine's locale. Only the channel name gets natural ordering; a test pins that serials stay byte-wise (`SN10` before `SN2`).

**The order has to be total.** `AI01` and `AI1` are the same number but different columns, so neither is reported equal to the other — the comparer falls back to ordinal over the whole name. The tests check antisymmetry, transitivity and "distinct names are never equal" directly over an awkward set, because a comparer that contradicts itself makes a sort's output depend on the input order it happened to be given.

## Edge cases

- Digits are **counted, not parsed**, so an arbitrarily long run can't overflow a `long`.
- Only ASCII `'0'`–`'9'` count. `char.IsDigit` also accepts other scripts' decimal digits, which would be split off and then compared as text anyway — worse than leaving them in the prefix.
- Unnumbered names sort before the numbered one sharing their prefix (`AI` before `AI0`); nulls sort first.

## Backward compatibility

Unchanged for devices with fewer than ten channels — a test pins that their column order does not move. Devices with ten or more get corrected column order, which is the point.

## Not in this PR

Adopting the comparer in `daqifi-desktop`'s `LoggingSessionSampleSource` (whose two `OrderBy` chains are the live site of the bug, and which also disagree with each other — the in-memory branch passes no comparer at all, so it orders by current culture). That's a separate repository; follow-up issue to come, same as [#669](https://github.com/daqifi/daqifi-core-example-app/issues/49) did for the example-app.

## Testing

Full suite green on net9.0 and net10.0: 4015 passed, 0 failed. Includes a 12-channel end-to-end export asserting the header **and** that the values line up under it, plus a test that pins the old lexicographic header as the thing being fixed — confirming the fix belongs in the source, not in `CsvExporter`, which correctly writes whatever order it is handed.

Closes daqifi/daqifi-core#675

🤖 Generated with [Claude Code](https://claude.com/claude-code)