### PR TITLE
fix(device): every DIO pin came back as an input after a reconnect

### DIFF
--- a/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
+++ b/src/Daqifi.Core.Tests/Device/ChannelPopulationTests.cs
@@ -581,7 +581,7 @@ public class ChannelPopulationTests
     }
 
     [Fact]
-    public void PopulateChannelsFromStatus_DigitalChannelsHaveCorrectDirection()
+    public void PopulateChannelsFromStatus_DigitalChannelsDefaultToInput_WhenTheDeviceReportsNoDirections()
     {
         // Arrange
         var device = new DaqifiDevice("TestDevice");
@@ -596,6 +596,31 @@ public class ChannelPopulationTests
         // Assert
         var digitalChannels = device.Channels.Where(c => c.Type == ChannelType.Digital).ToList();
         Assert.All(digitalChannels, c => Assert.Equal(ChannelDirection.Input, c.Direction));
+    }
+
+    [Fact]
+    public void PopulateChannelsFromStatus_DigitalChannelsTakeTheirDirectionFromTheDevice()
+    {
+        // #685: the direction the device reports (digital_port_dir, TRIS-encoded: bit set = input)
+        // is the truth, and it survives a reconnect on the board even though Core's init sequence
+        // never resets it.
+        // Arrange
+        var device = new DaqifiDevice("TestDevice");
+        var message = new DaqifiOutMessage
+        {
+            DigitalPortNum = 16,
+            DigitalPortDir = Google.Protobuf.ByteString.CopyFrom(new byte[] { 0b1111_1011, 0b1111_1111 })
+        };
+
+        // Act
+        device.PopulateChannelsFromStatus(message);
+
+        // Assert
+        var digitalChannels = device.Channels.Where(c => c.Type == ChannelType.Digital).ToList();
+        Assert.Equal(ChannelDirection.Output, digitalChannels[2].Direction);
+        Assert.All(
+            digitalChannels.Where(c => c.ChannelNumber != 2),
+            c => Assert.Equal(ChannelDirection.Input, c.Direction));
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
@@ -307,6 +307,38 @@ public class DaqifiStreamingDeviceDecodeTests
     }
 
     [Fact]
+    public void Decode_Digital_SkipsOutputDirectionChannels_TheDeviceItselfReported()
+    {
+        // Regression for #685. A pin left as an output by a previous session stays an output on
+        // the board across a reconnect, and nothing in Core's init sequence resets it. Before the
+        // fix Core hardcoded every freshly populated channel to Input, so the guard above never
+        // fired on a reconnect and the pin's own driven level was delivered as an input reading.
+        // Nobody calls SetDioDirection here — the direction comes only from the status frame.
+        var device = new DecodableStreamingDevice("TestDevice");
+        device.Connect();
+
+        var status = new DaqifiOutMessage { DigitalPortNum = 2 };
+        status.DigitalPortDir = ByteString.CopyFrom(new byte[] { 0b1111_1101 }); // TRIS: DIO1 is an output
+        device.PopulateChannelsFromStatus(status);
+
+        var dio0 = DigitalChannel(device, 0);
+        var dio1 = DigitalChannel(device, 1);
+        dio0.IsEnabled = true;
+        dio1.IsEnabled = true;
+        device.StartStreaming();
+
+        var frame = new DaqifiOutMessage { MsgTimeStamp = 5 };
+        frame.DigitalData = ByteString.CopyFrom(new byte[] { 0b11 });
+
+        device.InvokeStreamMessage(frame);
+
+        Assert.Equal(ChannelDirection.Output, dio1.Direction);
+        Assert.NotNull(dio0.ActiveSample);
+        Assert.Equal(1.0, dio0.ActiveSample!.Value);
+        Assert.Null(dio1.ActiveSample);
+    }
+
+    [Fact]
     public void Decode_Digital_BeyondTwoBytes_ReadsCorrectByteWithoutWrapping()
     {
         // Regression for Qodo #279: with >16 enabled digital channels / >2 payload bytes, bit

--- a/src/Daqifi.Core.Tests/Device/Internal/ChannelControlOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ChannelControlOperationsTests.cs
@@ -4,6 +4,7 @@ using Daqifi.Core.Device;
 using Daqifi.Core.Device.Internal;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -259,6 +260,41 @@ public class ChannelControlOperationsTests
         Assert.True(digital.DirectionWrittenUnderLock);
         Assert.Equal(ChannelDirection.Output, digital.Direction);
         Assert.Equal(new[] { "send:DIO:PORt:DIRection 5,1" }, host.Calls);
+    }
+
+    [Fact]
+    public void SetDioDirection_CommandWins_WhenAStatusFrameLandsWhileItIsInFlight()
+    {
+        // Qodo, PR #686. A status frame the device encoded before it applied this command can
+        // land while the command is in flight and revert Core's view. Nothing would repair that:
+        // this device sends no unsolicited status frames (bench-measured), so there may be no
+        // later frame at all, and Core would report the pin backwards indefinitely while the
+        // device sat in the commanded direction. The command has to have the last word.
+        var digital = new DigitalChannel(channelNumber: 5) { Direction = ChannelDirection.Input };
+        var host = new FakeHost(digital);
+        var ops = new ChannelControlOperations(host);
+
+        // A stale status frame resyncing Direction back to Input, mid-command.
+        host.OnSend = () => digital.Direction = ChannelDirection.Input;
+
+        ops.SetDioDirection(digital, ChannelDirection.Output);
+
+        Assert.Equal(ChannelDirection.Output, digital.Direction);
+        Assert.Equal(new[] { "send:DIO:PORt:DIRection 5,1" }, host.Calls);
+    }
+
+    [Fact]
+    public void SetDioDirection_FailedSend_LeavesCoreDirectionUntouched()
+    {
+        // Recording a direction the pin never took would tell every caller the pin is doing
+        // something it is not — the same principle as the PWM guard (#449).
+        var digital = new DigitalChannel(channelNumber: 5) { Direction = ChannelDirection.Input };
+        var host = new FakeHost(digital) { SendFailure = new IOException("cable pulled") };
+        var ops = new ChannelControlOperations(host);
+
+        Assert.Throws<IOException>(() => ops.SetDioDirection(digital, ChannelDirection.Output));
+
+        Assert.Equal(ChannelDirection.Input, digital.Direction);
     }
 
     [Fact]
@@ -728,6 +764,18 @@ public class ChannelControlOperationsTests
             lock (_calls) { _calls.Add(call); }
         }
 
+        /// <summary>
+        /// Runs at the moment of a <see cref="Send{T}"/>, so a test can simulate something landing
+        /// while a command is in flight — a status frame resyncing channel state, say.
+        /// </summary>
+        public Action? OnSend { get; set; }
+
+        /// <summary>
+        /// When set, <see cref="Send{T}"/> throws this instead of recording, so a test can check
+        /// what local state a failed command leaves behind.
+        /// </summary>
+        public Exception? SendFailure { get; set; }
+
         public void Send<T>(IOutboundMessage<T> message)
         {
             if (_inChannelsLock)
@@ -737,7 +785,13 @@ public class ChannelControlOperationsTests
                     "the channels lock (see IDeviceOperationHost.WithChannelsLock).");
             }
 
+            if (SendFailure is not null)
+            {
+                throw SendFailure;
+            }
+
             Record("send:" + message.Data);
+            OnSend?.Invoke();
         }
 
         public IReadOnlyList<IChannel> SnapshotChannels() => _channels.ToArray();

--- a/src/Daqifi.Core.Tests/Device/Internal/ChannelControlOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ChannelControlOperationsTests.cs
@@ -243,6 +243,25 @@ public class ChannelControlOperationsTests
     }
 
     [Fact]
+    public void SetDioDirection_MutatesDirectionUnderTheChannelsLock()
+    {
+        // The status-frame resync writes this same property under the channels lock (#685), so
+        // the command path has to write it under that lock too — the discipline SetChannelsEnabled
+        // already follows for analog IsEnabled (#409). Qodo flagged the unsynchronized pair on
+        // PR #686.
+        var digital = new LockObservingDigitalChannel(channelNumber: 5);
+        var host = new FakeHost(digital);
+        digital.Host = host;
+        var ops = new ChannelControlOperations(host);
+
+        ops.SetDioDirection(digital, ChannelDirection.Output);
+
+        Assert.True(digital.DirectionWrittenUnderLock);
+        Assert.Equal(ChannelDirection.Output, digital.Direction);
+        Assert.Equal(new[] { "send:DIO:PORt:DIRection 5,1" }, host.Calls);
+    }
+
+    [Fact]
     public void SetDioDirection_AnalogChannel_ThrowsBeforeConnectionCheck()
     {
         var analog = new AnalogChannel(channelNumber: 0, resolution: 65535);
@@ -606,6 +625,57 @@ public class ChannelControlOperationsTests
 
     #endregion
 
+    /// <summary>
+    /// An <see cref="IDigitalChannel"/> that records whether its <see cref="Direction"/> was
+    /// assigned from inside <see cref="FakeHost.WithChannelsLock"/>. A wrapper rather than a
+    /// subclass because <see cref="DigitalChannel.Direction"/> is not virtual; every other member
+    /// forwards to a real <see cref="DigitalChannel"/> so the behaviour under test is unchanged.
+    /// </summary>
+    private sealed class LockObservingDigitalChannel : IDigitalChannel
+    {
+        private readonly DigitalChannel _inner;
+
+        public LockObservingDigitalChannel(int channelNumber)
+        {
+            _inner = new DigitalChannel(channelNumber);
+        }
+
+        public FakeHost? Host { get; set; }
+
+        public bool DirectionWrittenUnderLock { get; private set; }
+
+        public ChannelDirection Direction
+        {
+            get => _inner.Direction;
+            set
+            {
+                DirectionWrittenUnderLock = Host?.InChannelsLock ?? false;
+                _inner.Direction = value;
+            }
+        }
+
+        public int ChannelNumber => _inner.ChannelNumber;
+        public string Name { get => _inner.Name; set => _inner.Name = value; }
+        public bool IsEnabled { get => _inner.IsEnabled; set => _inner.IsEnabled = value; }
+        public ChannelType Type => _inner.Type;
+        public IDataSample? ActiveSample => _inner.ActiveSample;
+        public bool OutputValue { get => _inner.OutputValue; set => _inner.OutputValue = value; }
+        public bool IsHigh => _inner.IsHigh;
+        public bool IsPwmCapable => _inner.IsPwmCapable;
+        public bool IsPwmEnabled { get => _inner.IsPwmEnabled; set => _inner.IsPwmEnabled = value; }
+        public int PwmDutyCyclePercent { get => _inner.PwmDutyCyclePercent; set => _inner.PwmDutyCyclePercent = value; }
+
+        public event EventHandler<SampleReceivedEventArgs>? SampleReceived
+        {
+            add => _inner.SampleReceived += value;
+            remove => _inner.SampleReceived -= value;
+        }
+
+        public void SetActiveSample(double value, DateTime timestamp) => _inner.SetActiveSample(value, timestamp);
+
+        public void SetActiveSample(IDataSample sample) => _inner.SetActiveSample(sample);
+    }
+
     #region Fake host
 
     /// <summary>
@@ -629,6 +699,12 @@ public class ChannelControlOperationsTests
         /// passing it.
         /// </summary>
         private bool _inChannelsLock;
+
+        /// <summary>
+        /// Whether a <see cref="WithChannelsLock"/> callback is currently on the stack, so a test
+        /// can assert that a mutation happens inside the critical section rather than beside it.
+        /// </summary>
+        public bool InChannelsLock => _inChannelsLock;
 
         public FakeHost(params IChannel[] channels)
         {

--- a/src/Daqifi.Core.Tests/Device/Internal/StatusChannelPopulatorTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StatusChannelPopulatorTests.cs
@@ -1,6 +1,7 @@
 using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device.Internal;
+using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
@@ -132,6 +133,84 @@ public class StatusChannelPopulatorTests
 
         var channel = Assert.IsType<DigitalChannel>(destination[channelNumber]);
         Assert.Equal(expected, channel.IsPwmCapable);
+    }
+
+    [Theory]
+    [InlineData(0b1111_1111, ChannelDirection.Input)]
+    [InlineData(0b1111_1011, ChannelDirection.Output)]
+    public void Populate_SetsDigitalDirection_FromTheReportedDirectionMask(byte lowByte, ChannelDirection expected)
+    {
+        // digital_port_dir is TRIS-encoded: bit set = input, bit clear = output — the inverse of
+        // the argument Core sends outbound. Bit 2 is the one under test here (#685).
+        var message = new DaqifiOutMessage { DigitalPortNum = 16 };
+        message.DigitalPortDir = ByteString.CopyFrom(new byte[] { lowByte, 0xFF });
+        var destination = new List<IChannel>();
+
+        Create().Populate(message, Array.Empty<IChannel>(), destination);
+
+        Assert.Equal(expected, destination[2].Direction);
+        // The channels the device reported as inputs are unaffected either way.
+        Assert.Equal(ChannelDirection.Input, destination[4].Direction);
+        Assert.Equal(ChannelDirection.Input, destination[15].Direction);
+    }
+
+    [Fact]
+    public void Populate_ResyncsDigitalDirection_OnAnExistingChannel()
+    {
+        // The device's own view outranks Core's, the same way analog IsEnabled does (#409):
+        // an output pin left driven by a previous session must not come back as an input.
+        var existing = new DigitalChannel(2, isPwmCapable: false) { Direction = ChannelDirection.Input };
+        var message = new DaqifiOutMessage { DigitalPortNum = 3 };
+        message.DigitalPortDir = ByteString.CopyFrom(new byte[] { 0b1111_1011 });
+        var destination = new List<IChannel>();
+
+        Create().Populate(message, new IChannel[] { existing }, destination);
+
+        Assert.Same(existing, destination[2]);
+        Assert.Equal(ChannelDirection.Output, existing.Direction);
+    }
+
+    [Fact]
+    public void Populate_LeavesDigitalDirectionAlone_WhenNoDirectionMaskIsReported()
+    {
+        // Firmware that never populates the field, and the SD-card/replay paths that synthesize
+        // status messages without one, must not stomp a locally-commanded direction.
+        var existing = new DigitalChannel(0, isPwmCapable: true) { Direction = ChannelDirection.Output };
+        var destination = new List<IChannel>();
+
+        Create().Populate(
+            new DaqifiOutMessage { DigitalPortNum = 1 }, new IChannel[] { existing }, destination);
+
+        Assert.Equal(ChannelDirection.Output, destination[0].Direction);
+    }
+
+    [Fact]
+    public void Populate_DefaultsDigitalDirectionToInput_ForChannelsBeyondTheReportedMask()
+    {
+        // A one-byte mask describes channels 0-7 only; channel 8 is "not reported", not "output".
+        var existingBeyondMask = new DigitalChannel(8, isPwmCapable: false) { Direction = ChannelDirection.Output };
+        var message = new DaqifiOutMessage { DigitalPortNum = 9 };
+        message.DigitalPortDir = ByteString.CopyFrom(new byte[] { 0b1111_1011 });
+        var destination = new List<IChannel>();
+
+        Create().Populate(message, new IChannel[] { existingBeyondMask }, destination);
+
+        Assert.Equal(ChannelDirection.Output, destination[2].Direction);   // described, and an output
+        Assert.Equal(ChannelDirection.Input, destination[7].Direction);    // described, and an input
+        Assert.Equal(ChannelDirection.Output, destination[8].Direction);   // undescribed: left as it was
+    }
+
+    [Fact]
+    public void Populate_DefaultsNewDigitalChannelsToInput_WhenTheMaskIsTooShort()
+    {
+        var message = new DaqifiOutMessage { DigitalPortNum = 10 };
+        message.DigitalPortDir = ByteString.CopyFrom(new byte[] { 0b0000_0000 });
+        var destination = new List<IChannel>();
+
+        Create().Populate(message, Array.Empty<IChannel>(), destination);
+
+        Assert.Equal(ChannelDirection.Output, destination[0].Direction);   // described
+        Assert.Equal(ChannelDirection.Input, destination[9].Direction);    // undescribed: Input default
     }
 
     [Theory]

--- a/src/Daqifi.Core/Channel/IChannel.cs
+++ b/src/Daqifi.Core/Channel/IChannel.cs
@@ -28,6 +28,13 @@ public interface IChannel
     /// <summary>
     /// Gets or sets the channel direction (Input or Output).
     /// </summary>
+    /// <remarks>
+    /// On a digital channel this tracks the direction the <i>device</i> reports, resynced from
+    /// every status message, so it stays right across a reconnect even though the pin's direction
+    /// persists on the board and nothing in Core's init sequence resets it (#685). Use
+    /// <c>IStreamingDevice.SetDioDirection</c> to change it; assigning here only moves Core's
+    /// view, and the next status message will overwrite it with the device's.
+    /// </remarks>
     ChannelDirection Direction { get; set; }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
@@ -141,23 +141,31 @@ namespace Daqifi.Core.Device.Internal
             EnsureChannelBelongs(channel);
             EnsurePwmNotEnabled(channel);
 
-            // Mutate under the channels lock, which is the same lock the status-frame resync of
-            // this property writes under (#685) — the discipline SetChannelsEnabled already
-            // follows for analog IsEnabled (#409). Without it the command's write and a
-            // concurrent population's write to the same property are unsynchronized.
+            // Send first, then record the new direction — the reverse of the mirror-then-send
+            // order used elsewhere, and deliberately so now that a status frame can write this
+            // same property (#685).
             //
-            // What the lock does not give is causal ordering against a status frame the device
-            // encoded before it applied this command: if one is in flight, it wins briefly and
-            // the next status frame corrects it. That is the same accepted characteristic as
-            // analog IsEnabled, and its window is narrow in practice — the device sends no
-            // unsolicited status frames at all (measured on an Nq1, fw 3.7.2: zero over 10s idle
-            // and 10s streaming), so a status frame only exists here if a caller has a
-            // RefreshDeviceStatusAsync running concurrently on another thread.
-            _host.WithChannelsLock(() => channel.Direction = direction);
-
+            // Mirroring first would leave a window between the local write and the wire write in
+            // which a status frame the device encoded *before* it applied this command can land
+            // and revert Core's view. Ordinarily a later frame would repair that, but this device
+            // sends no unsolicited status frames at all — measured on an Nq1 (fw 3.7.2): zero over
+            // 10s idle and zero over 10s of streaming, they arrive only as replies to
+            // SYSTem:SYSInfoPB?. So there may be no later frame, and Core would report the pin
+            // backwards indefinitely while the device sat in the commanded direction.
+            //
+            // Writing after the send closes that: whatever a concurrent status refresh wrote
+            // while the command was in flight, the commanded value has the last word within this
+            // call, and it is the value the device is now in. It also means a send that throws
+            // leaves Core's view untouched rather than claiming a direction the pin never took —
+            // the same principle as the PWM guard above (#449).
             _host.Send(ScpiMessageProducer.SetDioPortDirection(
                 channel.ChannelNumber,
                 direction == ChannelDirection.Output ? 1 : 0));
+
+            // Under the channels lock, which is the lock the status-frame resync of this property
+            // writes under — the discipline SetChannelsEnabled already follows for analog
+            // IsEnabled (#409). Blocking I/O stays outside it, hence the send above.
+            _host.WithChannelsLock(() => channel.Direction = direction);
         }
 
         /// <inheritdoc cref="IStreamingDevice.SetDioValue" />

--- a/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
+++ b/src/Daqifi.Core/Device/Internal/ChannelControlOperations.cs
@@ -141,7 +141,20 @@ namespace Daqifi.Core.Device.Internal
             EnsureChannelBelongs(channel);
             EnsurePwmNotEnabled(channel);
 
-            channel.Direction = direction;
+            // Mutate under the channels lock, which is the same lock the status-frame resync of
+            // this property writes under (#685) — the discipline SetChannelsEnabled already
+            // follows for analog IsEnabled (#409). Without it the command's write and a
+            // concurrent population's write to the same property are unsynchronized.
+            //
+            // What the lock does not give is causal ordering against a status frame the device
+            // encoded before it applied this command: if one is in flight, it wins briefly and
+            // the next status frame corrects it. That is the same accepted characteristic as
+            // analog IsEnabled, and its window is narrow in practice — the device sends no
+            // unsolicited status frames at all (measured on an Nq1, fw 3.7.2: zero over 10s idle
+            // and 10s streaming), so a status frame only exists here if a caller has a
+            // RefreshDeviceStatusAsync running concurrently on another thread.
+            _host.WithChannelsLock(() => channel.Direction = direction);
+
             _host.Send(ScpiMessageProducer.SetDioPortDirection(
                 channel.ChannelNumber,
                 direction == ChannelDirection.Output ? 1 : 0));

--- a/src/Daqifi.Core/Device/Internal/StatusChannelPopulator.cs
+++ b/src/Daqifi.Core/Device/Internal/StatusChannelPopulator.cs
@@ -60,11 +60,12 @@ namespace Daqifi.Core.Device.Internal
         /// <param name="existing">
         /// The channels from the prior population. Any whose identity (type, number) still appears
         /// in <paramref name="message"/> is updated in place and re-used, so consumer-held
-        /// <see cref="IChannel"/> references — and the configuration on them (direction/output/PWM
-        /// state) — survive a routine status re-population untouched. <c>IsEnabled</c> is the
-        /// exception: analog channels resync it from the device-reported enabled mask (field 22)
-        /// whenever the device sends one, so Core's view cannot silently drift from the device's
-        /// (#409).
+        /// <see cref="IChannel"/> references — and the configuration on them (output value, PWM
+        /// state) — survive a routine status re-population untouched. The two exceptions are the
+        /// pieces of state the device itself reports, which resync from it whenever it sends one,
+        /// so Core's view cannot silently drift from the device's: analog <c>IsEnabled</c> from
+        /// the enabled mask (field 22, #409) and digital <c>Direction</c> from the direction mask
+        /// (field 37, #685).
         /// </param>
         /// <param name="destination">The list to append the resulting channel instances to, in order.</param>
         /// <returns>How many analog and digital channels were populated.</returns>
@@ -229,14 +230,20 @@ namespace Daqifi.Core.Device.Internal
         private static int PopulateDigitalChannels(DaqifiOutMessage message, Dictionary<(ChannelType, int), IChannel> existingByKey, List<IChannel> destination)
         {
             var count = (int)message.DigitalPortNum;
+            var digitalPortDir = message.DigitalPortDir;
 
             for (var i = 0; i < count; i++)
             {
                 var isPwmCapable = i < 32 && (PwmCapableChannelMask & (1 << i)) != 0;
+                var reportedDirection = ReadReportedDirection(digitalPortDir, i);
 
                 if (existingByKey.TryGetValue((ChannelType.Digital, i), out var existing) && existing is DigitalChannel existingDigital)
                 {
                     existingDigital.IsPwmCapable = isPwmCapable;
+                    if (reportedDirection.HasValue)
+                    {
+                        existingDigital.Direction = reportedDirection.Value;
+                    }
                     destination.Add(existingDigital);
                     continue;
                 }
@@ -244,7 +251,7 @@ namespace Daqifi.Core.Device.Internal
                 var channel = new DigitalChannel(i, isPwmCapable)
                 {
                     Name = $"DIO{i}",
-                    Direction = ChannelDirection.Input,
+                    Direction = reportedDirection ?? ChannelDirection.Input,
                     IsEnabled = false
                 };
 
@@ -252,6 +259,43 @@ namespace Daqifi.Core.Device.Internal
             }
 
             return count;
+        }
+
+        /// <summary>
+        /// Reads channel <paramref name="channelNumber"/>'s direction out of a device-reported
+        /// direction mask (digital_port_dir, field 37), or <c>null</c> when the device did not
+        /// report a bit for that channel.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The mask is bit-packed the same way the analog enable mask is — little-endian, bit
+        /// <c>n</c> = channel <c>n</c>, 2 bytes for 16 channels — but its <b>polarity is inverted
+        /// relative to the direction Core sends outbound</b>. This is the PIC's TRIS register as
+        /// the firmware holds it, so <c>1</c> means <i>input</i> and <c>0</c> means <i>output</i>,
+        /// while <see cref="Communication.Producers.ScpiMessageProducer.SetDioPortDirection"/>
+        /// sends <c>1</c> for output. Do not copy the outbound convention here; the round trip was
+        /// confirmed on an Nq1 (fw 3.7.2) — commanding DIO2 to Output clears its bit, commanding
+        /// it back to Input sets it (#685).
+        /// </para>
+        /// <para>
+        /// Returning <c>null</c> rather than a direction when the mask is absent or too short is
+        /// what keeps a locally-commanded direction from being stomped: firmware that never
+        /// populates the field, and the SD-card/replay paths that synthesize status messages
+        /// without one, leave <see cref="IChannel.Direction"/> exactly as it was (or at the
+        /// <see cref="ChannelDirection.Input"/> default for a channel being created).
+        /// </para>
+        /// </remarks>
+        private static ChannelDirection? ReadReportedDirection(Google.Protobuf.ByteString mask, int channelNumber)
+        {
+            var byteIndex = channelNumber / 8;
+            if (byteIndex >= mask.Length)
+            {
+                return null;
+            }
+
+            return (mask[byteIndex] & (1 << (channelNumber % 8))) != 0
+                ? ChannelDirection.Input
+                : ChannelDirection.Output;
         }
 
         /// <summary>


### PR DESCRIPTION
## What was wrong

A DIO pin's direction lives on the board, and it survives a disconnect — nothing in Core's init sequence resets it. But Core hardcoded every digital channel to **Input** when it built the channel list from a status message, so a pin your last session left driving an output came back reported as an input.

Two things went wrong for anyone using the library:

- **Streaming handed out a bogus "reading" for an output pin.** Core deliberately doesn't sample output pins — their state is client-driven, not measured — but that check reads `channel.Direction`, which Core had just set to `Input` for everything. So after a reconnect the pin's *own driven level* was delivered as if it were an external signal.
- **`channel.Direction` lied.** It's the obvious thing to check before driving or reading a pin. A consumer who saw `Input`, skipped `SetDioDirection`, and read the pin got back whatever the pin was driving itself.

The device was reporting the truth the whole time — `digital_port_dir` arrives on every status frame — and not one line of production code read it.

## What changed

Each digital channel's `Direction` now comes from that field. No API changes; an existing property just stopped lying.

Two details worth a reviewer's eye:

- **The encoding is inverted from what Core sends.** `digital_port_dir` is the PIC's TRIS register: `1` = input, `0` = output — the opposite of the `DIO:PORt:DIRection <ch>,1` = output that Core sends outbound. Easy to get backwards, so it's called out at the decode site. Confirmed by round-trip on hardware.
- **It resyncs on every status frame, not just the first.** That matches how analog `IsEnabled` already resyncs from the device's own enabled mask (#409) — the device's view of its own pins outranks Core's. Channels the device didn't describe (firmware that omits the field, the SD-card/replay paths that synthesize status messages without one, or a mask shorter than the channel count) are left exactly as they were, so nothing off the live-device path changes behaviour.

## Bench evidence

Nq1, fw 3.7.2, `/dev/cu.usbmodem101`, DIO2 ↔ DIO4 loopback.

DIO2 left as an output by a previous session, then a **fresh connect**:

```
device digital_port_dir (1=input) = 1101111111111111
Core says OUTPUT pins             = [2]        <-- was [] before this change
```

Streaming with all 16 DIO enabled, driving DIO2 from Core (`-` = no sample delivered):

```
DIO2 driven HIGH -> 00-0100000100000
DIO2 driven LOW  -> 00-0000000100000
```

Bit 2 is now skipped entirely, which is what an output pin must show. Bit 4 is the loopback partner and still follows DIO2, so genuine inputs are unaffected; bit 10 is tied to 5V on this rig. Before the fix bit 2 read `1`/`0` right along with bit 4 — the device reporting Core's own output back to it.

Board restored to as-found: all 16 pins inputs.

## Tests

Unit coverage for the TRIS polarity, the resync onto an existing channel, the "field absent → leave it alone" path, and the short-mask boundary (a one-byte mask describes channels 0-7; channel 8 is *not reported*, not *output*), plus an end-to-end decode regression showing the skip-outputs guard now fires on a direction nobody commanded. Full suite green: 4026 passed.

Fixes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)