### PR TITLE
chore(api): check in the public API surface so a break is a reviewable diff

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,19 @@ root = true
 # applying to every [*.cs] in the repo.
 [src/Daqifi.Core/**.cs]
 dotnet_diagnostic.CA2007.severity = warning
+
+# RS0041 (public API should not use nullable-oblivious types) applies to the
+# hand-written surface only.
+#
+# Protos/DaqifiOutMessage.proto is compiled by protoc into a C# file with no
+# '#nullable enable', so every reference type on its generated public surface is
+# oblivious and RS0041 fires 166 times on code nobody hand-edits. The fix -
+# annotating the output - is not ours to make: protoc regenerates the file.
+#
+# The obliviousness is still recorded, not lost: those members appear in
+# PublicAPI.Shipped.txt with the analyzer's own '~' prefix, which is how an
+# oblivious signature is spelled there, so a change in their nullability still
+# shows up as an API diff. Scoped to the one generated file on purpose, so
+# RS0041 keeps guarding every public member Daqifi.Core actually writes.
+[src/Daqifi.Core/Communication/Messages/DaqifiOutMessage.cs]
+dotnet_diagnostic.RS0041.severity = none

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,35 @@ that block on their own async work. An `await` that resumes on the caller's
 thread. CA2007 is enabled for the library project (see the `[src/Daqifi.Core/**.cs]` section of the root `.editorconfig`)
 and warnings are errors, so a naked `await` fails the build. Test projects are exempt.
 
+### Changing the public API means updating `PublicAPI.*.txt`
+
+[ADR 0002](docs/adr/0002-binary-compatibility-policy.md) promises source compatibility for
+`Daqifi.Core`'s public API, so the surface is checked in as two files next to
+`src/Daqifi.Core/Daqifi.Core.csproj`:
+
+- `PublicAPI.Shipped.txt` - the surface as of the last published release.
+- `PublicAPI.Unshipped.txt` - everything added since. It doubles as the release-notes
+  checklist ADR 0002 asks for.
+
+Add, remove or change a public member and the build fails (RS0016/RS0017) until the files
+agree with the code again. Put the new entries in `PublicAPI.Unshipped.txt`; your IDE offers
+"Add to public API" as a code fix on the error, or run:
+
+```
+dotnet format analyzers src/Daqifi.Core/Daqifi.Core.csproj --diagnostics RS0016 --severity warn
+```
+
+The resulting diff is the point: a reviewer can see exactly what the change does to the API
+without reconstructing it from the code.
+
+When a release goes out, the `Unshipped` entries move into `Shipped` and `Unshipped` is emptied.
+
+Two things the tool will not do for you. The protoc-generated `DaqifiOutMessage.cs` is skipped
+by the code fix, so entries for it have to be added by hand from the RS0016 message (the symbol
+name in the message is already the exact line to add - those types sit in the global namespace).
+And a *removal* is never automatic: deleting the entry is the deliberate act of declaring a
+breaking change, and ADR 0002 says what that costs.
+
 ## Security: how we do and don't accept code
 
 **We only ever accept code changes as pull requests against this repository.** A PR gives

--- a/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
+++ b/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
@@ -1,0 +1,173 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Daqifi.Core.Device;
+
+namespace Daqifi.Core.Tests.Build;
+
+/// <summary>
+/// Guards the public API surface tracking added for issue #636: the
+/// <c>Microsoft.CodeAnalysis.PublicApiAnalyzers</c> wiring in <c>Daqifi.Core.csproj</c> and the
+/// two <c>PublicAPI.*.txt</c> files it reads.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The analyzer is the real guard - RS0016/RS0017 fail the build when the public surface and the
+/// API files disagree. What the analyzer cannot guard is its own wiring. Delete the two
+/// <c>AdditionalFiles</c> lines and the analyzer finds no API files, reports nothing, and the
+/// build stays green with the whole promise of ADR 0002 silently unenforced. That failure mode -
+/// a guard that stops guarding without anything going red - is what these tests exist for.
+/// </para>
+/// <para>
+/// The last two tests cross-check the files against the assembly by reflection rather than by
+/// reading the csproj, so they still fail if the analyzer is disabled some other way - a severity
+/// override, a NoWarn - and the files then go stale.
+/// </para>
+/// <para>
+/// Every test here was checked to fail on a <b>green</b> build. Two obvious candidates are
+/// deliberately absent for failing that check: an entry present in both API files is already
+/// RS0025, and dropping <c>PrivateAssets</c> from the analyzer reference already breaks the build
+/// because the analyzer then flows down the project reference into this test project. Asserting
+/// either would only restate a build error.
+/// </para>
+/// </remarks>
+public class PublicApiTrackingTests
+{
+    private static string RepositoryRoot =>
+        Path.GetFullPath(
+            typeof(PublicApiTrackingTests).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(a => a.Key == "RepositoryRoot")
+                .Value!);
+
+    private static string CoreProjectPath =>
+        Path.Combine(RepositoryRoot, "src", "Daqifi.Core", "Daqifi.Core.csproj");
+
+    private static string ApiFilePath(string fileName) =>
+        Path.Combine(RepositoryRoot, "src", "Daqifi.Core", fileName);
+
+    private const string ShippedFileName = "PublicAPI.Shipped.txt";
+    private const string UnshippedFileName = "PublicAPI.Unshipped.txt";
+
+    /// <summary>
+    /// The entries of one API file: every non-empty line that is not a directive such as
+    /// <c>#nullable enable</c>.
+    /// </summary>
+    private static IReadOnlyList<string> EntriesIn(string fileName) =>
+        File.ReadAllLines(ApiFilePath(fileName))
+            .Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith('#'))
+            .ToList();
+
+    [Fact]
+    public void CoreProject_ReferencesThePublicApiAnalyzer()
+    {
+        var reference = XDocument.Load(CoreProjectPath)
+            .Descendants("PackageReference")
+            .SingleOrDefault(e =>
+                string.Equals(
+                    (string?)e.Attribute("Include"),
+                    "Microsoft.CodeAnalysis.PublicApiAnalyzers",
+                    StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(reference != null,
+            "Daqifi.Core.csproj no longer references Microsoft.CodeAnalysis.PublicApiAnalyzers, "
+            + "so nothing enforces the source-compatibility promise in ADR 0002.");
+    }
+
+    [Theory]
+    [InlineData(ShippedFileName)]
+    [InlineData(UnshippedFileName)]
+    public void CoreProject_DeclaresTheApiFileAsAnAdditionalFile(string fileName)
+    {
+        // This is the silent failure mode: with no AdditionalFiles the analyzer has no API files
+        // to compare against, reports nothing at all, and the build stays green.
+        var additionalFiles = XDocument.Load(CoreProjectPath)
+            .Descendants("AdditionalFiles")
+            .Select(e => (string?)e.Attribute("Include"))
+            .ToList();
+
+        Assert.Contains(fileName, additionalFiles);
+    }
+
+    [Theory]
+    [InlineData(ShippedFileName)]
+    [InlineData(UnshippedFileName)]
+    public void ApiFile_ExistsAndEnablesNullability(string fileName)
+    {
+        var path = ApiFilePath(fileName);
+        Assert.True(File.Exists(path), $"Expected {fileName} next to Daqifi.Core.csproj.");
+
+        // Without the directive the analyzer strips nullability from every entry, so a public
+        // member changing from `string!` to `string?` would not show up as an API diff at all.
+        Assert.Equal("#nullable enable", File.ReadAllLines(path).First().Trim());
+    }
+
+    [Fact]
+    public void EveryPublicTypeInTheAssembly_IsDeclaredInAnApiFile()
+    {
+        // An independent check on the analyzer rather than a restatement of it: it reads the
+        // compiled assembly, not the csproj, so it still fails if the analyzer is switched off
+        // some other way (a NoWarn, a severity override) and the files then drift.
+        var declared = EntriesIn(ShippedFileName)
+            .Concat(EntriesIn(UnshippedFileName))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = typeof(DaqifiDevice).Assembly
+            .GetExportedTypes()
+            .Select(ApiNameOf)
+            .Where(name => !declared.Contains(name))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "These public types are not declared in either PublicAPI file:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, missing));
+    }
+
+    [Fact]
+    public void EveryPublicTypeInTheAssembly_IsFoundByTheNamingUsedAbove()
+    {
+        // Anti-vacuity guard for the test above: if ApiNameOf ever stopped producing the spelling
+        // the API files use, every type would silently "match nothing" - except the assertion is
+        // written as "nothing is missing", so the test would still pass while checking nothing.
+        // Reverse the question: at least the well-known types must be found, including the two
+        // shapes ApiNameOf handles specially.
+        var declared = EntriesIn(ShippedFileName)
+            .Concat(EntriesIn(UnshippedFileName))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Contains("Daqifi.Core.Device.DaqifiDevice", declared);
+        // Generic: mangled as `IMessageConsumer\`1` by reflection.
+        Assert.Contains("Daqifi.Core.Communication.Consumers.IMessageConsumer<T>", declared);
+        // Global namespace: the protoc-generated message type has no namespace at all.
+        Assert.Contains("DaqifiOutMessage", declared);
+    }
+
+    /// <summary>
+    /// The name a type is spelled with in a <c>PublicAPI.*.txt</c> file: namespace-qualified,
+    /// nested types joined with a dot rather than reflection's <c>+</c>, and generic type
+    /// definitions written with their type parameter names rather than reflection's arity tick.
+    /// </summary>
+    private static string ApiNameOf(Type type)
+    {
+        var name = type.Name;
+
+        if (type.IsGenericTypeDefinition)
+        {
+            var tick = name.IndexOf('`', StringComparison.Ordinal);
+            if (tick >= 0)
+            {
+                name = name[..tick];
+            }
+
+            name += "<" + string.Join(", ", type.GetGenericArguments().Select(a => a.Name)) + ">";
+        }
+
+        if (type.IsNested)
+        {
+            return ApiNameOf(type.DeclaringType!) + "." + name;
+        }
+
+        return string.IsNullOrEmpty(type.Namespace) ? name : type.Namespace + "." + name;
+    }
+}

--- a/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
+++ b/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
@@ -18,9 +18,14 @@ namespace Daqifi.Core.Tests.Build;
 /// a guard that stops guarding without anything going red - is what these tests exist for.
 /// </para>
 /// <para>
-/// The last two tests cross-check the files against the assembly by reflection rather than by
-/// reading the csproj, so they still fail if the analyzer is disabled some other way - a severity
-/// override, a NoWarn - and the files then go stale.
+/// The last two tests check the files against the assembly by reflection rather than by reading
+/// the csproj, so they still fail if the analyzer is disabled some other way - a severity
+/// override, a NoWarn. Their reach is deliberately shallow: <b>public type names only, and only
+/// in the direction "declared in the assembly but missing from the files"</b>. A changed
+/// signature, a changed nullability annotation, or a removed public member is invisible to them.
+/// Catching those is the analyzer's job, and reimplementing its entry format here would just be a
+/// second, worse copy of it. What these two do catch is the coarse failure - enforcement off and
+/// the files no longer tracking the assembly at all.
 /// </para>
 /// <para>
 /// Every test here was checked to fail on a <b>green</b> build. Two obvious candidates are
@@ -104,9 +109,14 @@ public class PublicApiTrackingTests
     [Fact]
     public void EveryPublicTypeInTheAssembly_IsDeclaredInAnApiFile()
     {
-        // An independent check on the analyzer rather than a restatement of it: it reads the
-        // compiled assembly, not the csproj, so it still fails if the analyzer is switched off
-        // some other way (a NoWarn, a severity override) and the files then drift.
+        // Reads the compiled assembly, not the csproj, so it still fails when the analyzer is
+        // switched off some other way (a NoWarn, a severity override) and a new public type then
+        // never reaches the files.
+        //
+        // Type names only, and only in this one direction. A removed type, a changed signature or
+        // a changed nullability annotation all leave this test green - the analyzer is what
+        // catches those, and spelling out entry formats here to catch them too would be a second
+        // copy of the analyzer that could disagree with the first.
         var declared = EntriesIn(ShippedFileName)
             .Concat(EntriesIn(UnshippedFileName))
             .ToHashSet(StringComparer.Ordinal);

--- a/src/Daqifi.Core/Daqifi.Core.csproj
+++ b/src/Daqifi.Core/Daqifi.Core.csproj
@@ -28,6 +28,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
     <PackageReference Include="System.IO.Ports" Version="10.0.11" />
+    <!-- Public API surface tracking (issue #636). ADR 0002 makes source
+         compatibility a promise; RS0016/RS0017 turn a change to the public
+         surface into a build error until PublicAPI.*.txt is updated in the same
+         PR, so the break is a reviewable diff rather than something a consumer
+         discovers on their next restore. PrivateAssets="all" keeps the analyzer
+         out of the published package's dependencies. See CONTRIBUTING.md. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" PrivateAssets="all" />
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
     <InternalsVisibleTo Include="Daqifi.Core.Tests" />
   </ItemGroup>
 

--- a/src/Daqifi.Core/PublicAPI.Shipped.txt
+++ b/src/Daqifi.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,2669 @@
+#nullable enable
+Daqifi.Core.Channel.AnalogChannel
+Daqifi.Core.Channel.AnalogChannel.ActiveSample.get -> Daqifi.Core.Channel.IDataSample?
+Daqifi.Core.Channel.AnalogChannel.AnalogChannel(int channelNumber, uint resolution = 65535, bool resolutionIsAssumed = false) -> void
+Daqifi.Core.Channel.AnalogChannel.CalibrationB.get -> double
+Daqifi.Core.Channel.AnalogChannel.CalibrationB.set -> void
+Daqifi.Core.Channel.AnalogChannel.CalibrationM.get -> double
+Daqifi.Core.Channel.AnalogChannel.CalibrationM.set -> void
+Daqifi.Core.Channel.AnalogChannel.ChannelNumber.get -> int
+Daqifi.Core.Channel.AnalogChannel.Direction.get -> Daqifi.Core.Channel.ChannelDirection
+Daqifi.Core.Channel.AnalogChannel.Direction.set -> void
+Daqifi.Core.Channel.AnalogChannel.GetScaledValue(int rawValue) -> double
+Daqifi.Core.Channel.AnalogChannel.InternalScaleM.get -> double
+Daqifi.Core.Channel.AnalogChannel.InternalScaleM.set -> void
+Daqifi.Core.Channel.AnalogChannel.IsBipolar.get -> bool
+Daqifi.Core.Channel.AnalogChannel.IsEnabled.get -> bool
+Daqifi.Core.Channel.AnalogChannel.IsEnabled.set -> void
+Daqifi.Core.Channel.AnalogChannel.MaxValue.get -> double
+Daqifi.Core.Channel.AnalogChannel.MaxValue.set -> void
+Daqifi.Core.Channel.AnalogChannel.MinValue.get -> double
+Daqifi.Core.Channel.AnalogChannel.MinValue.set -> void
+Daqifi.Core.Channel.AnalogChannel.Name.get -> string!
+Daqifi.Core.Channel.AnalogChannel.Name.set -> void
+Daqifi.Core.Channel.AnalogChannel.PortRange.get -> double
+Daqifi.Core.Channel.AnalogChannel.PortRange.set -> void
+Daqifi.Core.Channel.AnalogChannel.Resolution.get -> uint
+Daqifi.Core.Channel.AnalogChannel.ResolutionIsAssumed.get -> bool
+Daqifi.Core.Channel.AnalogChannel.SampleReceived -> System.EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs!>?
+Daqifi.Core.Channel.AnalogChannel.Scaling.get -> Daqifi.Core.Channel.ChannelScaling?
+Daqifi.Core.Channel.AnalogChannel.Scaling.set -> void
+Daqifi.Core.Channel.AnalogChannel.SetActiveSample(Daqifi.Core.Channel.IDataSample! sample) -> void
+Daqifi.Core.Channel.AnalogChannel.SetActiveSample(double value, System.DateTime timestamp) -> void
+Daqifi.Core.Channel.AnalogChannel.Type.get -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Channel.AnalogOutputChannel
+Daqifi.Core.Channel.AnalogOutputChannel.ActiveSample.get -> Daqifi.Core.Channel.IDataSample?
+Daqifi.Core.Channel.AnalogOutputChannel.AnalogOutputChannel(int channelNumber, int resolutionBits = 12, double minimumVoltage = 0, double maximumVoltage = 10, bool rangeIsAssumed = false) -> void
+Daqifi.Core.Channel.AnalogOutputChannel.ChannelNumber.get -> int
+Daqifi.Core.Channel.AnalogOutputChannel.Direction.get -> Daqifi.Core.Channel.ChannelDirection
+Daqifi.Core.Channel.AnalogOutputChannel.Direction.set -> void
+Daqifi.Core.Channel.AnalogOutputChannel.IsEnabled.get -> bool
+Daqifi.Core.Channel.AnalogOutputChannel.IsEnabled.set -> void
+Daqifi.Core.Channel.AnalogOutputChannel.IsInRange(double voltage) -> bool
+Daqifi.Core.Channel.AnalogOutputChannel.MaximumVoltage.get -> double
+Daqifi.Core.Channel.AnalogOutputChannel.MinimumVoltage.get -> double
+Daqifi.Core.Channel.AnalogOutputChannel.Name.get -> string!
+Daqifi.Core.Channel.AnalogOutputChannel.Name.set -> void
+Daqifi.Core.Channel.AnalogOutputChannel.OutputVoltage.get -> double?
+Daqifi.Core.Channel.AnalogOutputChannel.PendingVoltage.get -> double?
+Daqifi.Core.Channel.AnalogOutputChannel.RangeIsAssumed.get -> bool
+Daqifi.Core.Channel.AnalogOutputChannel.ResolutionBits.get -> int
+Daqifi.Core.Channel.AnalogOutputChannel.SampleReceived -> System.EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs!>?
+Daqifi.Core.Channel.AnalogOutputChannel.SetActiveSample(Daqifi.Core.Channel.IDataSample! sample) -> void
+Daqifi.Core.Channel.AnalogOutputChannel.SetActiveSample(double value, System.DateTime timestamp) -> void
+Daqifi.Core.Channel.AnalogOutputChannel.Type.get -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Channel.ChannelDirection
+Daqifi.Core.Channel.ChannelDirection.Input = 0 -> Daqifi.Core.Channel.ChannelDirection
+Daqifi.Core.Channel.ChannelDirection.Output = 1 -> Daqifi.Core.Channel.ChannelDirection
+Daqifi.Core.Channel.ChannelDirection.Unknown = 2 -> Daqifi.Core.Channel.ChannelDirection
+Daqifi.Core.Channel.ChannelScaling
+Daqifi.Core.Channel.ChannelScaling.<Clone>$() -> Daqifi.Core.Channel.ChannelScaling!
+Daqifi.Core.Channel.ChannelScaling.Apply(double value) -> double
+Daqifi.Core.Channel.ChannelScaling.ChannelScaling(double gain, double offset = 0, string? unit = null) -> void
+Daqifi.Core.Channel.ChannelScaling.Equals(Daqifi.Core.Channel.ChannelScaling? other) -> bool
+Daqifi.Core.Channel.ChannelScaling.Gain.get -> double
+Daqifi.Core.Channel.ChannelScaling.IsIdentity.get -> bool
+Daqifi.Core.Channel.ChannelScaling.Offset.get -> double
+Daqifi.Core.Channel.ChannelScaling.TryApply(double value, out double scaled) -> bool
+Daqifi.Core.Channel.ChannelScaling.Unit.get -> string?
+Daqifi.Core.Channel.ChannelScaling.WithUnit(string? unit) -> Daqifi.Core.Channel.ChannelScaling!
+Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Channel.ChannelType.Analog = 1 -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Channel.ChannelType.AnalogOutput = 2 -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Channel.ChannelType.Digital = 0 -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Channel.DataSample
+Daqifi.Core.Channel.DataSample.DataSample() -> void
+Daqifi.Core.Channel.DataSample.DataSample(System.DateTime timestamp, double value) -> void
+Daqifi.Core.Channel.DataSample.DataSample(System.DateTime timestamp, double value, int? rawValue, uint? deviceTimestamp) -> void
+Daqifi.Core.Channel.DataSample.DeviceTimestamp.get -> uint?
+Daqifi.Core.Channel.DataSample.DeviceTimestamp.init -> void
+Daqifi.Core.Channel.DataSample.RawValue.get -> int?
+Daqifi.Core.Channel.DataSample.RawValue.init -> void
+Daqifi.Core.Channel.DataSample.ScaledValue.get -> double
+Daqifi.Core.Channel.DataSample.Scaling.get -> Daqifi.Core.Channel.ChannelScaling?
+Daqifi.Core.Channel.DataSample.Scaling.init -> void
+Daqifi.Core.Channel.DataSample.Timestamp.get -> System.DateTime
+Daqifi.Core.Channel.DataSample.Timestamp.init -> void
+Daqifi.Core.Channel.DataSample.Unit.get -> string?
+Daqifi.Core.Channel.DataSample.Value.get -> double
+Daqifi.Core.Channel.DataSample.Value.set -> void
+Daqifi.Core.Channel.DigitalChannel
+Daqifi.Core.Channel.DigitalChannel.ActiveSample.get -> Daqifi.Core.Channel.IDataSample?
+Daqifi.Core.Channel.DigitalChannel.ChannelNumber.get -> int
+Daqifi.Core.Channel.DigitalChannel.DigitalChannel(int channelNumber, bool isPwmCapable = false) -> void
+Daqifi.Core.Channel.DigitalChannel.Direction.get -> Daqifi.Core.Channel.ChannelDirection
+Daqifi.Core.Channel.DigitalChannel.Direction.set -> void
+Daqifi.Core.Channel.DigitalChannel.IsEnabled.get -> bool
+Daqifi.Core.Channel.DigitalChannel.IsEnabled.set -> void
+Daqifi.Core.Channel.DigitalChannel.IsHigh.get -> bool
+Daqifi.Core.Channel.DigitalChannel.IsPwmCapable.get -> bool
+Daqifi.Core.Channel.DigitalChannel.IsPwmEnabled.get -> bool
+Daqifi.Core.Channel.DigitalChannel.IsPwmEnabled.set -> void
+Daqifi.Core.Channel.DigitalChannel.Name.get -> string!
+Daqifi.Core.Channel.DigitalChannel.Name.set -> void
+Daqifi.Core.Channel.DigitalChannel.OutputValue.get -> bool
+Daqifi.Core.Channel.DigitalChannel.OutputValue.set -> void
+Daqifi.Core.Channel.DigitalChannel.PwmDutyCyclePercent.get -> int
+Daqifi.Core.Channel.DigitalChannel.PwmDutyCyclePercent.set -> void
+Daqifi.Core.Channel.DigitalChannel.SampleReceived -> System.EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs!>?
+Daqifi.Core.Channel.DigitalChannel.SetActiveSample(Daqifi.Core.Channel.IDataSample! sample) -> void
+Daqifi.Core.Channel.DigitalChannel.SetActiveSample(double value, System.DateTime timestamp) -> void
+Daqifi.Core.Channel.DigitalChannel.Type.get -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Channel.IAnalogChannel
+Daqifi.Core.Channel.IAnalogChannel.CalibrationB.get -> double
+Daqifi.Core.Channel.IAnalogChannel.CalibrationB.set -> void
+Daqifi.Core.Channel.IAnalogChannel.CalibrationM.get -> double
+Daqifi.Core.Channel.IAnalogChannel.CalibrationM.set -> void
+Daqifi.Core.Channel.IAnalogChannel.GetScaledValue(int rawValue) -> double
+Daqifi.Core.Channel.IAnalogChannel.InternalScaleM.get -> double
+Daqifi.Core.Channel.IAnalogChannel.InternalScaleM.set -> void
+Daqifi.Core.Channel.IAnalogChannel.IsBipolar.get -> bool
+Daqifi.Core.Channel.IAnalogChannel.MaxValue.get -> double
+Daqifi.Core.Channel.IAnalogChannel.MaxValue.set -> void
+Daqifi.Core.Channel.IAnalogChannel.MinValue.get -> double
+Daqifi.Core.Channel.IAnalogChannel.MinValue.set -> void
+Daqifi.Core.Channel.IAnalogChannel.PortRange.get -> double
+Daqifi.Core.Channel.IAnalogChannel.PortRange.set -> void
+Daqifi.Core.Channel.IAnalogChannel.Resolution.get -> uint
+Daqifi.Core.Channel.IAnalogChannel.ResolutionIsAssumed.get -> bool
+Daqifi.Core.Channel.IAnalogOutputChannel
+Daqifi.Core.Channel.IAnalogOutputChannel.IsInRange(double voltage) -> bool
+Daqifi.Core.Channel.IAnalogOutputChannel.MaximumVoltage.get -> double
+Daqifi.Core.Channel.IAnalogOutputChannel.MinimumVoltage.get -> double
+Daqifi.Core.Channel.IAnalogOutputChannel.OutputVoltage.get -> double?
+Daqifi.Core.Channel.IAnalogOutputChannel.PendingVoltage.get -> double?
+Daqifi.Core.Channel.IAnalogOutputChannel.RangeIsAssumed.get -> bool
+Daqifi.Core.Channel.IAnalogOutputChannel.ResolutionBits.get -> int
+Daqifi.Core.Channel.IChannel
+Daqifi.Core.Channel.IChannel.ActiveSample.get -> Daqifi.Core.Channel.IDataSample?
+Daqifi.Core.Channel.IChannel.ChannelNumber.get -> int
+Daqifi.Core.Channel.IChannel.Direction.get -> Daqifi.Core.Channel.ChannelDirection
+Daqifi.Core.Channel.IChannel.Direction.set -> void
+Daqifi.Core.Channel.IChannel.IsEnabled.get -> bool
+Daqifi.Core.Channel.IChannel.IsEnabled.set -> void
+Daqifi.Core.Channel.IChannel.Name.get -> string!
+Daqifi.Core.Channel.IChannel.Name.set -> void
+Daqifi.Core.Channel.IChannel.SampleReceived -> System.EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs!>?
+Daqifi.Core.Channel.IChannel.SetActiveSample(Daqifi.Core.Channel.IDataSample! sample) -> void
+Daqifi.Core.Channel.IChannel.SetActiveSample(double value, System.DateTime timestamp) -> void
+Daqifi.Core.Channel.IChannel.Type.get -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Channel.IDataSample
+Daqifi.Core.Channel.IDataSample.DeviceTimestamp.get -> uint?
+Daqifi.Core.Channel.IDataSample.RawValue.get -> int?
+Daqifi.Core.Channel.IDataSample.ScaledValue.get -> double
+Daqifi.Core.Channel.IDataSample.Scaling.get -> Daqifi.Core.Channel.ChannelScaling?
+Daqifi.Core.Channel.IDataSample.Timestamp.get -> System.DateTime
+Daqifi.Core.Channel.IDataSample.Unit.get -> string?
+Daqifi.Core.Channel.IDataSample.Value.get -> double
+Daqifi.Core.Channel.IDataSample.Value.set -> void
+Daqifi.Core.Channel.IDigitalChannel
+Daqifi.Core.Channel.IDigitalChannel.IsHigh.get -> bool
+Daqifi.Core.Channel.IDigitalChannel.IsPwmCapable.get -> bool
+Daqifi.Core.Channel.IDigitalChannel.IsPwmEnabled.get -> bool
+Daqifi.Core.Channel.IDigitalChannel.IsPwmEnabled.set -> void
+Daqifi.Core.Channel.IDigitalChannel.OutputValue.get -> bool
+Daqifi.Core.Channel.IDigitalChannel.OutputValue.set -> void
+Daqifi.Core.Channel.IDigitalChannel.PwmDutyCyclePercent.get -> int
+Daqifi.Core.Channel.IDigitalChannel.PwmDutyCyclePercent.set -> void
+Daqifi.Core.Channel.IScaledChannel
+Daqifi.Core.Channel.IScaledChannel.Scaling.get -> Daqifi.Core.Channel.ChannelScaling?
+Daqifi.Core.Channel.IScaledChannel.Scaling.set -> void
+Daqifi.Core.Channel.IScaledChannel.Unit.get -> string?
+Daqifi.Core.Channel.LiveSample
+Daqifi.Core.Channel.LiveSample.<Clone>$() -> Daqifi.Core.Channel.LiveSample!
+Daqifi.Core.Channel.LiveSample.Channel.get -> Daqifi.Core.Channel.IChannel!
+Daqifi.Core.Channel.LiveSample.Channel.init -> void
+Daqifi.Core.Channel.LiveSample.Deconstruct(out Daqifi.Core.Channel.IChannel! Channel, out Daqifi.Core.Channel.IDataSample! Sample) -> void
+Daqifi.Core.Channel.LiveSample.Equals(Daqifi.Core.Channel.LiveSample? other) -> bool
+Daqifi.Core.Channel.LiveSample.LiveSample(Daqifi.Core.Channel.IChannel! Channel, Daqifi.Core.Channel.IDataSample! Sample) -> void
+Daqifi.Core.Channel.LiveSample.Sample.get -> Daqifi.Core.Channel.IDataSample!
+Daqifi.Core.Channel.LiveSample.Sample.init -> void
+Daqifi.Core.Channel.SampleReceivedEventArgs
+Daqifi.Core.Channel.SampleReceivedEventArgs.Channel.get -> Daqifi.Core.Channel.IChannel!
+Daqifi.Core.Channel.SampleReceivedEventArgs.Sample.get -> Daqifi.Core.Channel.IDataSample!
+Daqifi.Core.Channel.SampleReceivedEventArgs.SampleReceivedEventArgs(Daqifi.Core.Channel.IChannel! channel, Daqifi.Core.Channel.IDataSample! sample) -> void
+Daqifi.Core.Communication.Consumers.CompositeMessageParser
+Daqifi.Core.Communication.Consumers.CompositeMessageParser.CompositeMessageParser(Daqifi.Core.Communication.Consumers.IMessageParser<string!>? textParser = null, Daqifi.Core.Communication.Consumers.IMessageParser<DaqifiOutMessage!>? protobufParser = null) -> void
+Daqifi.Core.Communication.Consumers.CompositeMessageParser.ParseMessages(byte[]! data, out int consumedBytes) -> System.Collections.Generic.IEnumerable<Daqifi.Core.Communication.Messages.IInboundMessage<object!>!>!
+Daqifi.Core.Communication.Consumers.ConsumerThreadNotExitedException
+Daqifi.Core.Communication.Consumers.ConsumerThreadNotExitedException.ConsumerThreadNotExitedException() -> void
+Daqifi.Core.Communication.Consumers.ConsumerThreadNotExitedException.ConsumerThreadNotExitedException(string! message) -> void
+Daqifi.Core.Communication.Consumers.ConsumerThreadNotExitedException.ConsumerThreadNotExitedException(string! message, System.Exception! innerException) -> void
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>.ClearBuffer() -> void
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>.ErrorOccurred -> System.EventHandler<Daqifi.Core.Communication.Consumers.MessageConsumerErrorEventArgs!>?
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>.IsRunning.get -> bool
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>.MessageReceived -> System.EventHandler<Daqifi.Core.Communication.Consumers.MessageReceivedEventArgs<T>!>?
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>.QueuedMessageCount.get -> int
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>.Start() -> void
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>.Stop() -> void
+Daqifi.Core.Communication.Consumers.IMessageConsumer<T>.StopSafely(int timeoutMs = 1000) -> bool
+Daqifi.Core.Communication.Consumers.IMessageParser<T>
+Daqifi.Core.Communication.Consumers.IMessageParser<T>.ParseMessages(System.ReadOnlySpan<byte> data, out int consumedBytes) -> System.Collections.Generic.IEnumerable<Daqifi.Core.Communication.Messages.IInboundMessage<T>!>!
+Daqifi.Core.Communication.Consumers.IMessageParser<T>.ParseMessages(byte[]! data, out int consumedBytes) -> System.Collections.Generic.IEnumerable<Daqifi.Core.Communication.Messages.IInboundMessage<T>!>!
+Daqifi.Core.Communication.Consumers.LineBasedMessageParser
+Daqifi.Core.Communication.Consumers.LineBasedMessageParser.LineBasedMessageParser(string! lineEnding = "\r\n", System.Text.Encoding? encoding = null) -> void
+Daqifi.Core.Communication.Consumers.LineBasedMessageParser.ParseMessages(System.ReadOnlySpan<byte> data, out int consumedBytes) -> System.Collections.Generic.IEnumerable<Daqifi.Core.Communication.Messages.IInboundMessage<string!>!>!
+Daqifi.Core.Communication.Consumers.LineBasedMessageParser.ParseMessages(byte[]! data, out int consumedBytes) -> System.Collections.Generic.IEnumerable<Daqifi.Core.Communication.Messages.IInboundMessage<string!>!>!
+Daqifi.Core.Communication.Consumers.MessageConsumerErrorEventArgs
+Daqifi.Core.Communication.Consumers.MessageConsumerErrorEventArgs.Error.get -> System.Exception!
+Daqifi.Core.Communication.Consumers.MessageConsumerErrorEventArgs.MessageConsumerErrorEventArgs(System.Exception! error, byte[]? rawData = null) -> void
+Daqifi.Core.Communication.Consumers.MessageConsumerErrorEventArgs.RawData.get -> byte[]?
+Daqifi.Core.Communication.Consumers.MessageConsumerErrorEventArgs.Timestamp.get -> System.DateTime
+Daqifi.Core.Communication.Consumers.MessageReceivedEventArgs<T>
+Daqifi.Core.Communication.Consumers.MessageReceivedEventArgs<T>.Message.get -> Daqifi.Core.Communication.Messages.IInboundMessage<T>!
+Daqifi.Core.Communication.Consumers.MessageReceivedEventArgs<T>.MessageReceivedEventArgs(Daqifi.Core.Communication.Messages.IInboundMessage<T>! message, byte[]! rawData) -> void
+Daqifi.Core.Communication.Consumers.MessageReceivedEventArgs<T>.RawData.get -> byte[]!
+Daqifi.Core.Communication.Consumers.MessageReceivedEventArgs<T>.Timestamp.get -> System.DateTime
+Daqifi.Core.Communication.Consumers.ObjectInboundMessage
+Daqifi.Core.Communication.Consumers.ObjectInboundMessage.Data.get -> object!
+Daqifi.Core.Communication.Consumers.ObjectInboundMessage.ObjectInboundMessage(object! data) -> void
+Daqifi.Core.Communication.Consumers.ProtobufMessageParser
+Daqifi.Core.Communication.Consumers.ProtobufMessageParser.ParseMessages(System.ReadOnlySpan<byte> data, out int consumedBytes) -> System.Collections.Generic.IEnumerable<Daqifi.Core.Communication.Messages.IInboundMessage<DaqifiOutMessage!>!>!
+Daqifi.Core.Communication.Consumers.ProtobufMessageParser.ParseMessages(byte[]! data, out int consumedBytes) -> System.Collections.Generic.IEnumerable<Daqifi.Core.Communication.Messages.IInboundMessage<DaqifiOutMessage!>!>!
+Daqifi.Core.Communication.Consumers.ProtobufMessageParser.ProtobufMessageParser() -> void
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.ClearBuffer() -> void
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.Dispose() -> void
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.ErrorOccurred -> System.EventHandler<Daqifi.Core.Communication.Consumers.MessageConsumerErrorEventArgs!>?
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.IsRunning.get -> bool
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.MessageReceived -> System.EventHandler<Daqifi.Core.Communication.Consumers.MessageReceivedEventArgs<T>!>?
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.QueuedMessageCount.get -> int
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.Start() -> void
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.Stop() -> void
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.StopSafely(int timeoutMs = 1000) -> bool
+Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.StreamMessageConsumer(System.IO.Stream! stream, Daqifi.Core.Communication.Consumers.IMessageParser<T>! messageParser, int bufferSize = 4096, Daqifi.Core.Communication.Transport.ITransportHealthSink? healthSink = null) -> void
+Daqifi.Core.Communication.Consumers.TextInboundMessage
+Daqifi.Core.Communication.Consumers.TextInboundMessage.Data.get -> string!
+Daqifi.Core.Communication.Consumers.TextInboundMessage.TextInboundMessage(string! data) -> void
+Daqifi.Core.Communication.Messages.GenericInboundMessage<T>
+Daqifi.Core.Communication.Messages.GenericInboundMessage<T>.Data.get -> T
+Daqifi.Core.Communication.Messages.GenericInboundMessage<T>.GenericInboundMessage(T data) -> void
+Daqifi.Core.Communication.Messages.IInboundMessage<T>
+Daqifi.Core.Communication.Messages.IInboundMessage<T>.Data.get -> T
+Daqifi.Core.Communication.Messages.IOutboundMessage<T>
+Daqifi.Core.Communication.Messages.IOutboundMessage<T>.Data.get -> T
+Daqifi.Core.Communication.Messages.IOutboundMessage<T>.Data.set -> void
+Daqifi.Core.Communication.Messages.IOutboundMessage<T>.GetBytes() -> byte[]!
+Daqifi.Core.Communication.Messages.ProtobufMessage
+Daqifi.Core.Communication.Messages.ProtobufMessage.Data.get -> DaqifiOutMessage!
+Daqifi.Core.Communication.Messages.ProtobufMessage.ProtobufMessage(DaqifiOutMessage! message) -> void
+Daqifi.Core.Communication.Messages.ScpiMessage
+Daqifi.Core.Communication.Messages.ScpiMessage.Data.get -> string!
+Daqifi.Core.Communication.Messages.ScpiMessage.Data.set -> void
+Daqifi.Core.Communication.Messages.ScpiMessage.GetBytes() -> byte[]!
+Daqifi.Core.Communication.Messages.ScpiMessage.ScpiMessage(string! command) -> void
+Daqifi.Core.Communication.Producers.IMessageProducer<T>
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.IsIdle.get -> bool
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.IsRunning.get -> bool
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.QueuedMessageCount.get -> int
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.Send(Daqifi.Core.Communication.Messages.IOutboundMessage<T>! message) -> void
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.SendFailed -> System.EventHandler<Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<T>!>?
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.Start() -> void
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.StartedWriteCount.get -> long?
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.Stop() -> void
+Daqifi.Core.Communication.Producers.IMessageProducer<T>.StopSafely(int timeoutMs = 1000) -> bool
+Daqifi.Core.Communication.Producers.MessageProducer<T>
+Daqifi.Core.Communication.Producers.MessageProducer<T>.Dispose() -> void
+Daqifi.Core.Communication.Producers.MessageProducer<T>.IsIdle.get -> bool
+Daqifi.Core.Communication.Producers.MessageProducer<T>.IsRunning.get -> bool
+Daqifi.Core.Communication.Producers.MessageProducer<T>.MessageProducer(System.IO.Stream! stream, Microsoft.Extensions.Logging.ILogger<Daqifi.Core.Communication.Producers.MessageProducer<T>!>? logger = null, Daqifi.Core.Communication.Transport.ITransportHealthSink? healthSink = null) -> void
+Daqifi.Core.Communication.Producers.MessageProducer<T>.QueuedMessageCount.get -> int
+Daqifi.Core.Communication.Producers.MessageProducer<T>.Send(Daqifi.Core.Communication.Messages.IOutboundMessage<T>! message) -> void
+Daqifi.Core.Communication.Producers.MessageProducer<T>.SendFailed -> System.EventHandler<Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<T>!>?
+Daqifi.Core.Communication.Producers.MessageProducer<T>.Start() -> void
+Daqifi.Core.Communication.Producers.MessageProducer<T>.StartedWriteCount.get -> long?
+Daqifi.Core.Communication.Producers.MessageProducer<T>.Stop() -> void
+Daqifi.Core.Communication.Producers.MessageProducer<T>.StopSafely(int timeoutMs = 1000) -> bool
+Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<T>
+Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<T>.Error.get -> System.Exception!
+Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<T>.IsTimeout.get -> bool
+Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<T>.Message.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<T>!
+Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<T>.MessageSendFailedEventArgs(Daqifi.Core.Communication.Messages.IOutboundMessage<T>! message, System.Exception! error) -> void
+Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<T>.Timestamp.get -> System.DateTime
+Daqifi.Core.Communication.Producers.ScpiMessageProducer
+Daqifi.Core.Communication.Producers.ScpiMessageProducer.ScpiMessageProducer() -> void
+Daqifi.Core.Communication.StreamInterface
+Daqifi.Core.Communication.StreamInterface.All = 3 -> Daqifi.Core.Communication.StreamInterface
+Daqifi.Core.Communication.StreamInterface.SdCard = 2 -> Daqifi.Core.Communication.StreamInterface
+Daqifi.Core.Communication.StreamInterface.Usb = 0 -> Daqifi.Core.Communication.StreamInterface
+Daqifi.Core.Communication.StreamInterface.WiFi = 1 -> Daqifi.Core.Communication.StreamInterface
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.BackoffMultiplier.get -> double
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.BackoffMultiplier.set -> void
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.CalculateDelay(int attemptNumber) -> System.TimeSpan
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.ConnectionRetryOptions() -> void
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.ConnectionTimeout.get -> System.TimeSpan
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.ConnectionTimeout.set -> void
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.Enabled.get -> bool
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.Enabled.set -> void
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.InitialDelay.get -> System.TimeSpan
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.InitialDelay.set -> void
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.MaxAttempts.get -> int
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.MaxAttempts.set -> void
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.MaxDelay.get -> System.TimeSpan
+Daqifi.Core.Communication.Transport.ConnectionRetryOptions.MaxDelay.set -> void
+Daqifi.Core.Communication.Transport.HidDeviceInfo
+Daqifi.Core.Communication.Transport.HidDeviceInfo.DevicePath.get -> string!
+Daqifi.Core.Communication.Transport.HidDeviceInfo.HidDeviceInfo(int vendorId, int productId, string! devicePath, string? serialNumber = null, string? productName = null) -> void
+Daqifi.Core.Communication.Transport.HidDeviceInfo.ProductId.get -> int
+Daqifi.Core.Communication.Transport.HidDeviceInfo.ProductName.get -> string?
+Daqifi.Core.Communication.Transport.HidDeviceInfo.SerialNumber.get -> string?
+Daqifi.Core.Communication.Transport.HidDeviceInfo.VendorId.get -> int
+Daqifi.Core.Communication.Transport.HidLibraryDeviceEnumerator
+Daqifi.Core.Communication.Transport.HidLibraryDeviceEnumerator.EnumerateAsync(int? vendorId = null, int? productId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Daqifi.Core.Communication.Transport.HidDeviceInfo!>!>!
+Daqifi.Core.Communication.Transport.HidLibraryDeviceEnumerator.HidLibraryDeviceEnumerator() -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport
+Daqifi.Core.Communication.Transport.HidLibraryTransport.Connect(int vendorId, int productId, string? serialNumber = null) -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ConnectAsync(int vendorId, int productId, string? serialNumber = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ConnectByPath(string! devicePath) -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ConnectByPathAsync(string! devicePath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.HidLibraryTransport.DevicePath.get -> string?
+Daqifi.Core.Communication.Transport.HidLibraryTransport.Disconnect() -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport.DisconnectAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.HidLibraryTransport.Dispose() -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ExclusiveAccess.get -> bool
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ExclusiveAccess.set -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport.HidLibraryTransport() -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport.IsConnected.get -> bool
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ProductId.get -> int?
+Daqifi.Core.Communication.Transport.HidLibraryTransport.Read(System.TimeSpan? timeout = null) -> byte[]!
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ReadAsync(System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<byte[]!>!
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ReadTimeout.get -> System.TimeSpan
+Daqifi.Core.Communication.Transport.HidLibraryTransport.ReadTimeout.set -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport.SerialNumber.get -> string?
+Daqifi.Core.Communication.Transport.HidLibraryTransport.VendorId.get -> int?
+Daqifi.Core.Communication.Transport.HidLibraryTransport.Write(byte[]! data) -> void
+Daqifi.Core.Communication.Transport.HidLibraryTransport.WriteAsync(byte[]! data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.HidLibraryTransport.WriteTimeout.get -> System.TimeSpan
+Daqifi.Core.Communication.Transport.HidLibraryTransport.WriteTimeout.set -> void
+Daqifi.Core.Communication.Transport.IHidDeviceEnumerator
+Daqifi.Core.Communication.Transport.IHidDeviceEnumerator.EnumerateAsync(int? vendorId = null, int? productId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Daqifi.Core.Communication.Transport.HidDeviceInfo!>!>!
+Daqifi.Core.Communication.Transport.IHidTransport
+Daqifi.Core.Communication.Transport.IHidTransport.Connect(int vendorId, int productId, string? serialNumber = null) -> void
+Daqifi.Core.Communication.Transport.IHidTransport.ConnectAsync(int vendorId, int productId, string? serialNumber = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IHidTransport.ConnectByPath(string! devicePath) -> void
+Daqifi.Core.Communication.Transport.IHidTransport.ConnectByPathAsync(string! devicePath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IHidTransport.DevicePath.get -> string?
+Daqifi.Core.Communication.Transport.IHidTransport.Disconnect() -> void
+Daqifi.Core.Communication.Transport.IHidTransport.DisconnectAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IHidTransport.IsConnected.get -> bool
+Daqifi.Core.Communication.Transport.IHidTransport.ProductId.get -> int?
+Daqifi.Core.Communication.Transport.IHidTransport.Read(System.TimeSpan? timeout = null) -> byte[]!
+Daqifi.Core.Communication.Transport.IHidTransport.ReadAsync(System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<byte[]!>!
+Daqifi.Core.Communication.Transport.IHidTransport.ReadTimeout.get -> System.TimeSpan
+Daqifi.Core.Communication.Transport.IHidTransport.ReadTimeout.set -> void
+Daqifi.Core.Communication.Transport.IHidTransport.SerialNumber.get -> string?
+Daqifi.Core.Communication.Transport.IHidTransport.VendorId.get -> int?
+Daqifi.Core.Communication.Transport.IHidTransport.Write(byte[]! data) -> void
+Daqifi.Core.Communication.Transport.IHidTransport.WriteAsync(byte[]! data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IHidTransport.WriteTimeout.get -> System.TimeSpan
+Daqifi.Core.Communication.Transport.IHidTransport.WriteTimeout.set -> void
+Daqifi.Core.Communication.Transport.IStreamTransport
+Daqifi.Core.Communication.Transport.IStreamTransport.Connect() -> void
+Daqifi.Core.Communication.Transport.IStreamTransport.ConnectAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IStreamTransport.ConnectAsync(Daqifi.Core.Communication.Transport.ConnectionRetryOptions? retryOptions) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IStreamTransport.ConnectAsync(Daqifi.Core.Communication.Transport.ConnectionRetryOptions? retryOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IStreamTransport.ConnectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IStreamTransport.ConnectionInfo.get -> string!
+Daqifi.Core.Communication.Transport.IStreamTransport.Disconnect() -> void
+Daqifi.Core.Communication.Transport.IStreamTransport.DisconnectAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IStreamTransport.IsConnected.get -> bool
+Daqifi.Core.Communication.Transport.IStreamTransport.StatusChanged -> System.EventHandler<Daqifi.Core.Communication.Transport.TransportStatusEventArgs!>?
+Daqifi.Core.Communication.Transport.IStreamTransport.Stream.get -> System.IO.Stream!
+Daqifi.Core.Communication.Transport.ITransportHealthSink
+Daqifi.Core.Communication.Transport.ITransportHealthSink.ReportIoFault(System.Exception! error) -> void
+Daqifi.Core.Communication.Transport.ITransportHealthSink.ReportIoSuccess() -> void
+Daqifi.Core.Communication.Transport.IUdpTransport
+Daqifi.Core.Communication.Transport.IUdpTransport.Close() -> void
+Daqifi.Core.Communication.Transport.IUdpTransport.CloseAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IUdpTransport.ConnectionInfo.get -> string!
+Daqifi.Core.Communication.Transport.IUdpTransport.IsOpen.get -> bool
+Daqifi.Core.Communication.Transport.IUdpTransport.Open() -> void
+Daqifi.Core.Communication.Transport.IUdpTransport.OpenAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IUdpTransport.ReceiveAsync(System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<(byte[]! Data, System.Net.IPEndPoint! RemoteEndPoint)?>!
+Daqifi.Core.Communication.Transport.IUdpTransport.SendBroadcastAsync(byte[]! data, System.Net.IPEndPoint! endPoint) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IUdpTransport.SendBroadcastAsync(byte[]! data, int port) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IUdpTransport.SendUnicastAsync(byte[]! data, System.Net.IPEndPoint! endPoint) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.IUdpTransport.StatusChanged -> System.EventHandler<Daqifi.Core.Communication.Transport.TransportStatusEventArgs!>?
+Daqifi.Core.Communication.Transport.SerialPortConnectException
+Daqifi.Core.Communication.Transport.SerialPortConnectException.PortName.get -> string!
+Daqifi.Core.Communication.Transport.SerialPortConnectException.Reason.get -> Daqifi.Core.Communication.Transport.SerialPortConnectFailure
+Daqifi.Core.Communication.Transport.SerialPortConnectException.SerialPortConnectException(string! portName, Daqifi.Core.Communication.Transport.SerialPortConnectFailure reason, string! message, System.Exception? innerException = null) -> void
+Daqifi.Core.Communication.Transport.SerialPortConnectFailure
+Daqifi.Core.Communication.Transport.SerialPortConnectFailure.AccessDenied = 3 -> Daqifi.Core.Communication.Transport.SerialPortConnectFailure
+Daqifi.Core.Communication.Transport.SerialPortConnectFailure.InUse = 2 -> Daqifi.Core.Communication.Transport.SerialPortConnectFailure
+Daqifi.Core.Communication.Transport.SerialPortConnectFailure.NotFound = 1 -> Daqifi.Core.Communication.Transport.SerialPortConnectFailure
+Daqifi.Core.Communication.Transport.SerialPortConnectFailure.Unknown = 0 -> Daqifi.Core.Communication.Transport.SerialPortConnectFailure
+Daqifi.Core.Communication.Transport.SerialStreamTransport
+Daqifi.Core.Communication.Transport.SerialStreamTransport.Connect() -> void
+Daqifi.Core.Communication.Transport.SerialStreamTransport.ConnectAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.SerialStreamTransport.ConnectAsync(Daqifi.Core.Communication.Transport.ConnectionRetryOptions? retryOptions) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.SerialStreamTransport.ConnectAsync(Daqifi.Core.Communication.Transport.ConnectionRetryOptions? retryOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.SerialStreamTransport.ConnectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.SerialStreamTransport.ConnectionInfo.get -> string!
+Daqifi.Core.Communication.Transport.SerialStreamTransport.Disconnect() -> void
+Daqifi.Core.Communication.Transport.SerialStreamTransport.DisconnectAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.SerialStreamTransport.Dispose() -> void
+Daqifi.Core.Communication.Transport.SerialStreamTransport.IsConnected.get -> bool
+Daqifi.Core.Communication.Transport.SerialStreamTransport.ReportIoFault(System.Exception! error) -> void
+Daqifi.Core.Communication.Transport.SerialStreamTransport.ReportIoSuccess() -> void
+Daqifi.Core.Communication.Transport.SerialStreamTransport.SerialStreamTransport(string! portName, int baudRate = 9600, System.IO.Ports.Parity parity = System.IO.Ports.Parity.None, int dataBits = 8, System.IO.Ports.StopBits stopBits = System.IO.Ports.StopBits.One, bool enableDtr = true, bool enableRts = false, System.TimeSpan? livenessCheckInterval = null) -> void
+Daqifi.Core.Communication.Transport.SerialStreamTransport.StatusChanged -> System.EventHandler<Daqifi.Core.Communication.Transport.TransportStatusEventArgs!>?
+Daqifi.Core.Communication.Transport.SerialStreamTransport.Stream.get -> System.IO.Stream!
+Daqifi.Core.Communication.Transport.TcpStreamTransport
+Daqifi.Core.Communication.Transport.TcpStreamTransport.Connect() -> void
+Daqifi.Core.Communication.Transport.TcpStreamTransport.ConnectAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.TcpStreamTransport.ConnectAsync(Daqifi.Core.Communication.Transport.ConnectionRetryOptions? retryOptions) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.TcpStreamTransport.ConnectAsync(Daqifi.Core.Communication.Transport.ConnectionRetryOptions? retryOptions, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.TcpStreamTransport.ConnectAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.TcpStreamTransport.ConnectionInfo.get -> string!
+Daqifi.Core.Communication.Transport.TcpStreamTransport.Disconnect() -> void
+Daqifi.Core.Communication.Transport.TcpStreamTransport.DisconnectAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.TcpStreamTransport.Dispose() -> void
+Daqifi.Core.Communication.Transport.TcpStreamTransport.Hostname.get -> string?
+Daqifi.Core.Communication.Transport.TcpStreamTransport.IsConnected.get -> bool
+Daqifi.Core.Communication.Transport.TcpStreamTransport.LocalInterface.get -> System.Net.IPAddress?
+Daqifi.Core.Communication.Transport.TcpStreamTransport.ReportIoFault(System.Exception! error) -> void
+Daqifi.Core.Communication.Transport.TcpStreamTransport.ReportIoSuccess() -> void
+Daqifi.Core.Communication.Transport.TcpStreamTransport.StatusChanged -> System.EventHandler<Daqifi.Core.Communication.Transport.TransportStatusEventArgs!>?
+Daqifi.Core.Communication.Transport.TcpStreamTransport.Stream.get -> System.IO.Stream!
+Daqifi.Core.Communication.Transport.TcpStreamTransport.TcpStreamTransport(System.Net.IPAddress! ipAddress, int port, System.Net.IPAddress? localInterface = null) -> void
+Daqifi.Core.Communication.Transport.TcpStreamTransport.TcpStreamTransport(string! host, int port, System.Net.IPAddress? localInterface = null) -> void
+Daqifi.Core.Communication.Transport.TransportNotConnectedException
+Daqifi.Core.Communication.Transport.TransportNotConnectedException.TransportNotConnectedException() -> void
+Daqifi.Core.Communication.Transport.TransportNotConnectedException.TransportNotConnectedException(string! message) -> void
+Daqifi.Core.Communication.Transport.TransportNotConnectedException.TransportNotConnectedException(string! message, System.Exception? innerException) -> void
+Daqifi.Core.Communication.Transport.TransportStatusEventArgs
+Daqifi.Core.Communication.Transport.TransportStatusEventArgs.ConnectionInfo.get -> string!
+Daqifi.Core.Communication.Transport.TransportStatusEventArgs.Error.get -> System.Exception?
+Daqifi.Core.Communication.Transport.TransportStatusEventArgs.IsConnected.get -> bool
+Daqifi.Core.Communication.Transport.TransportStatusEventArgs.TransportStatusEventArgs(bool isConnected, string! connectionInfo, System.Exception? error = null) -> void
+Daqifi.Core.Communication.Transport.UdpTransport
+Daqifi.Core.Communication.Transport.UdpTransport.Close() -> void
+Daqifi.Core.Communication.Transport.UdpTransport.CloseAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.UdpTransport.ConnectionInfo.get -> string!
+Daqifi.Core.Communication.Transport.UdpTransport.Dispose() -> void
+Daqifi.Core.Communication.Transport.UdpTransport.IsOpen.get -> bool
+Daqifi.Core.Communication.Transport.UdpTransport.LocalPort.get -> int
+Daqifi.Core.Communication.Transport.UdpTransport.Open() -> void
+Daqifi.Core.Communication.Transport.UdpTransport.OpenAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.UdpTransport.ReceiveAsync(System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<(byte[]! Data, System.Net.IPEndPoint! RemoteEndPoint)?>!
+Daqifi.Core.Communication.Transport.UdpTransport.SendBroadcastAsync(byte[]! data, System.Net.IPEndPoint! endPoint) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.UdpTransport.SendBroadcastAsync(byte[]! data, int port) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.UdpTransport.SendUnicastAsync(byte[]! data, System.Net.IPEndPoint! endPoint) -> System.Threading.Tasks.Task!
+Daqifi.Core.Communication.Transport.UdpTransport.StatusChanged -> System.EventHandler<Daqifi.Core.Communication.Transport.TransportStatusEventArgs!>?
+Daqifi.Core.Communication.Transport.UdpTransport.UdpTransport() -> void
+Daqifi.Core.Communication.Transport.UdpTransport.UdpTransport(int localPort) -> void
+Daqifi.Core.Device.AcquisitionStatistics
+Daqifi.Core.Device.AcquisitionStatistics.AcquisitionStatistics() -> void
+Daqifi.Core.Device.AcquisitionStatistics.AcquisitionStatistics(Daqifi.Core.Device.IStreamingDevice! device) -> void
+Daqifi.Core.Device.AcquisitionStatistics.Dispose() -> void
+Daqifi.Core.Device.AcquisitionStatistics.Record(Daqifi.Core.Channel.IChannel! channel, Daqifi.Core.Channel.IDataSample! sample) -> void
+Daqifi.Core.Device.AcquisitionStatistics.Record(Daqifi.Core.Channel.LiveSample! sample) -> void
+Daqifi.Core.Device.AcquisitionStatistics.Reset() -> void
+Daqifi.Core.Device.AcquisitionStatistics.Snapshot() -> Daqifi.Core.Device.AcquisitionStatisticsSnapshot!
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.<Clone>$() -> Daqifi.Core.Device.AcquisitionStatisticsSnapshot!
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.AcquisitionStatisticsSnapshot(System.DateTime StartedAt, long TotalSampleCount, System.DateTime FirstReceivedAt, System.DateTime LastReceivedAt, System.TimeSpan MinLatency, System.TimeSpan MaxLatency, System.TimeSpan MeanLatency, System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.ChannelAcquisitionStatistics!>! Channels) -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.Channels.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.ChannelAcquisitionStatistics!>!
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.Channels.init -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.Deconstruct(out System.DateTime StartedAt, out long TotalSampleCount, out System.DateTime FirstReceivedAt, out System.DateTime LastReceivedAt, out System.TimeSpan MinLatency, out System.TimeSpan MaxLatency, out System.TimeSpan MeanLatency, out System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.ChannelAcquisitionStatistics!>! Channels) -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.Duration.get -> System.TimeSpan
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.Equals(Daqifi.Core.Device.AcquisitionStatisticsSnapshot? other) -> bool
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.FirstReceivedAt.get -> System.DateTime
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.FirstReceivedAt.init -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.LastReceivedAt.get -> System.DateTime
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.LastReceivedAt.init -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.MaxLatency.get -> System.TimeSpan
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.MaxLatency.init -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.MeanLatency.get -> System.TimeSpan
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.MeanLatency.init -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.MinLatency.get -> System.TimeSpan
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.MinLatency.init -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.StartedAt.get -> System.DateTime
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.StartedAt.init -> void
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.TotalSampleCount.get -> long
+Daqifi.Core.Device.AcquisitionStatisticsSnapshot.TotalSampleCount.init -> void
+Daqifi.Core.Device.BootloaderSessionDevice
+Daqifi.Core.Device.BootloaderSessionDevice.BootloaderSessionDevice(string? name = null) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.Channels.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>!
+Daqifi.Core.Device.BootloaderSessionDevice.ChannelsPopulated -> System.EventHandler<Daqifi.Core.Device.ChannelsPopulatedEventArgs!>?
+Daqifi.Core.Device.BootloaderSessionDevice.Connect() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.DisableAllChannels() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.DisableChannel(Daqifi.Core.Channel.IChannel! channel) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.Disconnect() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.DisconnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Daqifi.Core.Device.BootloaderSessionDevice.EnableChannel(Daqifi.Core.Channel.IChannel! channel) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.EnableChannels(System.Collections.Generic.IEnumerable<Daqifi.Core.Channel.IChannel!>! channels) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.ErrorOccurred -> System.EventHandler<Daqifi.Core.Device.DeviceErrorEventArgs!>?
+Daqifi.Core.Device.BootloaderSessionDevice.GetChannelsSnapshot() -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>!
+Daqifi.Core.Device.BootloaderSessionDevice.IpAddress.get -> System.Net.IPAddress?
+Daqifi.Core.Device.BootloaderSessionDevice.IsConnected.get -> bool
+Daqifi.Core.Device.BootloaderSessionDevice.IsStreaming.get -> bool
+Daqifi.Core.Device.BootloaderSessionDevice.LoadAdcCalibration() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.LoadAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.LoadFactoryAdcCalibration() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.LoadFactoryAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.LoadVoltagePrecision() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.LoadVoltagePrecisionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.MessageReceived -> System.EventHandler<Daqifi.Core.Device.MessageReceivedEventArgs!>?
+Daqifi.Core.Device.BootloaderSessionDevice.Metadata.get -> Daqifi.Core.Device.DeviceMetadata!
+Daqifi.Core.Device.BootloaderSessionDevice.Name.get -> string!
+Daqifi.Core.Device.BootloaderSessionDevice.PwmFrequencyHz.get -> int
+Daqifi.Core.Device.BootloaderSessionDevice.Reboot() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SaveAdcCalibration() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SaveAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.SaveFactoryAdcCalibration() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SaveFactoryAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.SaveVoltagePrecision() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SaveVoltagePrecisionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.Send<T>(Daqifi.Core.Communication.Messages.IOutboundMessage<T>! message) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SetAdcCalibrationOffset(int channelNumber, double calB) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SetAdcCalibrationOffsetAsync(int channelNumber, double calB, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.SetAdcCalibrationSlope(int channelNumber, double calM) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SetAdcCalibrationSlopeAsync(int channelNumber, double calM, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.BootloaderSessionDevice.SetAnalogOutput(int channelNumber, double voltage) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SetDioDirection(Daqifi.Core.Channel.IChannel! channel, Daqifi.Core.Channel.ChannelDirection direction) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SetDioValue(Daqifi.Core.Channel.IChannel! channel, bool value) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SetPwmDutyCycle(Daqifi.Core.Channel.IChannel! channel, int dutyCyclePercent) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SetPwmEnabled(Daqifi.Core.Channel.IChannel! channel, bool enabled) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.SetPwmFrequency(int frequencyHz) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.StartStreaming() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.Status.get -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.BootloaderSessionDevice.StatusChanged -> System.EventHandler<Daqifi.Core.Device.DeviceStatusEventArgs!>?
+Daqifi.Core.Device.BootloaderSessionDevice.StopStreaming() -> void
+Daqifi.Core.Device.BootloaderSessionDevice.StreamingFrequency.get -> int
+Daqifi.Core.Device.BootloaderSessionDevice.StreamingFrequency.set -> void
+Daqifi.Core.Device.BootloaderSessionDevice.UseAdcCalibration(int bank) -> void
+Daqifi.Core.Device.BootloaderSessionDevice.UseAdcCalibrationAsync(int bank, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Capabilities.CapabilityChannel
+Daqifi.Core.Device.Capabilities.CapabilityChannel.CalibrationIntercept.get -> double?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.CalibrationIntercept.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.CalibrationSlope.get -> double?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.CalibrationSlope.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.CapabilityChannel() -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.Id.get -> int
+Daqifi.Core.Device.Capabilities.CapabilityChannel.Id.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.IsDifferential.get -> bool
+Daqifi.Core.Device.Capabilities.CapabilityChannel.IsDifferential.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.IsSimultaneous.get -> bool
+Daqifi.Core.Device.Capabilities.CapabilityChannel.IsSimultaneous.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.Kind.get -> Daqifi.Core.Device.Capabilities.CapabilityChannelKind
+Daqifi.Core.Device.Capabilities.CapabilityChannel.Kind.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.PwmMaximumFrequencyHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.PwmMaximumFrequencyHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.PwmMinimumFrequencyHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.PwmMinimumFrequencyHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.RangeMaximum.get -> double?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.RangeMaximum.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.RangeMinimum.get -> double?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.RangeMinimum.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.RawKind.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.RawKind.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.ResolutionBits.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.ResolutionBits.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.SignalType.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.SignalType.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.SupportsPwm.get -> bool
+Daqifi.Core.Device.Capabilities.CapabilityChannel.SupportsPwm.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannel.Unit.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityChannel.Unit.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityChannelKind
+Daqifi.Core.Device.Capabilities.CapabilityChannelKind.AnalogInput = 1 -> Daqifi.Core.Device.Capabilities.CapabilityChannelKind
+Daqifi.Core.Device.Capabilities.CapabilityChannelKind.AnalogOutput = 2 -> Daqifi.Core.Device.Capabilities.CapabilityChannelKind
+Daqifi.Core.Device.Capabilities.CapabilityChannelKind.DigitalIo = 3 -> Daqifi.Core.Device.Capabilities.CapabilityChannelKind
+Daqifi.Core.Device.Capabilities.CapabilityChannelKind.Unknown = 0 -> Daqifi.Core.Device.Capabilities.CapabilityChannelKind
+Daqifi.Core.Device.Capabilities.CapabilityDocument
+Daqifi.Core.Device.Capabilities.CapabilityDocument.BatteryPresent.get -> bool?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.BatteryPresent.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.CapabilityDocument() -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.Channels.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.Capabilities.CapabilityChannel!>!
+Daqifi.Core.Device.Capabilities.CapabilityDocument.Channels.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.CountChannels(Daqifi.Core.Device.Capabilities.CapabilityChannelKind kind) -> int
+Daqifi.Core.Device.Capabilities.CapabilityDocument.EthernetSupported.get -> bool?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.EthernetSupported.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.ExternalPowerSupported.get -> bool?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.ExternalPowerSupported.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.Identity.get -> Daqifi.Core.Device.Capabilities.CapabilityIdentity?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.Identity.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.MergeInto(Daqifi.Core.Device.DeviceCapabilities! capabilities) -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.RawJson.get -> string!
+Daqifi.Core.Device.Capabilities.CapabilityDocument.RawJson.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.SchemaUri.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.SchemaUri.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.SchemaVersion.get -> int
+Daqifi.Core.Device.Capabilities.CapabilityDocument.SchemaVersion.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.SdSupported.get -> bool?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.SdSupported.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.Streaming.get -> Daqifi.Core.Device.Capabilities.CapabilityStreaming?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.Streaming.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.UsbSupported.get -> bool?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.UsbSupported.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocument.WifiSupported.get -> bool?
+Daqifi.Core.Device.Capabilities.CapabilityDocument.WifiSupported.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityDocumentParser
+Daqifi.Core.Device.Capabilities.CapabilityIdentity
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.CapabilityIdentity() -> void
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.FirmwareRevision.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.FirmwareRevision.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.HardwareRevision.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.HardwareRevision.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.Model.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.Model.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.Serial.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.Serial.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.Variant.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.Variant.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.Vendor.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityIdentity.Vendor.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityRateModel
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.AbsoluteMaximumHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.AbsoluteMaximumHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.CapabilityRateModel() -> void
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.Formula.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.Formula.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.PerTickBudgetHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.PerTickBudgetHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.PerTickOverhead.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.PerTickOverhead.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.TryComputeMaxRateHz(int simultaneousChannelCount, int totalChannelCount, out int maxRateHz) -> bool
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.Type1AggregateMaximumHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityRateModel.Type1AggregateMaximumHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.CapabilityStreaming() -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.ConservativeEnvelopeHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.ConservativeEnvelopeHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.CurrentMaximumRateHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.CurrentMaximumRateHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.Encodings.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.Encodings.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.MaximumSampleRateHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.MaximumSampleRateHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.MinimumSampleRateHz.get -> int?
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.MinimumSampleRateHz.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.RateModel.get -> Daqifi.Core.Device.Capabilities.CapabilityRateModel?
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.RateModel.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.RateValidation.get -> string?
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.RateValidation.init -> void
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.Transports.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Daqifi.Core.Device.Capabilities.CapabilityStreaming.Transports.init -> void
+Daqifi.Core.Device.Capabilities.SampleRateCap
+Daqifi.Core.Device.ChannelAcquisitionStatistics
+Daqifi.Core.Device.ChannelAcquisitionStatistics.<Clone>$() -> Daqifi.Core.Device.ChannelAcquisitionStatistics!
+Daqifi.Core.Device.ChannelAcquisitionStatistics.ChannelAcquisitionStatistics(Daqifi.Core.Channel.ChannelType ChannelType, int ChannelNumber, string! Name, long SampleCount, System.DateTime EarliestSampleTimestamp, System.DateTime LatestSampleTimestamp, System.DateTime FirstReceivedAt, System.DateTime LastReceivedAt, System.TimeSpan MinSampleInterval, System.TimeSpan MaxSampleInterval, long OutOfOrderSampleCount, double MinValue, double MaxValue, double MeanValue, string? Unit = null, long ValueSampleCount = 0) -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.ChannelNumber.get -> int
+Daqifi.Core.Device.ChannelAcquisitionStatistics.ChannelNumber.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.ChannelType.get -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Device.ChannelAcquisitionStatistics.ChannelType.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.Deconstruct(out Daqifi.Core.Channel.ChannelType ChannelType, out int ChannelNumber, out string! Name, out long SampleCount, out System.DateTime EarliestSampleTimestamp, out System.DateTime LatestSampleTimestamp, out System.DateTime FirstReceivedAt, out System.DateTime LastReceivedAt, out System.TimeSpan MinSampleInterval, out System.TimeSpan MaxSampleInterval, out long OutOfOrderSampleCount, out double MinValue, out double MaxValue, out double MeanValue, out string? Unit, out long ValueSampleCount) -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.DeviceClockSampleRateHz.get -> double
+Daqifi.Core.Device.ChannelAcquisitionStatistics.EarliestSampleTimestamp.get -> System.DateTime
+Daqifi.Core.Device.ChannelAcquisitionStatistics.EarliestSampleTimestamp.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.Equals(Daqifi.Core.Device.ChannelAcquisitionStatistics? other) -> bool
+Daqifi.Core.Device.ChannelAcquisitionStatistics.FirstReceivedAt.get -> System.DateTime
+Daqifi.Core.Device.ChannelAcquisitionStatistics.FirstReceivedAt.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.LastReceivedAt.get -> System.DateTime
+Daqifi.Core.Device.ChannelAcquisitionStatistics.LastReceivedAt.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.LatestSampleTimestamp.get -> System.DateTime
+Daqifi.Core.Device.ChannelAcquisitionStatistics.LatestSampleTimestamp.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MaxSampleInterval.get -> System.TimeSpan
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MaxSampleInterval.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MaxValue.get -> double
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MaxValue.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MeanSampleInterval.get -> System.TimeSpan
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MeanValue.get -> double
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MeanValue.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MeasuredSampleRateHz.get -> double
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MinSampleInterval.get -> System.TimeSpan
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MinSampleInterval.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MinValue.get -> double
+Daqifi.Core.Device.ChannelAcquisitionStatistics.MinValue.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.Name.get -> string!
+Daqifi.Core.Device.ChannelAcquisitionStatistics.Name.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.OutOfOrderSampleCount.get -> long
+Daqifi.Core.Device.ChannelAcquisitionStatistics.OutOfOrderSampleCount.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.SampleCount.get -> long
+Daqifi.Core.Device.ChannelAcquisitionStatistics.SampleCount.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.Unit.get -> string?
+Daqifi.Core.Device.ChannelAcquisitionStatistics.Unit.init -> void
+Daqifi.Core.Device.ChannelAcquisitionStatistics.ValueSampleCount.get -> long
+Daqifi.Core.Device.ChannelAcquisitionStatistics.ValueSampleCount.init -> void
+Daqifi.Core.Device.ChannelsPopulatedEventArgs
+Daqifi.Core.Device.ChannelsPopulatedEventArgs.AnalogChannelCount.get -> int
+Daqifi.Core.Device.ChannelsPopulatedEventArgs.Channels.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>!
+Daqifi.Core.Device.ChannelsPopulatedEventArgs.ChannelsPopulatedEventArgs(System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>! channels, int analogChannelCount, int digitalChannelCount) -> void
+Daqifi.Core.Device.ChannelsPopulatedEventArgs.DigitalChannelCount.get -> int
+Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.ConnectionStatus.Connected = 2 -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.ConnectionStatus.Connecting = 1 -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.ConnectionStatus.Disconnected = 0 -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.ConnectionStatus.Failed = 5 -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.ConnectionStatus.Lost = 3 -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.ConnectionStatus.Retrying = 4 -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.DaqifiDevice
+Daqifi.Core.Device.DaqifiDevice.CancelReconnect() -> void
+Daqifi.Core.Device.DaqifiDevice.Channels.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>!
+Daqifi.Core.Device.DaqifiDevice.ChannelsPopulated -> System.EventHandler<Daqifi.Core.Device.ChannelsPopulatedEventArgs!>?
+Daqifi.Core.Device.DaqifiDevice.Connect() -> void
+Daqifi.Core.Device.DaqifiDevice.ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiDevice.CreateFeatureNotSupportedException(Daqifi.Core.Device.DeviceFeature feature) -> Daqifi.Core.Device.FeatureNotSupportedException!
+Daqifi.Core.Device.DaqifiDevice.DaqifiDevice(string! name, Daqifi.Core.Communication.Transport.IStreamTransport! transport, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Daqifi.Core.Device.DaqifiDevice.DaqifiDevice(string! name, System.IO.Stream! stream, System.Net.IPAddress? ipAddress = null, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Daqifi.Core.Device.DaqifiDevice.DaqifiDevice(string! name, System.Net.IPAddress? ipAddress = null, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Daqifi.Core.Device.DaqifiDevice.Disconnect() -> void
+Daqifi.Core.Device.DaqifiDevice.DisconnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiDevice.Dispose() -> void
+Daqifi.Core.Device.DaqifiDevice.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Daqifi.Core.Device.DaqifiDevice.DroppedDeferredSendCount.get -> long
+Daqifi.Core.Device.DaqifiDevice.EnsureSupported(Daqifi.Core.Device.DeviceFeature feature) -> void
+Daqifi.Core.Device.DaqifiDevice.ErrorOccurred -> System.EventHandler<Daqifi.Core.Device.DeviceErrorEventArgs!>?
+Daqifi.Core.Device.DaqifiDevice.GetChannelsSnapshot() -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>!
+Daqifi.Core.Device.DaqifiDevice.IpAddress.get -> System.Net.IPAddress?
+Daqifi.Core.Device.DaqifiDevice.IsConnected.get -> bool
+Daqifi.Core.Device.DaqifiDevice.IsFirmwareVersionSupported.get -> bool
+Daqifi.Core.Device.DaqifiDevice.IsReconnecting.get -> bool
+Daqifi.Core.Device.DaqifiDevice.MessageReceived -> System.EventHandler<Daqifi.Core.Device.MessageReceivedEventArgs!>?
+Daqifi.Core.Device.DaqifiDevice.Metadata.get -> Daqifi.Core.Device.DeviceMetadata!
+Daqifi.Core.Device.DaqifiDevice.Name.get -> string!
+Daqifi.Core.Device.DaqifiDevice.PreserveActiveStream.get -> bool
+Daqifi.Core.Device.DaqifiDevice.PreserveActiveStream.set -> void
+Daqifi.Core.Device.DaqifiDevice.RaiseDeviceError(Daqifi.Core.Device.DeviceErrorSource source, System.Exception! error, byte[]? rawData = null) -> void
+Daqifi.Core.Device.DaqifiDevice.ReconnectAttempt -> System.EventHandler<Daqifi.Core.Device.ReconnectAttemptEventArgs!>?
+Daqifi.Core.Device.DaqifiDevice.ReconnectFailed -> System.EventHandler<Daqifi.Core.Device.ReconnectFailedEventArgs!>?
+Daqifi.Core.Device.DaqifiDevice.ReconnectOptions.get -> Daqifi.Core.Device.ReconnectOptions!
+Daqifi.Core.Device.DaqifiDevice.ReconnectOptions.set -> void
+Daqifi.Core.Device.DaqifiDevice.Reconnected -> System.EventHandler<Daqifi.Core.Device.ReconnectedEventArgs!>?
+Daqifi.Core.Device.DaqifiDevice.RefreshDeviceStatusAsync(System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiDevice.RunExclusiveAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiDevice.RunExclusiveAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>!
+Daqifi.Core.Device.DaqifiDevice.SendFailed -> System.EventHandler<Daqifi.Core.Communication.Producers.MessageSendFailedEventArgs<string!>!>?
+Daqifi.Core.Device.DaqifiDevice.SnapshotChannels() -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>!
+Daqifi.Core.Device.DaqifiDevice.State.get -> Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DaqifiDevice.Status.get -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.DaqifiDevice.StatusChanged -> System.EventHandler<Daqifi.Core.Device.DeviceStatusEventArgs!>?
+Daqifi.Core.Device.DaqifiDevice.StatusMessageReceived -> System.Action<DaqifiOutMessage!>?
+Daqifi.Core.Device.DaqifiDevice.StreamMessageReceived -> System.Action<DaqifiOutMessage!>?
+Daqifi.Core.Device.DaqifiDevice.Supports(Daqifi.Core.Device.DeviceFeature feature) -> bool
+Daqifi.Core.Device.DaqifiDevice.SyncAnalogOutputChannelsFromCapabilities() -> int
+Daqifi.Core.Device.DaqifiDevice.TimestampFrequency.get -> uint
+Daqifi.Core.Device.DaqifiDevice.Transport.get -> Daqifi.Core.Communication.Transport.IStreamTransport?
+Daqifi.Core.Device.DaqifiDevice.WithChannelsLock(System.Action! action) -> void
+Daqifi.Core.Device.DaqifiDevice.WithChannelsLock<T>(System.Func<T>! action) -> T
+Daqifi.Core.Device.DaqifiDeviceFactory
+Daqifi.Core.Device.DaqifiDeviceRegistry
+Daqifi.Core.Device.DaqifiDeviceRegistry.Clear() -> void
+Daqifi.Core.Device.DaqifiDeviceRegistry.ConnectAsync(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo, string? key = null, Daqifi.Core.Device.DeviceConnectionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.DeviceRegistrationResult!>!
+Daqifi.Core.Device.DaqifiDeviceRegistry.Count.get -> int
+Daqifi.Core.Device.DaqifiDeviceRegistry.DaqifiDeviceRegistry() -> void
+Daqifi.Core.Device.DaqifiDeviceRegistry.DeviceAdded -> System.EventHandler<Daqifi.Core.Device.DeviceRegisteredEventArgs!>?
+Daqifi.Core.Device.DaqifiDeviceRegistry.DeviceRemoved -> System.EventHandler<Daqifi.Core.Device.DeviceRemovedEventArgs!>?
+Daqifi.Core.Device.DaqifiDeviceRegistry.Devices.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.DeviceRegistration!>!
+Daqifi.Core.Device.DaqifiDeviceRegistry.Dispose() -> void
+Daqifi.Core.Device.DaqifiDeviceRegistry.DuplicatePolicy.get -> System.Func<Daqifi.Core.Device.DuplicateDeviceCheck!, Daqifi.Core.Device.DuplicateDeviceAction>?
+Daqifi.Core.Device.DaqifiDeviceRegistry.DuplicatePolicy.set -> void
+Daqifi.Core.Device.DaqifiDeviceRegistry.Find(Daqifi.Core.Device.DeviceIdentity! identity) -> Daqifi.Core.Device.DeviceRegistration?
+Daqifi.Core.Device.DaqifiDeviceRegistry.PruneDisconnected() -> int
+Daqifi.Core.Device.DaqifiDeviceRegistry.Register(Daqifi.Core.Device.DaqifiDevice! device, Daqifi.Core.Device.Discovery.IDeviceInfo? deviceInfo = null, string? key = null) -> Daqifi.Core.Device.DeviceRegistrationResult!
+Daqifi.Core.Device.DaqifiDeviceRegistry.Remove(Daqifi.Core.Device.DaqifiDevice! device) -> bool
+Daqifi.Core.Device.DaqifiDeviceRegistry.Remove(string! key) -> bool
+Daqifi.Core.Device.DaqifiDeviceRegistry.TryGet(string! key, out Daqifi.Core.Device.DeviceRegistration? registration) -> bool
+Daqifi.Core.Device.DaqifiDeviceRegistry.TryGetDevice(string! key, out Daqifi.Core.Device.DaqifiDevice? device) -> bool
+Daqifi.Core.Device.DaqifiStreamingDevice
+Daqifi.Core.Device.DaqifiStreamingDevice.CheckSdCardSpaceAsync(Daqifi.Core.Device.SdCard.SdCardCaptureEstimate? plannedCapture = null, long minimumFreeBytes = 104857600, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.ClearSystemLogAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.DaqifiStreamingDevice(string! name, Daqifi.Core.Communication.Transport.IStreamTransport! transport, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.DaqifiStreamingDevice(string! name, System.Net.IPAddress? ipAddress = null, Microsoft.Extensions.Logging.ILogger? logger = null) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.DecodeFailureCount.get -> long
+Daqifi.Core.Device.DaqifiStreamingDevice.DeleteSdCardFileAsync(string! fileName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.DisableAllChannels() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.DisableAllChannelsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.DisableChannel(Daqifi.Core.Channel.IChannel! channel) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.DisableChannelAsync(Daqifi.Core.Channel.IChannel! channel, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.DiscardedStreamFrameCount.get -> long
+Daqifi.Core.Device.DaqifiStreamingDevice.DownloadSdCardFileAsync(string! fileName, System.IO.Stream! destinationStream, System.IProgress<Daqifi.Core.Device.SdCard.SdCardTransferProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardDownloadResult!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.DownloadSdCardFileAsync(string! fileName, System.IProgress<Daqifi.Core.Device.SdCard.SdCardTransferProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardDownloadResult!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.DroppedLiveSampleCount.get -> long
+Daqifi.Core.Device.DaqifiStreamingDevice.EnableChannel(Daqifi.Core.Channel.IChannel! channel) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.EnableChannelAsync(Daqifi.Core.Channel.IChannel! channel, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.EnableChannels(System.Collections.Generic.IEnumerable<Daqifi.Core.Channel.IChannel!>! channels) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.EnableChannelsAsync(System.Collections.Generic.IEnumerable<Daqifi.Core.Channel.IChannel!>! channels, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.EnforceStreamingFrequencyCap() -> int?
+Daqifi.Core.Device.DaqifiStreamingDevice.FactoryResetNetworkAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.FormatSdCardAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.GapDetected -> System.EventHandler<Daqifi.Core.Device.TimestampGapEventArgs!>?
+Daqifi.Core.Device.DaqifiStreamingDevice.GetAnalogOutputAsync(int channelNumber, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<double>!
+Daqifi.Core.Device.DaqifiStreamingDevice.GetCommandHistoryAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.GetLanChipInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.LanChipInfo?>!
+Daqifi.Core.Device.DaqifiStreamingDevice.GetMemoryDiagnosticsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.Diagnostics.MemoryDiagnostics!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.GetSdCardFilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.SdCard.SdCardFileInfo!>!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.GetSdCardStorageAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardStorageInfo!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.GetStreamStatsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.Diagnostics.StreamStats!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.GetSystemErrorCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+Daqifi.Core.Device.DaqifiStreamingDevice.GetSystemLogAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.Diagnostics.SystemLogEntry!>!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.IsLoggingToSdCard.get -> bool
+Daqifi.Core.Device.DaqifiStreamingDevice.IsStreaming.get -> bool
+Daqifi.Core.Device.DaqifiStreamingDevice.LatchAnalogOutputs() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.LoadAdcCalibration() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.LoadAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.LoadFactoryAdcCalibration() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.LoadFactoryAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.LoadNetworkConfigurationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.LoadVoltagePrecision() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.LoadVoltagePrecisionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.LowSdSpaceWarning -> System.EventHandler<Daqifi.Core.Device.SdCard.LowSdSpaceWarningEventArgs!>?
+Daqifi.Core.Device.DaqifiStreamingDevice.MaximumStreamingFrequencyHz.get -> int
+Daqifi.Core.Device.DaqifiStreamingDevice.NetworkConfiguration.get -> Daqifi.Core.Device.Network.NetworkConfiguration!
+Daqifi.Core.Device.DaqifiStreamingDevice.PrepareLanInterface() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.PrepareSdInterface() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.PwmFrequencyHz.get -> int
+Daqifi.Core.Device.DaqifiStreamingDevice.Reboot() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.RebootAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SaveAdcCalibration() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SaveAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SaveFactoryAdcCalibration() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SaveFactoryAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SaveVoltagePrecision() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SaveVoltagePrecisionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SdCardFiles.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.SdCard.SdCardFileInfo!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetAdcCalibrationOffset(int channelNumber, double calB) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SetAdcCalibrationOffsetAsync(int channelNumber, double calB, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetAdcCalibrationSlope(int channelNumber, double calM) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SetAdcCalibrationSlopeAsync(int channelNumber, double calM, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetAnalogOutput(int channelNumber, double voltage) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SetAnalogOutputAsync(int channelNumber, double voltage, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetDioDirection(Daqifi.Core.Channel.IChannel! channel, Daqifi.Core.Channel.ChannelDirection direction) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SetDioDirectionAsync(Daqifi.Core.Channel.IChannel! channel, Daqifi.Core.Channel.ChannelDirection direction, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetDioValue(Daqifi.Core.Channel.IChannel! channel, bool value) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SetDioValueAsync(Daqifi.Core.Channel.IChannel! channel, bool value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetFriendlyNameAsync(string! name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetLogLevelAsync(string! module, int level, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.Diagnostics.LogLevelSetting!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetPwmDutyCycle(Daqifi.Core.Channel.IChannel! channel, int dutyCyclePercent) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SetPwmDutyCycleAsync(Daqifi.Core.Channel.IChannel! channel, int dutyCyclePercent, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetPwmEnabled(Daqifi.Core.Channel.IChannel! channel, bool enabled) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SetPwmEnabledAsync(Daqifi.Core.Channel.IChannel! channel, bool enabled, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetPwmFrequency(int frequencyHz) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.SetPwmFrequencyAsync(int frequencyHz, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.SetSdCardMinimumFreeSpace(long bytes) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.StageAnalogOutput(int channelNumber, double voltage) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.StartSdCardLoggingAsync(string? fileName = null, string? channelMask = null, Daqifi.Core.Device.SdCard.SdCardLogFormat format = Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.StartSdCardLoggingSessionAsync(string? fileName = null, string? channelMask = null, Daqifi.Core.Device.SdCard.SdCardLogFormat format = Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLoggingSession!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.StartStreaming() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.StartStreamingAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.StopSdCardLoggingAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.StopStreaming() -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.StopStreamingAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.StreamFrameDiscarded -> System.EventHandler<Daqifi.Core.Device.StreamFrameDiscardedEventArgs!>?
+Daqifi.Core.Device.DaqifiStreamingDevice.StreamSamplesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), int? bufferCapacity = null) -> System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Channel.LiveSample!>!
+Daqifi.Core.Device.DaqifiStreamingDevice.StreamingFrequency.get -> int
+Daqifi.Core.Device.DaqifiStreamingDevice.StreamingFrequency.set -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.TestSystemLogAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.UpdateNetworkConfigurationAsync(Daqifi.Core.Device.Network.NetworkConfiguration! configuration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DaqifiStreamingDevice.UseAdcCalibration(int bank) -> void
+Daqifi.Core.Device.DaqifiStreamingDevice.UseAdcCalibrationAsync(int bank, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.DeviceCapabilities
+Daqifi.Core.Device.DeviceCapabilities.AnalogInputChannels.get -> int
+Daqifi.Core.Device.DeviceCapabilities.AnalogInputChannels.set -> void
+Daqifi.Core.Device.DeviceCapabilities.AnalogOutputChannels.get -> int
+Daqifi.Core.Device.DeviceCapabilities.AnalogOutputChannels.set -> void
+Daqifi.Core.Device.DeviceCapabilities.Clone() -> Daqifi.Core.Device.DeviceCapabilities!
+Daqifi.Core.Device.DeviceCapabilities.DeviceCapabilities() -> void
+Daqifi.Core.Device.DeviceCapabilities.DigitalChannels.get -> int
+Daqifi.Core.Device.DeviceCapabilities.DigitalChannels.set -> void
+Daqifi.Core.Device.DeviceCapabilities.HasSdCard.get -> bool
+Daqifi.Core.Device.DeviceCapabilities.HasSdCard.set -> void
+Daqifi.Core.Device.DeviceCapabilities.HasUsb.get -> bool
+Daqifi.Core.Device.DeviceCapabilities.HasUsb.set -> void
+Daqifi.Core.Device.DeviceCapabilities.HasWiFi.get -> bool
+Daqifi.Core.Device.DeviceCapabilities.HasWiFi.set -> void
+Daqifi.Core.Device.DeviceCapabilities.HasWincWifiModule.get -> bool
+Daqifi.Core.Device.DeviceCapabilities.HasWincWifiModule.set -> void
+Daqifi.Core.Device.DeviceCapabilities.MaxSamplingRate.get -> int
+Daqifi.Core.Device.DeviceCapabilities.MaxSamplingRate.set -> void
+Daqifi.Core.Device.DeviceCapabilities.SupportsStreaming.get -> bool
+Daqifi.Core.Device.DeviceCapabilities.SupportsStreaming.set -> void
+Daqifi.Core.Device.DeviceCommandFailedException
+Daqifi.Core.Device.DeviceCommandFailedException.Command.get -> string!
+Daqifi.Core.Device.DeviceCommandFailedException.DeviceCommandFailedException(string! command, int errorCode, string! deviceResponse) -> void
+Daqifi.Core.Device.DeviceCommandFailedException.DeviceCommandFailedException(string! command, string? deviceResponse = null) -> void
+Daqifi.Core.Device.DeviceCommandFailedException.DeviceResponse.get -> string?
+Daqifi.Core.Device.DeviceCommandFailedException.ErrorCode.get -> int?
+Daqifi.Core.Device.DeviceConnectionOptions
+Daqifi.Core.Device.DeviceConnectionOptions.ChannelPopulationTimeout.get -> System.TimeSpan
+Daqifi.Core.Device.DeviceConnectionOptions.ChannelPopulationTimeout.set -> void
+Daqifi.Core.Device.DeviceConnectionOptions.ConnectionRetry.get -> Daqifi.Core.Communication.Transport.ConnectionRetryOptions?
+Daqifi.Core.Device.DeviceConnectionOptions.ConnectionRetry.set -> void
+Daqifi.Core.Device.DeviceConnectionOptions.DeviceConnectionOptions() -> void
+Daqifi.Core.Device.DeviceConnectionOptions.DeviceName.get -> string!
+Daqifi.Core.Device.DeviceConnectionOptions.DeviceName.set -> void
+Daqifi.Core.Device.DeviceConnectionOptions.InitializeDevice.get -> bool
+Daqifi.Core.Device.DeviceConnectionOptions.InitializeDevice.set -> void
+Daqifi.Core.Device.DeviceConnectionOptions.Logger.get -> Microsoft.Extensions.Logging.ILogger?
+Daqifi.Core.Device.DeviceConnectionOptions.Logger.set -> void
+Daqifi.Core.Device.DeviceConnectionOptions.PreserveActiveStream.get -> bool
+Daqifi.Core.Device.DeviceConnectionOptions.PreserveActiveStream.set -> void
+Daqifi.Core.Device.DeviceErrorEventArgs
+Daqifi.Core.Device.DeviceErrorEventArgs.DeviceErrorEventArgs(Daqifi.Core.Device.DeviceErrorSource source, System.Exception! error, int suppressedCount = 0, byte[]? rawData = null) -> void
+Daqifi.Core.Device.DeviceErrorEventArgs.Error.get -> System.Exception!
+Daqifi.Core.Device.DeviceErrorEventArgs.RawData.get -> byte[]?
+Daqifi.Core.Device.DeviceErrorEventArgs.Source.get -> Daqifi.Core.Device.DeviceErrorSource
+Daqifi.Core.Device.DeviceErrorEventArgs.SuppressedCount.get -> int
+Daqifi.Core.Device.DeviceErrorEventArgs.Timestamp.get -> System.DateTime
+Daqifi.Core.Device.DeviceErrorSource
+Daqifi.Core.Device.DeviceErrorSource.MessageConsumer = 1 -> Daqifi.Core.Device.DeviceErrorSource
+Daqifi.Core.Device.DeviceErrorSource.Reconnect = 3 -> Daqifi.Core.Device.DeviceErrorSource
+Daqifi.Core.Device.DeviceErrorSource.StatusNotification = 4 -> Daqifi.Core.Device.DeviceErrorSource
+Daqifi.Core.Device.DeviceErrorSource.StreamDecode = 2 -> Daqifi.Core.Device.DeviceErrorSource
+Daqifi.Core.Device.DeviceErrorSource.Unknown = 0 -> Daqifi.Core.Device.DeviceErrorSource
+Daqifi.Core.Device.DeviceFeature
+Daqifi.Core.Device.DeviceFeature.AnalogOutput = 0 -> Daqifi.Core.Device.DeviceFeature
+Daqifi.Core.Device.DeviceFeature.CapabilityDocument = 2 -> Daqifi.Core.Device.DeviceFeature
+Daqifi.Core.Device.DeviceFeature.SdFileTransferOverWifi = 3 -> Daqifi.Core.Device.DeviceFeature
+Daqifi.Core.Device.DeviceFeature.SdStorageQuery = 1 -> Daqifi.Core.Device.DeviceFeature
+Daqifi.Core.Device.DeviceHealth
+Daqifi.Core.Device.DeviceHealth.BatteryPercent.get -> int?
+Daqifi.Core.Device.DeviceHealth.BatteryPercent.set -> void
+Daqifi.Core.Device.DeviceHealth.BoardTemperatureCelsius.get -> int?
+Daqifi.Core.Device.DeviceHealth.BoardTemperatureCelsius.set -> void
+Daqifi.Core.Device.DeviceHealth.Clone() -> Daqifi.Core.Device.DeviceHealth!
+Daqifi.Core.Device.DeviceHealth.DeviceHealth() -> void
+Daqifi.Core.Device.DeviceHealth.DeviceStatus.get -> uint
+Daqifi.Core.Device.DeviceHealth.DeviceStatus.set -> void
+Daqifi.Core.Device.DeviceHealth.PowerStatus.get -> uint
+Daqifi.Core.Device.DeviceHealth.PowerStatus.set -> void
+Daqifi.Core.Device.DeviceIdentity
+Daqifi.Core.Device.DeviceIdentity.IsEmpty.get -> bool
+Daqifi.Core.Device.DeviceIdentity.Key.get -> string!
+Daqifi.Core.Device.DeviceIdentity.LocationKey.get -> string?
+Daqifi.Core.Device.DeviceIdentity.MacAddress.get -> string?
+Daqifi.Core.Device.DeviceIdentity.Matches(Daqifi.Core.Device.DeviceIdentity? other) -> bool
+Daqifi.Core.Device.DeviceIdentity.MergeWith(Daqifi.Core.Device.DeviceIdentity? fallback) -> Daqifi.Core.Device.DeviceIdentity!
+Daqifi.Core.Device.DeviceIdentity.SerialNumber.get -> string?
+Daqifi.Core.Device.DeviceMetadata
+Daqifi.Core.Device.DeviceMetadata.ApplyCapabilityDocument(Daqifi.Core.Device.Capabilities.CapabilityDocument! document) -> void
+Daqifi.Core.Device.DeviceMetadata.Capabilities.get -> Daqifi.Core.Device.DeviceCapabilities!
+Daqifi.Core.Device.DeviceMetadata.Capabilities.set -> void
+Daqifi.Core.Device.DeviceMetadata.CapabilityDocument.get -> Daqifi.Core.Device.Capabilities.CapabilityDocument?
+Daqifi.Core.Device.DeviceMetadata.CopyFrom(Daqifi.Core.Device.DeviceMetadata! source) -> void
+Daqifi.Core.Device.DeviceMetadata.DeviceMetadata() -> void
+Daqifi.Core.Device.DeviceMetadata.DevicePort.get -> int
+Daqifi.Core.Device.DeviceMetadata.DevicePort.set -> void
+Daqifi.Core.Device.DeviceMetadata.DeviceType.get -> Daqifi.Core.Device.DeviceType
+Daqifi.Core.Device.DeviceMetadata.DeviceType.set -> void
+Daqifi.Core.Device.DeviceMetadata.FirmwareVersion.get -> string!
+Daqifi.Core.Device.DeviceMetadata.FirmwareVersion.set -> void
+Daqifi.Core.Device.DeviceMetadata.FriendlyName.get -> string!
+Daqifi.Core.Device.DeviceMetadata.FriendlyName.set -> void
+Daqifi.Core.Device.DeviceMetadata.HardwareRevision.get -> string!
+Daqifi.Core.Device.DeviceMetadata.HardwareRevision.set -> void
+Daqifi.Core.Device.DeviceMetadata.Health.get -> Daqifi.Core.Device.DeviceHealth!
+Daqifi.Core.Device.DeviceMetadata.Health.set -> void
+Daqifi.Core.Device.DeviceMetadata.HostName.get -> string!
+Daqifi.Core.Device.DeviceMetadata.HostName.set -> void
+Daqifi.Core.Device.DeviceMetadata.IpAddress.get -> string!
+Daqifi.Core.Device.DeviceMetadata.IpAddress.set -> void
+Daqifi.Core.Device.DeviceMetadata.MacAddress.get -> string!
+Daqifi.Core.Device.DeviceMetadata.MacAddress.set -> void
+Daqifi.Core.Device.DeviceMetadata.PartNumber.get -> string!
+Daqifi.Core.Device.DeviceMetadata.PartNumber.set -> void
+Daqifi.Core.Device.DeviceMetadata.SerialNumber.get -> string!
+Daqifi.Core.Device.DeviceMetadata.SerialNumber.set -> void
+Daqifi.Core.Device.DeviceMetadata.Ssid.get -> string!
+Daqifi.Core.Device.DeviceMetadata.Ssid.set -> void
+Daqifi.Core.Device.DeviceMetadata.UpdateFromProtobuf(DaqifiOutMessage! message) -> void
+Daqifi.Core.Device.DeviceMetadata.WifiInfrastructureMode.get -> uint
+Daqifi.Core.Device.DeviceMetadata.WifiInfrastructureMode.set -> void
+Daqifi.Core.Device.DeviceMetadata.WifiSecurityMode.get -> uint
+Daqifi.Core.Device.DeviceMetadata.WifiSecurityMode.set -> void
+Daqifi.Core.Device.DeviceNotConnectedException
+Daqifi.Core.Device.DeviceNotConnectedException.DeviceNotConnectedException() -> void
+Daqifi.Core.Device.DeviceNotConnectedException.DeviceNotConnectedException(string! message) -> void
+Daqifi.Core.Device.DeviceNotConnectedException.DeviceNotConnectedException(string! message, System.Exception? innerException) -> void
+Daqifi.Core.Device.DeviceNotConnectedException.DeviceNotConnectedException(string! message, System.Exception? innerException, bool isShuttingDown) -> void
+Daqifi.Core.Device.DeviceNotConnectedException.DeviceNotConnectedException(string! message, bool isShuttingDown) -> void
+Daqifi.Core.Device.DeviceNotConnectedException.IsShuttingDown.get -> bool
+Daqifi.Core.Device.DeviceReconnectFailedException
+Daqifi.Core.Device.DeviceReconnectFailedException.AttemptsMade.get -> int
+Daqifi.Core.Device.DeviceReconnectFailedException.DeviceName.get -> string!
+Daqifi.Core.Device.DeviceReconnectFailedException.DeviceReconnectFailedException(string! deviceName, int attemptsMade, System.Exception? innerException = null) -> void
+Daqifi.Core.Device.DeviceRegisteredEventArgs
+Daqifi.Core.Device.DeviceRegisteredEventArgs.DeviceRegisteredEventArgs(Daqifi.Core.Device.DeviceRegistration! registration) -> void
+Daqifi.Core.Device.DeviceRegisteredEventArgs.Registration.get -> Daqifi.Core.Device.DeviceRegistration!
+Daqifi.Core.Device.DeviceRegistration
+Daqifi.Core.Device.DeviceRegistration.ConnectionType.get -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.DeviceRegistration.Device.get -> Daqifi.Core.Device.DaqifiDevice!
+Daqifi.Core.Device.DeviceRegistration.DiscoveryInfo.get -> Daqifi.Core.Device.Discovery.IDeviceInfo?
+Daqifi.Core.Device.DeviceRegistration.Identity.get -> Daqifi.Core.Device.DeviceIdentity!
+Daqifi.Core.Device.DeviceRegistration.Key.get -> string!
+Daqifi.Core.Device.DeviceRegistrationOutcome
+Daqifi.Core.Device.DeviceRegistrationOutcome.Canceled = 3 -> Daqifi.Core.Device.DeviceRegistrationOutcome
+Daqifi.Core.Device.DeviceRegistrationOutcome.DuplicateRejected = 2 -> Daqifi.Core.Device.DeviceRegistrationOutcome
+Daqifi.Core.Device.DeviceRegistrationOutcome.Registered = 0 -> Daqifi.Core.Device.DeviceRegistrationOutcome
+Daqifi.Core.Device.DeviceRegistrationOutcome.ReplacedExisting = 1 -> Daqifi.Core.Device.DeviceRegistrationOutcome
+Daqifi.Core.Device.DeviceRegistrationResult
+Daqifi.Core.Device.DeviceRegistrationResult.Device.get -> Daqifi.Core.Device.DaqifiDevice?
+Daqifi.Core.Device.DeviceRegistrationResult.IsRegistered.get -> bool
+Daqifi.Core.Device.DeviceRegistrationResult.Key.get -> string?
+Daqifi.Core.Device.DeviceRegistrationResult.Outcome.get -> Daqifi.Core.Device.DeviceRegistrationOutcome
+Daqifi.Core.Device.DeviceRegistrationResult.Registration.get -> Daqifi.Core.Device.DeviceRegistration?
+Daqifi.Core.Device.DeviceRegistrationResult.WasDuplicate.get -> bool
+Daqifi.Core.Device.DeviceRemovalReason
+Daqifi.Core.Device.DeviceRemovalReason.Cleared = 3 -> Daqifi.Core.Device.DeviceRemovalReason
+Daqifi.Core.Device.DeviceRemovalReason.Disconnected = 2 -> Daqifi.Core.Device.DeviceRemovalReason
+Daqifi.Core.Device.DeviceRemovalReason.Removed = 0 -> Daqifi.Core.Device.DeviceRemovalReason
+Daqifi.Core.Device.DeviceRemovalReason.Replaced = 1 -> Daqifi.Core.Device.DeviceRemovalReason
+Daqifi.Core.Device.DeviceRemovedEventArgs
+Daqifi.Core.Device.DeviceRemovedEventArgs.DeviceRemovedEventArgs(Daqifi.Core.Device.DeviceRegistration! registration, Daqifi.Core.Device.DeviceRemovalReason reason) -> void
+Daqifi.Core.Device.DeviceRemovedEventArgs.Reason.get -> Daqifi.Core.Device.DeviceRemovalReason
+Daqifi.Core.Device.DeviceRemovedEventArgs.Registration.get -> Daqifi.Core.Device.DeviceRegistration!
+Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DeviceState.Connected = 2 -> Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DeviceState.Connecting = 1 -> Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DeviceState.Disconnected = 0 -> Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DeviceState.Error = 6 -> Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DeviceState.Initializing = 3 -> Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DeviceState.Ready = 4 -> Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DeviceState.Streaming = 5 -> Daqifi.Core.Device.DeviceState
+Daqifi.Core.Device.DeviceStatusEventArgs
+Daqifi.Core.Device.DeviceStatusEventArgs.DeviceStatusEventArgs(Daqifi.Core.Device.ConnectionStatus status) -> void
+Daqifi.Core.Device.DeviceStatusEventArgs.Status.get -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.DeviceType
+Daqifi.Core.Device.DeviceType.Nyquist1 = 1 -> Daqifi.Core.Device.DeviceType
+Daqifi.Core.Device.DeviceType.Nyquist2 = 2 -> Daqifi.Core.Device.DeviceType
+Daqifi.Core.Device.DeviceType.Nyquist3 = 3 -> Daqifi.Core.Device.DeviceType
+Daqifi.Core.Device.DeviceType.Unknown = 0 -> Daqifi.Core.Device.DeviceType
+Daqifi.Core.Device.DeviceTypeDetector
+Daqifi.Core.Device.Diagnostics.CommandHistoryParser
+Daqifi.Core.Device.Diagnostics.DeviceDiagnosticsCorruptedResponseException
+Daqifi.Core.Device.Diagnostics.DeviceDiagnosticsCorruptedResponseException.DeviceDiagnosticsCorruptedResponseException(string! message, System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse, System.Exception? innerException = null) -> void
+Daqifi.Core.Device.Diagnostics.DeviceDiagnosticsException
+Daqifi.Core.Device.Diagnostics.DeviceDiagnosticsException.DeviceDiagnosticsException(string! message, System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse, System.Exception? innerException = null) -> void
+Daqifi.Core.Device.Diagnostics.DeviceDiagnosticsException.RawDeviceResponse.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics.ClearSystemLogAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics.GetCommandHistoryAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics.GetMemoryDiagnosticsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.Diagnostics.MemoryDiagnostics!>!
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics.GetStreamStatsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.Diagnostics.StreamStats!>!
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics.GetSystemErrorCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics.GetSystemLogAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.Diagnostics.SystemLogEntry!>!>!
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics.SetLogLevelAsync(string! module, int level, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.Diagnostics.LogLevelSetting!>!
+Daqifi.Core.Device.Diagnostics.IDeviceDiagnostics.TestSystemLogAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Diagnostics.LogLevelParser
+Daqifi.Core.Device.Diagnostics.LogLevelSetting
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.<Clone>$() -> Daqifi.Core.Device.Diagnostics.LogLevelSetting!
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.Ceiling.get -> int
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.Ceiling.init -> void
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.Equals(Daqifi.Core.Device.Diagnostics.LogLevelSetting? other) -> bool
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.Level.get -> int
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.Level.init -> void
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.LogLevelSetting() -> void
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.Module.get -> string!
+Daqifi.Core.Device.Diagnostics.LogLevelSetting.Module.init -> void
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.<Clone>$() -> Daqifi.Core.Device.Diagnostics.MemoryDiagnostics!
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.CoherentPoolFree.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.CoherentPoolTotal.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.Equals(Daqifi.Core.Device.Diagnostics.MemoryDiagnostics? other) -> bool
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.HeapFree.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.HeapFreeBlocks.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.HeapMinEverFree.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.HeapTotal.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.HeapUsed.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.LargestFreeBlock.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.MemoryDiagnostics() -> void
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SampleElementBytes.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SampleNextFreeBytes.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SamplePoolBytes.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SamplePoolCount.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SamplePoolInUse.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SamplePoolMaxUsed.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SampleQueueBytes.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SdCircularSize.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.SmallestFreeBlock.get -> ulong?
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.Values.get -> System.Collections.Generic.IReadOnlyDictionary<string!, ulong>!
+Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.Values.init -> void
+Daqifi.Core.Device.Diagnostics.MemoryDiagnosticsParser
+Daqifi.Core.Device.Diagnostics.StreamStats
+Daqifi.Core.Device.Diagnostics.StreamStats.<Clone>$() -> Daqifi.Core.Device.Diagnostics.StreamStats!
+Daqifi.Core.Device.Diagnostics.StreamStats.Equals(Daqifi.Core.Device.Diagnostics.StreamStats? other) -> bool
+Daqifi.Core.Device.Diagnostics.StreamStats.QueueDroppedSamples.get -> ulong?
+Daqifi.Core.Device.Diagnostics.StreamStats.StreamStats() -> void
+Daqifi.Core.Device.Diagnostics.StreamStats.TimerISRCalls.get -> ulong?
+Daqifi.Core.Device.Diagnostics.StreamStats.TotalBytesStreamed.get -> ulong?
+Daqifi.Core.Device.Diagnostics.StreamStats.TotalSamplesStreamed.get -> ulong?
+Daqifi.Core.Device.Diagnostics.StreamStats.Values.get -> System.Collections.Generic.IReadOnlyDictionary<string!, ulong>!
+Daqifi.Core.Device.Diagnostics.StreamStats.Values.init -> void
+Daqifi.Core.Device.Diagnostics.StreamStatsParser
+Daqifi.Core.Device.Diagnostics.SystemLogEntry
+Daqifi.Core.Device.Diagnostics.SystemLogEntry.<Clone>$() -> Daqifi.Core.Device.Diagnostics.SystemLogEntry!
+Daqifi.Core.Device.Diagnostics.SystemLogEntry.Equals(Daqifi.Core.Device.Diagnostics.SystemLogEntry? other) -> bool
+Daqifi.Core.Device.Diagnostics.SystemLogEntry.Message.get -> string!
+Daqifi.Core.Device.Diagnostics.SystemLogEntry.Message.init -> void
+Daqifi.Core.Device.Diagnostics.SystemLogEntry.SystemLogEntry() -> void
+Daqifi.Core.Device.Diagnostics.SystemLogParser
+Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder
+Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder.AllTransportsDeviceFinder(System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceFinder!>! finders, System.Func<Daqifi.Core.Device.Discovery.IDeviceInfo!, string!>? identitySelector = null) -> void
+Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder.DeviceDiscovered -> System.EventHandler<Daqifi.Core.Device.Discovery.DeviceDiscoveredEventArgs!>?
+Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder.DiscoverAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder.DiscoverAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder.DiscoveryCompleted -> System.EventHandler?
+Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder.Dispose() -> void
+Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.Discovery.ConnectionType.Hid = 3 -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.Discovery.ConnectionType.Serial = 2 -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.Discovery.ConnectionType.Unknown = 0 -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.Discovery.ConnectionType.WiFi = 1 -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.ContinuousDeviceFinder(Daqifi.Core.Device.Discovery.IDeviceFinder! finder, Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions? options = null) -> void
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.DeviceDiscovered -> System.EventHandler<Daqifi.Core.Device.Discovery.DeviceDiscoveredEventArgs!>?
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.DeviceLost -> System.EventHandler<Daqifi.Core.Device.Discovery.DeviceLostEventArgs!>?
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.Devices.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.Discovery.IDeviceInfo!>!
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.Dispose() -> void
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.IsRunning.get -> bool
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.ScanError -> System.EventHandler<Daqifi.Core.Device.Discovery.ContinuousDiscoveryErrorEventArgs!>?
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.Start() -> void
+Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.StopAsync() -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryErrorEventArgs
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryErrorEventArgs.ContinuousDiscoveryErrorEventArgs(System.Exception! exception) -> void
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryErrorEventArgs.Exception.get -> System.Exception!
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.ContinuousDiscoveryOptions() -> void
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.IdentitySelector.get -> System.Func<Daqifi.Core.Device.Discovery.IDeviceInfo!, string!>?
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.IdentitySelector.set -> void
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.Interval.get -> System.TimeSpan
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.Interval.set -> void
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.LeaveInnerFinderOpen.get -> bool
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.LeaveInnerFinderOpen.set -> void
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.MissThreshold.get -> int
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.MissThreshold.set -> void
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.PassTimeout.get -> System.TimeSpan
+Daqifi.Core.Device.Discovery.ContinuousDiscoveryOptions.PassTimeout.set -> void
+Daqifi.Core.Device.Discovery.DaqifiUsbIds
+Daqifi.Core.Device.Discovery.DeviceDiscoveredEventArgs
+Daqifi.Core.Device.Discovery.DeviceDiscoveredEventArgs.DeviceDiscoveredEventArgs(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo) -> void
+Daqifi.Core.Device.Discovery.DeviceDiscoveredEventArgs.DeviceInfo.get -> Daqifi.Core.Device.Discovery.IDeviceInfo!
+Daqifi.Core.Device.Discovery.DeviceFinderBase
+Daqifi.Core.Device.Discovery.DeviceFinderBase.DeviceDiscovered -> System.EventHandler<Daqifi.Core.Device.Discovery.DeviceDiscoveredEventArgs!>?
+Daqifi.Core.Device.Discovery.DeviceFinderBase.DeviceFinderBase() -> void
+Daqifi.Core.Device.Discovery.DeviceFinderBase.DiscoveryCompleted -> System.EventHandler?
+Daqifi.Core.Device.Discovery.DeviceFinderBase.DiscoverySemaphore.get -> System.Threading.SemaphoreSlim!
+Daqifi.Core.Device.Discovery.DeviceFinderBase.Dispose() -> void
+Daqifi.Core.Device.Discovery.DeviceFinderBase.IsDisposed.get -> bool
+Daqifi.Core.Device.Discovery.DeviceFinderBase.ThrowIfDisposed() -> void
+Daqifi.Core.Device.Discovery.DeviceInfo
+Daqifi.Core.Device.Discovery.DeviceInfo.ConnectionType.get -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.Discovery.DeviceInfo.ConnectionType.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.DeviceInfo() -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.DevicePath.get -> string?
+Daqifi.Core.Device.Discovery.DeviceInfo.DevicePath.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.FirmwareVersion.get -> string!
+Daqifi.Core.Device.Discovery.DeviceInfo.FirmwareVersion.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.IPAddress.get -> System.Net.IPAddress?
+Daqifi.Core.Device.Discovery.DeviceInfo.IPAddress.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.IsPowerOn.get -> bool
+Daqifi.Core.Device.Discovery.DeviceInfo.IsPowerOn.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.LocalInterfaceAddress.get -> System.Net.IPAddress?
+Daqifi.Core.Device.Discovery.DeviceInfo.LocalInterfaceAddress.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.LocationKey.get -> string?
+Daqifi.Core.Device.Discovery.DeviceInfo.LocationKey.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.MacAddress.get -> string?
+Daqifi.Core.Device.Discovery.DeviceInfo.MacAddress.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.Name.get -> string!
+Daqifi.Core.Device.Discovery.DeviceInfo.Name.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.Port.get -> int?
+Daqifi.Core.Device.Discovery.DeviceInfo.Port.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.PortName.get -> string?
+Daqifi.Core.Device.Discovery.DeviceInfo.PortName.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.SerialNumber.get -> string!
+Daqifi.Core.Device.Discovery.DeviceInfo.SerialNumber.set -> void
+Daqifi.Core.Device.Discovery.DeviceInfo.Type.get -> Daqifi.Core.Device.Discovery.DeviceType
+Daqifi.Core.Device.Discovery.DeviceInfo.Type.set -> void
+Daqifi.Core.Device.Discovery.DeviceLostEventArgs
+Daqifi.Core.Device.Discovery.DeviceLostEventArgs.DeviceInfo.get -> Daqifi.Core.Device.Discovery.IDeviceInfo!
+Daqifi.Core.Device.Discovery.DeviceLostEventArgs.DeviceLostEventArgs(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo) -> void
+Daqifi.Core.Device.Discovery.DeviceType
+Daqifi.Core.Device.Discovery.DeviceType.Nyquist1 = 1 -> Daqifi.Core.Device.Discovery.DeviceType
+Daqifi.Core.Device.Discovery.DeviceType.Nyquist2 = 2 -> Daqifi.Core.Device.Discovery.DeviceType
+Daqifi.Core.Device.Discovery.DeviceType.Nyquist3 = 3 -> Daqifi.Core.Device.Discovery.DeviceType
+Daqifi.Core.Device.Discovery.DeviceType.Unknown = 0 -> Daqifi.Core.Device.Discovery.DeviceType
+Daqifi.Core.Device.Discovery.HidDeviceFinder
+Daqifi.Core.Device.Discovery.HidDeviceFinder.DiscoverAsync(int? vendorIdFilter, int? productIdFilter, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+Daqifi.Core.Device.Discovery.HidDeviceFinder.HidDeviceFinder() -> void
+Daqifi.Core.Device.Discovery.HidDeviceFinder.ProductIdFilter.get -> int?
+Daqifi.Core.Device.Discovery.HidDeviceFinder.ProductIdFilter.set -> void
+Daqifi.Core.Device.Discovery.HidDeviceFinder.VendorIdFilter.get -> int?
+Daqifi.Core.Device.Discovery.HidDeviceFinder.VendorIdFilter.set -> void
+Daqifi.Core.Device.Discovery.IDeviceFinder
+Daqifi.Core.Device.Discovery.IDeviceFinder.DeviceDiscovered -> System.EventHandler<Daqifi.Core.Device.Discovery.DeviceDiscoveredEventArgs!>?
+Daqifi.Core.Device.Discovery.IDeviceFinder.DiscoverAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+Daqifi.Core.Device.Discovery.IDeviceFinder.DiscoverAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+Daqifi.Core.Device.Discovery.IDeviceFinder.DiscoveryCompleted -> System.EventHandler?
+Daqifi.Core.Device.Discovery.IDeviceInfo
+Daqifi.Core.Device.Discovery.IDeviceInfo.ConnectionType.get -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.Discovery.IDeviceInfo.DevicePath.get -> string?
+Daqifi.Core.Device.Discovery.IDeviceInfo.FirmwareVersion.get -> string!
+Daqifi.Core.Device.Discovery.IDeviceInfo.IPAddress.get -> System.Net.IPAddress?
+Daqifi.Core.Device.Discovery.IDeviceInfo.IsPowerOn.get -> bool
+Daqifi.Core.Device.Discovery.IDeviceInfo.LocalInterfaceAddress.get -> System.Net.IPAddress?
+Daqifi.Core.Device.Discovery.IDeviceInfo.LocationKey.get -> string?
+Daqifi.Core.Device.Discovery.IDeviceInfo.MacAddress.get -> string?
+Daqifi.Core.Device.Discovery.IDeviceInfo.Name.get -> string!
+Daqifi.Core.Device.Discovery.IDeviceInfo.Port.get -> int?
+Daqifi.Core.Device.Discovery.IDeviceInfo.PortName.get -> string?
+Daqifi.Core.Device.Discovery.IDeviceInfo.SerialNumber.get -> string!
+Daqifi.Core.Device.Discovery.IDeviceInfo.Type.get -> Daqifi.Core.Device.Discovery.DeviceType
+Daqifi.Core.Device.Discovery.IUsbLocationProvider
+Daqifi.Core.Device.Discovery.IUsbLocationProvider.GetLocationKey(string! portNameOrDevicePath) -> string?
+Daqifi.Core.Device.Discovery.IUsbPortDescriptorProvider
+Daqifi.Core.Device.Discovery.IUsbPortDescriptorProvider.GetDescriptor(string! portName) -> Daqifi.Core.Device.Discovery.UsbPortDescriptor?
+Daqifi.Core.Device.Discovery.SerialDeviceFinder
+Daqifi.Core.Device.Discovery.SerialDeviceFinder.SerialDeviceFinder() -> void
+Daqifi.Core.Device.Discovery.SerialDeviceFinder.SerialDeviceFinder(int baudRate) -> void
+Daqifi.Core.Device.Discovery.UsbPortDescriptor
+Daqifi.Core.Device.Discovery.UsbPortDescriptor.<Clone>$() -> Daqifi.Core.Device.Discovery.UsbPortDescriptor!
+Daqifi.Core.Device.Discovery.UsbPortDescriptor.Deconstruct(out int VendorId, out int ProductId) -> void
+Daqifi.Core.Device.Discovery.UsbPortDescriptor.Equals(Daqifi.Core.Device.Discovery.UsbPortDescriptor? other) -> bool
+Daqifi.Core.Device.Discovery.UsbPortDescriptor.ProductId.get -> int
+Daqifi.Core.Device.Discovery.UsbPortDescriptor.ProductId.init -> void
+Daqifi.Core.Device.Discovery.UsbPortDescriptor.UsbPortDescriptor(int VendorId, int ProductId) -> void
+Daqifi.Core.Device.Discovery.UsbPortDescriptor.VendorId.get -> int
+Daqifi.Core.Device.Discovery.UsbPortDescriptor.VendorId.init -> void
+Daqifi.Core.Device.Discovery.WiFiDeviceFinder
+Daqifi.Core.Device.Discovery.WiFiDeviceFinder.WiFiDeviceFinder() -> void
+Daqifi.Core.Device.Discovery.WiFiDeviceFinder.WiFiDeviceFinder(int discoveryPort) -> void
+Daqifi.Core.Device.DuplicateCheckPhase
+Daqifi.Core.Device.DuplicateCheckPhase.AfterConnect = 1 -> Daqifi.Core.Device.DuplicateCheckPhase
+Daqifi.Core.Device.DuplicateCheckPhase.BeforeConnect = 0 -> Daqifi.Core.Device.DuplicateCheckPhase
+Daqifi.Core.Device.DuplicateDeviceAction
+Daqifi.Core.Device.DuplicateDeviceAction.Cancel = 2 -> Daqifi.Core.Device.DuplicateDeviceAction
+Daqifi.Core.Device.DuplicateDeviceAction.KeepExisting = 0 -> Daqifi.Core.Device.DuplicateDeviceAction
+Daqifi.Core.Device.DuplicateDeviceAction.SwitchToNew = 1 -> Daqifi.Core.Device.DuplicateDeviceAction
+Daqifi.Core.Device.DuplicateDeviceCheck
+Daqifi.Core.Device.DuplicateDeviceCheck.Existing.get -> Daqifi.Core.Device.DeviceRegistration!
+Daqifi.Core.Device.DuplicateDeviceCheck.ExistingConnectionType.get -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.DuplicateDeviceCheck.NewConnectionType.get -> Daqifi.Core.Device.Discovery.ConnectionType
+Daqifi.Core.Device.DuplicateDeviceCheck.NewDevice.get -> Daqifi.Core.Device.DaqifiDevice?
+Daqifi.Core.Device.DuplicateDeviceCheck.NewDeviceInfo.get -> Daqifi.Core.Device.Discovery.IDeviceInfo?
+Daqifi.Core.Device.DuplicateDeviceCheck.NewIdentity.get -> Daqifi.Core.Device.DeviceIdentity!
+Daqifi.Core.Device.DuplicateDeviceCheck.Phase.get -> Daqifi.Core.Device.DuplicateCheckPhase
+Daqifi.Core.Device.FeatureNotSupportedException
+Daqifi.Core.Device.FeatureNotSupportedException.ActualVersion.get -> string?
+Daqifi.Core.Device.FeatureNotSupportedException.Board.get -> Daqifi.Core.Device.DeviceType?
+Daqifi.Core.Device.FeatureNotSupportedException.Feature.get -> Daqifi.Core.Device.DeviceFeature
+Daqifi.Core.Device.FeatureNotSupportedException.FeatureNotSupportedException(Daqifi.Core.Device.DeviceFeature feature, Daqifi.Core.Firmware.FirmwareVersion? requiredVersion = null, string? actualVersion = null, Daqifi.Core.Device.DeviceType? board = null) -> void
+Daqifi.Core.Device.FeatureNotSupportedException.RequiredVersion.get -> Daqifi.Core.Firmware.FirmwareVersion?
+Daqifi.Core.Device.IConfirmingDeviceAdministration
+Daqifi.Core.Device.IConfirmingDeviceAdministration.LoadAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IConfirmingDeviceAdministration.LoadFactoryAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IConfirmingDeviceAdministration.LoadVoltagePrecisionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IConfirmingDeviceAdministration.SaveAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IConfirmingDeviceAdministration.SaveFactoryAdcCalibrationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IConfirmingDeviceAdministration.SaveVoltagePrecisionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IConfirmingDeviceAdministration.SetAdcCalibrationOffsetAsync(int channelNumber, double calB, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IConfirmingDeviceAdministration.SetAdcCalibrationSlopeAsync(int channelNumber, double calM, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IConfirmingDeviceAdministration.UseAdcCalibrationAsync(int bank, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IDevice
+Daqifi.Core.Device.IDevice.Connect() -> void
+Daqifi.Core.Device.IDevice.ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IDevice.Disconnect() -> void
+Daqifi.Core.Device.IDevice.DisconnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IDevice.ErrorOccurred -> System.EventHandler<Daqifi.Core.Device.DeviceErrorEventArgs!>!
+Daqifi.Core.Device.IDevice.IpAddress.get -> System.Net.IPAddress?
+Daqifi.Core.Device.IDevice.IsConnected.get -> bool
+Daqifi.Core.Device.IDevice.MessageReceived -> System.EventHandler<Daqifi.Core.Device.MessageReceivedEventArgs!>!
+Daqifi.Core.Device.IDevice.Name.get -> string!
+Daqifi.Core.Device.IDevice.Send<T>(Daqifi.Core.Communication.Messages.IOutboundMessage<T>! message) -> void
+Daqifi.Core.Device.IDevice.Status.get -> Daqifi.Core.Device.ConnectionStatus
+Daqifi.Core.Device.IDevice.StatusChanged -> System.EventHandler<Daqifi.Core.Device.DeviceStatusEventArgs!>!
+Daqifi.Core.Device.ILiveSampleSource
+Daqifi.Core.Device.ILiveSampleSource.DroppedLiveSampleCount.get -> long
+Daqifi.Core.Device.ILiveSampleSource.StreamSamplesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), int? bufferCapacity = null) -> System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Channel.LiveSample!>!
+Daqifi.Core.Device.IStreamingDevice
+Daqifi.Core.Device.IStreamingDevice.Channels.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>!
+Daqifi.Core.Device.IStreamingDevice.ChannelsPopulated -> System.EventHandler<Daqifi.Core.Device.ChannelsPopulatedEventArgs!>?
+Daqifi.Core.Device.IStreamingDevice.DisableAllChannels() -> void
+Daqifi.Core.Device.IStreamingDevice.DisableAllChannelsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.DisableChannel(Daqifi.Core.Channel.IChannel! channel) -> void
+Daqifi.Core.Device.IStreamingDevice.DisableChannelAsync(Daqifi.Core.Channel.IChannel! channel, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.EnableChannel(Daqifi.Core.Channel.IChannel! channel) -> void
+Daqifi.Core.Device.IStreamingDevice.EnableChannelAsync(Daqifi.Core.Channel.IChannel! channel, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.EnableChannels(System.Collections.Generic.IEnumerable<Daqifi.Core.Channel.IChannel!>! channels) -> void
+Daqifi.Core.Device.IStreamingDevice.EnableChannelsAsync(System.Collections.Generic.IEnumerable<Daqifi.Core.Channel.IChannel!>! channels, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.EnforceStreamingFrequencyCap() -> int?
+Daqifi.Core.Device.IStreamingDevice.GetChannelsSnapshot() -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Channel.IChannel!>!
+Daqifi.Core.Device.IStreamingDevice.IsStreaming.get -> bool
+Daqifi.Core.Device.IStreamingDevice.LoadAdcCalibration() -> void
+Daqifi.Core.Device.IStreamingDevice.LoadFactoryAdcCalibration() -> void
+Daqifi.Core.Device.IStreamingDevice.LoadVoltagePrecision() -> void
+Daqifi.Core.Device.IStreamingDevice.MaximumStreamingFrequencyHz.get -> int
+Daqifi.Core.Device.IStreamingDevice.Metadata.get -> Daqifi.Core.Device.DeviceMetadata!
+Daqifi.Core.Device.IStreamingDevice.PwmFrequencyHz.get -> int
+Daqifi.Core.Device.IStreamingDevice.Reboot() -> void
+Daqifi.Core.Device.IStreamingDevice.RebootAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.SaveAdcCalibration() -> void
+Daqifi.Core.Device.IStreamingDevice.SaveFactoryAdcCalibration() -> void
+Daqifi.Core.Device.IStreamingDevice.SaveVoltagePrecision() -> void
+Daqifi.Core.Device.IStreamingDevice.SetAdcCalibrationOffset(int channelNumber, double calB) -> void
+Daqifi.Core.Device.IStreamingDevice.SetAdcCalibrationSlope(int channelNumber, double calM) -> void
+Daqifi.Core.Device.IStreamingDevice.SetAnalogOutput(int channelNumber, double voltage) -> void
+Daqifi.Core.Device.IStreamingDevice.SetAnalogOutputAsync(int channelNumber, double voltage, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.SetDioDirection(Daqifi.Core.Channel.IChannel! channel, Daqifi.Core.Channel.ChannelDirection direction) -> void
+Daqifi.Core.Device.IStreamingDevice.SetDioDirectionAsync(Daqifi.Core.Channel.IChannel! channel, Daqifi.Core.Channel.ChannelDirection direction, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.SetDioValue(Daqifi.Core.Channel.IChannel! channel, bool value) -> void
+Daqifi.Core.Device.IStreamingDevice.SetDioValueAsync(Daqifi.Core.Channel.IChannel! channel, bool value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.SetPwmDutyCycle(Daqifi.Core.Channel.IChannel! channel, int dutyCyclePercent) -> void
+Daqifi.Core.Device.IStreamingDevice.SetPwmDutyCycleAsync(Daqifi.Core.Channel.IChannel! channel, int dutyCyclePercent, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.SetPwmEnabled(Daqifi.Core.Channel.IChannel! channel, bool enabled) -> void
+Daqifi.Core.Device.IStreamingDevice.SetPwmEnabledAsync(Daqifi.Core.Channel.IChannel! channel, bool enabled, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.SetPwmFrequency(int frequencyHz) -> void
+Daqifi.Core.Device.IStreamingDevice.SetPwmFrequencyAsync(int frequencyHz, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.StartStreaming() -> void
+Daqifi.Core.Device.IStreamingDevice.StartStreamingAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.StopStreaming() -> void
+Daqifi.Core.Device.IStreamingDevice.StopStreamingAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.IStreamingDevice.StreamingFrequency.get -> int
+Daqifi.Core.Device.IStreamingDevice.StreamingFrequency.set -> void
+Daqifi.Core.Device.IStreamingDevice.UseAdcCalibration(int bank) -> void
+Daqifi.Core.Device.ITimestampProcessor
+Daqifi.Core.Device.ITimestampProcessor.GetTickPeriod(string! deviceId) -> double
+Daqifi.Core.Device.ITimestampProcessor.HasTimestampFrequency(string! deviceId) -> bool
+Daqifi.Core.Device.ITimestampProcessor.ProcessTimestamp(string! deviceId, uint deviceTimestamp) -> Daqifi.Core.Device.TimestampResult!
+Daqifi.Core.Device.ITimestampProcessor.Reset(string! deviceId) -> void
+Daqifi.Core.Device.ITimestampProcessor.ResetAll() -> void
+Daqifi.Core.Device.ITimestampProcessor.SetTimestampFrequency(string! deviceId, uint frequencyHz) -> void
+Daqifi.Core.Device.ITimestampProcessor.TickPeriod.get -> double
+Daqifi.Core.Device.MessageReceivedEventArgs
+Daqifi.Core.Device.MessageReceivedEventArgs.Message.get -> Daqifi.Core.Communication.Messages.IInboundMessage<object!>!
+Daqifi.Core.Device.MessageReceivedEventArgs.MessageReceivedEventArgs(Daqifi.Core.Communication.Messages.IInboundMessage<object!>! message) -> void
+Daqifi.Core.Device.Network.INetworkConfigurable
+Daqifi.Core.Device.Network.INetworkConfigurable.FactoryResetNetworkAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Network.INetworkConfigurable.LoadNetworkConfigurationAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Network.INetworkConfigurable.NetworkConfiguration.get -> Daqifi.Core.Device.Network.NetworkConfiguration!
+Daqifi.Core.Device.Network.INetworkConfigurable.PrepareLanInterface() -> void
+Daqifi.Core.Device.Network.INetworkConfigurable.PrepareSdInterface() -> void
+Daqifi.Core.Device.Network.INetworkConfigurable.UpdateNetworkConfigurationAsync(Daqifi.Core.Device.Network.NetworkConfiguration! configuration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Network.NetworkAddressHelper
+Daqifi.Core.Device.Network.NetworkConfiguration
+Daqifi.Core.Device.Network.NetworkConfiguration.Clone() -> Daqifi.Core.Device.Network.NetworkConfiguration!
+Daqifi.Core.Device.Network.NetworkConfiguration.Gateway.get -> System.Net.IPAddress?
+Daqifi.Core.Device.Network.NetworkConfiguration.Gateway.set -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.Mode.get -> Daqifi.Core.Device.Network.WifiMode
+Daqifi.Core.Device.Network.NetworkConfiguration.Mode.set -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.NetworkConfiguration() -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.NetworkConfiguration(Daqifi.Core.Device.Network.WifiMode mode, Daqifi.Core.Device.Network.WifiSecurityType securityType, string! ssid, string! password) -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.NetworkConfiguration(Daqifi.Core.Device.Network.WifiMode mode, Daqifi.Core.Device.Network.WifiSecurityType securityType, string! ssid, string! password, System.Net.IPAddress? staticIP, System.Net.IPAddress? subnetMask, System.Net.IPAddress? gateway) -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.Password.get -> string!
+Daqifi.Core.Device.Network.NetworkConfiguration.Password.set -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.SecurityType.get -> Daqifi.Core.Device.Network.WifiSecurityType
+Daqifi.Core.Device.Network.NetworkConfiguration.SecurityType.set -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.Ssid.get -> string!
+Daqifi.Core.Device.Network.NetworkConfiguration.Ssid.set -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.StaticIP.get -> System.Net.IPAddress?
+Daqifi.Core.Device.Network.NetworkConfiguration.StaticIP.set -> void
+Daqifi.Core.Device.Network.NetworkConfiguration.SubnetMask.get -> System.Net.IPAddress?
+Daqifi.Core.Device.Network.NetworkConfiguration.SubnetMask.set -> void
+Daqifi.Core.Device.Network.WifiMode
+Daqifi.Core.Device.Network.WifiMode.ExistingNetwork = 1 -> Daqifi.Core.Device.Network.WifiMode
+Daqifi.Core.Device.Network.WifiMode.SelfHosted = 4 -> Daqifi.Core.Device.Network.WifiMode
+Daqifi.Core.Device.Network.WifiSecurityType
+Daqifi.Core.Device.Network.WifiSecurityType.None = 0 -> Daqifi.Core.Device.Network.WifiSecurityType
+Daqifi.Core.Device.Network.WifiSecurityType.WpaPskPhrase = 3 -> Daqifi.Core.Device.Network.WifiSecurityType
+Daqifi.Core.Device.Protocol.IProtocolHandler
+Daqifi.Core.Device.Protocol.IProtocolHandler.CanHandle(Daqifi.Core.Communication.Messages.IInboundMessage<object!>! message) -> bool
+Daqifi.Core.Device.Protocol.IProtocolHandler.HandleAsync(Daqifi.Core.Communication.Messages.IInboundMessage<object!>! message) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Protocol.ProtobufMessageType
+Daqifi.Core.Device.Protocol.ProtobufMessageType.Error = 4 -> Daqifi.Core.Device.Protocol.ProtobufMessageType
+Daqifi.Core.Device.Protocol.ProtobufMessageType.SdCard = 3 -> Daqifi.Core.Device.Protocol.ProtobufMessageType
+Daqifi.Core.Device.Protocol.ProtobufMessageType.Status = 1 -> Daqifi.Core.Device.Protocol.ProtobufMessageType
+Daqifi.Core.Device.Protocol.ProtobufMessageType.Stream = 2 -> Daqifi.Core.Device.Protocol.ProtobufMessageType
+Daqifi.Core.Device.Protocol.ProtobufMessageType.Unknown = 0 -> Daqifi.Core.Device.Protocol.ProtobufMessageType
+Daqifi.Core.Device.Protocol.ProtobufProtocolHandler
+Daqifi.Core.Device.Protocol.ProtobufProtocolHandler.CanHandle(Daqifi.Core.Communication.Messages.IInboundMessage<object!>! message) -> bool
+Daqifi.Core.Device.Protocol.ProtobufProtocolHandler.Handle(DaqifiOutMessage! message) -> void
+Daqifi.Core.Device.Protocol.ProtobufProtocolHandler.HandleAsync(Daqifi.Core.Communication.Messages.IInboundMessage<object!>! message) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.Protocol.ProtobufProtocolHandler.ProtobufProtocolHandler(System.Action<DaqifiOutMessage!>? statusMessageHandler = null, System.Action<DaqifiOutMessage!>? streamMessageHandler = null, System.Action<DaqifiOutMessage!>? sdCardMessageHandler = null, System.Action<DaqifiOutMessage!>? errorMessageHandler = null) -> void
+Daqifi.Core.Device.ReconnectAttemptEventArgs
+Daqifi.Core.Device.ReconnectAttemptEventArgs.AttemptNumber.get -> int
+Daqifi.Core.Device.ReconnectAttemptEventArgs.Delay.get -> System.TimeSpan
+Daqifi.Core.Device.ReconnectAttemptEventArgs.MaxAttempts.get -> int
+Daqifi.Core.Device.ReconnectAttemptEventArgs.PreviousError.get -> System.Exception?
+Daqifi.Core.Device.ReconnectAttemptEventArgs.ReconnectAttemptEventArgs(int attemptNumber, int maxAttempts, System.TimeSpan delay, System.Exception? previousError = null) -> void
+Daqifi.Core.Device.ReconnectAttemptEventArgs.Timestamp.get -> System.DateTime
+Daqifi.Core.Device.ReconnectFailedEventArgs
+Daqifi.Core.Device.ReconnectFailedEventArgs.AttemptsMade.get -> int
+Daqifi.Core.Device.ReconnectFailedEventArgs.LastError.get -> System.Exception?
+Daqifi.Core.Device.ReconnectFailedEventArgs.ReconnectFailedEventArgs(int attemptsMade, System.Exception? lastError, bool wasCanceled) -> void
+Daqifi.Core.Device.ReconnectFailedEventArgs.Timestamp.get -> System.DateTime
+Daqifi.Core.Device.ReconnectFailedEventArgs.WasCanceled.get -> bool
+Daqifi.Core.Device.ReconnectOptions
+Daqifi.Core.Device.ReconnectOptions.BackoffMultiplier.get -> double
+Daqifi.Core.Device.ReconnectOptions.BackoffMultiplier.set -> void
+Daqifi.Core.Device.ReconnectOptions.CalculateDelay(int attemptNumber) -> System.TimeSpan
+Daqifi.Core.Device.ReconnectOptions.Enabled.get -> bool
+Daqifi.Core.Device.ReconnectOptions.Enabled.set -> void
+Daqifi.Core.Device.ReconnectOptions.InitialDelay.get -> System.TimeSpan
+Daqifi.Core.Device.ReconnectOptions.InitialDelay.set -> void
+Daqifi.Core.Device.ReconnectOptions.MaxAttempts.get -> int
+Daqifi.Core.Device.ReconnectOptions.MaxAttempts.set -> void
+Daqifi.Core.Device.ReconnectOptions.MaxDelay.get -> System.TimeSpan
+Daqifi.Core.Device.ReconnectOptions.MaxDelay.set -> void
+Daqifi.Core.Device.ReconnectOptions.ReconnectOptions() -> void
+Daqifi.Core.Device.ReconnectOptions.ResumeStreaming.get -> bool
+Daqifi.Core.Device.ReconnectOptions.ResumeStreaming.set -> void
+Daqifi.Core.Device.ReconnectedEventArgs
+Daqifi.Core.Device.ReconnectedEventArgs.AttemptNumber.get -> int
+Daqifi.Core.Device.ReconnectedEventArgs.Outage.get -> System.TimeSpan
+Daqifi.Core.Device.ReconnectedEventArgs.ReconnectedEventArgs(int attemptNumber, System.TimeSpan outage, bool streamingResumed) -> void
+Daqifi.Core.Device.ReconnectedEventArgs.StreamingResumed.get -> bool
+Daqifi.Core.Device.ReconnectedEventArgs.Timestamp.get -> System.DateTime
+Daqifi.Core.Device.ScpiInitializationErrorException
+Daqifi.Core.Device.ScpiInitializationErrorException.LastScpiError.get -> string?
+Daqifi.Core.Device.ScpiInitializationErrorException.RawDeviceResponse.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Daqifi.Core.Device.ScpiInitializationErrorException.ScpiInitializationErrorException(string! message, System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse, string? lastScpiError = null, System.Exception? innerException = null) -> void
+Daqifi.Core.Device.SdCard.ISdCardOperations
+Daqifi.Core.Device.SdCard.ISdCardOperations.CheckSdCardSpaceAsync(Daqifi.Core.Device.SdCard.SdCardCaptureEstimate? plannedCapture = null, long minimumFreeBytes = 104857600, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult!>!
+Daqifi.Core.Device.SdCard.ISdCardOperations.DeleteSdCardFileAsync(string! fileName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.SdCard.ISdCardOperations.DownloadSdCardFileAsync(string! fileName, System.IO.Stream! destinationStream, System.IProgress<Daqifi.Core.Device.SdCard.SdCardTransferProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardDownloadResult!>!
+Daqifi.Core.Device.SdCard.ISdCardOperations.DownloadSdCardFileAsync(string! fileName, System.IProgress<Daqifi.Core.Device.SdCard.SdCardTransferProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardDownloadResult!>!
+Daqifi.Core.Device.SdCard.ISdCardOperations.FormatSdCardAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.SdCard.ISdCardOperations.GetSdCardFilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.SdCard.SdCardFileInfo!>!>!
+Daqifi.Core.Device.SdCard.ISdCardOperations.GetSdCardStorageAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardStorageInfo!>!
+Daqifi.Core.Device.SdCard.ISdCardOperations.IsLoggingToSdCard.get -> bool
+Daqifi.Core.Device.SdCard.ISdCardOperations.LowSdSpaceWarning -> System.EventHandler<Daqifi.Core.Device.SdCard.LowSdSpaceWarningEventArgs!>!
+Daqifi.Core.Device.SdCard.ISdCardOperations.SdCardFiles.get -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.SdCard.SdCardFileInfo!>!
+Daqifi.Core.Device.SdCard.ISdCardOperations.SetSdCardMinimumFreeSpace(long bytes) -> void
+Daqifi.Core.Device.SdCard.ISdCardOperations.StartSdCardLoggingAsync(string? fileName = null, string? channelMask = null, Daqifi.Core.Device.SdCard.SdCardLogFormat format = Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.SdCard.ISdCardOperations.StartSdCardLoggingSessionAsync(string? fileName = null, string? channelMask = null, Daqifi.Core.Device.SdCard.SdCardLogFormat format = Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLoggingSession!>!
+Daqifi.Core.Device.SdCard.ISdCardOperations.StopSdCardLoggingAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Device.SdCard.LowSdSpaceWarningEventArgs
+Daqifi.Core.Device.SdCard.LowSdSpaceWarningEventArgs.LowSdSpaceWarningEventArgs(Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult! result) -> void
+Daqifi.Core.Device.SdCard.LowSdSpaceWarningEventArgs.Result.get -> Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult!
+Daqifi.Core.Device.SdCard.SdCardBusyException
+Daqifi.Core.Device.SdCard.SdCardBusyException.SdCardBusyException(System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse, string? lastScpiError = null) -> void
+Daqifi.Core.Device.SdCard.SdCardCaptureEstimate
+Daqifi.Core.Device.SdCard.SdCardCaptureEstimate.BytesPerSamplePerChannel.get -> int
+Daqifi.Core.Device.SdCard.SdCardCaptureEstimate.BytesPerSecond.get -> long
+Daqifi.Core.Device.SdCard.SdCardCaptureEstimate.ChannelCount.get -> int
+Daqifi.Core.Device.SdCard.SdCardCaptureEstimate.Duration.get -> System.TimeSpan
+Daqifi.Core.Device.SdCard.SdCardCaptureEstimate.EstimatedBytes.get -> long
+Daqifi.Core.Device.SdCard.SdCardCaptureEstimate.FrequencyHz.get -> int
+Daqifi.Core.Device.SdCard.SdCardCaptureEstimate.SdCardCaptureEstimate(int frequencyHz, int channelCount, System.TimeSpan duration, int bytesPerSamplePerChannel = 2) -> void
+Daqifi.Core.Device.SdCard.SdCardCsvFileParser
+Daqifi.Core.Device.SdCard.SdCardCsvFileParser.ParseAsync(System.IO.Stream! fileStream, string! fileName, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+Daqifi.Core.Device.SdCard.SdCardCsvFileParser.ParseFileAsync(string! filePath, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+Daqifi.Core.Device.SdCard.SdCardCsvFileParser.SdCardCsvFileParser() -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.<Clone>$() -> Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration!
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.AnalogPortCount.get -> int
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.AnalogPortCount.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.CalibrationValues.get -> System.Collections.Generic.IReadOnlyList<(double Slope, double Intercept)>?
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.CalibrationValues.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.Deconstruct(out int AnalogPortCount, out int DigitalPortCount, out uint TimestampFrequency, out string? DeviceSerialNumber, out string? DevicePartNumber, out string? FirmwareRevision, out System.Collections.Generic.IReadOnlyList<(double Slope, double Intercept)>? CalibrationValues, out uint Resolution, out System.Collections.Generic.IReadOnlyList<double>? PortRange, out System.Collections.Generic.IReadOnlyList<double>? InternalScaleM) -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.DevicePartNumber.get -> string?
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.DevicePartNumber.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.DeviceSerialNumber.get -> string?
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.DeviceSerialNumber.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.DigitalPortCount.get -> int
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.DigitalPortCount.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.Equals(Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration? other) -> bool
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.FirmwareRevision.get -> string?
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.FirmwareRevision.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.InternalScaleM.get -> System.Collections.Generic.IReadOnlyList<double>?
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.InternalScaleM.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.PortRange.get -> System.Collections.Generic.IReadOnlyList<double>?
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.PortRange.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.Resolution.get -> uint
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.Resolution.init -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.SdCardDeviceConfiguration(int AnalogPortCount, int DigitalPortCount, uint TimestampFrequency, string? DeviceSerialNumber, string? DevicePartNumber, string? FirmwareRevision, System.Collections.Generic.IReadOnlyList<(double Slope, double Intercept)>? CalibrationValues, uint Resolution = 0, System.Collections.Generic.IReadOnlyList<double>? PortRange = null, System.Collections.Generic.IReadOnlyList<double>? InternalScaleM = null) -> void
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.TimestampFrequency.get -> uint
+Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.TimestampFrequency.init -> void
+Daqifi.Core.Device.SdCard.SdCardDirectoryNotFoundException
+Daqifi.Core.Device.SdCard.SdCardDirectoryNotFoundException.DirectoryPath.get -> string?
+Daqifi.Core.Device.SdCard.SdCardDirectoryNotFoundException.SdCardDirectoryNotFoundException(System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse, string? lastScpiError, string! deviceMessage, string? directoryPath) -> void
+Daqifi.Core.Device.SdCard.SdCardDownloadResult
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.<Clone>$() -> Daqifi.Core.Device.SdCard.SdCardDownloadResult!
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.Deconstruct(out string! FileName, out long FileSize, out System.TimeSpan Duration, out string? FilePath) -> void
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.Duration.get -> System.TimeSpan
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.Duration.init -> void
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.Equals(Daqifi.Core.Device.SdCard.SdCardDownloadResult? other) -> bool
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.FileName.get -> string!
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.FileName.init -> void
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.FilePath.get -> string?
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.FilePath.init -> void
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.FileSize.get -> long
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.FileSize.init -> void
+Daqifi.Core.Device.SdCard.SdCardDownloadResult.SdCardDownloadResult(string! FileName, long FileSize, System.TimeSpan Duration, string? FilePath = null) -> void
+Daqifi.Core.Device.SdCard.SdCardEmptyTransferException
+Daqifi.Core.Device.SdCard.SdCardEmptyTransferException.FileName.get -> string!
+Daqifi.Core.Device.SdCard.SdCardEmptyTransferException.ListedSizeInBytes.get -> long?
+Daqifi.Core.Device.SdCard.SdCardEmptyTransferException.SdCardEmptyTransferException(string! fileName, long? listedSizeInBytes = null) -> void
+Daqifi.Core.Device.SdCard.SdCardFileInfo
+Daqifi.Core.Device.SdCard.SdCardFileInfo.CreatedDate.get -> System.DateTime?
+Daqifi.Core.Device.SdCard.SdCardFileInfo.FileName.get -> string!
+Daqifi.Core.Device.SdCard.SdCardFileInfo.SdCardFileInfo(string! fileName, System.DateTime? createdDate = null, long? sizeInBytes = null) -> void
+Daqifi.Core.Device.SdCard.SdCardFileInfo.SizeInBytes.get -> long?
+Daqifi.Core.Device.SdCard.SdCardFileListParser
+Daqifi.Core.Device.SdCard.SdCardFileParser
+Daqifi.Core.Device.SdCard.SdCardFileParser.ParseAsync(System.IO.Stream! fileStream, string! fileName, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+Daqifi.Core.Device.SdCard.SdCardFileParser.ParseFileAsync(string! filePath, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+Daqifi.Core.Device.SdCard.SdCardFileParser.SdCardFileParser() -> void
+Daqifi.Core.Device.SdCard.SdCardFileParserFactory
+Daqifi.Core.Device.SdCard.SdCardFileReceiver
+Daqifi.Core.Device.SdCard.SdCardFileReceiver.ReceiveAsync(System.IO.Stream! destinationStream, string! fileName, System.IProgress<Daqifi.Core.Device.SdCard.SdCardTransferProgress!>? progress = null, System.TimeSpan? timeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), long? listedFileSizeBytes = null) -> System.Threading.Tasks.Task<long>!
+Daqifi.Core.Device.SdCard.SdCardFileReceiver.SdCardFileReceiver(System.IO.Stream! sourceStream, bool zeroLengthReadMeansClosed, System.TimeSpan? idleTimeout = null, int bufferSize = 16384) -> void
+Daqifi.Core.Device.SdCard.SdCardFileReceiver.SdCardFileReceiver(System.IO.Stream! sourceStream, int bufferSize = 16384) -> void
+Daqifi.Core.Device.SdCard.SdCardFilesystemException
+Daqifi.Core.Device.SdCard.SdCardFilesystemException.DeviceMessage.get -> string!
+Daqifi.Core.Device.SdCard.SdCardFilesystemException.SdCardFilesystemException(System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse, string? lastScpiError, string! deviceMessage) -> void
+Daqifi.Core.Device.SdCard.SdCardJsonFileParser
+Daqifi.Core.Device.SdCard.SdCardJsonFileParser.ParseAsync(System.IO.Stream! fileStream, string! fileName, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+Daqifi.Core.Device.SdCard.SdCardJsonFileParser.ParseFileAsync(string! filePath, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+Daqifi.Core.Device.SdCard.SdCardJsonFileParser.SdCardJsonFileParser() -> void
+Daqifi.Core.Device.SdCard.SdCardListIncompleteException
+Daqifi.Core.Device.SdCard.SdCardListIncompleteException.SdCardListIncompleteException(System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse) -> void
+Daqifi.Core.Device.SdCard.SdCardListingStatus
+Daqifi.Core.Device.SdCard.SdCardListingStatus.Complete = 1 -> Daqifi.Core.Device.SdCard.SdCardListingStatus
+Daqifi.Core.Device.SdCard.SdCardListingStatus.Failed = 3 -> Daqifi.Core.Device.SdCard.SdCardListingStatus
+Daqifi.Core.Device.SdCard.SdCardListingStatus.Incomplete = 2 -> Daqifi.Core.Device.SdCard.SdCardListingStatus
+Daqifi.Core.Device.SdCard.SdCardListingStatus.Unterminated = 0 -> Daqifi.Core.Device.SdCard.SdCardListingStatus
+Daqifi.Core.Device.SdCard.SdCardLogEntry
+Daqifi.Core.Device.SdCard.SdCardLogEntry.<Clone>$() -> Daqifi.Core.Device.SdCard.SdCardLogEntry!
+Daqifi.Core.Device.SdCard.SdCardLogEntry.AnalogTimestamps.get -> System.Collections.Generic.IReadOnlyList<uint>?
+Daqifi.Core.Device.SdCard.SdCardLogEntry.AnalogTimestamps.init -> void
+Daqifi.Core.Device.SdCard.SdCardLogEntry.AnalogValues.get -> System.Collections.Generic.IReadOnlyList<double>!
+Daqifi.Core.Device.SdCard.SdCardLogEntry.AnalogValues.init -> void
+Daqifi.Core.Device.SdCard.SdCardLogEntry.Deconstruct(out System.DateTime Timestamp, out System.Collections.Generic.IReadOnlyList<double>! AnalogValues, out uint DigitalData, out System.Collections.Generic.IReadOnlyList<uint>? AnalogTimestamps) -> void
+Daqifi.Core.Device.SdCard.SdCardLogEntry.DigitalData.get -> uint
+Daqifi.Core.Device.SdCard.SdCardLogEntry.DigitalData.init -> void
+Daqifi.Core.Device.SdCard.SdCardLogEntry.Equals(Daqifi.Core.Device.SdCard.SdCardLogEntry? other) -> bool
+Daqifi.Core.Device.SdCard.SdCardLogEntry.HasDeviceTimestamp.get -> bool
+Daqifi.Core.Device.SdCard.SdCardLogEntry.HasDeviceTimestamp.init -> void
+Daqifi.Core.Device.SdCard.SdCardLogEntry.SdCardLogEntry(System.DateTime Timestamp, System.Collections.Generic.IReadOnlyList<double>! AnalogValues, uint DigitalData, System.Collections.Generic.IReadOnlyList<uint>? AnalogTimestamps) -> void
+Daqifi.Core.Device.SdCard.SdCardLogEntry.Timestamp.get -> System.DateTime
+Daqifi.Core.Device.SdCard.SdCardLogEntry.Timestamp.init -> void
+Daqifi.Core.Device.SdCard.SdCardLogFormat
+Daqifi.Core.Device.SdCard.SdCardLogFormat.Csv = 2 -> Daqifi.Core.Device.SdCard.SdCardLogFormat
+Daqifi.Core.Device.SdCard.SdCardLogFormat.Json = 1 -> Daqifi.Core.Device.SdCard.SdCardLogFormat
+Daqifi.Core.Device.SdCard.SdCardLogFormat.Protobuf = 0 -> Daqifi.Core.Device.SdCard.SdCardLogFormat
+Daqifi.Core.Device.SdCard.SdCardLogSession
+Daqifi.Core.Device.SdCard.SdCardLogSession.DeviceConfig.get -> Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration?
+Daqifi.Core.Device.SdCard.SdCardLogSession.FileCreatedDate.get -> System.DateTime?
+Daqifi.Core.Device.SdCard.SdCardLogSession.FileName.get -> string!
+Daqifi.Core.Device.SdCard.SdCardLogSession.Samples.get -> System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Device.SdCard.SdCardLogEntry!>!
+Daqifi.Core.Device.SdCard.SdCardLogSession.SdCardLogSession(string! fileName, System.DateTime? fileCreatedDate, Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration? deviceConfig, System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Device.SdCard.SdCardLogEntry!>! samples) -> void
+Daqifi.Core.Device.SdCard.SdCardLogSession.TimestampFrequency.get -> uint
+Daqifi.Core.Device.SdCard.SdCardLogSession.TimestampFrequency.init -> void
+Daqifi.Core.Device.SdCard.SdCardLogSession.TimestampFrequencySource.get -> Daqifi.Core.Device.SdCard.SdCardTimestampSource
+Daqifi.Core.Device.SdCard.SdCardLogSession.TimestampFrequencySource.init -> void
+Daqifi.Core.Device.SdCard.SdCardLoggingSession
+Daqifi.Core.Device.SdCard.SdCardLoggingSession.FileName.get -> string!
+Daqifi.Core.Device.SdCard.SdCardLoggingSession.Format.get -> Daqifi.Core.Device.SdCard.SdCardLogFormat
+Daqifi.Core.Device.SdCard.SdCardLoggingSession.SdCardLoggingSession(string! fileName, Daqifi.Core.Device.SdCard.SdCardLogFormat format) -> void
+Daqifi.Core.Device.SdCard.SdCardNotPresentException
+Daqifi.Core.Device.SdCard.SdCardNotPresentException.SdCardNotPresentException(System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse, string? lastScpiError = null) -> void
+Daqifi.Core.Device.SdCard.SdCardOperationException
+Daqifi.Core.Device.SdCard.SdCardOperationException.LastScpiError.get -> string?
+Daqifi.Core.Device.SdCard.SdCardOperationException.RawDeviceResponse.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Daqifi.Core.Device.SdCard.SdCardOperationException.SdCardOperationException(string! message, System.Collections.Generic.IReadOnlyList<string!>! rawDeviceResponse, string? lastScpiError = null, System.Exception? innerException = null) -> void
+Daqifi.Core.Device.SdCard.SdCardParseOptions
+Daqifi.Core.Device.SdCard.SdCardParseOptions.BufferSize.get -> int
+Daqifi.Core.Device.SdCard.SdCardParseOptions.BufferSize.set -> void
+Daqifi.Core.Device.SdCard.SdCardParseOptions.ConfigurationOverride.get -> Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration?
+Daqifi.Core.Device.SdCard.SdCardParseOptions.ConfigurationOverride.set -> void
+Daqifi.Core.Device.SdCard.SdCardParseOptions.ConfigurationScanMessageLimit.get -> int
+Daqifi.Core.Device.SdCard.SdCardParseOptions.ConfigurationScanMessageLimit.set -> void
+Daqifi.Core.Device.SdCard.SdCardParseOptions.FallbackTimestampFrequency.get -> uint
+Daqifi.Core.Device.SdCard.SdCardParseOptions.FallbackTimestampFrequency.set -> void
+Daqifi.Core.Device.SdCard.SdCardParseOptions.Progress.get -> System.IProgress<Daqifi.Core.Device.SdCard.SdCardParseProgress!>?
+Daqifi.Core.Device.SdCard.SdCardParseOptions.Progress.set -> void
+Daqifi.Core.Device.SdCard.SdCardParseOptions.SdCardParseOptions() -> void
+Daqifi.Core.Device.SdCard.SdCardParseOptions.SessionStartTime.get -> System.DateTime?
+Daqifi.Core.Device.SdCard.SdCardParseOptions.SessionStartTime.set -> void
+Daqifi.Core.Device.SdCard.SdCardParseProgress
+Daqifi.Core.Device.SdCard.SdCardParseProgress.<Clone>$() -> Daqifi.Core.Device.SdCard.SdCardParseProgress!
+Daqifi.Core.Device.SdCard.SdCardParseProgress.BytesRead.get -> long
+Daqifi.Core.Device.SdCard.SdCardParseProgress.BytesRead.init -> void
+Daqifi.Core.Device.SdCard.SdCardParseProgress.Deconstruct(out long BytesRead, out long TotalBytes, out int MessagesRead) -> void
+Daqifi.Core.Device.SdCard.SdCardParseProgress.Equals(Daqifi.Core.Device.SdCard.SdCardParseProgress? other) -> bool
+Daqifi.Core.Device.SdCard.SdCardParseProgress.MessagesRead.get -> int
+Daqifi.Core.Device.SdCard.SdCardParseProgress.MessagesRead.init -> void
+Daqifi.Core.Device.SdCard.SdCardParseProgress.SdCardParseProgress(long BytesRead, long TotalBytes, int MessagesRead) -> void
+Daqifi.Core.Device.SdCard.SdCardParseProgress.TotalBytes.get -> long
+Daqifi.Core.Device.SdCard.SdCardParseProgress.TotalBytes.init -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheck
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.<Clone>$() -> Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult!
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.Deconstruct(out Daqifi.Core.Device.SdCard.SdCardStorageInfo! Storage, out long? EstimatedCaptureBytes, out long MinimumFreeBytes, out bool IsNearlyFull, out bool IsInsufficientForCapture, out System.TimeSpan? EstimatedTimeUntilFull, out string? Message) -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.Equals(Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult? other) -> bool
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.EstimatedCaptureBytes.get -> long?
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.EstimatedCaptureBytes.init -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.EstimatedTimeUntilFull.get -> System.TimeSpan?
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.EstimatedTimeUntilFull.init -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.IsInsufficientForCapture.get -> bool
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.IsInsufficientForCapture.init -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.IsNearlyFull.get -> bool
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.IsNearlyFull.init -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.Message.get -> string?
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.Message.init -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.MinimumFreeBytes.get -> long
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.MinimumFreeBytes.init -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.SdCardSpaceCheckResult(Daqifi.Core.Device.SdCard.SdCardStorageInfo! Storage, long? EstimatedCaptureBytes, long MinimumFreeBytes, bool IsNearlyFull, bool IsInsufficientForCapture, System.TimeSpan? EstimatedTimeUntilFull, string? Message) -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.ShouldWarn.get -> bool
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.Storage.get -> Daqifi.Core.Device.SdCard.SdCardStorageInfo!
+Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.Storage.init -> void
+Daqifi.Core.Device.SdCard.SdCardSpaceParser
+Daqifi.Core.Device.SdCard.SdCardStorageInfo
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.<Clone>$() -> Daqifi.Core.Device.SdCard.SdCardStorageInfo!
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.Deconstruct(out long FreeBytes, out long TotalBytes) -> void
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.Equals(Daqifi.Core.Device.SdCard.SdCardStorageInfo? other) -> bool
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.FreeBytes.get -> long
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.FreeBytes.init -> void
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.SdCardStorageInfo(long FreeBytes, long TotalBytes) -> void
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.TotalBytes.get -> long
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.TotalBytes.init -> void
+Daqifi.Core.Device.SdCard.SdCardStorageInfo.UsedBytes.get -> long
+Daqifi.Core.Device.SdCard.SdCardTimestampSource
+Daqifi.Core.Device.SdCard.SdCardTimestampSource.Device = 2 -> Daqifi.Core.Device.SdCard.SdCardTimestampSource
+Daqifi.Core.Device.SdCard.SdCardTimestampSource.Fallback = 3 -> Daqifi.Core.Device.SdCard.SdCardTimestampSource
+Daqifi.Core.Device.SdCard.SdCardTimestampSource.LogFile = 1 -> Daqifi.Core.Device.SdCard.SdCardTimestampSource
+Daqifi.Core.Device.SdCard.SdCardTimestampSource.None = 0 -> Daqifi.Core.Device.SdCard.SdCardTimestampSource
+Daqifi.Core.Device.SdCard.SdCardTransferProgress
+Daqifi.Core.Device.SdCard.SdCardTransferProgress.<Clone>$() -> Daqifi.Core.Device.SdCard.SdCardTransferProgress!
+Daqifi.Core.Device.SdCard.SdCardTransferProgress.BytesReceived.get -> long
+Daqifi.Core.Device.SdCard.SdCardTransferProgress.BytesReceived.init -> void
+Daqifi.Core.Device.SdCard.SdCardTransferProgress.Deconstruct(out long BytesReceived, out string! FileName) -> void
+Daqifi.Core.Device.SdCard.SdCardTransferProgress.Equals(Daqifi.Core.Device.SdCard.SdCardTransferProgress? other) -> bool
+Daqifi.Core.Device.SdCard.SdCardTransferProgress.FileName.get -> string!
+Daqifi.Core.Device.SdCard.SdCardTransferProgress.FileName.init -> void
+Daqifi.Core.Device.SdCard.SdCardTransferProgress.SdCardTransferProgress(long BytesReceived, string! FileName) -> void
+Daqifi.Core.Device.SdCard.SdCardTransferStallReason
+Daqifi.Core.Device.SdCard.SdCardTransferStallReason.NoDataReceived = 0 -> Daqifi.Core.Device.SdCard.SdCardTransferStallReason
+Daqifi.Core.Device.SdCard.SdCardTransferStallReason.TransferTimeout = 2 -> Daqifi.Core.Device.SdCard.SdCardTransferStallReason
+Daqifi.Core.Device.SdCard.SdCardTransferStallReason.TransportClosed = 1 -> Daqifi.Core.Device.SdCard.SdCardTransferStallReason
+Daqifi.Core.Device.SdCard.SdCardTransferStalledException
+Daqifi.Core.Device.SdCard.SdCardTransferStalledException.BytesReceived.get -> long
+Daqifi.Core.Device.SdCard.SdCardTransferStalledException.FileName.get -> string!
+Daqifi.Core.Device.SdCard.SdCardTransferStalledException.Reason.get -> Daqifi.Core.Device.SdCard.SdCardTransferStallReason
+Daqifi.Core.Device.SdCard.SdCardTransferStalledException.SdCardTransferStalledException(string! fileName, long bytesReceived, Daqifi.Core.Device.SdCard.SdCardTransferStallReason reason, System.TimeSpan? timeout = null, System.Exception? innerException = null) -> void
+Daqifi.Core.Device.SdCard.SdCardTransferStalledException.Timeout.get -> System.TimeSpan?
+Daqifi.Core.Device.SdCard.SdCardTruncatedTransferException
+Daqifi.Core.Device.SdCard.SdCardTruncatedTransferException.BytesReceived.get -> long
+Daqifi.Core.Device.SdCard.SdCardTruncatedTransferException.FileName.get -> string!
+Daqifi.Core.Device.SdCard.SdCardTruncatedTransferException.ListedSizeInBytes.get -> long
+Daqifi.Core.Device.SdCard.SdCardTruncatedTransferException.SdCardTruncatedTransferException(string! fileName, long listedSizeInBytes, long bytesReceived) -> void
+Daqifi.Core.Device.StreamFrameDiscardReason
+Daqifi.Core.Device.StreamFrameDiscardReason.PartialAnalogFrame = 0 -> Daqifi.Core.Device.StreamFrameDiscardReason
+Daqifi.Core.Device.StreamFrameDiscardReason.StaleLeftoverFrame = 1 -> Daqifi.Core.Device.StreamFrameDiscardReason
+Daqifi.Core.Device.StreamFrameDiscardedEventArgs
+Daqifi.Core.Device.StreamFrameDiscardedEventArgs.AnalogValueCount.get -> int
+Daqifi.Core.Device.StreamFrameDiscardedEventArgs.DeviceTimestamp.get -> uint
+Daqifi.Core.Device.StreamFrameDiscardedEventArgs.EnabledAnalogChannelCount.get -> int
+Daqifi.Core.Device.StreamFrameDiscardedEventArgs.Reason.get -> Daqifi.Core.Device.StreamFrameDiscardReason
+Daqifi.Core.Device.StreamFrameDiscardedEventArgs.StreamFrameDiscardedEventArgs(Daqifi.Core.Device.StreamFrameDiscardReason reason, uint deviceTimestamp, int analogValueCount, int enabledAnalogChannelCount) -> void
+Daqifi.Core.Device.TimestampGapDetector
+Daqifi.Core.Device.TimestampGapDetector.EmaAlpha.get -> double
+Daqifi.Core.Device.TimestampGapDetector.GapThresholdMultiplier.get -> double
+Daqifi.Core.Device.TimestampGapDetector.IsGap(double? secondsBetweenMessages) -> bool
+Daqifi.Core.Device.TimestampGapDetector.Reset() -> void
+Daqifi.Core.Device.TimestampGapDetector.TimestampGapDetector(double gapThresholdMultiplier = 2, double emaAlpha = 0.1) -> void
+Daqifi.Core.Device.TimestampGapEventArgs
+Daqifi.Core.Device.TimestampGapEventArgs.DeviceTimestamp.get -> uint
+Daqifi.Core.Device.TimestampGapEventArgs.SecondsSincePreviousMessage.get -> double
+Daqifi.Core.Device.TimestampGapEventArgs.Timestamp.get -> System.DateTime
+Daqifi.Core.Device.TimestampGapEventArgs.TimestampGapEventArgs(System.DateTime timestamp, double secondsSincePreviousMessage, uint deviceTimestamp) -> void
+Daqifi.Core.Device.TimestampProcessor
+Daqifi.Core.Device.TimestampProcessor.GetTickPeriod(string! deviceId) -> double
+Daqifi.Core.Device.TimestampProcessor.HasTimestampFrequency(string! deviceId) -> bool
+Daqifi.Core.Device.TimestampProcessor.ProcessTimestamp(string! deviceId, uint deviceTimestamp) -> Daqifi.Core.Device.TimestampResult!
+Daqifi.Core.Device.TimestampProcessor.Reset(string! deviceId) -> void
+Daqifi.Core.Device.TimestampProcessor.ResetAll() -> void
+Daqifi.Core.Device.TimestampProcessor.SetTimestampFrequency(string! deviceId, uint frequencyHz) -> void
+Daqifi.Core.Device.TimestampProcessor.TickPeriod.get -> double
+Daqifi.Core.Device.TimestampProcessor.TimestampProcessor() -> void
+Daqifi.Core.Device.TimestampProcessor.TimestampProcessor(double tickPeriod) -> void
+Daqifi.Core.Device.TimestampResult
+Daqifi.Core.Device.TimestampResult.ClockCyclesBetweenMessages.get -> uint
+Daqifi.Core.Device.TimestampResult.IsFirstMessage.get -> bool
+Daqifi.Core.Device.TimestampResult.SecondsBetweenMessages.get -> double
+Daqifi.Core.Device.TimestampResult.Timestamp.get -> System.DateTime
+Daqifi.Core.Device.TimestampResult.TimestampResult(System.DateTime timestamp, bool wasRollover, uint clockCyclesBetweenMessages, double secondsBetweenMessages, bool isFirstMessage, bool usedFallbackTickPeriod = false) -> void
+Daqifi.Core.Device.TimestampResult.UsedFallbackTickPeriod.get -> bool
+Daqifi.Core.Device.TimestampResult.WasRollover.get -> bool
+Daqifi.Core.Firmware.Crc16
+Daqifi.Core.Firmware.Crc16.Crc.get -> ushort
+Daqifi.Core.Firmware.Crc16.Crc16(byte[]! data) -> void
+Daqifi.Core.Firmware.Crc16.High.get -> byte
+Daqifi.Core.Firmware.Crc16.Low.get -> byte
+Daqifi.Core.Firmware.ExternalProcessRequest
+Daqifi.Core.Firmware.ExternalProcessRequest.Arguments.get -> string!
+Daqifi.Core.Firmware.ExternalProcessRequest.Arguments.set -> void
+Daqifi.Core.Firmware.ExternalProcessRequest.ExternalProcessRequest() -> void
+Daqifi.Core.Firmware.ExternalProcessRequest.FileName.get -> string!
+Daqifi.Core.Firmware.ExternalProcessRequest.FileName.set -> void
+Daqifi.Core.Firmware.ExternalProcessRequest.OnStandardErrorLine.get -> System.Action<string!>?
+Daqifi.Core.Firmware.ExternalProcessRequest.OnStandardErrorLine.set -> void
+Daqifi.Core.Firmware.ExternalProcessRequest.OnStandardOutputLine.get -> System.Action<string!>?
+Daqifi.Core.Firmware.ExternalProcessRequest.OnStandardOutputLine.set -> void
+Daqifi.Core.Firmware.ExternalProcessRequest.StandardInputResponseFactory.get -> System.Func<string!, string?>?
+Daqifi.Core.Firmware.ExternalProcessRequest.StandardInputResponseFactory.set -> void
+Daqifi.Core.Firmware.ExternalProcessRequest.Timeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.ExternalProcessRequest.Timeout.set -> void
+Daqifi.Core.Firmware.ExternalProcessRequest.WorkingDirectory.get -> string?
+Daqifi.Core.Firmware.ExternalProcessRequest.WorkingDirectory.set -> void
+Daqifi.Core.Firmware.ExternalProcessResult
+Daqifi.Core.Firmware.ExternalProcessResult.Duration.get -> System.TimeSpan
+Daqifi.Core.Firmware.ExternalProcessResult.ExitCode.get -> int
+Daqifi.Core.Firmware.ExternalProcessResult.ExternalProcessResult(int exitCode, bool timedOut, System.TimeSpan duration, System.Collections.Generic.IReadOnlyList<string!>! standardOutputLines, System.Collections.Generic.IReadOnlyList<string!>! standardErrorLines) -> void
+Daqifi.Core.Firmware.ExternalProcessResult.StandardErrorLines.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Daqifi.Core.Firmware.ExternalProcessResult.StandardOutputLines.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Daqifi.Core.Firmware.ExternalProcessResult.TimedOut.get -> bool
+Daqifi.Core.Firmware.FirmwareReleaseInfo
+Daqifi.Core.Firmware.FirmwareReleaseInfo.AssetFileName.get -> string?
+Daqifi.Core.Firmware.FirmwareReleaseInfo.AssetFileName.init -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.AssetSize.get -> long?
+Daqifi.Core.Firmware.FirmwareReleaseInfo.AssetSize.init -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.DownloadUrl.get -> string?
+Daqifi.Core.Firmware.FirmwareReleaseInfo.DownloadUrl.init -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.FirmwareReleaseInfo() -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.IsPreRelease.get -> bool
+Daqifi.Core.Firmware.FirmwareReleaseInfo.IsPreRelease.init -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.PublishedAt.get -> System.DateTimeOffset?
+Daqifi.Core.Firmware.FirmwareReleaseInfo.PublishedAt.init -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.ReleaseNotes.get -> string?
+Daqifi.Core.Firmware.FirmwareReleaseInfo.ReleaseNotes.init -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.TagName.get -> string!
+Daqifi.Core.Firmware.FirmwareReleaseInfo.TagName.init -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.Version.get -> Daqifi.Core.Firmware.FirmwareVersion
+Daqifi.Core.Firmware.FirmwareReleaseInfo.Version.init -> void
+Daqifi.Core.Firmware.FirmwareReleaseInfo.ZipballUrl.get -> string?
+Daqifi.Core.Firmware.FirmwareReleaseInfo.ZipballUrl.init -> void
+Daqifi.Core.Firmware.FirmwareUpdateCheckResult
+Daqifi.Core.Firmware.FirmwareUpdateCheckResult.DeviceVersion.get -> Daqifi.Core.Firmware.FirmwareVersion?
+Daqifi.Core.Firmware.FirmwareUpdateCheckResult.DeviceVersion.init -> void
+Daqifi.Core.Firmware.FirmwareUpdateCheckResult.FirmwareUpdateCheckResult() -> void
+Daqifi.Core.Firmware.FirmwareUpdateCheckResult.LatestRelease.get -> Daqifi.Core.Firmware.FirmwareReleaseInfo?
+Daqifi.Core.Firmware.FirmwareUpdateCheckResult.LatestRelease.init -> void
+Daqifi.Core.Firmware.FirmwareUpdateCheckResult.UpdateAvailable.get -> bool
+Daqifi.Core.Firmware.FirmwareUpdateCheckResult.UpdateAvailable.init -> void
+Daqifi.Core.Firmware.FirmwareUpdateException
+Daqifi.Core.Firmware.FirmwareUpdateException.FailedState.get -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateException.FirmwareUpdateException(Daqifi.Core.Firmware.FirmwareUpdateState failedState, string! operation, string! message, string? recoveryGuidance = null, System.Exception? innerException = null) -> void
+Daqifi.Core.Firmware.FirmwareUpdateException.Operation.get -> string!
+Daqifi.Core.Firmware.FirmwareUpdateException.RecoveryGuidance.get -> string?
+Daqifi.Core.Firmware.FirmwareUpdateProgress
+Daqifi.Core.Firmware.FirmwareUpdateProgress.BytesWritten.get -> long
+Daqifi.Core.Firmware.FirmwareUpdateProgress.BytesWritten.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateProgress.CurrentOperation.get -> string!
+Daqifi.Core.Firmware.FirmwareUpdateProgress.CurrentOperation.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateProgress.FirmwareUpdateProgress() -> void
+Daqifi.Core.Firmware.FirmwareUpdateProgress.PercentComplete.get -> double
+Daqifi.Core.Firmware.FirmwareUpdateProgress.PercentComplete.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateProgress.State.get -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateProgress.State.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateProgress.TotalBytes.get -> long
+Daqifi.Core.Firmware.FirmwareUpdateProgress.TotalBytes.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateService
+Daqifi.Core.Firmware.FirmwareUpdateService.CheckBootloaderHealthAsync(string? targetDevicePath = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+Daqifi.Core.Firmware.FirmwareUpdateService.CheckWifiFirmwareStatusAsync(Daqifi.Core.Device.IStreamingDevice! device, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.WifiFirmwareStatus!>!
+Daqifi.Core.Firmware.FirmwareUpdateService.CurrentState.get -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateService.Dispose() -> void
+Daqifi.Core.Firmware.FirmwareUpdateService.FirmwareDownloadService.get -> Daqifi.Core.Firmware.IFirmwareDownloadService!
+Daqifi.Core.Firmware.FirmwareUpdateService.FirmwareUpdateService(Daqifi.Core.Communication.Transport.IHidTransport! hidTransport, Daqifi.Core.Firmware.IFirmwareDownloadService! firmwareDownloadService, Daqifi.Core.Firmware.IExternalProcessRunner! externalProcessRunner, Microsoft.Extensions.Logging.ILogger<Daqifi.Core.Firmware.FirmwareUpdateService!>? logger = null, Daqifi.Core.Firmware.IBootloaderProtocol? bootloaderProtocol = null, Daqifi.Core.Communication.Transport.IHidDeviceEnumerator? hidDeviceEnumerator = null, Daqifi.Core.Firmware.FirmwareUpdateServiceOptions? options = null, Daqifi.Core.Device.Discovery.IUsbLocationProvider? usbLocationProvider = null) -> void
+Daqifi.Core.Firmware.FirmwareUpdateService.ResetBootloaderAsync(string? targetDevicePath = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.FirmwareUpdateService.StateChanged -> System.EventHandler<Daqifi.Core.Firmware.FirmwareUpdateStateChangedEventArgs!>?
+Daqifi.Core.Firmware.FirmwareUpdateService.UpdateFirmwareAsync(Daqifi.Core.Device.IStreamingDevice! device, string! hexFilePath, System.IProgress<Daqifi.Core.Firmware.FirmwareUpdateProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.FirmwareUpdateService.UpdateFirmwareAsync(Daqifi.Core.Device.IStreamingDevice! device, string! hexFilePath, System.IProgress<Daqifi.Core.Firmware.FirmwareUpdateProgress!>? progress, string? targetDevicePath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.FirmwareUpdateService.UpdateFirmwareAsync(Daqifi.Core.Device.IStreamingDevice! device, string! hexFilePath, System.IProgress<Daqifi.Core.Firmware.FirmwareUpdateProgress!>? progress, string? targetDevicePath, string? targetLocationKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.FirmwareUpdateService.UpdateWifiModuleAsync(Daqifi.Core.Device.IStreamingDevice! device, string! firmwarePath, System.IProgress<Daqifi.Core.Firmware.FirmwareUpdateProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), bool skipVersionCheck = false) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.BootloaderProductId.get -> int
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.BootloaderProductId.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.BootloaderResponseTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.BootloaderResponseTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.BootloaderVendorId.get -> int
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.BootloaderVendorId.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.ConnectingTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.ConnectingTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.ErasingFlashTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.ErasingFlashTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.FirmwareUpdateServiceOptions() -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.FlashWriteRetryCount.get -> int
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.FlashWriteRetryCount.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.FlashWriteRetryDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.FlashWriteRetryDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.GetStateTimeout(Daqifi.Core.Firmware.FirmwareUpdateState state) -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.HidConnectRetryCount.get -> int
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.HidConnectRetryCount.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.HidConnectRetryDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.HidConnectRetryDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.JumpingToApplicationTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.JumpingToApplicationTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.KickLanApplyOnNotInitialized.get -> bool
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.KickLanApplyOnNotInitialized.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.LanChipInfoMaxAttempts.get -> int
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.LanChipInfoMaxAttempts.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.LanChipInfoRetryDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.LanChipInfoRetryDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.LanChipInfoTotalTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.LanChipInfoTotalTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.MinimumSupportedWifiFirmwareVersion.get -> string!
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.MinimumSupportedWifiFirmwareVersion.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PollInterval.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PollInterval.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostForceBootDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostForceBootDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostLanDisconnectPortReleaseDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostLanDisconnectPortReleaseDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostLanFirmwareModeDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostLanFirmwareModeDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostReconnectReadinessProbe.get -> System.Func<Daqifi.Core.Device.IStreamingDevice!, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>!>?
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostReconnectReadinessProbe.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostReconnectReadinessRetryDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostReconnectReadinessRetryDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostReconnectReadinessTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostReconnectReadinessTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostReconnectStaleHandleDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostReconnectStaleHandleDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostUsbTransparentModeExitDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostUsbTransparentModeExitDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostWifiReconnectDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PostWifiReconnectDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PowerOnWifiModuleBeforeLanUpdateMode.get -> bool
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PowerOnWifiModuleBeforeLanUpdateMode.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PowerOnWifiModuleBeforeProbe.get -> bool
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PowerOnWifiModuleBeforeProbe.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PowerOnWifiModuleSettleDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PowerOnWifiModuleSettleDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PreparingDeviceTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.PreparingDeviceTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.ProgrammingTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.ProgrammingTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.Validate() -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.VerifyingTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.VerifyingTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WaitingForBootloaderTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WaitingForBootloaderTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiBridgeActivationCallback.get -> System.Action?
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiBridgeActivationCallback.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashAttempts.get -> int
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashAttempts.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashRetryDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashRetryDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashSuccessMarker.get -> string!
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashSuccessMarker.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashToolArgumentsTemplate.get -> string!
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashToolArgumentsTemplate.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashToolFileName.get -> string!
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiFlashToolFileName.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiPortOverride.get -> string?
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiPortOverride.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiProcessTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WifiProcessTimeout.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WincBootPromptResponseDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.WincBootPromptResponseDelay.set -> void
+Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.CleaningUp = 10 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.Complete = 8 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.Connecting = 3 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.ErasingFlash = 4 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.Failed = 9 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.Idle = 0 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.JumpingToApp = 7 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.PreparingDevice = 1 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.Programming = 5 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.ReconnectingAfterFlash = 12 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.Recovered = 11 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.Verifying = 6 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateState.WaitingForBootloader = 2 -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateStateChangedEventArgs
+Daqifi.Core.Firmware.FirmwareUpdateStateChangedEventArgs.ChangedAtUtc.get -> System.DateTimeOffset
+Daqifi.Core.Firmware.FirmwareUpdateStateChangedEventArgs.CurrentState.get -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareUpdateStateChangedEventArgs.FirmwareUpdateStateChangedEventArgs(Daqifi.Core.Firmware.FirmwareUpdateState previousState, Daqifi.Core.Firmware.FirmwareUpdateState currentState, string! operation) -> void
+Daqifi.Core.Firmware.FirmwareUpdateStateChangedEventArgs.Operation.get -> string!
+Daqifi.Core.Firmware.FirmwareUpdateStateChangedEventArgs.PreviousState.get -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.FirmwareVersion
+Daqifi.Core.Firmware.FirmwareVersion.CompareTo(Daqifi.Core.Firmware.FirmwareVersion other) -> int
+Daqifi.Core.Firmware.FirmwareVersion.Deconstruct(out int Major, out int Minor, out int Patch, out string? PreLabel, out int PreNumber) -> void
+Daqifi.Core.Firmware.FirmwareVersion.Equals(Daqifi.Core.Firmware.FirmwareVersion other) -> bool
+Daqifi.Core.Firmware.FirmwareVersion.FirmwareVersion() -> void
+Daqifi.Core.Firmware.FirmwareVersion.FirmwareVersion(int Major, int Minor, int Patch, string? PreLabel, int PreNumber) -> void
+Daqifi.Core.Firmware.FirmwareVersion.IsPreRelease.get -> bool
+Daqifi.Core.Firmware.FirmwareVersion.Major.get -> int
+Daqifi.Core.Firmware.FirmwareVersion.Major.init -> void
+Daqifi.Core.Firmware.FirmwareVersion.Minor.get -> int
+Daqifi.Core.Firmware.FirmwareVersion.Minor.init -> void
+Daqifi.Core.Firmware.FirmwareVersion.Patch.get -> int
+Daqifi.Core.Firmware.FirmwareVersion.Patch.init -> void
+Daqifi.Core.Firmware.FirmwareVersion.PreLabel.get -> string?
+Daqifi.Core.Firmware.FirmwareVersion.PreLabel.init -> void
+Daqifi.Core.Firmware.FirmwareVersion.PreNumber.get -> int
+Daqifi.Core.Firmware.FirmwareVersion.PreNumber.init -> void
+Daqifi.Core.Firmware.FlashCrcRegion
+Daqifi.Core.Firmware.FlashCrcRegion.Address.get -> uint
+Daqifi.Core.Firmware.FlashCrcRegion.ExpectedCrc.get -> ushort
+Daqifi.Core.Firmware.FlashCrcRegion.FlashCrcRegion(uint address, uint length, ushort expectedCrc) -> void
+Daqifi.Core.Firmware.FlashCrcRegion.Length.get -> uint
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService.CheckForUpdateAsync(string! deviceVersionString, bool includePreRelease = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.FirmwareUpdateCheckResult!>!
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService.DownloadFirmwareByTagAsync(string! tagName, string! destinationDirectory, System.IProgress<int>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService.DownloadLatestFirmwareAsync(string! destinationDirectory, bool includePreRelease = false, System.IProgress<int>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService.DownloadWifiFirmwareAsync(string! destinationDirectory, System.IProgress<int>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<(string! ExtractedPath, string! Version)?>!
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService.GetLatestReleaseAsync(bool includePreRelease = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.FirmwareReleaseInfo?>!
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService.GetLatestWifiReleaseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.FirmwareReleaseInfo?>!
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService.GitHubFirmwareDownloadService(System.Net.Http.HttpClient! httpClient, string! firmwareRepo = "daqifi/daqifi-nyquist-firmware", string! wifiRepo = "daqifi/winc1500-Manual-UART-Firmware-Update", System.TimeSpan? cacheTtl = null) -> void
+Daqifi.Core.Firmware.GitHubFirmwareDownloadService.InvalidateCache() -> void
+Daqifi.Core.Firmware.HexFileRecord
+Daqifi.Core.Firmware.HexFileRecord.Address.get -> uint
+Daqifi.Core.Firmware.HexFileRecord.Data.get -> byte[]!
+Daqifi.Core.Firmware.HexFileRecord.HexFileRecord(uint address, byte[]! data, byte recordType) -> void
+Daqifi.Core.Firmware.HexFileRecord.RecordType.get -> byte
+Daqifi.Core.Firmware.IBootloaderProtocol
+Daqifi.Core.Firmware.IBootloaderProtocol.ComputeCrcRegions(string![]! hexFileLines) -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Firmware.FlashCrcRegion!>!
+Daqifi.Core.Firmware.IBootloaderProtocol.CreateEraseFlashMessage() -> byte[]!
+Daqifi.Core.Firmware.IBootloaderProtocol.CreateJumpToApplicationMessage() -> byte[]!
+Daqifi.Core.Firmware.IBootloaderProtocol.CreateProgramFlashMessage(byte[]! hexRecord) -> byte[]!
+Daqifi.Core.Firmware.IBootloaderProtocol.CreateReadCrcMessage(uint address, uint length) -> byte[]!
+Daqifi.Core.Firmware.IBootloaderProtocol.CreateRequestVersionMessage() -> byte[]!
+Daqifi.Core.Firmware.IBootloaderProtocol.DecodeEraseFlashResponse(byte[]! data) -> bool
+Daqifi.Core.Firmware.IBootloaderProtocol.DecodeProgramFlashResponse(byte[]! data) -> bool
+Daqifi.Core.Firmware.IBootloaderProtocol.DecodeReadCrcResponse(byte[]! data) -> ushort
+Daqifi.Core.Firmware.IBootloaderProtocol.DecodeVersionResponse(byte[]! data) -> string!
+Daqifi.Core.Firmware.IBootloaderProtocol.ParseHexFile(string![]! hexFileLines) -> System.Collections.Generic.List<byte[]!>!
+Daqifi.Core.Firmware.IExternalProcessRunner
+Daqifi.Core.Firmware.IExternalProcessRunner.RunAsync(Daqifi.Core.Firmware.ExternalProcessRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.ExternalProcessResult!>!
+Daqifi.Core.Firmware.IFirmwareDownloadService
+Daqifi.Core.Firmware.IFirmwareDownloadService.CheckForUpdateAsync(string! deviceVersionString, bool includePreRelease = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.FirmwareUpdateCheckResult!>!
+Daqifi.Core.Firmware.IFirmwareDownloadService.DownloadFirmwareByTagAsync(string! tagName, string! destinationDirectory, System.IProgress<int>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+Daqifi.Core.Firmware.IFirmwareDownloadService.DownloadLatestFirmwareAsync(string! destinationDirectory, bool includePreRelease = false, System.IProgress<int>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+Daqifi.Core.Firmware.IFirmwareDownloadService.DownloadWifiFirmwareAsync(string! destinationDirectory, System.IProgress<int>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<(string! ExtractedPath, string! Version)?>!
+Daqifi.Core.Firmware.IFirmwareDownloadService.GetLatestReleaseAsync(bool includePreRelease = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.FirmwareReleaseInfo?>!
+Daqifi.Core.Firmware.IFirmwareDownloadService.GetLatestWifiReleaseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.FirmwareReleaseInfo?>!
+Daqifi.Core.Firmware.IFirmwareDownloadService.InvalidateCache() -> void
+Daqifi.Core.Firmware.IFirmwareUpdateService
+Daqifi.Core.Firmware.IFirmwareUpdateService.CheckWifiFirmwareStatusAsync(Daqifi.Core.Device.IStreamingDevice! device, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.WifiFirmwareStatus!>!
+Daqifi.Core.Firmware.IFirmwareUpdateService.CurrentState.get -> Daqifi.Core.Firmware.FirmwareUpdateState
+Daqifi.Core.Firmware.IFirmwareUpdateService.StateChanged -> System.EventHandler<Daqifi.Core.Firmware.FirmwareUpdateStateChangedEventArgs!>?
+Daqifi.Core.Firmware.IFirmwareUpdateService.UpdateFirmwareAsync(Daqifi.Core.Device.IStreamingDevice! device, string! hexFilePath, System.IProgress<Daqifi.Core.Firmware.FirmwareUpdateProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.IFirmwareUpdateService.UpdateFirmwareAsync(Daqifi.Core.Device.IStreamingDevice! device, string! hexFilePath, System.IProgress<Daqifi.Core.Firmware.FirmwareUpdateProgress!>? progress, string? targetDevicePath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.IFirmwareUpdateService.UpdateFirmwareAsync(Daqifi.Core.Device.IStreamingDevice! device, string! hexFilePath, System.IProgress<Daqifi.Core.Firmware.FirmwareUpdateProgress!>? progress, string? targetDevicePath, string? targetLocationKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.IFirmwareUpdateService.UpdateWifiModuleAsync(Daqifi.Core.Device.IStreamingDevice! device, string! firmwarePath, System.IProgress<Daqifi.Core.Firmware.FirmwareUpdateProgress!>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), bool skipVersionCheck = false) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.ILanChipInfoProvider
+Daqifi.Core.Firmware.ILanChipInfoProvider.GetLanChipInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.LanChipInfo?>!
+Daqifi.Core.Firmware.IPic32BootloaderDiagnostics
+Daqifi.Core.Firmware.IPic32BootloaderDiagnostics.CheckBootloaderHealthAsync(string? targetDevicePath = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+Daqifi.Core.Firmware.IPic32BootloaderDiagnostics.ResetBootloaderAsync(string? targetDevicePath = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Firmware.IntelHexParser
+Daqifi.Core.Firmware.IntelHexParser.IntelHexParser() -> void
+Daqifi.Core.Firmware.IntelHexParser.IntelHexParser(uint beginProtectedAddress, uint endProtectedAddress) -> void
+Daqifi.Core.Firmware.IntelHexParser.ParseHexRecords(string![]! lines) -> System.Collections.Generic.List<byte[]!>!
+Daqifi.Core.Firmware.IntelHexParser.ParseRecords(string![]! lines) -> System.Collections.Generic.List<Daqifi.Core.Firmware.HexFileRecord!>!
+Daqifi.Core.Firmware.LanChipInfo
+Daqifi.Core.Firmware.LanChipInfo.<Clone>$() -> Daqifi.Core.Firmware.LanChipInfo!
+Daqifi.Core.Firmware.LanChipInfo.BuildDate.get -> string!
+Daqifi.Core.Firmware.LanChipInfo.BuildDate.init -> void
+Daqifi.Core.Firmware.LanChipInfo.ChipId.get -> int
+Daqifi.Core.Firmware.LanChipInfo.ChipId.init -> void
+Daqifi.Core.Firmware.LanChipInfo.Equals(Daqifi.Core.Firmware.LanChipInfo? other) -> bool
+Daqifi.Core.Firmware.LanChipInfo.FwVersion.get -> string!
+Daqifi.Core.Firmware.LanChipInfo.FwVersion.init -> void
+Daqifi.Core.Firmware.LanChipInfo.LanChipInfo() -> void
+Daqifi.Core.Firmware.LanChipInfoParser
+Daqifi.Core.Firmware.LanChipInfoProbeResult
+Daqifi.Core.Firmware.LanChipInfoProbeResult.ChipInfo.get -> Daqifi.Core.Firmware.LanChipInfo?
+Daqifi.Core.Firmware.LanChipInfoProbeResult.ChipInfo.init -> void
+Daqifi.Core.Firmware.LanChipInfoProbeResult.Deconstruct(out Daqifi.Core.Firmware.LanChipInfo? ChipInfo, out bool WasLanNotInitialized) -> void
+Daqifi.Core.Firmware.LanChipInfoProbeResult.Equals(Daqifi.Core.Firmware.LanChipInfoProbeResult other) -> bool
+Daqifi.Core.Firmware.LanChipInfoProbeResult.LanChipInfoProbeResult() -> void
+Daqifi.Core.Firmware.LanChipInfoProbeResult.LanChipInfoProbeResult(Daqifi.Core.Firmware.LanChipInfo? ChipInfo, bool WasLanNotInitialized) -> void
+Daqifi.Core.Firmware.LanChipInfoProbeResult.Succeeded.get -> bool
+Daqifi.Core.Firmware.LanChipInfoProbeResult.WasLanNotInitialized.get -> bool
+Daqifi.Core.Firmware.LanChipInfoProbeResult.WasLanNotInitialized.init -> void
+Daqifi.Core.Firmware.LanChipInfoProviderExtensions
+Daqifi.Core.Firmware.LanChipInfoRetryOptions
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.<Clone>$() -> Daqifi.Core.Firmware.LanChipInfoRetryOptions!
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.Equals(Daqifi.Core.Firmware.LanChipInfoRetryOptions? other) -> bool
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.KickLanApplyOnNotInitialized.get -> bool
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.KickLanApplyOnNotInitialized.init -> void
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.LanChipInfoRetryOptions() -> void
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.MaxAttempts.get -> int
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.MaxAttempts.init -> void
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.RetryDelay.get -> System.TimeSpan
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.RetryDelay.init -> void
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.TotalTimeout.get -> System.TimeSpan
+Daqifi.Core.Firmware.LanChipInfoRetryOptions.TotalTimeout.init -> void
+Daqifi.Core.Firmware.LanNotInitializedException
+Daqifi.Core.Firmware.LanNotInitializedException.LanNotInitializedException(string! message) -> void
+Daqifi.Core.Firmware.Pic32BootloaderMessageConsumer
+Daqifi.Core.Firmware.Pic32BootloaderMessageProducer
+Daqifi.Core.Firmware.Pic32BootloaderProtocol
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.ComputeCrcRegions(string![]! hexFileLines) -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Firmware.FlashCrcRegion!>!
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.CreateEraseFlashMessage() -> byte[]!
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.CreateJumpToApplicationMessage() -> byte[]!
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.CreateProgramFlashMessage(byte[]! hexRecord) -> byte[]!
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.CreateReadCrcMessage(uint address, uint length) -> byte[]!
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.CreateRequestVersionMessage() -> byte[]!
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.DecodeEraseFlashResponse(byte[]! data) -> bool
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.DecodeProgramFlashResponse(byte[]! data) -> bool
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.DecodeReadCrcResponse(byte[]! data) -> ushort
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.DecodeVersionResponse(byte[]! data) -> string!
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.ParseHexFile(string![]! hexFileLines) -> System.Collections.Generic.List<byte[]!>!
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.Pic32BootloaderProtocol() -> void
+Daqifi.Core.Firmware.Pic32BootloaderProtocol.Pic32BootloaderProtocol(uint beginProtectedAddress, uint endProtectedAddress) -> void
+Daqifi.Core.Firmware.ProcessExternalProcessRunner
+Daqifi.Core.Firmware.ProcessExternalProcessRunner.ProcessExternalProcessRunner() -> void
+Daqifi.Core.Firmware.ProcessExternalProcessRunner.RunAsync(Daqifi.Core.Firmware.ExternalProcessRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.ExternalProcessResult!>!
+Daqifi.Core.Firmware.WifiBridgeActivator
+Daqifi.Core.Firmware.WifiFirmwareStatus
+Daqifi.Core.Firmware.WifiFirmwareStatus.<Clone>$() -> Daqifi.Core.Firmware.WifiFirmwareStatus!
+Daqifi.Core.Firmware.WifiFirmwareStatus.CurrentChipInfo.get -> Daqifi.Core.Firmware.LanChipInfo?
+Daqifi.Core.Firmware.WifiFirmwareStatus.CurrentChipInfo.init -> void
+Daqifi.Core.Firmware.WifiFirmwareStatus.Equals(Daqifi.Core.Firmware.WifiFirmwareStatus? other) -> bool
+Daqifi.Core.Firmware.WifiFirmwareStatus.IsUpToDate.get -> bool
+Daqifi.Core.Firmware.WifiFirmwareStatus.IsUpToDate.init -> void
+Daqifi.Core.Firmware.WifiFirmwareStatus.LatestRelease.get -> Daqifi.Core.Firmware.FirmwareReleaseInfo?
+Daqifi.Core.Firmware.WifiFirmwareStatus.LatestRelease.init -> void
+Daqifi.Core.Firmware.WifiFirmwareStatus.MeetsMinimumSupportedVersion.get -> bool?
+Daqifi.Core.Firmware.WifiFirmwareStatus.MeetsMinimumSupportedVersion.init -> void
+Daqifi.Core.Firmware.WifiFirmwareStatus.MinimumSupportedVersion.get -> Daqifi.Core.Firmware.FirmwareVersion?
+Daqifi.Core.Firmware.WifiFirmwareStatus.MinimumSupportedVersion.init -> void
+Daqifi.Core.Firmware.WifiFirmwareStatus.Reason.get -> Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.WifiFirmwareStatus.Reason.init -> void
+Daqifi.Core.Firmware.WifiFirmwareStatus.WifiFirmwareStatus() -> void
+Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.WifiFirmwareStatusReason.ChipInfoUnavailable = 3 -> Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery = 2 -> Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.WifiFirmwareStatusReason.LanNotInitialized = 4 -> Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.WifiFirmwareStatusReason.LatestReleaseUnavailable = 5 -> Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.WifiFirmwareStatusReason.UpToDate = 0 -> Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.WifiFirmwareStatusReason.UpdateAvailable = 1 -> Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.WifiFirmwareStatusReason.VersionUnparseable = 6 -> Daqifi.Core.Firmware.WifiFirmwareStatusReason
+Daqifi.Core.Firmware.Winc.WincFlashToolLocator
+Daqifi.Core.Firmware.Winc.WincFlashToolLocator.IsAvailable(string! firmwarePath) -> bool
+Daqifi.Core.Firmware.Winc.WincFlashToolLocator.TryResolveToolPath(string! firmwarePath, out string? toolPath) -> bool
+Daqifi.Core.Firmware.Winc.WincFlashToolLocator.WincFlashToolLocator(string! toolFileName) -> void
+Daqifi.Core.Firmware.Winc.WincModuleIdentity
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.ChipId.get -> uint
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.ChipId.init -> void
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.FlashJedecId.get -> uint
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.FlashJedecId.init -> void
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.IsRecognizedWinc.get -> bool
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.IsRecognizedWinc.init -> void
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.NegotiatedBaudRate.get -> int
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.NegotiatedBaudRate.init -> void
+Daqifi.Core.Firmware.Winc.WincModuleIdentity.WincModuleIdentity() -> void
+Daqifi.Core.Firmware.Winc.WincModuleInspector
+Daqifi.Core.Firmware.Winc.WincModuleInspector.ReadFlashAsync(string! portName, uint offset, int length, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<byte[]!>!
+Daqifi.Core.Firmware.Winc.WincModuleInspector.ReadIdentityAsync(string! portName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.Winc.WincModuleIdentity!>!
+Daqifi.Core.Firmware.Winc.WincModuleInspector.WincModuleInspector(Microsoft.Extensions.Logging.ILogger<Daqifi.Core.Firmware.Winc.WincModuleInspector!>? logger = null) -> void
+Daqifi.Core.Logging.Export.ChannelDescriptor
+Daqifi.Core.Logging.Export.ChannelDescriptor.ChannelDescriptor(Daqifi.Core.Logging.Export.ChannelDescriptor! original) -> void
+Daqifi.Core.Logging.Export.ChannelDescriptor.ChannelDescriptor(string! DeviceName, string! DeviceSerialNo, string! ChannelName, Daqifi.Core.Channel.ChannelType ChannelType) -> void
+Daqifi.Core.Logging.Export.ChannelDescriptor.ChannelName.get -> string!
+Daqifi.Core.Logging.Export.ChannelDescriptor.ChannelName.init -> void
+Daqifi.Core.Logging.Export.ChannelDescriptor.ChannelType.get -> Daqifi.Core.Channel.ChannelType
+Daqifi.Core.Logging.Export.ChannelDescriptor.ChannelType.init -> void
+Daqifi.Core.Logging.Export.ChannelDescriptor.Deconstruct(out string! DeviceName, out string! DeviceSerialNo, out string! ChannelName, out Daqifi.Core.Channel.ChannelType ChannelType) -> void
+Daqifi.Core.Logging.Export.ChannelDescriptor.DeviceName.get -> string!
+Daqifi.Core.Logging.Export.ChannelDescriptor.DeviceName.init -> void
+Daqifi.Core.Logging.Export.ChannelDescriptor.DeviceSerialNo.get -> string!
+Daqifi.Core.Logging.Export.ChannelDescriptor.DeviceSerialNo.init -> void
+Daqifi.Core.Logging.Export.ChannelDescriptor.Key.get -> string!
+Daqifi.Core.Logging.Export.CsvExportOptions
+Daqifi.Core.Logging.Export.CsvExportOptions.AverageWindow.get -> int?
+Daqifi.Core.Logging.Export.CsvExportOptions.AverageWindow.init -> void
+Daqifi.Core.Logging.Export.CsvExportOptions.CsvExportOptions() -> void
+Daqifi.Core.Logging.Export.CsvExportOptions.Delimiter.get -> string!
+Daqifi.Core.Logging.Export.CsvExportOptions.Delimiter.init -> void
+Daqifi.Core.Logging.Export.CsvExportOptions.UseRelativeTime.get -> bool
+Daqifi.Core.Logging.Export.CsvExportOptions.UseRelativeTime.init -> void
+Daqifi.Core.Logging.Export.CsvExporter
+Daqifi.Core.Logging.Export.CsvExporter.CsvExporter() -> void
+Daqifi.Core.Logging.Export.CsvExporter.ExportAsync(Daqifi.Core.Logging.Export.ISampleSource! source, System.IO.TextWriter! writer, Daqifi.Core.Logging.Export.CsvExportOptions! options, System.IProgress<int>? progress = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Daqifi.Core.Logging.Export.ISampleSource
+Daqifi.Core.Logging.Export.ISampleSource.GetChannels() -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Logging.Export.ChannelDescriptor!>!
+Daqifi.Core.Logging.Export.ISampleSource.GetSampleCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<int>
+Daqifi.Core.Logging.Export.ISampleSource.StreamSamples(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Logging.Export.SampleRow!>!
+Daqifi.Core.Logging.Export.SampleRow
+Daqifi.Core.Logging.Export.SampleRow.ChannelKey.get -> string!
+Daqifi.Core.Logging.Export.SampleRow.ChannelKey.init -> void
+Daqifi.Core.Logging.Export.SampleRow.Deconstruct(out long TimestampTicks, out string! ChannelKey, out double Value) -> void
+Daqifi.Core.Logging.Export.SampleRow.SampleRow(Daqifi.Core.Logging.Export.SampleRow! original) -> void
+Daqifi.Core.Logging.Export.SampleRow.SampleRow(long TimestampTicks, string! ChannelKey, double Value) -> void
+Daqifi.Core.Logging.Export.SampleRow.TimestampTicks.get -> long
+Daqifi.Core.Logging.Export.SampleRow.TimestampTicks.init -> void
+Daqifi.Core.Logging.Export.SampleRow.Value.get -> double
+Daqifi.Core.Logging.Export.SampleRow.Value.init -> void
+DaqifiOutMessage
+DaqifiOutMessage.AnalogInPortNum.get -> uint
+DaqifiOutMessage.AnalogInPortNum.set -> void
+DaqifiOutMessage.AnalogInPortNumPriv.get -> uint
+DaqifiOutMessage.AnalogInPortNumPriv.set -> void
+DaqifiOutMessage.AnalogInRes.get -> uint
+DaqifiOutMessage.AnalogInRes.set -> void
+DaqifiOutMessage.AnalogInResPriv.get -> uint
+DaqifiOutMessage.AnalogInResPriv.set -> void
+DaqifiOutMessage.AnalogOutPortNum.get -> uint
+DaqifiOutMessage.AnalogOutPortNum.set -> void
+DaqifiOutMessage.AnalogOutPortRange.get -> float
+DaqifiOutMessage.AnalogOutPortRange.set -> void
+DaqifiOutMessage.AnalogOutRes.get -> uint
+DaqifiOutMessage.AnalogOutRes.set -> void
+DaqifiOutMessage.BattStatus.get -> uint
+DaqifiOutMessage.BattStatus.set -> void
+DaqifiOutMessage.CalculateSize() -> int
+DaqifiOutMessage.DaqifiOutMessage() -> void
+DaqifiOutMessage.DevicePort.get -> uint
+DaqifiOutMessage.DevicePort.set -> void
+DaqifiOutMessage.DeviceSn.get -> ulong
+DaqifiOutMessage.DeviceSn.set -> void
+DaqifiOutMessage.DeviceStatus.get -> uint
+DaqifiOutMessage.DeviceStatus.set -> void
+DaqifiOutMessage.DigitalPortNum.get -> uint
+DaqifiOutMessage.DigitalPortNum.set -> void
+DaqifiOutMessage.MsgTimeStamp.get -> uint
+DaqifiOutMessage.MsgTimeStamp.set -> void
+DaqifiOutMessage.PwrStatus.get -> uint
+DaqifiOutMessage.PwrStatus.set -> void
+DaqifiOutMessage.SsidStrength.get -> uint
+DaqifiOutMessage.SsidStrength.set -> void
+DaqifiOutMessage.TempStatus.get -> int
+DaqifiOutMessage.TempStatus.set -> void
+DaqifiOutMessage.TimestampFreq.get -> uint
+DaqifiOutMessage.TimestampFreq.set -> void
+DaqifiOutMessage.WifiInfMode.get -> uint
+DaqifiOutMessage.WifiInfMode.set -> void
+DaqifiOutMessage.WifiSecurityMode.get -> uint
+DaqifiOutMessage.WifiSecurityMode.set -> void
+DaqifiOutMessageReflection
+abstract Daqifi.Core.Device.Discovery.DeviceFinderBase.DiscoverAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+const Daqifi.Core.Channel.AnalogChannel.MaxCalibrationMagnitude = 1000000 -> double
+const Daqifi.Core.Channel.AnalogChannel.MaxPortRangeVolts = 50 -> double
+const Daqifi.Core.Channel.AnalogChannel.MaxResolution = 16777216 -> uint
+const Daqifi.Core.Channel.AnalogChannel.MinResolution = 255 -> uint
+const Daqifi.Core.Channel.AnalogOutputChannel.DefaultMaximumVoltage = 10 -> double
+const Daqifi.Core.Channel.AnalogOutputChannel.DefaultMinimumVoltage = 0 -> double
+const Daqifi.Core.Channel.AnalogOutputChannel.DefaultResolutionBits = 12 -> int
+const Daqifi.Core.Channel.AnalogOutputChannel.MaxRangeMagnitudeVolts = 50 -> double
+const Daqifi.Core.Channel.AnalogOutputChannel.MaxResolutionBits = 32 -> int
+const Daqifi.Core.Channel.AnalogOutputChannel.MinResolutionBits = 1 -> int
+const Daqifi.Core.Communication.Producers.ScpiMessageProducer.MaxFriendlyNameLength = 31 -> int
+const Daqifi.Core.Device.BootloaderSessionDevice.DefaultName = "DAQiFi Bootloader" -> string!
+const Daqifi.Core.Device.DaqifiDevice.DefaultMaxDeferredSends = 1024 -> int
+const Daqifi.Core.Device.DaqifiDevice.MaximumCapabilityDocumentApiVersion = 2 -> int
+const Daqifi.Core.Device.DaqifiDevice.MinimumCapabilityDocumentApiVersion = 1 -> int
+const Daqifi.Core.Device.DaqifiDeviceFactory.DefaultTcpDataPort = 9760 -> int
+const Daqifi.Core.Device.DaqifiStreamingDevice.DefaultLiveSampleBufferCapacity = 4096 -> int
+const Daqifi.Core.Device.DaqifiStreamingDevice.DefaultPwmFrequencyHz = 1000 -> int
+const Daqifi.Core.Device.DaqifiStreamingDevice.MaxPwmFrequencyHz = 50000 -> int
+const Daqifi.Core.Device.DaqifiStreamingDevice.MinPwmFrequencyHz = 6 -> int
+const Daqifi.Core.Device.Discovery.DaqifiUsbIds.CdcProductId = 63380 -> int
+const Daqifi.Core.Device.Discovery.DaqifiUsbIds.VendorId = 1240 -> int
+const Daqifi.Core.Device.Discovery.HidDeviceFinder.DefaultProductId = 60 -> int
+const Daqifi.Core.Device.Discovery.HidDeviceFinder.DefaultVendorId = 1240 -> int
+const Daqifi.Core.Device.SdCard.SdCardCaptureEstimate.DefaultBytesPerSamplePerChannel = 2 -> int
+const Daqifi.Core.Device.SdCard.SdCardSpaceCheck.DefaultMinimumFreeBytes = 104857600 -> long
+const Daqifi.Core.Device.TimestampGapDetector.DefaultEmaAlpha = 0.1 -> double
+const Daqifi.Core.Device.TimestampGapDetector.DefaultGapThresholdMultiplier = 2 -> double
+const Daqifi.Core.Device.TimestampProcessor.DefaultTickPeriod = 2E-08 -> double
+const Daqifi.Core.Device.TimestampProcessor.DefaultTimestampFrequency = 50000000 -> uint
+const Daqifi.Core.Firmware.FirmwareUpdateServiceOptions.DefaultMinimumSupportedWifiFirmwareVersion = "19.7.7" -> string!
+const Daqifi.Core.Firmware.IntelHexParser.DEFAULT_BEGIN_PROTECTED_ADDRESS = 488505344 -> uint
+const Daqifi.Core.Firmware.IntelHexParser.DEFAULT_END_PROTECTED_ADDRESS = 488636416 -> uint
+const Daqifi.Core.Firmware.Winc.WincModuleInspector.FastBaudRate = 500000 -> int
+const Daqifi.Core.Firmware.Winc.WincModuleInspector.InitialBaudRate = 115200 -> int
+const DaqifiOutMessage.AnalogInCalBFieldNumber = 32 -> int
+const DaqifiOutMessage.AnalogInCalBPrivFieldNumber = 34 -> int
+const DaqifiOutMessage.AnalogInCalMFieldNumber = 31 -> int
+const DaqifiOutMessage.AnalogInCalMPrivFieldNumber = 33 -> int
+const DaqifiOutMessage.AnalogInDataFieldNumber = 2 -> int
+const DaqifiOutMessage.AnalogInDataFloatFieldNumber = 3 -> int
+const DaqifiOutMessage.AnalogInDataTsFieldNumber = 4 -> int
+const DaqifiOutMessage.AnalogInIntScaleMFieldNumber = 29 -> int
+const DaqifiOutMessage.AnalogInIntScaleMPrivFieldNumber = 30 -> int
+const DaqifiOutMessage.AnalogInPortAvRangeFieldNumber = 23 -> int
+const DaqifiOutMessage.AnalogInPortAvRangePrivFieldNumber = 24 -> int
+const DaqifiOutMessage.AnalogInPortAvRseFieldNumber = 20 -> int
+const DaqifiOutMessage.AnalogInPortEnabledFieldNumber = 22 -> int
+const DaqifiOutMessage.AnalogInPortNumFieldNumber = 17 -> int
+const DaqifiOutMessage.AnalogInPortNumPrivFieldNumber = 18 -> int
+const DaqifiOutMessage.AnalogInPortRangeFieldNumber = 25 -> int
+const DaqifiOutMessage.AnalogInPortRangePrivFieldNumber = 26 -> int
+const DaqifiOutMessage.AnalogInPortRseFieldNumber = 21 -> int
+const DaqifiOutMessage.AnalogInPortTypeFieldNumber = 19 -> int
+const DaqifiOutMessage.AnalogInResFieldNumber = 27 -> int
+const DaqifiOutMessage.AnalogInResPrivFieldNumber = 28 -> int
+const DaqifiOutMessage.AnalogOutDataFieldNumber = 7 -> int
+const DaqifiOutMessage.AnalogOutPortAvRangeFieldNumber = 41 -> int
+const DaqifiOutMessage.AnalogOutPortNumFieldNumber = 38 -> int
+const DaqifiOutMessage.AnalogOutPortRangeFieldNumber = 42 -> int
+const DaqifiOutMessage.AnalogOutPortTypeFieldNumber = 39 -> int
+const DaqifiOutMessage.AnalogOutResFieldNumber = 40 -> int
+const DaqifiOutMessage.AvSsidFieldNumber = 62 -> int
+const DaqifiOutMessage.AvSsidStrengthFieldNumber = 63 -> int
+const DaqifiOutMessage.AvWifiInfModeFieldNumber = 65 -> int
+const DaqifiOutMessage.AvWifiSecurityModeFieldNumber = 64 -> int
+const DaqifiOutMessage.BattStatusFieldNumber = 10 -> int
+const DaqifiOutMessage.DeviceFwRevFieldNumber = 68 -> int
+const DaqifiOutMessage.DeviceHwRevFieldNumber = 67 -> int
+const DaqifiOutMessage.DevicePnFieldNumber = 66 -> int
+const DaqifiOutMessage.DevicePortFieldNumber = 56 -> int
+const DaqifiOutMessage.DeviceSnFieldNumber = 69 -> int
+const DaqifiOutMessage.DeviceStatusFieldNumber = 8 -> int
+const DaqifiOutMessage.DigitalDataFieldNumber = 5 -> int
+const DaqifiOutMessage.DigitalDataTsFieldNumber = 6 -> int
+const DaqifiOutMessage.DigitalPortDirFieldNumber = 37 -> int
+const DaqifiOutMessage.DigitalPortNumFieldNumber = 35 -> int
+const DaqifiOutMessage.DigitalPortTypeFieldNumber = 36 -> int
+const DaqifiOutMessage.Eui64FieldNumber = 54 -> int
+const DaqifiOutMessage.FriendlyDeviceNameFieldNumber = 57 -> int
+const DaqifiOutMessage.GatewayFieldNumber = 45 -> int
+const DaqifiOutMessage.GatewayV6FieldNumber = 51 -> int
+const DaqifiOutMessage.HostNameFieldNumber = 55 -> int
+const DaqifiOutMessage.IpAddrFieldNumber = 43 -> int
+const DaqifiOutMessage.IpAddrV6FieldNumber = 49 -> int
+const DaqifiOutMessage.MacAddrFieldNumber = 48 -> int
+const DaqifiOutMessage.MsgTimeStampFieldNumber = 1 -> int
+const DaqifiOutMessage.NetMaskFieldNumber = 44 -> int
+const DaqifiOutMessage.PrimaryDnsFieldNumber = 46 -> int
+const DaqifiOutMessage.PrimaryDnsV6FieldNumber = 52 -> int
+const DaqifiOutMessage.PwrStatusFieldNumber = 9 -> int
+const DaqifiOutMessage.SecondaryDnsFieldNumber = 47 -> int
+const DaqifiOutMessage.SecondaryDnsV6FieldNumber = 53 -> int
+const DaqifiOutMessage.SsidFieldNumber = 58 -> int
+const DaqifiOutMessage.SsidStrengthFieldNumber = 59 -> int
+const DaqifiOutMessage.SubPreLengthV6FieldNumber = 50 -> int
+const DaqifiOutMessage.TempStatusFieldNumber = 11 -> int
+const DaqifiOutMessage.TimestampFreqFieldNumber = 16 -> int
+const DaqifiOutMessage.WifiInfModeFieldNumber = 61 -> int
+const DaqifiOutMessage.WifiSecurityModeFieldNumber = 60 -> int
+override Daqifi.Core.Channel.AnalogChannel.ToString() -> string!
+override Daqifi.Core.Channel.AnalogOutputChannel.ToString() -> string!
+override Daqifi.Core.Channel.ChannelScaling.Equals(object? obj) -> bool
+override Daqifi.Core.Channel.ChannelScaling.GetHashCode() -> int
+override Daqifi.Core.Channel.ChannelScaling.ToString() -> string!
+override Daqifi.Core.Channel.DataSample.ToString() -> string!
+override Daqifi.Core.Channel.DigitalChannel.ToString() -> string!
+override Daqifi.Core.Channel.LiveSample.Equals(object? obj) -> bool
+override Daqifi.Core.Channel.LiveSample.GetHashCode() -> int
+override Daqifi.Core.Channel.LiveSample.ToString() -> string!
+override Daqifi.Core.Communication.Transport.HidDeviceInfo.ToString() -> string!
+override Daqifi.Core.Device.AcquisitionStatisticsSnapshot.Equals(object? obj) -> bool
+override Daqifi.Core.Device.AcquisitionStatisticsSnapshot.GetHashCode() -> int
+override Daqifi.Core.Device.AcquisitionStatisticsSnapshot.ToString() -> string!
+override Daqifi.Core.Device.ChannelAcquisitionStatistics.Equals(object? obj) -> bool
+override Daqifi.Core.Device.ChannelAcquisitionStatistics.GetHashCode() -> int
+override Daqifi.Core.Device.ChannelAcquisitionStatistics.ToString() -> string!
+override Daqifi.Core.Device.DaqifiStreamingDevice.CaptureSessionSnapshot() -> void
+override Daqifi.Core.Device.DaqifiStreamingDevice.OnDeviceInitializingAsync(bool preserveActiveStream, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+override Daqifi.Core.Device.DaqifiStreamingDevice.OnStreamMessageReceived(DaqifiOutMessage! message) -> void
+override Daqifi.Core.Device.DaqifiStreamingDevice.RestoreSessionSnapshotAsync(Daqifi.Core.Device.ReconnectOptions! options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+override Daqifi.Core.Device.DaqifiStreamingDevice.Send<T>(Daqifi.Core.Communication.Messages.IOutboundMessage<T>! message) -> void
+override Daqifi.Core.Device.DeviceIdentity.ToString() -> string!
+override Daqifi.Core.Device.DeviceRegistration.ToString() -> string!
+override Daqifi.Core.Device.Diagnostics.LogLevelSetting.Equals(object? obj) -> bool
+override Daqifi.Core.Device.Diagnostics.LogLevelSetting.GetHashCode() -> int
+override Daqifi.Core.Device.Diagnostics.LogLevelSetting.ToString() -> string!
+override Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.Equals(object? obj) -> bool
+override Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.GetHashCode() -> int
+override Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.ToString() -> string!
+override Daqifi.Core.Device.Diagnostics.StreamStats.Equals(object? obj) -> bool
+override Daqifi.Core.Device.Diagnostics.StreamStats.GetHashCode() -> int
+override Daqifi.Core.Device.Diagnostics.StreamStats.ToString() -> string!
+override Daqifi.Core.Device.Diagnostics.SystemLogEntry.Equals(object? obj) -> bool
+override Daqifi.Core.Device.Diagnostics.SystemLogEntry.GetHashCode() -> int
+override Daqifi.Core.Device.Diagnostics.SystemLogEntry.ToString() -> string!
+override Daqifi.Core.Device.Discovery.DeviceInfo.ToString() -> string!
+override Daqifi.Core.Device.Discovery.HidDeviceFinder.DiscoverAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+override Daqifi.Core.Device.Discovery.SerialDeviceFinder.DiscoverAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+override Daqifi.Core.Device.Discovery.UsbPortDescriptor.Equals(object? obj) -> bool
+override Daqifi.Core.Device.Discovery.UsbPortDescriptor.GetHashCode() -> int
+override Daqifi.Core.Device.Discovery.UsbPortDescriptor.ToString() -> string!
+override Daqifi.Core.Device.Discovery.WiFiDeviceFinder.DiscoverAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+override Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.Equals(object? obj) -> bool
+override Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.GetHashCode() -> int
+override Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.ToString() -> string!
+override Daqifi.Core.Device.SdCard.SdCardDownloadResult.Equals(object? obj) -> bool
+override Daqifi.Core.Device.SdCard.SdCardDownloadResult.GetHashCode() -> int
+override Daqifi.Core.Device.SdCard.SdCardDownloadResult.ToString() -> string!
+override Daqifi.Core.Device.SdCard.SdCardLogEntry.Equals(object? obj) -> bool
+override Daqifi.Core.Device.SdCard.SdCardLogEntry.GetHashCode() -> int
+override Daqifi.Core.Device.SdCard.SdCardLogEntry.ToString() -> string!
+override Daqifi.Core.Device.SdCard.SdCardParseProgress.Equals(object? obj) -> bool
+override Daqifi.Core.Device.SdCard.SdCardParseProgress.GetHashCode() -> int
+override Daqifi.Core.Device.SdCard.SdCardParseProgress.ToString() -> string!
+override Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.Equals(object? obj) -> bool
+override Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.GetHashCode() -> int
+override Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.ToString() -> string!
+override Daqifi.Core.Device.SdCard.SdCardStorageInfo.Equals(object? obj) -> bool
+override Daqifi.Core.Device.SdCard.SdCardStorageInfo.GetHashCode() -> int
+override Daqifi.Core.Device.SdCard.SdCardStorageInfo.ToString() -> string!
+override Daqifi.Core.Device.SdCard.SdCardTransferProgress.Equals(object? obj) -> bool
+override Daqifi.Core.Device.SdCard.SdCardTransferProgress.GetHashCode() -> int
+override Daqifi.Core.Device.SdCard.SdCardTransferProgress.ToString() -> string!
+override Daqifi.Core.Firmware.FirmwareVersion.GetHashCode() -> int
+override Daqifi.Core.Firmware.FirmwareVersion.ToString() -> string!
+override Daqifi.Core.Firmware.LanChipInfo.Equals(object? obj) -> bool
+override Daqifi.Core.Firmware.LanChipInfo.GetHashCode() -> int
+override Daqifi.Core.Firmware.LanChipInfo.ToString() -> string!
+override Daqifi.Core.Firmware.LanChipInfoProbeResult.GetHashCode() -> int
+override Daqifi.Core.Firmware.LanChipInfoRetryOptions.Equals(object? obj) -> bool
+override Daqifi.Core.Firmware.LanChipInfoRetryOptions.GetHashCode() -> int
+override Daqifi.Core.Firmware.LanChipInfoRetryOptions.ToString() -> string!
+override Daqifi.Core.Firmware.WifiFirmwareStatus.Equals(object? obj) -> bool
+override Daqifi.Core.Firmware.WifiFirmwareStatus.GetHashCode() -> int
+override Daqifi.Core.Firmware.WifiFirmwareStatus.ToString() -> string!
+override Daqifi.Core.Logging.Export.ChannelDescriptor.Equals(object? obj) -> bool
+override Daqifi.Core.Logging.Export.ChannelDescriptor.GetHashCode() -> int
+override Daqifi.Core.Logging.Export.ChannelDescriptor.ToString() -> string!
+override Daqifi.Core.Logging.Export.SampleRow.Equals(object? obj) -> bool
+override Daqifi.Core.Logging.Export.SampleRow.GetHashCode() -> int
+override Daqifi.Core.Logging.Export.SampleRow.ToString() -> string!
+override DaqifiOutMessage.GetHashCode() -> int
+static Daqifi.Core.Channel.ChannelScaling.Identity.get -> Daqifi.Core.Channel.ChannelScaling!
+static Daqifi.Core.Channel.ChannelScaling.operator !=(Daqifi.Core.Channel.ChannelScaling? left, Daqifi.Core.Channel.ChannelScaling? right) -> bool
+static Daqifi.Core.Channel.ChannelScaling.operator ==(Daqifi.Core.Channel.ChannelScaling? left, Daqifi.Core.Channel.ChannelScaling? right) -> bool
+static Daqifi.Core.Channel.LiveSample.operator !=(Daqifi.Core.Channel.LiveSample? left, Daqifi.Core.Channel.LiveSample? right) -> bool
+static Daqifi.Core.Channel.LiveSample.operator ==(Daqifi.Core.Channel.LiveSample? left, Daqifi.Core.Channel.LiveSample? right) -> bool
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.ApplyNetworkLan.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.ClearSystemLog.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.DeleteSdFile(string! fileName) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.DisableDeviceEcho.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.DisableDioPorts() -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.DisableNetworkLan.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.DisableStorageSd.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.EnableAdcChannels(string! channelSetString) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.EnableDeviceEcho.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.EnableDioPorts() -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.EnableNetworkLan.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.EnableStorageSd.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.FactoryResetNetworkLan.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.ForceBootloader.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.FormatSdCard.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetAdcCalibrationBank.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetAdcCalibrationOffset(int channel) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetAdcCalibrationSlope(int channel) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetAnalogOutputVoltage(int channel) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetCapabilitiesApiVersion.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetCapabilitiesJson.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetCommandHistory.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetDeviceInfo.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetLanAddress.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetLanChipInfo.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetLanConfiguredAddress.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetLanConfiguredGateway.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetLanConfiguredMask.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetLanGateway.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetLanMask.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetMemoryDiagnostics.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetSdBenchmarkResults.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetSdFile(string! fileName) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetSdFileList.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetSdMaxFileSize.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetSdSpace.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetStreamFormat.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetStreamInterface.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetStreamStats.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetSystemError.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetSystemErrorCount.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.GetSystemLog.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.IsFriendlyNameValid(string? name) -> bool
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.LoadAdcCalibration.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.LoadFactoryAdcCalibration.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.LoadNetworkLan.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.LoadVoltagePrecision.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.RebootDevice.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.RunSdBenchmark(long size) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SaveAdcCalibration.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SaveDeviceName.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SaveFactoryAdcCalibration.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SaveNetworkLan.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SaveVoltagePrecision.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetAdcCalibrationOffset(int channel, double calB) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetAdcCalibrationSlope(int channel, double calM) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetAnalogOutputVoltage(int channel, double voltage) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetCsvStreamFormat.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetDeviceName(string? name) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetDioPortDirection(int channel, int direction) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetDioPortState(int channel, double value) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetJsonStreamFormat.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetLanAddress(System.Net.IPAddress! address) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetLanFirmwareUpdateMode.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetLanGateway(System.Net.IPAddress! gateway) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetLanMask(System.Net.IPAddress! mask) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetLogLevel(string! module, int level) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetNetworkWifiModeExisting.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetNetworkWifiModeSelfHosted.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetNetworkWifiPassword(string! password) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetNetworkWifiSecurityOpen.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetNetworkWifiSecurityWpa.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetNetworkWifiSsid(string! ssid) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetProtobufStreamFormat.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetPwmChannelDutyCycle(int channel, int dutyCyclePercent) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetPwmChannelEnabled(int channel, bool enabled) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetPwmChannelFrequency(int channel, int frequencyHz) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetSdLoggingFileName(string! fileName) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetSdMaxFileSize(long bytes) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetSdMinFreeSpace(long bytes) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetStreamInterface(Daqifi.Core.Communication.StreamInterface streamInterface) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.SetUsbTransparencyMode(int mode) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.StartStreaming(int frequency) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.StopStreaming.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.TestSystemLog.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.TurnDeviceOn.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.UpdateDacOutputs.get -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Producers.ScpiMessageProducer.UseAdcCalibration(int bank) -> Daqifi.Core.Communication.Messages.IOutboundMessage<string!>!
+static Daqifi.Core.Communication.Transport.ConnectionRetryOptions.Fast.get -> Daqifi.Core.Communication.Transport.ConnectionRetryOptions!
+static Daqifi.Core.Communication.Transport.ConnectionRetryOptions.NoRetry.get -> Daqifi.Core.Communication.Transport.ConnectionRetryOptions!
+static Daqifi.Core.Communication.Transport.ConnectionRetryOptions.Resilient.get -> Daqifi.Core.Communication.Transport.ConnectionRetryOptions!
+static Daqifi.Core.Communication.Transport.SerialStreamTransport.GetAvailablePortNames() -> string![]!
+static Daqifi.Core.Device.AcquisitionStatisticsSnapshot.operator !=(Daqifi.Core.Device.AcquisitionStatisticsSnapshot? left, Daqifi.Core.Device.AcquisitionStatisticsSnapshot? right) -> bool
+static Daqifi.Core.Device.AcquisitionStatisticsSnapshot.operator ==(Daqifi.Core.Device.AcquisitionStatisticsSnapshot? left, Daqifi.Core.Device.AcquisitionStatisticsSnapshot? right) -> bool
+static Daqifi.Core.Device.Capabilities.CapabilityDocumentParser.TryParse(string? json, out Daqifi.Core.Device.Capabilities.CapabilityDocument? document) -> bool
+static Daqifi.Core.Device.Capabilities.CapabilityDocumentParser.TryParseApiVersion(System.Collections.Generic.IEnumerable<string!>! lines, out int apiVersion) -> bool
+static Daqifi.Core.Device.Capabilities.CapabilityDocumentParser.TryParseLines(System.Collections.Generic.IEnumerable<string!>! lines, out Daqifi.Core.Device.Capabilities.CapabilityDocument? document) -> bool
+static Daqifi.Core.Device.Capabilities.SampleRateCap.Compute(int hardwareMaximumRateHz, int? deviceReportedCapHz, int? modelCapHz) -> int
+static Daqifi.Core.Device.Capabilities.SampleRateCap.ComputeForDevice(Daqifi.Core.Device.IStreamingDevice! device) -> int
+static Daqifi.Core.Device.Capabilities.SampleRateCap.Enforce(int currentRateHz, int capHz) -> (int NewRateHz, int? AdjustedFromHz)
+static Daqifi.Core.Device.Capabilities.SampleRateCap.EnforceOn(Daqifi.Core.Device.IStreamingDevice! device) -> int?
+static Daqifi.Core.Device.ChannelAcquisitionStatistics.operator !=(Daqifi.Core.Device.ChannelAcquisitionStatistics? left, Daqifi.Core.Device.ChannelAcquisitionStatistics? right) -> bool
+static Daqifi.Core.Device.ChannelAcquisitionStatistics.operator ==(Daqifi.Core.Device.ChannelAcquisitionStatistics? left, Daqifi.Core.Device.ChannelAcquisitionStatistics? right) -> bool
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectFromDeviceInfo(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo, Daqifi.Core.Device.DeviceConnectionOptions? options = null) -> Daqifi.Core.Device.DaqifiStreamingDevice!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectFromDeviceInfoAsync(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo, Daqifi.Core.Device.DeviceConnectionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.DaqifiStreamingDevice!>!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectSerial(string! portName, Daqifi.Core.Device.DeviceConnectionOptions? options = null) -> Daqifi.Core.Device.DaqifiStreamingDevice!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectSerial(string! portName, int baudRate, Daqifi.Core.Device.DeviceConnectionOptions? options = null) -> Daqifi.Core.Device.DaqifiStreamingDevice!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectSerialAsync(string! portName, Daqifi.Core.Device.DeviceConnectionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.DaqifiStreamingDevice!>!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectSerialAsync(string! portName, int baudRate, Daqifi.Core.Device.DeviceConnectionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.DaqifiStreamingDevice!>!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectTcp(System.Net.IPAddress! ipAddress, int port, Daqifi.Core.Device.DeviceConnectionOptions? options = null) -> Daqifi.Core.Device.DaqifiStreamingDevice!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectTcp(string! host, int port, Daqifi.Core.Device.DeviceConnectionOptions? options = null) -> Daqifi.Core.Device.DaqifiStreamingDevice!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectTcpAsync(System.Net.IPAddress! ipAddress, int port, Daqifi.Core.Device.DeviceConnectionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.DaqifiStreamingDevice!>!
+static Daqifi.Core.Device.DaqifiDeviceFactory.ConnectTcpAsync(string! host, int port, Daqifi.Core.Device.DeviceConnectionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.DaqifiStreamingDevice!>!
+static Daqifi.Core.Device.DaqifiDeviceFactory.DiscoverAndConnectAsync(System.Func<Daqifi.Core.Device.Discovery.IDeviceInfo!, bool>? filter = null, System.TimeSpan? timeout = null, Daqifi.Core.Device.DeviceConnectionOptions? options = null, Daqifi.Core.Device.Discovery.IDeviceFinder? finder = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.DaqifiStreamingDevice!>!
+static Daqifi.Core.Device.DeviceCapabilities.FromDeviceType(Daqifi.Core.Device.DeviceType deviceType) -> Daqifi.Core.Device.DeviceCapabilities!
+static Daqifi.Core.Device.DeviceConnectionOptions.Default.get -> Daqifi.Core.Device.DeviceConnectionOptions!
+static Daqifi.Core.Device.DeviceConnectionOptions.Fast.get -> Daqifi.Core.Device.DeviceConnectionOptions!
+static Daqifi.Core.Device.DeviceConnectionOptions.Observing.get -> Daqifi.Core.Device.DeviceConnectionOptions!
+static Daqifi.Core.Device.DeviceConnectionOptions.Resilient.get -> Daqifi.Core.Device.DeviceConnectionOptions!
+static Daqifi.Core.Device.DeviceIdentity.Create(string? serialNumber, string? macAddress = null, string? locationKey = null) -> Daqifi.Core.Device.DeviceIdentity!
+static Daqifi.Core.Device.DeviceIdentity.FromDiscovery(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo) -> Daqifi.Core.Device.DeviceIdentity!
+static Daqifi.Core.Device.DeviceIdentity.FromMetadata(Daqifi.Core.Device.DeviceMetadata! metadata, string? locationKey = null) -> Daqifi.Core.Device.DeviceIdentity!
+static Daqifi.Core.Device.DeviceTypeDetector.DetectFromPartNumber(string? partNumber) -> Daqifi.Core.Device.DeviceType
+static Daqifi.Core.Device.Diagnostics.CommandHistoryParser.Parse(System.Collections.Generic.IEnumerable<string!>! lines) -> System.Collections.Generic.IReadOnlyList<string!>!
+static Daqifi.Core.Device.Diagnostics.LogLevelParser.TryParse(string? line, out Daqifi.Core.Device.Diagnostics.LogLevelSetting? result) -> bool
+static Daqifi.Core.Device.Diagnostics.LogLevelParser.TryParseLines(System.Collections.Generic.IEnumerable<string!>! lines, out Daqifi.Core.Device.Diagnostics.LogLevelSetting? result) -> bool
+static Daqifi.Core.Device.Diagnostics.LogLevelSetting.operator !=(Daqifi.Core.Device.Diagnostics.LogLevelSetting? left, Daqifi.Core.Device.Diagnostics.LogLevelSetting? right) -> bool
+static Daqifi.Core.Device.Diagnostics.LogLevelSetting.operator ==(Daqifi.Core.Device.Diagnostics.LogLevelSetting? left, Daqifi.Core.Device.Diagnostics.LogLevelSetting? right) -> bool
+static Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.operator !=(Daqifi.Core.Device.Diagnostics.MemoryDiagnostics? left, Daqifi.Core.Device.Diagnostics.MemoryDiagnostics? right) -> bool
+static Daqifi.Core.Device.Diagnostics.MemoryDiagnostics.operator ==(Daqifi.Core.Device.Diagnostics.MemoryDiagnostics? left, Daqifi.Core.Device.Diagnostics.MemoryDiagnostics? right) -> bool
+static Daqifi.Core.Device.Diagnostics.MemoryDiagnosticsParser.TryParse(System.Collections.Generic.IEnumerable<string!>! lines, out Daqifi.Core.Device.Diagnostics.MemoryDiagnostics? result) -> bool
+static Daqifi.Core.Device.Diagnostics.StreamStats.operator !=(Daqifi.Core.Device.Diagnostics.StreamStats? left, Daqifi.Core.Device.Diagnostics.StreamStats? right) -> bool
+static Daqifi.Core.Device.Diagnostics.StreamStats.operator ==(Daqifi.Core.Device.Diagnostics.StreamStats? left, Daqifi.Core.Device.Diagnostics.StreamStats? right) -> bool
+static Daqifi.Core.Device.Diagnostics.StreamStatsParser.TryParse(System.Collections.Generic.IEnumerable<string!>! lines, out Daqifi.Core.Device.Diagnostics.StreamStats? result) -> bool
+static Daqifi.Core.Device.Diagnostics.SystemLogEntry.operator !=(Daqifi.Core.Device.Diagnostics.SystemLogEntry? left, Daqifi.Core.Device.Diagnostics.SystemLogEntry? right) -> bool
+static Daqifi.Core.Device.Diagnostics.SystemLogEntry.operator ==(Daqifi.Core.Device.Diagnostics.SystemLogEntry? left, Daqifi.Core.Device.Diagnostics.SystemLogEntry? right) -> bool
+static Daqifi.Core.Device.Diagnostics.SystemLogParser.Parse(System.Collections.Generic.IEnumerable<string!>! lines) -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.Diagnostics.SystemLogEntry!>!
+static Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder.CreateDefault(System.Func<Daqifi.Core.Device.Discovery.IDeviceInfo!, string!>? identitySelector = null) -> Daqifi.Core.Device.Discovery.AllTransportsDeviceFinder!
+static Daqifi.Core.Device.Discovery.DaqifiUsbIds.IsDaqifiCdcDevice(Daqifi.Core.Device.Discovery.UsbPortDescriptor! descriptor) -> bool
+static Daqifi.Core.Device.Discovery.UsbPortDescriptor.operator !=(Daqifi.Core.Device.Discovery.UsbPortDescriptor? left, Daqifi.Core.Device.Discovery.UsbPortDescriptor? right) -> bool
+static Daqifi.Core.Device.Discovery.UsbPortDescriptor.operator ==(Daqifi.Core.Device.Discovery.UsbPortDescriptor? left, Daqifi.Core.Device.Discovery.UsbPortDescriptor? right) -> bool
+static Daqifi.Core.Device.Discovery.WiFiDeviceFinder.ProbeTcpDataPortAsync(System.Net.IPAddress! host, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int?>!
+static Daqifi.Core.Device.Discovery.WiFiDeviceFinder.ProbeTcpDataPortAsync(System.Net.IPAddress! host, int discoveryPort, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int?>!
+static Daqifi.Core.Device.Network.NetworkAddressHelper.GetGatewayString(DaqifiOutMessage! message) -> string!
+static Daqifi.Core.Device.Network.NetworkAddressHelper.GetIpAddressString(DaqifiOutMessage! message) -> string!
+static Daqifi.Core.Device.Network.NetworkAddressHelper.GetMacAddressString(DaqifiOutMessage! message) -> string!
+static Daqifi.Core.Device.Network.NetworkAddressHelper.GetPrimaryDnsString(DaqifiOutMessage! message) -> string!
+static Daqifi.Core.Device.Network.NetworkAddressHelper.GetSecondaryDnsString(DaqifiOutMessage! message) -> string!
+static Daqifi.Core.Device.Network.NetworkAddressHelper.GetSubnetMaskString(DaqifiOutMessage! message) -> string!
+static Daqifi.Core.Device.Protocol.ProtobufProtocolHandler.DetectMessageType(DaqifiOutMessage! message) -> Daqifi.Core.Device.Protocol.ProtobufMessageType
+static Daqifi.Core.Device.ReconnectOptions.Default.get -> Daqifi.Core.Device.ReconnectOptions!
+static Daqifi.Core.Device.ReconnectOptions.Disabled.get -> Daqifi.Core.Device.ReconnectOptions!
+static Daqifi.Core.Device.ReconnectOptions.Fast.get -> Daqifi.Core.Device.ReconnectOptions!
+static Daqifi.Core.Device.ReconnectOptions.Resilient.get -> Daqifi.Core.Device.ReconnectOptions!
+static Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.FromDevice(Daqifi.Core.Device.DaqifiDevice! device) -> Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration?
+static Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.operator !=(Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration? left, Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration.operator ==(Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration? left, Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardDownloadResult.operator !=(Daqifi.Core.Device.SdCard.SdCardDownloadResult? left, Daqifi.Core.Device.SdCard.SdCardDownloadResult? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardDownloadResult.operator ==(Daqifi.Core.Device.SdCard.SdCardDownloadResult? left, Daqifi.Core.Device.SdCard.SdCardDownloadResult? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardFileListParser.GetListingStatus(System.Collections.Generic.IEnumerable<string!>! lines) -> Daqifi.Core.Device.SdCard.SdCardListingStatus
+static Daqifi.Core.Device.SdCard.SdCardFileListParser.ParseFileList(System.Collections.Generic.IEnumerable<string!>! lines) -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Device.SdCard.SdCardFileInfo!>!
+static Daqifi.Core.Device.SdCard.SdCardFileParserFactory.DetectFormat(string! fileName) -> Daqifi.Core.Device.SdCard.SdCardLogFormat
+static Daqifi.Core.Device.SdCard.SdCardFileParserFactory.ParseAsync(System.IO.Stream! fileStream, string! fileName, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+static Daqifi.Core.Device.SdCard.SdCardFileParserFactory.ParseFileAsync(string! filePath, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+static Daqifi.Core.Device.SdCard.SdCardFileParserFactory.ParseWithFormatAsync(System.IO.Stream! fileStream, string! fileName, Daqifi.Core.Device.SdCard.SdCardLogFormat format, Daqifi.Core.Device.SdCard.SdCardParseOptions? options = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.SdCard.SdCardLogSession!>!
+static Daqifi.Core.Device.SdCard.SdCardFileParserFactory.SupportedExtensions.get -> System.Collections.Generic.IReadOnlyList<string!>!
+static Daqifi.Core.Device.SdCard.SdCardFileParserFactory.TryDetectFormat(string! fileName, out Daqifi.Core.Device.SdCard.SdCardLogFormat format) -> bool
+static Daqifi.Core.Device.SdCard.SdCardLogEntry.operator !=(Daqifi.Core.Device.SdCard.SdCardLogEntry? left, Daqifi.Core.Device.SdCard.SdCardLogEntry? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardLogEntry.operator ==(Daqifi.Core.Device.SdCard.SdCardLogEntry? left, Daqifi.Core.Device.SdCard.SdCardLogEntry? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardParseProgress.operator !=(Daqifi.Core.Device.SdCard.SdCardParseProgress? left, Daqifi.Core.Device.SdCard.SdCardParseProgress? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardParseProgress.operator ==(Daqifi.Core.Device.SdCard.SdCardParseProgress? left, Daqifi.Core.Device.SdCard.SdCardParseProgress? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardSpaceCheck.Evaluate(Daqifi.Core.Device.SdCard.SdCardStorageInfo! storage, Daqifi.Core.Device.SdCard.SdCardCaptureEstimate? plannedCapture = null, long minimumFreeBytes = 104857600) -> Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult!
+static Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.operator !=(Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult? left, Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult.operator ==(Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult? left, Daqifi.Core.Device.SdCard.SdCardSpaceCheckResult? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardSpaceParser.TryParse(string? line, out Daqifi.Core.Device.SdCard.SdCardStorageInfo? result) -> bool
+static Daqifi.Core.Device.SdCard.SdCardSpaceParser.TryParseLines(System.Collections.Generic.IEnumerable<string!>! lines, out Daqifi.Core.Device.SdCard.SdCardStorageInfo? result) -> bool
+static Daqifi.Core.Device.SdCard.SdCardStorageInfo.operator !=(Daqifi.Core.Device.SdCard.SdCardStorageInfo? left, Daqifi.Core.Device.SdCard.SdCardStorageInfo? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardStorageInfo.operator ==(Daqifi.Core.Device.SdCard.SdCardStorageInfo? left, Daqifi.Core.Device.SdCard.SdCardStorageInfo? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardTransferProgress.operator !=(Daqifi.Core.Device.SdCard.SdCardTransferProgress? left, Daqifi.Core.Device.SdCard.SdCardTransferProgress? right) -> bool
+static Daqifi.Core.Device.SdCard.SdCardTransferProgress.operator ==(Daqifi.Core.Device.SdCard.SdCardTransferProgress? left, Daqifi.Core.Device.SdCard.SdCardTransferProgress? right) -> bool
+static Daqifi.Core.Firmware.FirmwareVersion.Compare(string? left, string? right) -> int
+static Daqifi.Core.Firmware.FirmwareVersion.TryParse(string? input, out Daqifi.Core.Firmware.FirmwareVersion version) -> bool
+static Daqifi.Core.Firmware.FirmwareVersion.operator !=(Daqifi.Core.Firmware.FirmwareVersion left, Daqifi.Core.Firmware.FirmwareVersion right) -> bool
+static Daqifi.Core.Firmware.FirmwareVersion.operator <(Daqifi.Core.Firmware.FirmwareVersion left, Daqifi.Core.Firmware.FirmwareVersion right) -> bool
+static Daqifi.Core.Firmware.FirmwareVersion.operator <=(Daqifi.Core.Firmware.FirmwareVersion left, Daqifi.Core.Firmware.FirmwareVersion right) -> bool
+static Daqifi.Core.Firmware.FirmwareVersion.operator ==(Daqifi.Core.Firmware.FirmwareVersion left, Daqifi.Core.Firmware.FirmwareVersion right) -> bool
+static Daqifi.Core.Firmware.FirmwareVersion.operator >(Daqifi.Core.Firmware.FirmwareVersion left, Daqifi.Core.Firmware.FirmwareVersion right) -> bool
+static Daqifi.Core.Firmware.FirmwareVersion.operator >=(Daqifi.Core.Firmware.FirmwareVersion left, Daqifi.Core.Firmware.FirmwareVersion right) -> bool
+static Daqifi.Core.Firmware.LanChipInfo.operator !=(Daqifi.Core.Firmware.LanChipInfo? left, Daqifi.Core.Firmware.LanChipInfo? right) -> bool
+static Daqifi.Core.Firmware.LanChipInfo.operator ==(Daqifi.Core.Firmware.LanChipInfo? left, Daqifi.Core.Firmware.LanChipInfo? right) -> bool
+static Daqifi.Core.Firmware.LanChipInfoParser.TryParse(string? json, out Daqifi.Core.Firmware.LanChipInfo? result) -> bool
+static Daqifi.Core.Firmware.LanChipInfoParser.TryParseLines(System.Collections.Generic.IEnumerable<string!>! lines, out Daqifi.Core.Firmware.LanChipInfo? result) -> bool
+static Daqifi.Core.Firmware.LanChipInfoProbeResult.operator !=(Daqifi.Core.Firmware.LanChipInfoProbeResult left, Daqifi.Core.Firmware.LanChipInfoProbeResult right) -> bool
+static Daqifi.Core.Firmware.LanChipInfoProbeResult.operator ==(Daqifi.Core.Firmware.LanChipInfoProbeResult left, Daqifi.Core.Firmware.LanChipInfoProbeResult right) -> bool
+static Daqifi.Core.Firmware.LanChipInfoProviderExtensions.GetLanChipInfoWithRetryAsync(this Daqifi.Core.Firmware.ILanChipInfoProvider! provider, Daqifi.Core.Firmware.LanChipInfoRetryOptions? options = null, Microsoft.Extensions.Logging.ILogger? logger = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Firmware.LanChipInfoProbeResult>!
+static Daqifi.Core.Firmware.LanChipInfoRetryOptions.operator !=(Daqifi.Core.Firmware.LanChipInfoRetryOptions? left, Daqifi.Core.Firmware.LanChipInfoRetryOptions? right) -> bool
+static Daqifi.Core.Firmware.LanChipInfoRetryOptions.operator ==(Daqifi.Core.Firmware.LanChipInfoRetryOptions? left, Daqifi.Core.Firmware.LanChipInfoRetryOptions? right) -> bool
+static Daqifi.Core.Firmware.Pic32BootloaderMessageConsumer.DecodeEraseFlashResponse(byte[]! data) -> bool
+static Daqifi.Core.Firmware.Pic32BootloaderMessageConsumer.DecodeProgramFlashResponse(byte[]! data) -> bool
+static Daqifi.Core.Firmware.Pic32BootloaderMessageConsumer.DecodeReadCrcResponse(byte[]! data) -> ushort
+static Daqifi.Core.Firmware.Pic32BootloaderMessageConsumer.DecodeVersionResponse(byte[]! data) -> string!
+static Daqifi.Core.Firmware.Pic32BootloaderMessageProducer.CreateEraseFlashMessage() -> byte[]!
+static Daqifi.Core.Firmware.Pic32BootloaderMessageProducer.CreateJumpToApplicationMessage() -> byte[]!
+static Daqifi.Core.Firmware.Pic32BootloaderMessageProducer.CreateProgramFlashMessage(byte[]! hexRecord) -> byte[]!
+static Daqifi.Core.Firmware.Pic32BootloaderMessageProducer.CreateReadCrcMessage(uint address, uint length) -> byte[]!
+static Daqifi.Core.Firmware.Pic32BootloaderMessageProducer.CreateRequestVersionMessage() -> byte[]!
+static Daqifi.Core.Firmware.WifiBridgeActivator.Activate(string! portName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static Daqifi.Core.Firmware.WifiBridgeActivator.ActivateAsync(string! portName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Daqifi.Core.Firmware.WifiBridgeActivator.Deactivate(string! portName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static Daqifi.Core.Firmware.WifiBridgeActivator.DeactivateAsync(string! portName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Daqifi.Core.Firmware.WifiFirmwareStatus.operator !=(Daqifi.Core.Firmware.WifiFirmwareStatus? left, Daqifi.Core.Firmware.WifiFirmwareStatus? right) -> bool
+static Daqifi.Core.Firmware.WifiFirmwareStatus.operator ==(Daqifi.Core.Firmware.WifiFirmwareStatus? left, Daqifi.Core.Firmware.WifiFirmwareStatus? right) -> bool
+static Daqifi.Core.Logging.Export.ChannelDescriptor.operator !=(Daqifi.Core.Logging.Export.ChannelDescriptor? left, Daqifi.Core.Logging.Export.ChannelDescriptor? right) -> bool
+static Daqifi.Core.Logging.Export.ChannelDescriptor.operator ==(Daqifi.Core.Logging.Export.ChannelDescriptor? left, Daqifi.Core.Logging.Export.ChannelDescriptor? right) -> bool
+static Daqifi.Core.Logging.Export.SampleRow.operator !=(Daqifi.Core.Logging.Export.SampleRow? left, Daqifi.Core.Logging.Export.SampleRow? right) -> bool
+static Daqifi.Core.Logging.Export.SampleRow.operator ==(Daqifi.Core.Logging.Export.SampleRow? left, Daqifi.Core.Logging.Export.SampleRow? right) -> bool
+static readonly Daqifi.Core.Communication.Transport.SerialStreamTransport.DefaultLivenessCheckInterval -> System.TimeSpan
+static readonly Daqifi.Core.Device.DaqifiDevice.MinSupportedFirmware -> Daqifi.Core.Firmware.FirmwareVersion
+static readonly Daqifi.Core.Device.DeviceIdentity.Empty -> Daqifi.Core.Device.DeviceIdentity!
+virtual Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.OnErrorOccurred(System.Exception! error, byte[]? rawData = null) -> void
+virtual Daqifi.Core.Communication.Consumers.StreamMessageConsumer<T>.OnMessageReceived(Daqifi.Core.Communication.Messages.IInboundMessage<T>! message, byte[]! rawData) -> void
+virtual Daqifi.Core.Communication.Transport.SerialStreamTransport.OnStatusChanged(bool isConnected, System.Exception? error) -> void
+virtual Daqifi.Core.Communication.Transport.TcpStreamTransport.OnStatusChanged(bool isConnected, System.Exception? error) -> void
+virtual Daqifi.Core.Communication.Transport.UdpTransport.OnStatusChanged(bool isOpen, System.Exception? error) -> void
+virtual Daqifi.Core.Device.DaqifiDevice.CaptureSessionSnapshot() -> void
+virtual Daqifi.Core.Device.DaqifiDevice.DrainErrorQueueAsync(int maxIterations = 256, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+virtual Daqifi.Core.Device.DaqifiDevice.ExecuteRawCaptureAsync(System.Func<System.IO.Stream!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! rawAction, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+virtual Daqifi.Core.Device.DaqifiDevice.ExecuteTextCommandAsync(System.Action! setupAction, int responseTimeoutMs = 1000, int completionTimeoutMs = 250, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>? prepareAsync = null, System.Func<System.Threading.Tasks.Task!>? finalizeAsync = null, bool keepBlankLines = false) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+virtual Daqifi.Core.Device.DaqifiDevice.ExecuteTextCommandAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! setupActionAsync, int responseTimeoutMs = 1000, int completionTimeoutMs = 250, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+virtual Daqifi.Core.Device.DaqifiDevice.InitializeAsync(System.TimeSpan? channelPopulationTimeout = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+virtual Daqifi.Core.Device.DaqifiDevice.OnDeviceInitializingAsync(bool preserveActiveStream, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+virtual Daqifi.Core.Device.DaqifiDevice.OnMessageReceived(Daqifi.Core.Communication.Messages.IInboundMessage<object!>! message) -> void
+virtual Daqifi.Core.Device.DaqifiDevice.OnStatusMessageReceived(DaqifiOutMessage! message) -> void
+virtual Daqifi.Core.Device.DaqifiDevice.OnStreamMessageReceived(DaqifiOutMessage! message) -> void
+virtual Daqifi.Core.Device.DaqifiDevice.PopulateChannelsFromStatus(DaqifiOutMessage! message) -> void
+virtual Daqifi.Core.Device.DaqifiDevice.ReadCapabilityDocumentAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Device.Capabilities.CapabilityDocument?>!
+virtual Daqifi.Core.Device.DaqifiDevice.RestoreSessionSnapshotAsync(Daqifi.Core.Device.ReconnectOptions! options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+virtual Daqifi.Core.Device.DaqifiDevice.Send<T>(Daqifi.Core.Communication.Messages.IOutboundMessage<T>! message) -> void
+virtual Daqifi.Core.Device.DaqifiStreamingDevice.IsUsbConnection.get -> bool
+virtual Daqifi.Core.Device.DaqifiStreamingDevice.OnLowSdSpaceWarning(Daqifi.Core.Device.SdCard.LowSdSpaceWarningEventArgs! e) -> void
+virtual Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.OnDeviceDiscovered(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo) -> void
+virtual Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.OnDeviceLost(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo) -> void
+virtual Daqifi.Core.Device.Discovery.ContinuousDeviceFinder.OnScanError(System.Exception! exception) -> void
+virtual Daqifi.Core.Device.Discovery.DeviceFinderBase.DiscoverAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Daqifi.Core.Device.Discovery.IDeviceInfo!>!>!
+virtual Daqifi.Core.Device.Discovery.DeviceFinderBase.Dispose(bool disposing) -> void
+virtual Daqifi.Core.Device.Discovery.DeviceFinderBase.OnDeviceDiscovered(Daqifi.Core.Device.Discovery.IDeviceInfo! deviceInfo) -> void
+virtual Daqifi.Core.Device.Discovery.DeviceFinderBase.OnDiscoveryCompleted() -> void
+virtual Daqifi.Core.Logging.Export.ChannelDescriptor.<Clone>$() -> Daqifi.Core.Logging.Export.ChannelDescriptor!
+virtual Daqifi.Core.Logging.Export.ChannelDescriptor.EqualityContract.get -> System.Type!
+virtual Daqifi.Core.Logging.Export.ChannelDescriptor.Equals(Daqifi.Core.Logging.Export.ChannelDescriptor? other) -> bool
+virtual Daqifi.Core.Logging.Export.ChannelDescriptor.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual Daqifi.Core.Logging.Export.SampleRow.<Clone>$() -> Daqifi.Core.Logging.Export.SampleRow!
+virtual Daqifi.Core.Logging.Export.SampleRow.EqualityContract.get -> System.Type!
+virtual Daqifi.Core.Logging.Export.SampleRow.Equals(Daqifi.Core.Logging.Export.SampleRow? other) -> bool
+virtual Daqifi.Core.Logging.Export.SampleRow.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~DaqifiOutMessage.AnalogInCalB.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInCalBPriv.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInCalM.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInCalMPriv.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInData.get -> Google.Protobuf.Collections.RepeatedField<int>
+~DaqifiOutMessage.AnalogInDataFloat.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInDataTs.get -> Google.Protobuf.Collections.RepeatedField<uint>
+~DaqifiOutMessage.AnalogInIntScaleM.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInIntScaleMPriv.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInPortAvRange.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInPortAvRangePriv.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInPortAvRse.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.AnalogInPortAvRse.set -> void
+~DaqifiOutMessage.AnalogInPortEnabled.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.AnalogInPortEnabled.set -> void
+~DaqifiOutMessage.AnalogInPortRange.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInPortRangePriv.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogInPortRse.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.AnalogInPortRse.set -> void
+~DaqifiOutMessage.AnalogInPortType.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.AnalogInPortType.set -> void
+~DaqifiOutMessage.AnalogOutData.get -> Google.Protobuf.Collections.RepeatedField<uint>
+~DaqifiOutMessage.AnalogOutPortAvRange.get -> Google.Protobuf.Collections.RepeatedField<float>
+~DaqifiOutMessage.AnalogOutPortType.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.AnalogOutPortType.set -> void
+~DaqifiOutMessage.AvSsid.get -> Google.Protobuf.Collections.RepeatedField<string>
+~DaqifiOutMessage.AvSsidStrength.get -> Google.Protobuf.Collections.RepeatedField<uint>
+~DaqifiOutMessage.AvWifiInfMode.get -> Google.Protobuf.Collections.RepeatedField<uint>
+~DaqifiOutMessage.AvWifiSecurityMode.get -> Google.Protobuf.Collections.RepeatedField<uint>
+~DaqifiOutMessage.Clone() -> DaqifiOutMessage
+~DaqifiOutMessage.DaqifiOutMessage(DaqifiOutMessage other) -> void
+~DaqifiOutMessage.DeviceFwRev.get -> string
+~DaqifiOutMessage.DeviceFwRev.set -> void
+~DaqifiOutMessage.DeviceHwRev.get -> string
+~DaqifiOutMessage.DeviceHwRev.set -> void
+~DaqifiOutMessage.DevicePn.get -> string
+~DaqifiOutMessage.DevicePn.set -> void
+~DaqifiOutMessage.DigitalData.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.DigitalData.set -> void
+~DaqifiOutMessage.DigitalDataTs.get -> Google.Protobuf.Collections.RepeatedField<uint>
+~DaqifiOutMessage.DigitalPortDir.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.DigitalPortDir.set -> void
+~DaqifiOutMessage.DigitalPortType.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.DigitalPortType.set -> void
+~DaqifiOutMessage.Equals(DaqifiOutMessage other) -> bool
+~DaqifiOutMessage.Eui64.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.Eui64.set -> void
+~DaqifiOutMessage.FriendlyDeviceName.get -> string
+~DaqifiOutMessage.FriendlyDeviceName.set -> void
+~DaqifiOutMessage.Gateway.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.Gateway.set -> void
+~DaqifiOutMessage.GatewayV6.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.GatewayV6.set -> void
+~DaqifiOutMessage.HostName.get -> string
+~DaqifiOutMessage.HostName.set -> void
+~DaqifiOutMessage.IpAddr.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.IpAddr.set -> void
+~DaqifiOutMessage.IpAddrV6.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.IpAddrV6.set -> void
+~DaqifiOutMessage.MacAddr.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.MacAddr.set -> void
+~DaqifiOutMessage.MergeFrom(DaqifiOutMessage other) -> void
+~DaqifiOutMessage.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~DaqifiOutMessage.NetMask.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.NetMask.set -> void
+~DaqifiOutMessage.PrimaryDns.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.PrimaryDns.set -> void
+~DaqifiOutMessage.PrimaryDnsV6.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.PrimaryDnsV6.set -> void
+~DaqifiOutMessage.SecondaryDns.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.SecondaryDns.set -> void
+~DaqifiOutMessage.SecondaryDnsV6.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.SecondaryDnsV6.set -> void
+~DaqifiOutMessage.Ssid.get -> string
+~DaqifiOutMessage.Ssid.set -> void
+~DaqifiOutMessage.SubPreLengthV6.get -> Google.Protobuf.ByteString
+~DaqifiOutMessage.SubPreLengthV6.set -> void
+~DaqifiOutMessage.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~override Daqifi.Core.Firmware.FirmwareVersion.Equals(object obj) -> bool
+~override Daqifi.Core.Firmware.LanChipInfoProbeResult.Equals(object obj) -> bool
+~override Daqifi.Core.Firmware.LanChipInfoProbeResult.ToString() -> string
+~override DaqifiOutMessage.Equals(object other) -> bool
+~override DaqifiOutMessage.ToString() -> string
+~static DaqifiOutMessage.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static DaqifiOutMessage.Parser.get -> Google.Protobuf.MessageParser<DaqifiOutMessage>
+~static DaqifiOutMessageReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor

--- a/src/Daqifi.Core/PublicAPI.Unshipped.txt
+++ b/src/Daqifi.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,52 @@
+#nullable enable
+Daqifi.Core.Logging.Export.ChannelDescriptorComparer
+Daqifi.Core.Logging.Export.ChannelDescriptorComparer.Compare(Daqifi.Core.Logging.Export.ChannelDescriptor? x, Daqifi.Core.Logging.Export.ChannelDescriptor? y) -> int
+Daqifi.Core.Logging.Export.ChannelNameComparer
+Daqifi.Core.Logging.Export.ChannelNameComparer.Compare(string? x, string? y) -> int
+Daqifi.Core.Logging.Export.LiveCsvRecordingExtensions
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.Deconstruct(out long SampleCount, out long RowCount, out long DroppedSampleCount, out long UnmappedSampleCount, out long NonMonotonicSampleCount) -> void
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.DroppedSampleCount.get -> long
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.DroppedSampleCount.init -> void
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.Equals(Daqifi.Core.Logging.Export.LiveCsvRecordingResult other) -> bool
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.LiveCsvRecordingResult() -> void
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.LiveCsvRecordingResult(long SampleCount, long RowCount, long DroppedSampleCount, long UnmappedSampleCount, long NonMonotonicSampleCount) -> void
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.NonMonotonicSampleCount.get -> long
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.NonMonotonicSampleCount.init -> void
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.RowCount.get -> long
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.RowCount.init -> void
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.SampleCount.get -> long
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.SampleCount.init -> void
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.UnmappedSampleCount.get -> long
+Daqifi.Core.Logging.Export.LiveCsvRecordingResult.UnmappedSampleCount.init -> void
+Daqifi.Core.Logging.Export.LiveSampleSource
+Daqifi.Core.Logging.Export.LiveSampleSource.GetChannels() -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Logging.Export.ChannelDescriptor!>!
+Daqifi.Core.Logging.Export.LiveSampleSource.GetSampleCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<int>
+Daqifi.Core.Logging.Export.LiveSampleSource.LiveSampleSource(System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Channel.LiveSample!>! samples, System.Collections.Generic.IEnumerable<Daqifi.Core.Channel.IChannel!>! channels, string! deviceName, string? deviceSerialNumber) -> void
+Daqifi.Core.Logging.Export.LiveSampleSource.NonMonotonicSampleCount.get -> long
+Daqifi.Core.Logging.Export.LiveSampleSource.RowCount.get -> long
+Daqifi.Core.Logging.Export.LiveSampleSource.SampleCount.get -> long
+Daqifi.Core.Logging.Export.LiveSampleSource.StreamSamples(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Logging.Export.SampleRow!>!
+Daqifi.Core.Logging.Export.LiveSampleSource.UnmappedSampleCount.get -> long
+Daqifi.Core.Logging.Export.SdCardLogSampleSource
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.AnalogChannelCount.get -> int
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.DroppedAnalogColumns.get -> int
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.GetChannels() -> System.Collections.Generic.IReadOnlyList<Daqifi.Core.Logging.Export.ChannelDescriptor!>!
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.GetSampleCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<int>
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.NonMonotonicEntryCount.get -> long
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.RowCount.get -> long
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.SampleCount.get -> long
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.SdCardLogSampleSource(System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Device.SdCard.SdCardLogEntry!>! samples, string? deviceSerialNumber, int analogChannelCount, string? deviceName = null) -> void
+Daqifi.Core.Logging.Export.SdCardLogSampleSource.StreamSamples(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Daqifi.Core.Logging.Export.SampleRow!>!
+Daqifi.Core.Logging.Export.SdCardLogSessionExtensions
+const Daqifi.Core.Logging.Export.SdCardLogSampleSource.DefaultDeviceName = "Daqifi" -> string!
+const Daqifi.Core.Logging.Export.SdCardLogSampleSource.DigitalChannelName = "DIO" -> string!
+override Daqifi.Core.Logging.Export.LiveCsvRecordingResult.GetHashCode() -> int
+static Daqifi.Core.Logging.Export.ChannelDescriptorComparer.Default.get -> Daqifi.Core.Logging.Export.ChannelDescriptorComparer!
+static Daqifi.Core.Logging.Export.ChannelNameComparer.Instance.get -> Daqifi.Core.Logging.Export.ChannelNameComparer!
+static Daqifi.Core.Logging.Export.LiveCsvRecordingExtensions.RecordLiveSamplesToCsvAsync(this Daqifi.Core.Device.IStreamingDevice! device, System.IO.TextWriter! writer, Daqifi.Core.Logging.Export.CsvExportOptions? options = null, System.TimeSpan? duration = null, int? bufferCapacity = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Daqifi.Core.Logging.Export.LiveCsvRecordingResult>!
+static Daqifi.Core.Logging.Export.LiveCsvRecordingResult.operator !=(Daqifi.Core.Logging.Export.LiveCsvRecordingResult left, Daqifi.Core.Logging.Export.LiveCsvRecordingResult right) -> bool
+static Daqifi.Core.Logging.Export.LiveCsvRecordingResult.operator ==(Daqifi.Core.Logging.Export.LiveCsvRecordingResult left, Daqifi.Core.Logging.Export.LiveCsvRecordingResult right) -> bool
+static Daqifi.Core.Logging.Export.SdCardLogSessionExtensions.AsSampleSource(this Daqifi.Core.Device.SdCard.SdCardLogSession! session, Daqifi.Core.Device.SdCard.SdCardDeviceConfiguration? fallbackConfiguration = null, string? deviceName = null) -> Daqifi.Core.Logging.Export.SdCardLogSampleSource!
+~override Daqifi.Core.Logging.Export.LiveCsvRecordingResult.Equals(object obj) -> bool
+~override Daqifi.Core.Logging.Export.LiveCsvRecordingResult.ToString() -> string


### PR DESCRIPTION
### What was wrong

ADR 0002 promises that `Daqifi.Core` keeps source compatibility for its public API — 231 public types, ~2,700 members. Nothing in the build checked that. Delete a public method, narrow a parameter type, add a member to a public interface, and you get a green build and a green CI run. The break shows up later, when `daqifi-desktop`, `Daqifi.Mcp` or an outside integrator next restores the package. That is how #557 was found — by an adversarial audit on a PR, not by tooling — and it is the reason #612 and #616 are parked: everyone agrees their fix "breaks the API", but there was no artifact saying what the API even is.

### How it was fixed

The public surface is now checked in, as `PublicAPI.Shipped.txt` (what v1.7.0 published) and `PublicAPI.Unshipped.txt` (what has been added since), and `Microsoft.CodeAnalysis.PublicApiAnalyzers` fails the build whenever the code and those files disagree. Changing the API is still allowed — it just has to arrive as an explicit diff to the API file in the same PR, where a reviewer can see it.

Seeding the files against the v1.7.0 tag rather than against `main` also answered a question nobody could answer before: **51 public members have been added since the release and none removed.** The promise has held in practice.

Two things worth pushing back on, so they are not buried:

- **`Daqifi.Core.csproj` is +9 lines; `PublicAPI.Shipped.txt` is 2,669.** That file is a generated baseline and is meant to be skimmed, not read. The reviewable part is the csproj, the `.editorconfig` stanza, `CONTRIBUTING.md`, and `PublicAPI.Unshipped.txt` — 51 lines that should look exactly like the public API added since v1.7.0.
- **`EnablePackageValidation` (the second half of #636) is deliberately not here**, so this does not close the issue. It runs at `dotnet pack` time, and CI never packs — only the release workflow does — so it would catch breaks at release rather than in the PR. It also trips `CP0003` immediately, because the repo has no `<Version>` and so packs locally as `1.0.0`, which is "lower than" the 1.7.0 baseline. That wants its own decision about repo versioning, not a suppression tacked onto this PR.

### Detail

- The protoc-generated `DaqifiOutMessage.cs` is skipped by the analyzer's own code fix, so its 191 entries were added by hand from the RS0016 diagnostics. Noted in `CONTRIBUTING.md` for whoever regenerates the protos next. (Its types sit in the **global namespace**, which is its own small surprise.)
- `RS0041` (public members should not use nullable-oblivious types) is switched off for that one generated file. It fires 166 times there and the fix — annotating protoc's output — is not ours to make. The obliviousness is not lost: those entries carry the analyzer's `~` prefix, so a change in their nullability still shows as an API diff. The rule stays active for every hand-written public member.
- `RS0026`/`RS0027` (overloads with optional parameters) do not fire on this baseline, but they will on a *future* addition that follows the repo's existing optional-parameter convention. Left at default rather than pre-suppressed; that is a decision for the PR that first hits it.

### Verified

- Full `dotnet test Daqifi.Core.sln -warnaserror` green on both frameworks: net9.0 4022 passed / 2 skipped, net10.0 4022 passed / 2 skipped (+7 new cases).
- The guard was mutation-tested three ways, each confirmed to fail the build: add a public member (RS0016), delete an API entry (RS0016), leave a stale entry behind (RS0017).
- The five new tests in `PublicApiTrackingTests` guard the analyzer's *wiring* — delete the two `AdditionalFiles` lines and the analyzer silently finds nothing to compare against and reports nothing at all. Each was checked to fail on a **green** build; two candidate tests were dropped for failing that check (duplicates are already RS0025, and dropping `PrivateAssets` already breaks the build).
- **No production source changed.** Packed from `main` and from this branch in the same directory: identical package contents, byte-identical XML docs, identical assembly sizes, and no new package dependency.
- Bench, Nq1 fw 3.7.2 on `/dev/cu.usbmodem1101`: connect → status → AI0/AI1 → 100 Hz → 3 s CSV capture → clean disconnect, exit 0. Non-destructive.

Addresses #636 (leaves the `EnablePackageValidation` half open, see above).

Not merging — for review.