### PR TITLE
chore(build): ship the daqifi-mcp tool for .NET 10 as well as .NET 9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,11 +12,15 @@
     packages lives in the repo-root Directory.Build.targets (issue #644), which
     is imported late enough to see $(IsPackable) and skip the test projects.
 
-    TargetFramework(s) is deliberately NOT centralized: the projects genuinely
-    differ (Daqifi.Core and Daqifi.Core.Tests multi-target net9.0;net10.0, while
-    Daqifi.Mcp and Daqifi.Mcp.Tests are net9.0 only), and a shared default here
-    would hide that difference rather than resolve it. See issue #643 for the
-    Daqifi.Mcp target-framework decision.
+    TargetFramework(s) is deliberately NOT centralized, even though all four
+    projects now multi-target net9.0;net10.0 (issue #643 resolved the Daqifi.Mcp
+    asymmetry in favour of matching Daqifi.Core). Which frameworks a project
+    builds for is a fact a reader expects to find in that project's .csproj, and
+    a default here would silently apply to any project added later - a benchmark
+    harness, a sample - whether or not that is right for it. The uniformity that
+    actually matters is guarded by a test instead: Daqifi.Mcp must ship an asset
+    for every framework Daqifi.Core supports, so the tool runs wherever the
+    library does. See Daqifi.Core.Tests/Build/TargetFrameworkTests.cs.
   -->
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Daqifi.Core.Tests/Build/TargetFrameworkTests.cs
+++ b/src/Daqifi.Core.Tests/Build/TargetFrameworkTests.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace Daqifi.Core.Tests.Build;
+
+/// <summary>
+/// Guards the target-framework decision from issue #643: the <c>Daqifi.Mcp</c> dotnet tool
+/// must ship an asset for every framework <c>Daqifi.Core</c> supports, and its test project
+/// must cover every framework the tool ships.
+/// </summary>
+/// <remarks>
+/// The asymmetry this prevents already shipped. <c>Daqifi.Mcp</c> targeted <c>net9.0</c> alone
+/// while <c>Daqifi.Core</c> multi-targeted <c>net9.0;net10.0</c>, so the published tool package
+/// carried a single <c>tools/net9.0/any</c> asset: a machine with only the .NET 10 runtime had
+/// to install .NET 9 as well before <c>dotnet tool install -g Daqifi.Mcp</c> would run, even
+/// though the library underneath already supported .NET 10. Nothing in the build noticed —
+/// each project's framework list is correct in isolation, and only the relationship between
+/// them is wrong, which is exactly what no compiler checks.
+///
+/// The frameworks stay declared per-project rather than centralized in
+/// <c>Directory.Build.props</c> (see the comment there), so this test is what keeps them in
+/// step. The repository root is captured at build time as an assembly-metadata attribute; see
+/// <c>Daqifi.Core.Tests.csproj</c>.
+/// </remarks>
+public class TargetFrameworkTests
+{
+    private static string RepositoryRoot =>
+        Path.GetFullPath(
+            typeof(TargetFrameworkTests).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(a => a.Key == "RepositoryRoot")
+                .Value!);
+
+    private static string ProjectPath(string project) =>
+        Path.Combine(RepositoryRoot, "src", project, $"{project}.csproj");
+
+    /// <summary>
+    /// The target frameworks a project declares, from either <c>&lt;TargetFramework&gt;</c> or
+    /// <c>&lt;TargetFrameworks&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// Element names are matched case-insensitively because MSBuild property names are:
+    /// <c>&lt;targetframeworks&gt;</c> sets the same property as <c>&lt;TargetFrameworks&gt;</c>,
+    /// and a project that used the lower-case spelling would otherwise read as declaring no
+    /// frameworks at all and pass every assertion below vacuously.
+    /// </remarks>
+    private static HashSet<string> TargetFrameworksOf(string project)
+    {
+        var properties = XDocument.Load(ProjectPath(project))
+            .Descendants("PropertyGroup")
+            .Elements()
+            .Where(e => e.Name.LocalName.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase)
+                     || e.Name.LocalName.Equals("TargetFrameworks", StringComparison.OrdinalIgnoreCase));
+
+        return properties
+            .SelectMany(e => e.Value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string Describe(IEnumerable<string> frameworks) =>
+        string.Join(";", frameworks.OrderBy(f => f, StringComparer.Ordinal));
+
+    [Fact]
+    public void DaqifiCore_DeclaresItsTargetFrameworks()
+    {
+        // Anti-vacuity: every comparison below is against this set, so a parse that silently
+        // returned nothing would make the whole class pass by finding nothing.
+        var core = TargetFrameworksOf("Daqifi.Core");
+
+        Assert.NotEmpty(core);
+        Assert.Contains("net9.0", core);
+    }
+
+    [Fact]
+    public void DaqifiMcp_ShipsAnAssetForEveryFrameworkTheLibrarySupports()
+    {
+        // The point of #643. A `dotnet tool` package carries one self-contained asset folder
+        // per target framework and the shim picks the highest the machine can run, so a
+        // framework missing here is a machine that cannot run the tool without installing an
+        // older runtime.
+        var core = TargetFrameworksOf("Daqifi.Core");
+        var mcp = TargetFrameworksOf("Daqifi.Mcp");
+
+        var missing = core.Except(mcp, StringComparer.OrdinalIgnoreCase).ToList();
+
+        Assert.True(missing.Count == 0,
+            $"Daqifi.Core targets {Describe(core)} but the Daqifi.Mcp tool ships only " +
+            $"{Describe(mcp)}. A user whose machine has only {Describe(missing)} would have to " +
+            "install an older runtime to run `daqifi-mcp` (issue #643).");
+    }
+
+    [Fact]
+    public void DaqifiMcpTests_CoverEveryFrameworkTheToolShips()
+    {
+        // Otherwise the tool would publish an asset for a framework nothing ever ran.
+        var mcp = TargetFrameworksOf("Daqifi.Mcp");
+        var tests = TargetFrameworksOf("Daqifi.Mcp.Tests");
+
+        var untested = mcp.Except(tests, StringComparer.OrdinalIgnoreCase).ToList();
+
+        Assert.True(untested.Count == 0,
+            $"Daqifi.Mcp ships assets for {Describe(mcp)} but Daqifi.Mcp.Tests runs on " +
+            $"{Describe(tests)}, leaving {Describe(untested)} shipped untested.");
+    }
+
+    [Fact]
+    public void DaqifiCoreTests_CoverEveryFrameworkTheLibrarySupports()
+    {
+        var core = TargetFrameworksOf("Daqifi.Core");
+        var tests = TargetFrameworksOf("Daqifi.Core.Tests");
+
+        var untested = core.Except(tests, StringComparer.OrdinalIgnoreCase).ToList();
+
+        Assert.True(untested.Count == 0,
+            $"Daqifi.Core targets {Describe(core)} but Daqifi.Core.Tests runs on " +
+            $"{Describe(tests)}, leaving {Describe(untested)} shipped untested.");
+    }
+
+    [Fact]
+    public void TargetFrameworkElements_AreMatchedCaseInsensitively()
+    {
+        // Pins the behaviour the parser above depends on, so a future rewrite that switches to
+        // an ordinal element-name match fails here rather than by quietly reading every
+        // project as targeting nothing.
+        var document = XDocument.Parse(
+            "<Project><PropertyGroup><targetframeworks>net9.0;net10.0</targetframeworks></PropertyGroup></Project>");
+
+        var matched = document.Descendants("PropertyGroup")
+            .Elements()
+            .Where(e => e.Name.LocalName.Equals("TargetFrameworks", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(e => e.Value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal("net10.0;net9.0", Describe(matched));
+    }
+}

--- a/src/Daqifi.Core.Tests/Build/TargetFrameworkTests.cs
+++ b/src/Daqifi.Core.Tests/Build/TargetFrameworkTests.cs
@@ -44,9 +44,16 @@ public class TargetFrameworkTests
     /// and a project that used the lower-case spelling would otherwise read as declaring no
     /// frameworks at all and pass every assertion below vacuously.
     /// </remarks>
-    private static HashSet<string> TargetFrameworksOf(string project)
+    private static HashSet<string> TargetFrameworksOf(string project) =>
+        TargetFrameworksIn(XDocument.Load(ProjectPath(project)));
+
+    /// <summary>
+    /// The parsing half of <see cref="TargetFrameworksOf"/>, split out so a test can feed it an
+    /// in-memory project rather than reimplementing the query against one.
+    /// </summary>
+    private static HashSet<string> TargetFrameworksIn(XDocument project)
     {
-        var properties = XDocument.Load(ProjectPath(project))
+        var properties = project
             .Descendants("PropertyGroup")
             .Elements()
             .Where(e => e.Name.LocalName.Equals("TargetFramework", StringComparison.OrdinalIgnoreCase)
@@ -116,21 +123,18 @@ public class TargetFrameworkTests
             $"{Describe(tests)}, leaving {Describe(untested)} shipped untested.");
     }
 
-    [Fact]
-    public void TargetFrameworkElements_AreMatchedCaseInsensitively()
+    [Theory]
+    [InlineData("<Project><PropertyGroup><targetframeworks>net9.0;net10.0</targetframeworks></PropertyGroup></Project>")]
+    [InlineData("<Project><PropertyGroup><TARGETFRAMEWORKS>net9.0;net10.0</TARGETFRAMEWORKS></PropertyGroup></Project>")]
+    [InlineData("<Project><PropertyGroup><targetframework>net9.0</targetframework><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>")]
+    public void TargetFrameworkElements_AreMatchedCaseInsensitively(string project)
     {
-        // Pins the behaviour the parser above depends on, so a future rewrite that switches to
-        // an ordinal element-name match fails here rather than by quietly reading every
-        // project as targeting nothing.
-        var document = XDocument.Parse(
-            "<Project><PropertyGroup><targetframeworks>net9.0;net10.0</targetframeworks></PropertyGroup></Project>");
+        // Runs the real parser - not a copy of its query - over an in-memory project, so
+        // switching TargetFrameworksIn to an ordinal element-name match fails here rather than
+        // quietly making every lower-cased project read as targeting nothing, which would let
+        // the relationship checks above pass vacuously.
+        var frameworks = TargetFrameworksIn(XDocument.Parse(project));
 
-        var matched = document.Descendants("PropertyGroup")
-            .Elements()
-            .Where(e => e.Name.LocalName.Equals("TargetFrameworks", StringComparison.OrdinalIgnoreCase))
-            .SelectMany(e => e.Value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        Assert.Equal("net10.0;net9.0", Describe(matched));
+        Assert.Equal("net10.0;net9.0", Describe(frameworks));
     }
 }

--- a/src/Daqifi.Mcp.Tests/Daqifi.Mcp.Tests.csproj
+++ b/src/Daqifi.Mcp.Tests/Daqifi.Mcp.Tests.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Matches Daqifi.Mcp's single target framework; see issue #643. -->
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Matches Daqifi.Mcp's target frameworks, so the MCP server is tested on
+         every framework it ships an asset for; see issue #643. -->
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Daqifi.Mcp/Daqifi.Mcp.csproj
+++ b/src/Daqifi.Mcp/Daqifi.Mcp.csproj
@@ -2,9 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- Single-target while Daqifi.Core multi-targets net9.0;net10.0. Tracked as
-         an explicit decision in issue #643, not left implicit here. -->
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Multi-targeted to match Daqifi.Core (issue #643). This is a dotnet tool:
+         the package carries one self-contained asset folder per target framework,
+         and `dotnet tool install` picks the highest one the machine can run. With
+         net9.0 alone, a machine that has only the .NET 10 runtime had to install
+         .NET 9 as well just to run `daqifi-mcp`. -->
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Daqifi.Mcp</RootNamespace>
     <AssemblyName>daqifi-mcp</AssemblyName>
     <InvariantGlobalization>true</InvariantGlobalization>


### PR DESCRIPTION
**What was wrong.** `Daqifi.Core` supports .NET 9 and .NET 10, but the `daqifi-mcp` MCP server was built for .NET 9 only. Because a dotnet tool package carries a separate self-contained folder per framework, the published package had exactly one — `tools/net9.0/any`. So anyone whose machine had only the .NET 10 runtime installed had to go and install .NET 9 as well before `dotnet tool install -g Daqifi.Mcp` would give them a working `daqifi-mcp`, even though the library it wraps had supported .NET 10 all along. The repo README already advertised ".NET 9.0 and 10.0"; for the MCP tool that wasn't true.

**How it was fixed.** `Daqifi.Mcp` (and `Daqifi.Mcp.Tests`, so nothing ships untested) now multi-target `net9.0;net10.0`, matching `Daqifi.Core`. The package gains a `tools/net10.0/any` folder and the tool shim resolves to it on a .NET 10 machine. Nothing else about the package changes — verified by packing before and after: the `net9.0` asset's file list and the `.nuspec` are identical, so existing installs are unaffected. The `net10.0` asset is smaller only because five libraries (`System.Text.Json`, `System.Diagnostics.DiagnosticSource`, `System.IO.Pipelines`, `System.Net.ServerSentEvents`, `System.Text.Encodings.Web`) are in-box on .NET 10 and no longer need to be copied in.

The one thing worth pushing back on is the choice *not* to centralize `TargetFrameworks` in `Directory.Build.props` now that all four projects agree. The reasoning, written into the comment there: which frameworks a project builds for is a fact a reader expects to find in that project's `.csproj`, and a shared default would silently apply to any project added later (a benchmark harness, a sample) whether or not that is right for it. What actually needed guarding was the *relationship* between the projects, so that is what the new test asserts — the tool must ship an asset for every framework the library supports, and each test project must cover every framework its project ships. That relationship is precisely what no compiler checks: each project's framework list was correct in isolation, and only the pairing was wrong.

**Verification.**
- Full `dotnet test Daqifi.Core.sln -warnaserror` green: net9.0 4022 passed / 2 skipped, net10.0 4022 passed / 2 skipped, and `Daqifi.Mcp.Tests` 217 passed on *both* frameworks now (it previously ran on net9.0 only).
- Every new guard mutation-checked: reverting `Daqifi.Mcp` to net9.0-only, reverting `Daqifi.Mcp.Tests`, and dropping net10.0 from `Daqifi.Core.Tests` each fail the matching test; making the parser's element-name comparison ordinal fails all three case-insensitivity cases.
- Packed the tool, installed it from the local package, and confirmed the shim resolves to `tools/net10.0/any/daqifi-mcp.dll` on this .NET 10 machine.
- Bench, against the real Nq1 (fw 3.7.2) over `/dev/cu.usbmodem1101`, driving the **installed .NET 10 tool** over MCP stdio — this exercises a genuinely different `System.IO.Ports` binary (`runtimes/unix/lib/net10.0`): discovered both the serial and WiFi device, connected, read status, enabled AI0/AI1 at 100 Hz, captured 2 s (157 rows / 314 samples, 0 dropped), disconnected cleanly, exit 0. Non-destructive throughout.

**Review round 1 (Qodo, accepted).** The case-insensitivity guard originally reimplemented the parser's XML query rather than calling it, so switching the real parser to an ordinal match would have left the guard green while every project silently read as targeting nothing — the exact regression it exists to catch. The parsing half is now split out as `TargetFrameworksIn(XDocument)` with the file load as a thin wrapper, and the guard is a `[Theory]` feeding three spellings through the real code path.

closes #643

Not merging — for review.