### PR TITLE
docs(capabilities): warn that the advertised PWM minimum is not usable

### DIFF
--- a/src/Daqifi.Core/Device/Capabilities/CapabilityChannel.cs
+++ b/src/Daqifi.Core/Device/Capabilities/CapabilityChannel.cs
@@ -58,7 +58,19 @@ public sealed class CapabilityChannel
     /// </summary>
     public bool SupportsPwm { get; init; }
 
-    /// <summary>Gets the lowest PWM frequency the pin accepts, or <c>null</c> when not stated.</summary>
+    /// <summary>
+    /// Gets the lowest PWM frequency the pin advertises, or <c>null</c> when not stated.
+    /// </summary>
+    /// <remarks>
+    /// Do not use this as a floor. The device under-reports it: every supported firmware
+    /// advertises 1 Hz here, but below
+    /// <see cref="DaqifiStreamingDevice.MinPwmFrequencyHz"/> (6 Hz) the firmware's 16-bit
+    /// period register silently wraps and the output runs in the kilohertz range, so a commanded
+    /// 1 Hz is not what the pin produces. <see cref="DaqifiStreamingDevice.SetPwmFrequency"/>
+    /// rejects anything below that constant, which is the value to use as the real floor. This is
+    /// the one field on the capability document known to be wrong rather than merely absent —
+    /// <see cref="PwmMaximumFrequencyHz"/> and the set of PWM-capable pins both match the hardware.
+    /// </remarks>
     public int? PwmMinimumFrequencyHz { get; init; }
 
     /// <summary>Gets the highest PWM frequency the pin accepts, or <c>null</c> when not stated.</summary>

--- a/src/Daqifi.Core/Device/Capabilities/CapabilityDocument.cs
+++ b/src/Daqifi.Core/Device/Capabilities/CapabilityDocument.cs
@@ -21,6 +21,13 @@ namespace Daqifi.Core.Device.Capabilities;
 /// property that is <c>null</c> means "this document did not state it", never "the device does not
 /// have it".
 /// </para>
+/// <para>
+/// The document is the device's own account of itself, and it is accurate everywhere Core has
+/// checked it against hardware — with one exception. <see cref="CapabilityChannel.PwmMinimumFrequencyHz"/>
+/// advertises 1 Hz on every supported firmware, a frequency the hardware cannot actually produce;
+/// use <see cref="DaqifiStreamingDevice.MinPwmFrequencyHz"/> as the PWM floor instead. See that
+/// property's remarks for the detail.
+/// </para>
 /// </remarks>
 public sealed class CapabilityDocument
 {


### PR DESCRIPTION
## What was wrong

If you asked a Nyquist what its lowest PWM frequency is, it said 1 Hz — and Core repeated that
answer to you through `CapabilityChannel.PwmMinimumFrequencyHz`, documented as "the lowest PWM
frequency the pin accepts". Write the obvious thing:

```csharp
device.SetPwmFrequency(pin.PwmMinimumFrequencyHz!.Value);   // 1
```

…and Core throws `ArgumentOutOfRangeException: PWM frequency must be 6-50000 Hz`. The library was
advertising a floor it then refused. Worse, the firmware is the one that's wrong here: below 6 Hz
the 16-bit period register wraps and the pin actually outputs a kilohertz square wave, so a
consumer who bypassed Core and sent 1 Hz over raw SCPI would get silently bad output rather than
an error.

## How it was fixed

Documentation only. `PwmMinimumFrequencyHz` now says plainly not to use it as a floor, explains
why the device under-reports it, and points at `DaqifiStreamingDevice.MinPwmFrequencyHz` (6) as
the value that actually works. `CapabilityDocument`'s own remarks — which describe it as the
device's accurate self-description — now carry a matching note, since this is the single field on
that document known to be wrong rather than merely absent.

No API or behavior change was made. The parse is correct (the document really does say 1), and
nothing inside Core reads either PWM frequency field, so they are purely informational surface for
consumers. Fixing the value rather than the docs would mean Core lying about what the device said,
which is worse; the honest move is to keep the reported value and label it.

## Verification

Full suite green on net9.0 and net10.0 (4066 Core + 217 MCP tests each), 0 build warnings.
Bench evidence for the discrepancy is in the issue: Nq1, fw 3.7.2, `CONFigure:CAPabilities:JSON?`
reports min=1 / max=50000 with PWM pins `{0,3,4,5,6,7}` — only the floor disagrees with Core.

closes #684