### PR TITLE
test(discovery): report the three off-platform gate tests as skipped, not passed

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Discovery/LinuxUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/LinuxUsbPortDescriptorProviderTests.cs
@@ -1,5 +1,5 @@
 using Daqifi.Core.Device.Discovery;
-using System.Runtime.InteropServices;
+using Daqifi.Core.Tests.TestSupport;
 
 namespace Daqifi.Core.Tests.Device.Discovery;
 
@@ -326,16 +326,14 @@ public class LinuxUsbPortDescriptorProviderTests : IDisposable
         Assert.Null(provider.GetDescriptor("/dev/ttyDAQIFI-" + Guid.NewGuid().ToString("N")));
     }
 
-    [Fact]
+    // Elsewhere /sys/class/tty either does not exist or means something else, so the gate — not the
+    // filesystem — has to produce the answer. On Linux the same call is covered above.
+    [PlatformFact(
+        TestPlatforms.Linux,
+        "The off-Linux gate can only be observed off Linux; on Linux the same call reads the real " +
+        "/sys/class/tty and is covered by GetDescriptor_PortThatDoesNotExist_ReturnsNull.")]
     public void GetDescriptor_OffLinux_AnswersNullForEveryPort()
     {
-        // Elsewhere /sys/class/tty either does not exist or means something else, so the gate — not
-        // the filesystem — has to produce the answer. On Linux the same call is covered above.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            return;
-        }
-
         var provider = new LinuxUsbPortDescriptorProvider();
 
         Assert.Null(provider.GetDescriptor("ttyACM0"));

--- a/src/Daqifi.Core.Tests/Device/Discovery/MacOsUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/MacOsUsbPortDescriptorProviderTests.cs
@@ -1,5 +1,5 @@
 using Daqifi.Core.Device.Discovery;
-using System.Runtime.InteropServices;
+using Daqifi.Core.Tests.TestSupport;
 
 namespace Daqifi.Core.Tests.Device.Discovery;
 
@@ -153,17 +153,15 @@ public class MacOsUsbPortDescriptorProviderTests
 
     #region The platform gate
 
-    [Fact]
+    // Elsewhere ioreg either does not exist or means something else, so the gate has to produce the
+    // answer without ever spawning a process. On macOS the real ioreg-backed path is exercised
+    // manually rather than in CI, for the reasons in the type-level remarks.
+    [PlatformFact(
+        TestPlatforms.MacOS,
+        "The off-macOS gate can only be observed off macOS; on macOS the same call reaches the " +
+        "real ioreg, which CI does not exercise.")]
     public void GetDescriptor_OffMacOS_AnswersNullForEveryPort()
     {
-        // Elsewhere ioreg either does not exist or means something else, so the gate has to
-        // produce the answer without ever spawning a process. On macOS the real ioreg-backed path
-        // is exercised manually rather than in CI, for the reasons in the type-level remarks.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return;
-        }
-
         var provider = new MacOsUsbPortDescriptorProvider();
 
         Assert.Null(provider.GetDescriptor("/dev/cu.usbmodem101"));

--- a/src/Daqifi.Core.Tests/Device/Discovery/WindowsUsbPortDescriptorProviderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Discovery/WindowsUsbPortDescriptorProviderTests.cs
@@ -1,5 +1,5 @@
-using System.Runtime.InteropServices;
 using Daqifi.Core.Device.Discovery;
+using Daqifi.Core.Tests.TestSupport;
 
 namespace Daqifi.Core.Tests.Device.Discovery;
 
@@ -81,19 +81,17 @@ public class WindowsUsbPortDescriptorProviderTests
 
     // ---- the platform gate ------------------------------------------------
 
-    [Fact]
+    // Unlike LinuxUsbPortDescriptorProviderTests.GetDescriptor_OffLinux, there is no unconditional
+    // twin of this test that also exercises GetDescriptor on Windows: doing so would reach
+    // WindowsPnpPortMap.Shared, whose first lookup can rebuild the map and run a real WMI query —
+    // slow and flaky in a unit-test run. The Windows-side lookup logic is fully covered above
+    // through the injectable Resolve seam instead.
+    [PlatformFact(
+        TestPlatforms.Windows,
+        "The off-Windows gate can only be observed off Windows; on Windows the same call would " +
+        "reach WindowsPnpPortMap.Shared and run a real WMI query.")]
     public void GetDescriptor_OffWindows_ReturnsNullWithoutTouchingTheMap()
     {
-        // Unlike LinuxUsbPortDescriptorProviderTests.GetDescriptor_OffLinux, there is no
-        // unconditional twin of this test that also exercises GetDescriptor on Windows: doing so
-        // would reach WindowsPnpPortMap.Shared, whose first lookup can rebuild the map and run a
-        // real WMI query — slow and flaky in a unit-test run. The Windows-side lookup logic is
-        // fully covered above through the injectable Resolve seam instead.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return;
-        }
-
         var provider = new WindowsUsbPortDescriptorProvider();
 
 #pragma warning disable CA1416 // GetDescriptor is Windows-gated at runtime, not by this call site.

--- a/src/Daqifi.Core.Tests/TestSupport/PlatformFactAttribute.cs
+++ b/src/Daqifi.Core.Tests/TestSupport/PlatformFactAttribute.cs
@@ -1,0 +1,116 @@
+using System.Runtime.InteropServices;
+
+namespace Daqifi.Core.Tests.TestSupport;
+
+/// <summary>
+/// The operating systems a test can be gated on. A flags enum so one gate can name more than
+/// one platform, and so "which platform am I on" and "which platforms does this test skip on"
+/// are the same type.
+/// </summary>
+[Flags]
+public enum TestPlatforms
+{
+    /// <summary>No platform. Also what <see cref="PlatformFactAttribute.Current"/> answers on an
+    /// operating system this enum does not name.</summary>
+    None = 0,
+
+    /// <summary>Windows.</summary>
+    Windows = 1,
+
+    /// <summary>Linux.</summary>
+    Linux = 2,
+
+    /// <summary>macOS.</summary>
+    MacOS = 4,
+}
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that reports the test as <em>skipped</em> on the platforms it
+/// names, rather than letting it run and assert nothing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Some tests exist to pin a provider's off-platform gate — the branch that has to answer without
+/// touching a registry, an <c>ioreg</c> process, or <c>/sys/class/tty</c>. Such a test is
+/// meaningful on two of the three CI legs and meaningless on the third. Handling the third with a
+/// bare <c>return</c> makes it report <em>passed</em> while asserting nothing, so the run's skip
+/// count says nothing about it (issue #663).
+/// </para>
+/// <para>
+/// xunit 2.9.3 has no dynamic skip: <c>Xunit.Sdk.SkipException</c> and the
+/// <c>$XunitDynamicSkip$</c> token are present in the assembly, but v2's execution engine does not
+/// honour them and turns the throw into a failure. What v2 does honour is
+/// <see cref="FactAttribute.Skip"/>, which is read off the attribute instance at discovery time —
+/// so the platform decision is made in this constructor instead. Discovery and execution happen in
+/// the same process on the same machine, so deciding at discovery is sound.
+/// </para>
+/// <para>
+/// The attribute skips; it never inverts. A test that should run <em>only</em> on one platform is
+/// written by naming the other two.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class PlatformFactAttribute : FactAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlatformFactAttribute"/> class.
+    /// </summary>
+    /// <param name="skipOn">The platforms on which the test is to be skipped.</param>
+    /// <param name="because">
+    /// Why the test cannot be observed there. Required, and surfaced as the skip reason, so a
+    /// reader of the test results learns why the test did not run.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="because"/> is null, empty, or white space.
+    /// </exception>
+    public PlatformFactAttribute(TestPlatforms skipOn, string because)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(because);
+
+        SkipOn = skipOn;
+
+        if (ShouldSkip(skipOn, Current))
+        {
+            Skip = because;
+        }
+    }
+
+    /// <summary>Gets the platforms on which this test is skipped.</summary>
+    public TestPlatforms SkipOn { get; }
+
+    /// <summary>
+    /// Gets the platform this test run is executing on, or <see cref="TestPlatforms.None"/> on an
+    /// operating system <see cref="TestPlatforms"/> does not name.
+    /// </summary>
+    public static TestPlatforms Current { get; } = DetectCurrent();
+
+    /// <summary>
+    /// Decides whether a gate naming <paramref name="skipOn"/> skips on <paramref name="current"/>.
+    /// </summary>
+    /// <remarks>
+    /// Split out from the constructor so the decision can be tested against every platform, not
+    /// just the one the suite happens to be running on.
+    /// </remarks>
+    internal static bool ShouldSkip(TestPlatforms skipOn, TestPlatforms current)
+        => current != TestPlatforms.None && (skipOn & current) != TestPlatforms.None;
+
+    private static TestPlatforms DetectCurrent()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return TestPlatforms.Windows;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return TestPlatforms.Linux;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return TestPlatforms.MacOS;
+        }
+
+        return TestPlatforms.None;
+    }
+}

--- a/src/Daqifi.Core.Tests/TestSupport/PlatformFactAttributeTests.cs
+++ b/src/Daqifi.Core.Tests/TestSupport/PlatformFactAttributeTests.cs
@@ -1,0 +1,173 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Daqifi.Core.Tests.TestSupport;
+
+/// <summary>
+/// Covers the platform gate that replaced the three bare <c>return</c>s in the USB descriptor
+/// provider tests (issue #663). The decision itself is pure — <see cref="PlatformFactAttribute.ShouldSkip"/>
+/// takes the current platform as an argument — so every arm of it is exercised on every CI leg,
+/// which is exactly the property the gate exists to give the tests it guards.
+/// </summary>
+public class PlatformFactAttributeTests
+{
+    #region The skip decision, on every platform rather than the running one
+
+    [Theory]
+    [InlineData(TestPlatforms.Windows, TestPlatforms.Windows)]
+    [InlineData(TestPlatforms.Linux, TestPlatforms.Linux)]
+    [InlineData(TestPlatforms.MacOS, TestPlatforms.MacOS)]
+    public void ShouldSkip_PlatformIsNamed_Skips(TestPlatforms skipOn, TestPlatforms current)
+    {
+        Assert.True(PlatformFactAttribute.ShouldSkip(skipOn, current));
+    }
+
+    [Theory]
+    [InlineData(TestPlatforms.Windows, TestPlatforms.Linux)]
+    [InlineData(TestPlatforms.Windows, TestPlatforms.MacOS)]
+    [InlineData(TestPlatforms.Linux, TestPlatforms.Windows)]
+    [InlineData(TestPlatforms.Linux, TestPlatforms.MacOS)]
+    [InlineData(TestPlatforms.MacOS, TestPlatforms.Windows)]
+    [InlineData(TestPlatforms.MacOS, TestPlatforms.Linux)]
+    public void ShouldSkip_PlatformIsNotNamed_Runs(TestPlatforms skipOn, TestPlatforms current)
+    {
+        Assert.False(PlatformFactAttribute.ShouldSkip(skipOn, current));
+    }
+
+    [Theory]
+    [InlineData(TestPlatforms.Windows)]
+    [InlineData(TestPlatforms.Linux)]
+    [InlineData(TestPlatforms.MacOS)]
+    public void ShouldSkip_SeveralPlatformsNamed_SkipsOnEachOfThem(TestPlatforms current)
+    {
+        var all = TestPlatforms.Windows | TestPlatforms.Linux | TestPlatforms.MacOS;
+
+        Assert.True(PlatformFactAttribute.ShouldSkip(all, current));
+    }
+
+    [Fact]
+    public void ShouldSkip_TwoOfThreeNamed_RunsOnTheThird()
+    {
+        var windowsAndMac = TestPlatforms.Windows | TestPlatforms.MacOS;
+
+        Assert.False(PlatformFactAttribute.ShouldSkip(windowsAndMac, TestPlatforms.Linux));
+        Assert.True(PlatformFactAttribute.ShouldSkip(windowsAndMac, TestPlatforms.Windows));
+        Assert.True(PlatformFactAttribute.ShouldSkip(windowsAndMac, TestPlatforms.MacOS));
+    }
+
+    [Fact]
+    public void ShouldSkip_NamesNoPlatform_NeverSkips()
+    {
+        Assert.False(PlatformFactAttribute.ShouldSkip(TestPlatforms.None, TestPlatforms.Windows));
+        Assert.False(PlatformFactAttribute.ShouldSkip(TestPlatforms.None, TestPlatforms.Linux));
+        Assert.False(PlatformFactAttribute.ShouldSkip(TestPlatforms.None, TestPlatforms.MacOS));
+    }
+
+    [Fact]
+    public void ShouldSkip_UnrecognizedCurrentPlatform_RunsRatherThanSkippingEverything()
+    {
+        // Current answers None on an OS TestPlatforms does not name (FreeBSD, say). Running the
+        // test there is the safer default: a gate test that runs somewhere unexpected fails loudly
+        // if the gate is wrong, whereas skipping would quietly cover it up.
+        var all = TestPlatforms.Windows | TestPlatforms.Linux | TestPlatforms.MacOS;
+
+        Assert.False(PlatformFactAttribute.ShouldSkip(all, TestPlatforms.None));
+    }
+
+    #endregion
+
+    #region What the attribute hands xunit
+
+    [Fact]
+    public void Skip_NamesTheRunningPlatform_IsSetToTheReason()
+    {
+        // Derived from Current rather than hard-coded, so this asserts something real on every leg.
+        var attribute = new PlatformFactAttribute(PlatformFactAttribute.Current, "because reasons");
+
+        Assert.Equal("because reasons", attribute.Skip);
+    }
+
+    [Fact]
+    public void Skip_DoesNotNameTheRunningPlatform_IsNullSoTheTestRuns()
+    {
+        var attribute = new PlatformFactAttribute(NotCurrent(), "because reasons");
+
+        Assert.Null(attribute.Skip);
+    }
+
+    [Fact]
+    public void SkipOn_IsTheSetItWasGiven()
+    {
+        var both = TestPlatforms.Windows | TestPlatforms.MacOS;
+
+        Assert.Equal(both, new PlatformFactAttribute(both, "because reasons").SkipOn);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_ReasonIsMissing_Throws(string? because)
+    {
+        // The reason becomes the skip message a reader of the results sees, so an empty one would
+        // leave them with a skipped test and no explanation.
+        // ThrowsAny: the null case surfaces as ArgumentNullException, a subclass.
+        Assert.ThrowsAny<ArgumentException>(
+            () => new PlatformFactAttribute(TestPlatforms.Windows, because!));
+    }
+
+    [Fact]
+    public void Current_AgreesWithRuntimeInformation()
+    {
+        var expected =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? TestPlatforms.Windows
+            : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? TestPlatforms.Linux
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? TestPlatforms.MacOS
+            : TestPlatforms.None;
+
+        Assert.Equal(expected, PlatformFactAttribute.Current);
+    }
+
+    #endregion
+
+    #region The three gates it was introduced for
+
+    [Theory]
+    [InlineData(
+        typeof(Daqifi.Core.Tests.Device.Discovery.WindowsUsbPortDescriptorProviderTests),
+        "GetDescriptor_OffWindows_ReturnsNullWithoutTouchingTheMap",
+        TestPlatforms.Windows)]
+    [InlineData(
+        typeof(Daqifi.Core.Tests.Device.Discovery.MacOsUsbPortDescriptorProviderTests),
+        "GetDescriptor_OffMacOS_AnswersNullForEveryPort",
+        TestPlatforms.MacOS)]
+    [InlineData(
+        typeof(Daqifi.Core.Tests.Device.Discovery.LinuxUsbPortDescriptorProviderTests),
+        "GetDescriptor_OffLinux_AnswersNullForEveryPort",
+        TestPlatforms.Linux)]
+    public void OffPlatformGateTests_CarryThePlatformFact_SoTheyCannotSilentlyReturnAgain(
+        Type testClass,
+        string testMethod,
+        TestPlatforms expectedSkipOn)
+    {
+        // Pins the fix: each of these three used to be a [Fact] whose body opened with
+        // "if (on my own platform) return;", reporting passed while asserting nothing.
+        var method = testClass.GetMethod(testMethod, BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var gate = method.GetCustomAttribute<PlatformFactAttribute>();
+        Assert.NotNull(gate);
+        Assert.Equal(expectedSkipOn, gate.SkipOn);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Returns a platform the run is definitely not on, so a test can assert the not-skipped arm
+    /// wherever it runs.
+    /// </summary>
+    private static TestPlatforms NotCurrent()
+        => PlatformFactAttribute.Current == TestPlatforms.Windows
+            ? TestPlatforms.Linux
+            : TestPlatforms.Windows;
+}


### PR DESCRIPTION
## What was wrong

Three tests in the USB port-descriptor suite exist to pin a provider's *off-platform* gate — the branch that has to answer `null` without touching the Windows registry, macOS `ioreg`, or Linux `/sys/class/tty`. Each of them handled the one OS where it is inapplicable by opening with `if (I'm on that OS) return;`.

So on Windows the Windows gate test reported **passed** having asserted nothing at all — and the same on macOS and Linux for their own. Since #662 put the suite on all three OSes, exactly one leg per test was a silent no-op, and nothing in the results said so: the run's skip count stayed at 2 either way. Anyone reading a green run reasonably assumed three gates were checked when only two were.

## How it was fixed

A small `[PlatformFact(TestPlatforms.X, "because …")]` attribute, used in place of `[Fact]`, so the run actually says *skipped* with a reason instead of quietly passing.

The thing a reviewer will want to poke at is why this needed a custom attribute. xunit 2.9.3 has no dynamic skip — `Xunit.Sdk.SkipException` and the `$XunitDynamicSkip$` token are present in the assembly, but v2's execution engine does not honour them and turns the throw into a **failure**. That is exactly why this was attempted in #662 and backed out. What v2 *does* honour is `FactAttribute.Skip`, which it reads off the attribute instance at discovery time, so `PlatformFact` makes the platform decision in its constructor. Discovery and execution happen in the same process on the same machine, so deciding at discovery is sound.

This is option 3 of the three the issue laid out, chosen over migrating to xunit.v3 (much larger, and orthogonal to this) and over adding the `SkippableFact` package (a new dependency for ~40 lines of attribute).

The skip decision itself is a pure static that takes the current platform as an argument rather than reading it, so all nine platform combinations are exercised on *every* CI leg — which is the same property the gate is being introduced to give the tests it guards.

## Verification

- Full `dotnet test Daqifi.Core.sln -warnaserror` green: net9.0 **4039 passed / 3 skipped / 0 failed**, net10.0 **4039 passed / 3 skipped / 0 failed**, `Daqifi.Mcp.Tests` 217 passed.
- The skip count moving from 2 to 3 on this macOS run is the fix working: `GetDescriptor_OffMacOS_AnswersNullForEveryPort` now reports `[SKIP]` with its reason, where before it reported passed after asserting nothing. On the Windows and Linux CI legs the skipped one will be their own gate instead.
- No bench validation: the diff is confined to `src/Daqifi.Core.Tests`, and no production code is touched.

closes #663

Not merging — for review.