### PR TITLE
chore(build): drop the SourceLink pin the .NET SDK already bundles

### DIFF
--- a/src/Daqifi.Core.Tests/Build/DirectoryBuildPropsTests.cs
+++ b/src/Daqifi.Core.Tests/Build/DirectoryBuildPropsTests.cs
@@ -193,4 +193,123 @@ public class DirectoryBuildPropsTests
         Assert.Contains("Daqifi.Mcp.csproj", names);
         Assert.Contains("Daqifi.Mcp.Tests.csproj", names);
     }
+
+    /// <summary>
+    /// The package ids referenced by a project, covering both the <c>Include</c> form and the
+    /// <c>Update</c> form (which sets metadata on a reference the SDK supplies implicitly).
+    /// </summary>
+    private static IEnumerable<string> PackageReferenceIdsIn(string project) =>
+        XDocument.Load(project)
+            .Descendants("PackageReference")
+            .Select(e => (string?)e.Attribute("Include") ?? (string?)e.Attribute("Update"))
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!);
+
+    /// <summary>
+    /// Every target framework moniker declared anywhere under <c>src</c>, paired with the project
+    /// that declares it. <c>TargetFrameworks</c> is semicolon-separated, so it contributes one
+    /// entry per moniker.
+    /// </summary>
+    private static IReadOnlyList<(string Project, string Moniker)> TargetFrameworkMonikers()
+    {
+        var monikers = new List<(string, string)>();
+
+        foreach (var project in ProjectFiles())
+        {
+            var declared = XDocument.Load(project)
+                .Descendants("PropertyGroup")
+                .Elements()
+                .Where(e => e.Name.LocalName is "TargetFramework" or "TargetFrameworks")
+                .SelectMany(e => e.Value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+            foreach (var moniker in declared)
+            {
+                monikers.Add((Path.GetRelativePath(RepositoryRoot, project), moniker));
+            }
+        }
+
+        return monikers;
+    }
+
+    /// <summary>
+    /// The .NET version a moniker names, or <see langword="null"/> if it does not name one at all.
+    /// <c>net9.0-windows</c> is 9.0; <c>netstandard2.0</c> and <c>net472</c> are neither .NET Core
+    /// nor .NET 5+, so they come back null and are treated as "older than 8" by the callers.
+    /// </summary>
+    private static Version? NetVersionOf(string moniker)
+    {
+        var withoutPlatform = moniker.Split('-')[0];
+
+        if (!withoutPlatform.StartsWith("net", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        // Version.TryParse needs at least major.minor, so "472" (net472) and "standard2.0"
+        // (netstandard2.0) both fail here rather than being mistaken for a .NET 5+ moniker.
+        return Version.TryParse(withoutPlatform[3..], out var version) ? version : null;
+    }
+
+    [Fact]
+    public void NoProjectPinsTheSourceLinkPackageTheSdkAlreadyBundles()
+    {
+        // Issue #661: the .NET SDK has bundled SourceLink since .NET 8, so on the monikers this
+        // repo targets an explicit Microsoft.SourceLink.* PackageReference does nothing the SDK
+        // is not already doing. Daqifi.Mcp has never carried one and still emits a full
+        // sourcelink.json, which is what showed the pin on Daqifi.Core to be redundant. The cost
+        // of leaving one in is a version to keep bumping plus the false implication that
+        // SourceLink would stop working without it.
+        var offenders = ProjectFiles()
+            .SelectMany(project => PackageReferenceIdsIn(project)
+                .Where(id => id.StartsWith("Microsoft.SourceLink.", StringComparison.OrdinalIgnoreCase))
+                .Select(id => $"{Path.GetRelativePath(RepositoryRoot, project)} references {id}"))
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "The .NET SDK bundles SourceLink for every target framework in this repo, so these " +
+            "references are redundant pins: " + string.Join("; ", offenders));
+    }
+
+    [Fact]
+    public void EveryTargetFrameworkIsNet8OrLater_WhichIsWhatMakesThatPinRedundant()
+    {
+        // The precondition the check above rests on, asserted rather than assumed. SourceLink is
+        // only bundled from .NET 8 on, so a project that started targeting netstandard2.0 or
+        // net472 would need the PackageReference back - and without this test that project would
+        // silently ship without SourceLink while the guard above still passed.
+        var offenders = TargetFrameworkMonikers()
+            .Where(t => NetVersionOf(t.Moniker) is not { Major: >= 8 })
+            .Select(t => $"{t.Project} targets {t.Moniker}")
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "A target framework older than net8.0 does not get SourceLink from the SDK, so " +
+            "NoProjectPinsTheSourceLinkPackageTheSdkAlreadyBundles no longer holds for: " +
+            string.Join("; ", offenders));
+    }
+
+    [Fact]
+    public void TheTargetFrameworkSweepSeesTheMonikersTheRepoActuallyTargets()
+    {
+        // Guards the check above against going vacuous: if the sweep stopped finding monikers it
+        // would pass by looking at nothing rather than by the monikers being current.
+        var monikers = TargetFrameworkMonikers()
+            .Select(t => t.Moniker)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Contains("net9.0", monikers);
+        Assert.Contains("net10.0", monikers);
+    }
+
+    [Fact]
+    public void ThePackageReferenceSweepSeesTheReferencesTheProjectsActuallyDeclare()
+    {
+        // The same anti-vacuous guard for the PackageReference sweep.
+        var ids = ProjectFiles()
+            .SelectMany(PackageReferenceIdsIn)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Contains("Google.Protobuf", ids);
+        Assert.Contains("HidSharp", ids);
+    }
 }

--- a/src/Daqifi.Core.Tests/Build/DirectoryBuildPropsTests.cs
+++ b/src/Daqifi.Core.Tests/Build/DirectoryBuildPropsTests.cs
@@ -195,40 +195,77 @@ public class DirectoryBuildPropsTests
     }
 
     /// <summary>
-    /// The package ids referenced by a project, covering both the <c>Include</c> form and the
-    /// <c>Update</c> form (which sets metadata on a reference the SDK supplies implicitly).
+    /// Every build file that can put a <c>PackageReference</c> or a target framework into a
+    /// project here: the projects themselves, plus the two repo-root files MSBuild imports into
+    /// all of them.
     /// </summary>
-    private static IEnumerable<string> PackageReferenceIdsIn(string project) =>
-        XDocument.Load(project)
-            .Descendants("PackageReference")
-            .Select(e => (string?)e.Attribute("Include") ?? (string?)e.Attribute("Update"))
+    /// <remarks>
+    /// The imported files matter to the sweeps below even though neither declares a
+    /// <c>PackageReference</c> today. An item added to <c>Directory.Build.props</c> or
+    /// <c>Directory.Build.targets</c> reaches every evaluated project without appearing in any
+    /// <c>.csproj</c>, so a sweep that read only the projects would report clean while every
+    /// package in the repo carried the reference.
+    /// </remarks>
+    private static IReadOnlyList<string> BuildFilesThatCanDeclareThem()
+    {
+        var files = new List<string> { DirectoryBuildPropsPath, DirectoryBuildTargetsPath };
+        files.AddRange(ProjectFiles());
+        return files;
+    }
+
+    /// <summary>
+    /// Whether an MSBuild element or attribute name matches <paramref name="expected"/>. MSBuild
+    /// names are case-insensitive but <see cref="XDocument"/> lookups are not, so every raw-XML
+    /// comparison in this class has to say so explicitly.
+    /// </summary>
+    private static bool IsMsBuildName(string actual, string expected) =>
+        actual.Equals(expected, StringComparison.OrdinalIgnoreCase);
+
+    private static string? MsBuildAttribute(XElement element, string name) =>
+        element.Attributes().FirstOrDefault(a => IsMsBuildName(a.Name.LocalName, name))?.Value;
+
+    /// <summary>
+    /// The package ids a build file references, covering both the <c>Include</c> form and the
+    /// <c>Update</c> form (which sets metadata on a reference supplied from elsewhere).
+    /// </summary>
+    private static IEnumerable<string> PackageReferenceIdsIn(XDocument document) =>
+        document.Descendants()
+            .Where(e => IsMsBuildName(e.Name.LocalName, "PackageReference"))
+            .Select(e => MsBuildAttribute(e, "Include") ?? MsBuildAttribute(e, "Update"))
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .Select(id => id!);
 
     /// <summary>
-    /// Every target framework moniker declared anywhere under <c>src</c>, paired with the project
-    /// that declares it. <c>TargetFrameworks</c> is semicolon-separated, so it contributes one
-    /// entry per moniker.
+    /// The target framework monikers a build file declares. <c>TargetFrameworks</c> is
+    /// semicolon-separated, so it contributes one entry per moniker.
     /// </summary>
-    private static IReadOnlyList<(string Project, string Moniker)> TargetFrameworkMonikers()
+    private static IEnumerable<string> TargetFrameworkMonikersIn(XDocument document) =>
+        document.Descendants("PropertyGroup")
+            .Elements()
+            .Where(e => IsMsBuildName(e.Name.LocalName, "TargetFramework")
+                        || IsMsBuildName(e.Name.LocalName, "TargetFrameworks"))
+            .SelectMany(e => e.Value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+    /// <summary>
+    /// Applies <paramref name="reader"/> to every build file, tagging each result with the file
+    /// it came from so a failure message can name the offender.
+    /// </summary>
+    private static IReadOnlyList<(string File, string Value)> SweepBuildFiles(
+        Func<XDocument, IEnumerable<string>> reader)
     {
-        var monikers = new List<(string, string)>();
+        var found = new List<(string, string)>();
 
-        foreach (var project in ProjectFiles())
+        foreach (var file in BuildFilesThatCanDeclareThem())
         {
-            var declared = XDocument.Load(project)
-                .Descendants("PropertyGroup")
-                .Elements()
-                .Where(e => e.Name.LocalName is "TargetFramework" or "TargetFrameworks")
-                .SelectMany(e => e.Value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+            var relativePath = Path.GetRelativePath(RepositoryRoot, file);
 
-            foreach (var moniker in declared)
+            foreach (var value in reader(XDocument.Load(file)))
             {
-                monikers.Add((Path.GetRelativePath(RepositoryRoot, project), moniker));
+                found.Add((relativePath, value));
             }
         }
 
-        return monikers;
+        return found;
     }
 
     /// <summary>
@@ -251,7 +288,7 @@ public class DirectoryBuildPropsTests
     }
 
     [Fact]
-    public void NoProjectPinsTheSourceLinkPackageTheSdkAlreadyBundles()
+    public void NoBuildFilePinsTheSourceLinkPackageTheSdkAlreadyBundles()
     {
         // Issue #661: the .NET SDK has bundled SourceLink since .NET 8, so on the monikers this
         // repo targets an explicit Microsoft.SourceLink.* PackageReference does nothing the SDK
@@ -259,10 +296,9 @@ public class DirectoryBuildPropsTests
         // sourcelink.json, which is what showed the pin on Daqifi.Core to be redundant. The cost
         // of leaving one in is a version to keep bumping plus the false implication that
         // SourceLink would stop working without it.
-        var offenders = ProjectFiles()
-            .SelectMany(project => PackageReferenceIdsIn(project)
-                .Where(id => id.StartsWith("Microsoft.SourceLink.", StringComparison.OrdinalIgnoreCase))
-                .Select(id => $"{Path.GetRelativePath(RepositoryRoot, project)} references {id}"))
+        var offenders = SweepBuildFiles(PackageReferenceIdsIn)
+            .Where(found => found.Value.StartsWith("Microsoft.SourceLink.", StringComparison.OrdinalIgnoreCase))
+            .Select(found => $"{found.File} references {found.Value}")
             .ToList();
 
         Assert.True(offenders.Count == 0,
@@ -277,24 +313,38 @@ public class DirectoryBuildPropsTests
         // only bundled from .NET 8 on, so a project that started targeting netstandard2.0 or
         // net472 would need the PackageReference back - and without this test that project would
         // silently ship without SourceLink while the guard above still passed.
-        var offenders = TargetFrameworkMonikers()
-            .Where(t => NetVersionOf(t.Moniker) is not { Major: >= 8 })
-            .Select(t => $"{t.Project} targets {t.Moniker}")
+        var offenders = SweepBuildFiles(TargetFrameworkMonikersIn)
+            .Where(found => NetVersionOf(found.Value) is not { Major: >= 8 })
+            .Select(found => $"{found.File} targets {found.Value}")
             .ToList();
 
         Assert.True(offenders.Count == 0,
             "A target framework older than net8.0 does not get SourceLink from the SDK, so " +
-            "NoProjectPinsTheSourceLinkPackageTheSdkAlreadyBundles no longer holds for: " +
+            "NoBuildFilePinsTheSourceLinkPackageTheSdkAlreadyBundles no longer holds for: " +
             string.Join("; ", offenders));
+    }
+
+    [Fact]
+    public void TheSweepCoversTheImportedBuildFilesAndEveryProject()
+    {
+        // Guards both checks above against a scope gap rather than a value gap: if the file list
+        // silently stopped including the imported build files, a PackageReference added to one of
+        // them would reach every project while the no-pin test still reported clean.
+        var swept = BuildFilesThatCanDeclareThem().Select(Path.GetFileName).ToList();
+
+        Assert.Contains("Directory.Build.props", swept);
+        Assert.Contains("Directory.Build.targets", swept);
+        Assert.Contains("Daqifi.Core.csproj", swept);
+        Assert.Contains("Daqifi.Mcp.csproj", swept);
     }
 
     [Fact]
     public void TheTargetFrameworkSweepSeesTheMonikersTheRepoActuallyTargets()
     {
-        // Guards the check above against going vacuous: if the sweep stopped finding monikers it
-        // would pass by looking at nothing rather than by the monikers being current.
-        var monikers = TargetFrameworkMonikers()
-            .Select(t => t.Moniker)
+        // Guards the framework check against going vacuous: if the sweep stopped finding monikers
+        // it would pass by looking at nothing rather than by the monikers being current.
+        var monikers = SweepBuildFiles(TargetFrameworkMonikersIn)
+            .Select(found => found.Value)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         Assert.Contains("net9.0", monikers);
@@ -305,11 +355,37 @@ public class DirectoryBuildPropsTests
     public void ThePackageReferenceSweepSeesTheReferencesTheProjectsActuallyDeclare()
     {
         // The same anti-vacuous guard for the PackageReference sweep.
-        var ids = ProjectFiles()
-            .SelectMany(PackageReferenceIdsIn)
+        var ids = SweepBuildFiles(PackageReferenceIdsIn)
+            .Select(found => found.Value)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         Assert.Contains("Google.Protobuf", ids);
         Assert.Contains("HidSharp", ids);
+    }
+
+    [Fact]
+    public void TheRawXmlSweeps_MatchMsBuildNamesCaseInsensitively()
+    {
+        // MSBuild element, item and attribute names are case-insensitive, so <targetframework>
+        // declares the same property as <TargetFramework> and <packagereference include="..."/>
+        // declares the same item as <PackageReference Include="..."/>. XDocument lookups are not
+        // case-insensitive, so an exact-name match would skip those declarations and let a
+        // pre-net8.0 target or a re-added SourceLink pin walk straight past the guards. Same
+        // reasoning as CentralizedPropertyNames_AreMatchedCaseInsensitively above, which is why
+        // the property sweep there already uses OrdinalIgnoreCase.
+        var document = XDocument.Parse(
+            """
+            <Project>
+              <PropertyGroup>
+                <targetframework>netstandard2.0</targetframework>
+              </PropertyGroup>
+              <ItemGroup>
+                <packagereference include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        Assert.Equal(new[] { "netstandard2.0" }, TargetFrameworkMonikersIn(document).ToArray());
+        Assert.Equal(new[] { "Microsoft.SourceLink.GitHub" }, PackageReferenceIdsIn(document).ToArray());
     }
 }

--- a/src/Daqifi.Core/Daqifi.Core.csproj
+++ b/src/Daqifi.Core/Daqifi.Core.csproj
@@ -26,7 +26,6 @@
          IOKit DllImports compile on every target and only execute on macOS. -->
     <PackageReference Include="HidSharp" Version="2.6.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
     <PackageReference Include="System.IO.Ports" Version="10.0.11" />
     <InternalsVisibleTo Include="Daqifi.Core.Tests" />
   </ItemGroup>


### PR DESCRIPTION
**What was wrong.** Nothing visibly broke — this is a cleanup, and it changes nothing about what ships. `Daqifi.Core.csproj` pinned `Microsoft.SourceLink.GitHub`, but the .NET SDK has bundled SourceLink in-box since .NET 8 and this library targets net9.0/net10.0, so the reference was doing nothing the SDK wasn't already doing on its own. The tell was `Daqifi.Mcp`: it has never had the reference and still gets full SourceLink. The cost of leaving a redundant pin in place is one more package version to keep bumping, plus the false implication that stepping into DAQiFi sources would stop working without it.

**How it was fixed.** Deleted the one `PackageReference` line, then checked the published output really is unchanged rather than assuming it. With the reference gone, both `obj/Release/net{9,10}.0/Daqifi.Core.sourcelink.json` files are byte-identical to before and still map to `raw.githubusercontent.com`; the packed `.nuspec` is identical; and the `.snupkg` PDBs still embed the same SourceLink URL on both frameworks. The only difference anywhere in the two packages is the `.psmdcp` filename, which is a fresh GUID NuGet writes on every pack — packing the same source twice produces two different names with identical contents, so it is not attributable to this change.

The one thing worth pushing back on is that a deletion leaves nothing to stop the pin coming back, so this also adds guards to the existing `Build/DirectoryBuildPropsTests.cs` class: no build file may reference `Microsoft.SourceLink.*`; every target framework must be net8.0 or later (the precondition that makes the removal correct in the first place — a future netstandard2.0 target would need the pin back); and the rest are scope and anti-vacuous checks so neither sweep can pass by looking at nothing or by looking in the wrong place.

Getting those guards right took a second pass. As first written they read only the `.csproj` files and matched MSBuild names case-sensitively, which meant a `<targetframework>netstandard2.0</targetframework>`, or a SourceLink reference added to `Directory.Build.props`, would have sailed through while the tests still reported clean — the exact failure mode the guards exist to prevent. Both sweeps now cover the imported root build files too and match names case-insensitively, the way this class already does for the centralized-property sweep. Every substantive guard is mutation-checked: re-adding the pin, adding a `netstandard2.0` target, lower-casing that moniker, and hiding the pin in `Directory.Build.props` each fail the appropriate test, and each passed before the fix.

---

**Verified:** full `dotnet test Daqifi.Core.sln -warnaserror` green locally on both frameworks — net9.0 4021 passed / 2 skipped / 0 failed, net10.0 4021 passed / 2 skipped / 0 failed, `Daqifi.Mcp.Tests` 217 passed (baseline 4015; +6 new guards). Bench-checked on the real board over USB even though no runtime code changed, since the change affects how the assembly is built: the example CLI built against this branch connected to `/dev/cu.usbmodem1101`, streamed two analog channels at 100 Hz for 4 s, and disconnected cleanly (exit 0).

closes #661

Not merging — for review.