### PR TITLE
fix(diagnostics): stop a mid-stream system-log read from inventing hundreds of entries

### DIFF
--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsOperationsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsOperationsTests.cs
@@ -98,6 +98,40 @@ public class DeviceDiagnosticsOperationsTests
     }
 
     [Fact]
+    public async Task GetSystemLogAsync_CorruptedByStreamData_KeepsRealEntriesAndDropsTheNoise()
+    {
+        // Issue #682: mid-stream the firmware's protobuf frames split the reply into hundreds of
+        // mangled lines. The log read is destructive, so unlike the numeric queries this must NOT
+        // throw the survivors away -- it drops the mangled lines one by one instead.
+        var host = new FakeHost();
+        host.EnqueueResponse(
+            "\uFFFD\u0008\u0001\uFFFD\u0002",
+            "first entry",
+            "\u0000\u0012\u0004\uFFFD",
+            "second entry",
+            "");
+        var ops = new DeviceDiagnosticsOperations(host);
+
+        var entries = await ops.GetSystemLogAsync();
+
+        Assert.Equal(new[] { "first entry", "second entry" }, GetMessages(entries));
+    }
+
+    [Fact]
+    public async Task GetSystemLogAsync_EntirelyStreamNoise_ReturnsEmptyRatherThanThrowing()
+    {
+        // Documents the deliberate boundary of the #682 filter: an all-noise response is still a
+        // response, and the numeric queries' DeviceDiagnosticsCorruptedResponseException is
+        // deliberately not extended here (the read already cleared the device's buffer, so there
+        // is nothing to retry). On hardware real entries always survived alongside the noise.
+        var host = new FakeHost();
+        host.EnqueueResponse("\uFFFD\u0008\u0001", "\u0000\u0012\uFFFD", "");
+        var ops = new DeviceDiagnosticsOperations(host);
+
+        Assert.Empty(await ops.GetSystemLogAsync());
+    }
+
+    [Fact]
     public async Task GetSystemLogAsync_NotConnected_ThrowsAndSendsNothing()
     {
         var host = new FakeHost { IsConnected = false };

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/DeviceDiagnosticsTests.cs
@@ -405,9 +405,10 @@ public class DeviceDiagnosticsTests
     [Fact]
     public async Task GetSystemLogAsync_WhenALineIsCorrupted_StillReturnsTheSurvivingEntries()
     {
-        // Deliberately NOT guarded: the log read clears the buffer on the device, so the entries
-        // that did arrive are all anyone will ever get. Throwing them away would destroy more than
-        // it protects, and a missing entry is visible in the result anyway.
+        // The whole response is deliberately NOT rejected: the log read clears the buffer on the
+        // device, so the entries that did arrive are all anyone will ever get, and throwing them
+        // away would destroy more than it protects. The corrupted line itself is dropped though --
+        // mid-stream there are hundreds of them, and each one used to become a log entry (#682).
         var device = new TestableDiagnosticsDevice("TestDevice")
         {
             CannedTextResponse = { "\u0000Test log message 1", "Test info message" },
@@ -416,8 +417,7 @@ public class DeviceDiagnosticsTests
 
         var entries = await device.GetSystemLogAsync();
 
-        Assert.Equal(2, entries.Count);
-        Assert.Equal("Test info message", entries[1].Message);
+        Assert.Equal("Test info message", Assert.Single(entries).Message);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/SystemLogParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/SystemLogParserTests.cs
@@ -108,6 +108,26 @@ public class SystemLogParserTests
             entries.Select(e => e.Message));
     }
 
+    [Theory]
+    // Control characters that .NET also classifies as whitespace: an unrestricted Trim() would
+    // erase them at a line edge and hand a clean-looking string to the corruption check.
+    [InlineData("\u000B")] // vertical tab
+    [InlineData("\u000C")] // form feed
+    [InlineData("\u0085")] // NEL
+    public void Parse_DropsNoiseWhoseControlBytesSitAtTheLineEdge(string controlChar)
+    {
+        var lines = new[]
+        {
+            controlChar + "stream-junk",
+            "trailing-junk" + controlChar,
+            "Test info message",
+        };
+
+        var entries = SystemLogParser.Parse(lines);
+
+        Assert.Equal("Test info message", Assert.Single(entries).Message);
+    }
+
     [Fact]
     public void Parse_WhenEveryLineIsStreamNoise_ReturnsEmpty()
     {

--- a/src/Daqifi.Core.Tests/Device/Diagnostics/SystemLogParserTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Diagnostics/SystemLogParserTests.cs
@@ -65,6 +65,58 @@ public class SystemLogParserTests
     }
 
     [Fact]
+    public void Parse_DropsLinesCarryingStreamBytes()
+    {
+        // Issue #682: read mid-stream, the firmware's protobuf frames split the reply into
+        // hundreds of mangled lines and every one of them used to become a log entry.
+        var lines = new[]
+        {
+            "Test log message 1",
+            "\uFFFD\uFFFD\u0008\u0001\uFFFD\u0002",
+            "\u0000\u0012\u0004junk",
+            "Test info message",
+        };
+
+        var entries = SystemLogParser.Parse(lines);
+
+        Assert.Equal(new[] { "Test log message 1", "Test info message" }, entries.Select(e => e.Message));
+    }
+
+    [Fact]
+    public void Parse_DropsTheBoundaryEntryThatArrivesWithNoiseWeldedOn()
+    {
+        // The single real entry the frame bytes land on top of goes with them. Documented
+        // cost of the filter: losing 1 of 8 beats fabricating 715 (issue #682).
+        var lines = new[] { " * \uFFFD\uFFFDTest log message 1", "Test error message" };
+
+        var entries = SystemLogParser.Parse(lines);
+
+        Assert.Equal(new[] { "Test error message" }, entries.Select(e => e.Message));
+    }
+
+    [Fact]
+    public void Parse_KeepsCleanLinesWithTabsAndCarriageReturns()
+    {
+        // The filter must be inert on the normal (idle) path: tab is a real firmware
+        // delimiter, and a trailing CR from a CRLF line ending is not evidence of binary.
+        var lines = new[] { "12:00:01\tTest log message 1\r", "12:00:02\tTest info message\r" };
+
+        var entries = SystemLogParser.Parse(lines);
+
+        Assert.Equal(
+            new[] { "12:00:01\tTest log message 1", "12:00:02\tTest info message" },
+            entries.Select(e => e.Message));
+    }
+
+    [Fact]
+    public void Parse_WhenEveryLineIsStreamNoise_ReturnsEmpty()
+    {
+        var lines = new[] { "\uFFFD\u0008\u0001", "\u0000\u0012\uFFFD" };
+
+        Assert.Empty(SystemLogParser.Parse(lines));
+    }
+
+    [Fact]
     public void Parse_WhenEmpty_ReturnsEmpty()
     {
         Assert.Empty(SystemLogParser.Parse(Array.Empty<string>()));

--- a/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/DeviceDiagnosticsOperations.cs
@@ -278,7 +278,11 @@ namespace Daqifi.Core.Device.Diagnostics
         /// firmware-authored text, one entry per line. Losing one entry out of ten is visible in the
         /// result, and the log read is destructive on the device — the buffer is cleared by the very
         /// query that read it — so throwing the surviving entries away would destroy more than it
-        /// protects.
+        /// protects. Their parsers instead reject the mangled lines individually, which is what keeps
+        /// stream noise from being reported as log entries (issue #682): <see cref="SystemLogParser"/>
+        /// applies <see cref="ScpiResponseClassifier.IsBinaryCorruptedLine"/> per line, and
+        /// <see cref="CommandHistoryParser"/> gets it for free from requiring each line to match
+        /// <c>&lt;int&gt;: &lt;text&gt;</c>.
         /// </para>
         /// <para>
         /// <see cref="ClearSystemLogAsync"/> and <see cref="TestSystemLogAsync"/> answer with a short

--- a/src/Daqifi.Core/Device/Diagnostics/SystemLogParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/SystemLogParser.cs
@@ -7,9 +7,20 @@ namespace Daqifi.Core.Device.Diagnostics;
 /// Parses the response from the <c>SYSTem:LOG?</c> SCPI query into <see cref="SystemLogEntry"/> objects.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The firmware dumps the log buffer as free-form text, one entry per line. Blank lines and SCPI
 /// error/status lines (e.g. a <c>**ERROR</c> response if the query itself failed) are dropped; every
 /// other line becomes one <see cref="SystemLogEntry"/> with its trailing line ending trimmed.
+/// </para>
+/// <para>
+/// Lines carrying non-text bytes are dropped too. Reading the log does not stop the stream, so when
+/// the query runs mid-capture the firmware's protobuf frames land on the reply and split it into
+/// hundreds of mangled lines (issue #537). Without this filter every one of them became an entry: a
+/// bench read of an 8-entry log while streaming returned ~723 entries, 715 of them fabricated out of
+/// frame bytes (issue #682). Survivors are still kept -- the log read is destructive on the device,
+/// so discarding the whole response would lose the real entries for good -- at the cost of the one
+/// boundary entry that arrives with noise welded onto its front.
+/// </para>
 /// </remarks>
 public static class SystemLogParser
 {
@@ -38,6 +49,14 @@ public static class SystemLogParser
             var message = rawLine.Trim();
 
             if (ScpiResponseClassifier.IsErrorResponseLine(message))
+            {
+                continue;
+            }
+
+            // Tested against the trimmed line, not the raw one: the classifier treats any control
+            // character as evidence of binary, and a raw line still carrying its CR from a CRLF
+            // ending would trip it. Trim() has already removed CR/LF/tab at the ends by here.
+            if (ScpiResponseClassifier.IsBinaryCorruptedLine(message))
             {
                 continue;
             }

--- a/src/Daqifi.Core/Device/Diagnostics/SystemLogParser.cs
+++ b/src/Daqifi.Core/Device/Diagnostics/SystemLogParser.cs
@@ -25,6 +25,16 @@ namespace Daqifi.Core.Device.Diagnostics;
 public static class SystemLogParser
 {
     /// <summary>
+    /// The characters stripped from each end of a line before it is classified. Deliberately not
+    /// <see cref="string.Trim()"/>: that removes every Unicode whitespace character, which includes
+    /// control characters such as vertical tab (<c>\u000B</c>), form feed (<c>\u000C</c>) and NEL
+    /// (<c>\u0085</c>) — exactly the evidence the corruption check looks for, erased just before it
+    /// runs. Only the padding and line endings a real firmware line can carry are removed here, so
+    /// <c>"\u000Bstream-junk"</c> stays corrupt while <c>"entry\r"</c> still becomes <c>"entry"</c>.
+    /// </summary>
+    private static readonly char[] PaddingAndLineEndings = { ' ', '\t', '\r', '\n' };
+
+    /// <summary>
     /// Parses log response lines into entries.
     /// </summary>
     /// <param name="lines">The raw response lines from the device.</param>
@@ -46,16 +56,13 @@ public static class SystemLogParser
                 continue;
             }
 
-            var message = rawLine.Trim();
+            var message = rawLine.Trim(PaddingAndLineEndings);
 
             if (ScpiResponseClassifier.IsErrorResponseLine(message))
             {
                 continue;
             }
 
-            // Tested against the trimmed line, not the raw one: the classifier treats any control
-            // character as evidence of binary, and a raw line still carrying its CR from a CRLF
-            // ending would trip it. Trim() has already removed CR/LF/tab at the ends by here.
             if (ScpiResponseClassifier.IsBinaryCorruptedLine(message))
             {
                 continue;


### PR DESCRIPTION
## What was wrong

Reading the device's system log while it was streaming gave you back roughly **715 log entries that
were never log entries** — they were raw bytes from the stream, one fabricated entry per mangled
line. The device's log actually held 8. An app with a "Device System Log" view rendered 700 rows of
mojibake with the 8 real messages buried in the middle, and nothing threw or warned: it looked like
a successful read of a very busy log.

## How it was fixed

The log parser now drops lines that carry non-text bytes, using the same per-line predicate Core
already had for this. On the bench that turns "8 real + 715 fabricated" into "7 real + 0
fabricated".

The one thing worth pushing back on is that this drops a real entry — the single boundary entry
that arrives with stream noise welded onto its front (`" * ␦␦Test log message 1"`) goes with the
noise. Losing 1 of 8 beats fabricating 715. Note also what this deliberately does *not* do: it does
not extend the #537 whole-response rejection to the log read. That exclusion exists because the log
read clears the device's buffer, so discarding the response would lose the real entries for good —
filtering line by line serves that reasoning rather than reversing it, and no new exception is
introduced.

`GetCommandHistoryAsync` needed no change; its parser already requires `<int>: <text>` per line,
which binary noise essentially never matches.

## Verification

Full suite green on net9.0 and net10.0 (4066 passed, 3 platform-gated skips, plus 217 MCP tests).
New coverage: the filter drops stream noise, drops the boundary entry, and is inert on clean lines
carrying tabs and CRLF endings; at the operations level, a corrupted mid-stream reply still returns
its real entries. One existing test that asserted the old "corrupted line becomes an entry"
behavior was updated to assert the new one.

Bench measurements come from the issue's own run (Nq1 fw 3.7.2, 3 analog ch @ 100 Hz).

closes #682