### PR TITLE
fix(transport): reject an invalid ConnectionTimeout instead of retrying it

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Transport/ConnectionRetryOptionsTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/ConnectionRetryOptionsTests.cs
@@ -248,7 +248,7 @@ public class ConnectionRetryOptionsTests
 
         // Assert
         Assert.Equal(nameof(ConnectionRetryOptions.ConnectionTimeout), ex.ParamName);
-        Assert.Contains("greater than zero", ex.Message);
+        Assert.Contains("at least 1 millisecond", ex.Message);
         Assert.Equal(TimeSpan.FromSeconds(5), options.ConnectionTimeout); // unchanged
     }
 
@@ -264,6 +264,31 @@ public class ConnectionRetryOptionsTests
 
         // Assert
         Assert.Equal(nameof(ConnectionRetryOptions.ConnectionTimeout), ex.ParamName);
+    }
+
+    [Fact]
+    public void ConnectionTimeout_SubMillisecond_ShouldThrowNamingTheProperty()
+    {
+        // Arrange
+        var options = new ConnectionRetryOptions();
+
+        // Act — positive, but both transports narrow the timeout to a millisecond int, where a
+        // single tick truncates to 0 and lands back in the platform error this guard exists for.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => options.ConnectionTimeout = TimeSpan.FromTicks(1));
+
+        // Assert
+        Assert.Equal(nameof(ConnectionRetryOptions.ConnectionTimeout), ex.ParamName);
+    }
+
+    [Fact]
+    public void ConnectionTimeout_AtOneMillisecond_ShouldBeAccepted()
+    {
+        // Arrange & Act — the smallest value that survives the narrowing intact.
+        var options = new ConnectionRetryOptions { ConnectionTimeout = TimeSpan.FromMilliseconds(1) };
+
+        // Assert
+        Assert.Equal(1, (int)options.ConnectionTimeout.TotalMilliseconds);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Communication/Transport/ConnectionRetryOptionsTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Transport/ConnectionRetryOptionsTests.cs
@@ -161,4 +161,146 @@ public class ConnectionRetryOptionsTests
         Assert.Equal(TimeSpan.FromSeconds(1), delay2); // 1 * 1.5^0 = 1
         Assert.Equal(TimeSpan.FromMilliseconds(1500), delay3); // 1 * 1.5^1 = 1.5
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void MaxAttempts_BelowOne_ShouldThrowNamingTheProperty(int value)
+    {
+        // Arrange
+        var options = new ConnectionRetryOptions();
+
+        // Act
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => options.MaxAttempts = value);
+
+        // Assert
+        Assert.Equal(nameof(ConnectionRetryOptions.MaxAttempts), ex.ParamName);
+        Assert.Equal(3, options.MaxAttempts); // unchanged
+    }
+
+    [Fact]
+    public void InitialDelay_Negative_ShouldThrowNamingTheProperty()
+    {
+        // Arrange
+        var options = new ConnectionRetryOptions();
+
+        // Act
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => options.InitialDelay = TimeSpan.FromMilliseconds(-1));
+
+        // Assert
+        Assert.Equal(nameof(ConnectionRetryOptions.InitialDelay), ex.ParamName);
+    }
+
+    [Fact]
+    public void InitialDelay_Zero_ShouldBeAccepted()
+    {
+        // Arrange & Act — zero means "retry immediately", which the executor supports.
+        var options = new ConnectionRetryOptions { InitialDelay = TimeSpan.Zero };
+
+        // Assert
+        Assert.Equal(TimeSpan.Zero, options.InitialDelay);
+        Assert.Equal(TimeSpan.Zero, options.CalculateDelay(2));
+    }
+
+    [Fact]
+    public void MaxDelay_Negative_ShouldThrowNamingTheProperty()
+    {
+        // Arrange
+        var options = new ConnectionRetryOptions();
+
+        // Act
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => options.MaxDelay = TimeSpan.FromSeconds(-1));
+
+        // Assert
+        Assert.Equal(nameof(ConnectionRetryOptions.MaxDelay), ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.5)]
+    [InlineData(-2.0)]
+    [InlineData(double.NaN)]
+    public void BackoffMultiplier_BelowOne_ShouldThrowNamingTheProperty(double value)
+    {
+        // Arrange
+        var options = new ConnectionRetryOptions();
+
+        // Act
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => options.BackoffMultiplier = value);
+
+        // Assert
+        Assert.Equal(nameof(ConnectionRetryOptions.BackoffMultiplier), ex.ParamName);
+    }
+
+    [Fact]
+    public void ConnectionTimeout_Zero_ShouldThrowNamingTheProperty()
+    {
+        // Arrange
+        var options = new ConnectionRetryOptions();
+
+        // Act — the bench repro: the platform used to answer this with an
+        // ArgumentOutOfRangeException naming SerialPort.WriteTimeout, after the full backoff.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => options.ConnectionTimeout = TimeSpan.Zero);
+
+        // Assert
+        Assert.Equal(nameof(ConnectionRetryOptions.ConnectionTimeout), ex.ParamName);
+        Assert.Contains("greater than zero", ex.Message);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.ConnectionTimeout); // unchanged
+    }
+
+    [Fact]
+    public void ConnectionTimeout_Negative_ShouldThrowNamingTheProperty()
+    {
+        // Arrange
+        var options = new ConnectionRetryOptions();
+
+        // Act
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => options.ConnectionTimeout = TimeSpan.FromSeconds(-1));
+
+        // Assert
+        Assert.Equal(nameof(ConnectionRetryOptions.ConnectionTimeout), ex.ParamName);
+    }
+
+    [Fact]
+    public void ConnectionTimeout_BeyondIntMaxMilliseconds_ShouldThrowNamingTheProperty()
+    {
+        // Arrange
+        var options = new ConnectionRetryOptions();
+
+        // Act — both transports narrow this to a millisecond int, so a longer span would
+        // wrap round to a negative timeout and be rejected by the platform instead.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => options.ConnectionTimeout = TimeSpan.FromMilliseconds((double)int.MaxValue + 1));
+
+        // Assert
+        Assert.Equal(nameof(ConnectionRetryOptions.ConnectionTimeout), ex.ParamName);
+    }
+
+    [Fact]
+    public void ConnectionTimeout_AtIntMaxMilliseconds_ShouldBeAccepted()
+    {
+        // Arrange & Act
+        var options = new ConnectionRetryOptions
+        {
+            ConnectionTimeout = TimeSpan.FromMilliseconds(int.MaxValue)
+        };
+
+        // Assert
+        Assert.Equal(int.MaxValue, (int)options.ConnectionTimeout.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PresetPolicies_ShouldSatisfyTheirOwnGuards()
+    {
+        // Act & Assert — the presets go through the same setters, so this would throw
+        // at construction if a guard and a preset ever disagreed.
+        Assert.True(ConnectionRetryOptions.NoRetry.ConnectionTimeout > TimeSpan.Zero);
+        Assert.True(ConnectionRetryOptions.Fast.ConnectionTimeout > TimeSpan.Zero);
+        Assert.True(ConnectionRetryOptions.Resilient.ConnectionTimeout > TimeSpan.Zero);
+    }
 }

--- a/src/Daqifi.Core/Communication/Transport/ConnectionRetryOptions.cs
+++ b/src/Daqifi.Core/Communication/Transport/ConnectionRetryOptions.cs
@@ -104,23 +104,26 @@ public class ConnectionRetryOptions
     /// Gets or sets the connection timeout for each attempt. Default is 5 seconds.
     /// </summary>
     /// <remarks>
-    /// The upper bound exists because both transports hand this value to the platform as a
-    /// millisecond <see cref="int"/>; anything longer would silently wrap round to a negative
-    /// timeout and be rejected by the platform instead of by us.
+    /// Both bounds exist because both transports hand this value to the platform as a millisecond
+    /// <see cref="int"/>. A sub-millisecond span truncates to zero, which the platform rejects
+    /// exactly as it rejected an outright zero; anything longer than <see cref="int.MaxValue"/>
+    /// milliseconds wraps round to a negative timeout, which it also rejects. Both are the very
+    /// error this validation exists to keep away from the retry loop.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when the value is zero or negative, or longer than <see cref="int.MaxValue"/>
-    /// milliseconds (about 24.8 days).
+    /// Thrown when the value is under 1 millisecond (zero and negatives included) or longer than
+    /// <see cref="int.MaxValue"/> milliseconds (about 24.8 days).
     /// </exception>
     public TimeSpan ConnectionTimeout
     {
         get => _connectionTimeout;
         set
         {
-            if (value <= TimeSpan.Zero)
+            if (value.TotalMilliseconds < 1)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(ConnectionTimeout), value, "The connection timeout must be greater than zero.");
+                    nameof(ConnectionTimeout), value,
+                    "The connection timeout must be at least 1 millisecond.");
             }
 
             if (value.TotalMilliseconds > int.MaxValue)

--- a/src/Daqifi.Core/Communication/Transport/ConnectionRetryOptions.cs
+++ b/src/Daqifi.Core/Communication/Transport/ConnectionRetryOptions.cs
@@ -3,32 +3,136 @@ namespace Daqifi.Core.Communication.Transport;
 /// <summary>
 /// Configuration options for connection retry behavior with exponential backoff.
 /// </summary>
+/// <remarks>
+/// Every value is validated where it is set, so a misconfiguration is reported against the
+/// property the caller actually wrote — and reported before a connect is attempted at all
+/// (issue #681). Left to the platform, a zero or negative <see cref="ConnectionTimeout"/>
+/// surfaced as four different exceptions naming properties the caller never touched
+/// (<c>WriteTimeout</c>, <c>ReadTimeout</c>, a socket error), and, because the retry executor
+/// cannot tell a permanent misconfiguration from a transient connect failure, it then sat
+/// through the whole backoff curve re-dialling a healthy device.
+/// </remarks>
 public class ConnectionRetryOptions
 {
+    private int _maxAttempts = 3;
+    private TimeSpan _initialDelay = TimeSpan.FromSeconds(1);
+    private TimeSpan _maxDelay = TimeSpan.FromSeconds(30);
+    private double _backoffMultiplier = 2.0;
+    private TimeSpan _connectionTimeout = TimeSpan.FromSeconds(5);
+
     /// <summary>
     /// Gets or sets the maximum number of retry attempts. Default is 3.
     /// </summary>
-    public int MaxAttempts { get; set; } = 3;
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is less than 1.</exception>
+    public int MaxAttempts
+    {
+        get => _maxAttempts;
+        set
+        {
+            if (value < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(MaxAttempts), value, "At least one connection attempt must be allowed.");
+            }
+
+            _maxAttempts = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the initial delay before the first retry attempt. Default is 1 second.
+    /// Zero means retry immediately.
     /// </summary>
-    public TimeSpan InitialDelay { get; set; } = TimeSpan.FromSeconds(1);
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is negative.</exception>
+    public TimeSpan InitialDelay
+    {
+        get => _initialDelay;
+        set
+        {
+            if (value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(InitialDelay), value, "The delay cannot be negative.");
+            }
+
+            _initialDelay = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the maximum delay between retry attempts. Default is 30 seconds.
     /// </summary>
-    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromSeconds(30);
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is negative.</exception>
+    public TimeSpan MaxDelay
+    {
+        get => _maxDelay;
+        set
+        {
+            if (value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(MaxDelay), value, "The delay cannot be negative.");
+            }
+
+            _maxDelay = value;
+        }
+    }
 
     /// <summary>
-    /// Gets or sets the backoff multiplier for exponential backoff. Default is 2.0.
+    /// Gets or sets the backoff multiplier for exponential backoff. Default is 2.0; 1.0 gives a
+    /// fixed delay.
     /// </summary>
-    public double BackoffMultiplier { get; set; } = 2.0;
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is less than 1.</exception>
+    public double BackoffMultiplier
+    {
+        get => _backoffMultiplier;
+        set
+        {
+            // Negated rather than `value < 1.0` so NaN — which compares false against everything —
+            // is rejected too, instead of turning every backoff into NaN milliseconds.
+            if (!(value >= 1.0))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(BackoffMultiplier), value, "The backoff multiplier must be at least 1.0.");
+            }
+
+            _backoffMultiplier = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the connection timeout for each attempt. Default is 5 seconds.
     /// </summary>
-    public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(5);
+    /// <remarks>
+    /// The upper bound exists because both transports hand this value to the platform as a
+    /// millisecond <see cref="int"/>; anything longer would silently wrap round to a negative
+    /// timeout and be rejected by the platform instead of by us.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when the value is zero or negative, or longer than <see cref="int.MaxValue"/>
+    /// milliseconds (about 24.8 days).
+    /// </exception>
+    public TimeSpan ConnectionTimeout
+    {
+        get => _connectionTimeout;
+        set
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(ConnectionTimeout), value, "The connection timeout must be greater than zero.");
+            }
+
+            if (value.TotalMilliseconds > int.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(ConnectionTimeout), value,
+                    $"The connection timeout cannot exceed {int.MaxValue} milliseconds (about 24.8 days).");
+            }
+
+            _connectionTimeout = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets whether retry is enabled. Default is true.
@@ -74,6 +178,17 @@ public class ConnectionRetryOptions
         if (attemptNumber <= 1)
             return TimeSpan.Zero;
 
+        // Zero in, zero out. A caller who asked for immediate retries must get them at every
+        // attempt number: multiplying zero by the growing backoff factor is still zero, right up
+        // until that factor overflows Math.Pow to infinity, where 0 × ∞ is NaN and the arithmetic
+        // below would hand back MaxDelay — the exact opposite of the configured policy.
+        if (InitialDelay == TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        // Math.Pow overflows to +Infinity for a large enough attempt count. With a positive
+        // InitialDelay the product is then +Infinity too, and Math.Min yields MaxDelay — the
+        // intended cap. NaN is unreachable now that a zero InitialDelay returns above and
+        // BackoffMultiplier rejects NaN, so there is nothing further to guard here.
         var delay = InitialDelay.TotalMilliseconds * Math.Pow(BackoffMultiplier, attemptNumber - 2);
         return TimeSpan.FromMilliseconds(Math.Min(delay, MaxDelay.TotalMilliseconds));
     }


### PR DESCRIPTION
## What was wrong

If you set `ConnectionRetryOptions.ConnectionTimeout` to zero or a negative value, connecting
didn't tell you that. It failed with a raw platform exception naming a property you never
touched — `ArgumentOutOfRangeException ... (Parameter 'WriteTimeout')` on serial, a bare
`SocketException: Invalid argument` on TCP, four different messages for the one mistake — and
then Core **retried the misconfiguration**, sitting through the full exponential backoff against
a device that was plugged in and perfectly healthy. Bench-measured at 7.08 s with the default
4-attempt policy on a working Nq1; a `Resilient` policy would burn far longer. None of the four
messages mentioned `ConnectionTimeout`.

## How it was fixed

`ConnectionRetryOptions` now validates each value where it is set, so the failure is an
`ArgumentOutOfRangeException` naming `ConnectionTimeout`, thrown before any dialling happens.
Because it throws before the attempt loop is ever entered, the pointless backoff disappears for
free — no change to `ConnectRetryExecutor` was needed.

The other four properties are guarded in the same pass, since a negative `MaxDelay` makes
`CalculateDelay` return a negative span and a NaN `BackoffMultiplier` poisons the whole curve.
The shape is copied verbatim from the guards `ReconnectOptions` already carries, so the two
sibling policy classes still read the same way.

Two judgement calls worth pushing back on if you disagree:

- `BackoffMultiplier` must now be `>= 1.0`, matching `ReconnectOptions`. A value below 1 would
  shrink the delays, which isn't backoff — but it wasn't previously rejected.
- `ConnectionTimeout` also has an upper bound of `int.MaxValue` ms (~24.8 days), because both
  transports narrow it to a millisecond `int`; a longer span would wrap round to a negative
  timeout and land right back in the platform error this PR exists to remove.

## Verification

Full suite green on net9.0 and net10.0: 4084 Core tests (3 skipped, platform-gated) and 217 MCP
tests, zero build warnings. Eleven new tests cover each rejected value, each accepted boundary
(`InitialDelay = 0` still means "retry immediately", `ConnectionTimeout = int.MaxValue` ms is
accepted), and that the `NoRetry`/`Fast`/`Resilient` presets still satisfy their own guards.

closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)