### PR TITLE
docs(channel): RawValue is populated over USB too — it is not a transport distinction

### DIFF
--- a/docs/DEVICE_INTERFACES.md
+++ b/docs/DEVICE_INTERFACES.md
@@ -817,11 +817,13 @@ device.StopStreaming();
 ```
 
 `IDataSample.Value` is already scaled (volts for analog, 0/1 for digital). `RawValue` carries the raw
-ADC count or bit when one exists (`null` for the USB pre-scaled float path), and `DeviceTimestamp`
-carries the raw device tick count alongside the rollover-adjusted host `Timestamp`. A stray frame that
-arrives outside a streaming session is still re-raised via `MessageReceived` but is not decoded into
-samples. `GetChannelsSnapshot()` is used above (rather than the live `Channels` property) because the
-channel list can be repopulated concurrently when a new device status message arrives.
+ADC count or bit when one exists — every supported firmware streams raw ADC counts, on USB and WiFi
+alike, so a streamed analog sample always carries one and its `Value` is the result of Core's own
+calibration formula. `DeviceTimestamp` carries the raw device tick count alongside the
+rollover-adjusted host `Timestamp`. A stray frame that arrives outside a streaming session is still
+re-raised via `MessageReceived` but is not decoded into samples. `GetChannelsSnapshot()` is used
+above (rather than the live `Channels` property) because the channel list can be repopulated
+concurrently when a new device status message arrives.
 
 #### Engineering units (`ChannelScaling`)
 

--- a/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiStreamingDeviceDecodeTests.cs
@@ -116,7 +116,7 @@ public class DaqifiStreamingDeviceDecodeTests
     #region Analog decoding
 
     [Fact]
-    public void Decode_UsbFloatPath_UsesFloatsDirectlyWithNoRawValue()
+    public void Decode_PreScaledFloatFrame_UsesFloatsDirectlyWithNoRawValue()
     {
         // Arrange: 3 analog channels, enable AI0 and AI2 (leaving a gap at AI1).
         var device = CreateStreamingDevice(analogCount: 3);
@@ -148,7 +148,7 @@ public class DaqifiStreamingDeviceDecodeTests
     }
 
     [Fact]
-    public void Decode_WifiRawPath_AppliesChannelCalibrationAndPreservesRawCount()
+    public void Decode_RawCountFrame_AppliesChannelCalibrationAndPreservesRawCount()
     {
         // Arrange: give the channels a non-identity port range so scaling is observable.
         var device = CreateStreamingDevice(analogCount: 2, portRange: 10.0f, resolution: 65535);

--- a/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/StreamFrameDecoderTests.cs
@@ -594,8 +594,8 @@ public class StreamFrameDecoderTests
     #region Engineering units (#501)
 
     /// <summary>
-    /// The USB path is the one that bypasses <see cref="IAnalogChannel.GetScaledValue"/> entirely —
-    /// the firmware already sent volts — so it is the path an engineering-unit conversion is most
+    /// The pre-scaled float frame bypasses <see cref="IAnalogChannel.GetScaledValue"/> entirely —
+    /// the frame already carries volts — so it is the branch an engineering-unit conversion is most
     /// easily forgotten on.
     /// </summary>
     [Fact]
@@ -616,8 +616,8 @@ public class StreamFrameDecoderTests
     }
 
     /// <summary>
-    /// The WiFi path, where the calibration conversion runs first. Both conversions must apply, in
-    /// that order.
+    /// The raw-count frame — what every supported firmware sends — where the calibration conversion
+    /// runs first. Both conversions must apply, in that order.
     /// </summary>
     [Fact]
     public void RawCountSample_IsCalibratedThenScaled()
@@ -783,8 +783,8 @@ public class StreamFrameDecoderTests
     }
 
     /// <summary>
-    /// A frame carrying raw ADC counts rather than pre-scaled floats — the WiFi firmware's shape,
-    /// which is the branch that runs the per-channel calibration.
+    /// A frame carrying raw ADC counts rather than pre-scaled floats — the shape every supported
+    /// firmware sends, and the branch that runs the per-channel calibration.
     /// </summary>
     private static DaqifiOutMessage RawCountFrame(uint timestamp, params int[] counts)
     {

--- a/src/Daqifi.Core.Tests/Device/Protocol/ProtobufProtocolHandlerTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Protocol/ProtobufProtocolHandlerTests.cs
@@ -125,7 +125,8 @@ public class ProtobufProtocolHandlerTests
     [Fact]
     public async Task HandleAsync_WithFloatStreamMessage_CallsStreamHandler()
     {
-        // Arrange - USB firmware sends pre-scaled float values (AnalogInDataFloat)
+        // Arrange - a frame carrying pre-scaled floats (AnalogInDataFloat). No supported firmware
+        // sends this shape on any transport, but the protocol defines it and detection must cover it.
         var streamHandlerCalled = false;
         DaqifiOutMessage? receivedMessage = null;
 
@@ -161,7 +162,7 @@ public class ProtobufProtocolHandlerTests
     [InlineData(0u, 0u, 2u, 0u, 0, 0, false, ProtobufMessageType.Status)]
     [InlineData(0u, 0u, 0u, 12345u, 1, 0, false, ProtobufMessageType.Stream)]   // int data
     [InlineData(0u, 0u, 0u, 12345u, 0, 1, false, ProtobufMessageType.Stream)]   // digital data
-    [InlineData(0u, 0u, 0u, 12345u, 0, 0, true, ProtobufMessageType.Stream)]    // float data (USB firmware)
+    [InlineData(0u, 0u, 0u, 12345u, 0, 0, true, ProtobufMessageType.Stream)]    // float data (protocol-only shape)
     [InlineData(0u, 0u, 0u, 0u, 0, 0, false, ProtobufMessageType.Unknown)]
     public void DetectMessageType_ReturnsCorrectType(
         uint analogInPortNum,

--- a/src/Daqifi.Core/Channel/AnalogChannel.cs
+++ b/src/Daqifi.Core/Channel/AnalogChannel.cs
@@ -131,7 +131,7 @@ public class AnalogChannel : IAnalogChannel, IScaledChannel, IChannelEnablementN
     /// a <see cref="ChannelScaling"/> is immutable and stands alone, so a reader either sees the
     /// whole old instance or the whole new one — there is no torn state to protect and no invariant
     /// shared with the calibration fields. That matters because the decode path reads this once per
-    /// sample on the USB float path, which otherwise takes no lock at all;
+    /// sample while decoding a stream frame, a path that otherwise takes no lock at all;
     /// <see cref="Volatile"/> keeps the publication safe without putting a lock back into the hot
     /// path.
     /// </remarks>

--- a/src/Daqifi.Core/Channel/DataSample.cs
+++ b/src/Daqifi.Core/Channel/DataSample.cs
@@ -16,8 +16,10 @@ public class DataSample : IDataSample
     public double Value { get; set; }
 
     /// <summary>
-    /// Gets the raw device value this sample was decoded from, or <c>null</c> when the device
-    /// supplied an already-scaled value or the sample was not produced by the decode pipeline.
+    /// Gets the raw device value this sample was decoded from — the raw ADC count for a streamed
+    /// analog sample, or the 0/1 bit for a digital one. <c>null</c> when the sample was not
+    /// produced by the decode pipeline, or when its frame carried an already-scaled value instead
+    /// of a count, which no supported firmware sends.
     /// </summary>
     public int? RawValue { get; init; }
 

--- a/src/Daqifi.Core/Channel/IDataSample.cs
+++ b/src/Daqifi.Core/Channel/IDataSample.cs
@@ -19,9 +19,12 @@ public interface IDataSample
 
     /// <summary>
     /// Gets the raw device value this sample was decoded from, when one exists: the raw ADC count
-    /// for a calibration-scaled analog sample, or the 0/1 bit for a digital sample. It is
-    /// <c>null</c> when the device supplied an already-scaled value (e.g. the USB pre-scaled
-    /// float path) or when the sample was not produced by the decode pipeline.
+    /// for a calibration-scaled analog sample, or the 0/1 bit for a digital sample. Every supported
+    /// firmware streams raw ADC counts on every transport, so a streamed analog sample carries a
+    /// raw count here and its <see cref="Value"/> is the result of Core's calibration formula.
+    /// It is <c>null</c> when the sample was not produced by the decode pipeline, or when the
+    /// frame it came from carried an already-scaled value instead of a count — a case the protocol
+    /// still allows but no supported firmware produces.
     /// </summary>
     int? RawValue { get; }
 

--- a/src/Daqifi.Core/Device/Internal/StreamFrameDecoder.cs
+++ b/src/Daqifi.Core/Device/Internal/StreamFrameDecoder.cs
@@ -355,8 +355,9 @@ namespace Daqifi.Core.Device.Internal
         }
 
         /// <summary>
-        /// The number of analog values a frame carries, from whichever payload the transport used —
-        /// USB streams pre-scaled floats, WiFi streams raw ADC counts.
+        /// The number of analog values a frame carries, from whichever payload it used. Supported
+        /// firmware always fills the raw-count payload; the float payload is read only because the
+        /// protocol still defines it.
         /// </summary>
         private static int CountAnalogValues(DaqifiOutMessage message) =>
             message.AnalogInDataFloat.Count > 0
@@ -393,8 +394,9 @@ namespace Daqifi.Core.Device.Internal
 
         /// <summary>
         /// Decodes a streaming frame into per-channel samples: selects the active channels in
-        /// device order, chooses the correct value source (USB pre-scaled float vs. WiFi raw ADC
-        /// count scaled via calibration), unpacks digital bits, and pushes a sample to each channel.
+        /// device order, chooses the correct value source (the frame's raw ADC counts, scaled via
+        /// calibration, or the already-scaled floats it carries instead), unpacks digital bits, and
+        /// pushes a sample to each channel.
         /// </summary>
         /// <param name="message">The streaming message to decode.</param>
         /// <param name="suppressAnalog">
@@ -535,8 +537,10 @@ namespace Daqifi.Core.Device.Internal
 
         /// <summary>
         /// Maps a frame's analog values to the enabled analog channels, in ascending channel order.
-        /// USB firmware streams pre-scaled floats (used directly); WiFi firmware streams raw ADC
-        /// counts (scaled per channel via <see cref="IAnalogChannel.GetScaledValue"/>).
+        /// A frame carrying raw ADC counts is scaled per channel via
+        /// <see cref="IAnalogChannel.GetScaledValue"/> — this is what every supported firmware
+        /// sends, on every transport. A frame carrying pre-scaled floats is used as-is; the
+        /// protocol still defines that payload, but no supported firmware fills it.
         /// </summary>
         /// <param name="message">The frame being decoded.</param>
         /// <param name="activeAnalog">
@@ -546,7 +550,10 @@ namespace Daqifi.Core.Device.Internal
         /// </param>
         /// <param name="hostTimestamp">The reconstructed host timestamp for this frame.</param>
         /// <param name="deviceTimestamp">The frame's raw device tick value.</param>
-        /// <param name="hasFloat">Whether the frame carries pre-scaled floats rather than raw counts.</param>
+        /// <param name="hasFloat">
+        /// Whether the frame carries pre-scaled floats rather than raw counts. False for every frame
+        /// supported firmware sends; kept because the protocol still defines the float payload.
+        /// </param>
         private static void DecodeAnalog(
             DaqifiOutMessage message,
             IAnalogChannel[] activeAnalog,
@@ -565,13 +572,14 @@ namespace Daqifi.Core.Device.Internal
 
                 if (hasFloat)
                 {
-                    // USB firmware already scaled to volts; no raw ADC count is available.
+                    // The frame carried volts already; no raw ADC count to report. Defensive:
+                    // no supported firmware fills this payload.
                     scaled = message.AnalogInDataFloat[i];
                     raw = null;
                 }
                 else
                 {
-                    // WiFi firmware sent a raw ADC count; apply this channel's calibration.
+                    // The normal path: a raw ADC count, scaled by this channel's calibration.
                     var rawValue = message.AnalogInData[i];
                     scaled = channel.GetScaledValue(rawValue);
                     raw = rawValue;

--- a/src/Daqifi.Core/Device/Protocol/ProtobufProtocolHandler.cs
+++ b/src/Daqifi.Core/Device/Protocol/ProtobufProtocolHandler.cs
@@ -156,8 +156,8 @@ public class ProtobufProtocolHandler : IProtocolHandler
     private static bool IsStreamMessage(DaqifiOutMessage message)
     {
         // Stream messages contain timestamp and data.
-        // USB firmware sends AnalogInDataFloat (pre-scaled floats) while WiFi firmware
-        // may send AnalogInData (raw integer ADC counts). Both must be detected.
+        // Supported firmware sends AnalogInData (raw integer ADC counts) on every transport, but
+        // the protocol also defines AnalogInDataFloat (pre-scaled floats). Both must be detected.
         return message.MsgTimeStamp != 0 &&
                (message.AnalogInData.Count > 0 ||
                 message.AnalogInDataFloat.Count > 0 ||

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -346,9 +346,11 @@ public sealed record SdDeleteResult(string DeviceId, string FileName);
 /// <param name="Timestamp">When the sample was taken, reconstructed from the device clock.</param>
 /// <param name="DeviceTimestamp">The device's own clock ticks for the sample, verbatim.</param>
 /// <param name="RawValue">
-/// The raw ADC count the value was decoded from. Supported firmware streams raw counts on every
-/// transport, so an analog reading carries one; <c>null</c> means the channel is digital, or that
-/// the frame carried an already-scaled value, which no supported firmware sends.
+/// The raw device value the reading was decoded from: the raw ADC count for an analog channel, or
+/// the 0/1 bit for a digital one. Supported firmware streams raw counts on every transport, so an
+/// analog reading carries one. <c>null</c> means no sample arrived inside the read window (the same
+/// condition that makes <c>Value</c> null), or that the frame carried an already-scaled value
+/// instead of a count, which no supported firmware sends.
 /// </param>
 public sealed record ChannelReading(
     string Column,

--- a/src/Daqifi.Mcp/Dtos.cs
+++ b/src/Daqifi.Mcp/Dtos.cs
@@ -346,8 +346,9 @@ public sealed record SdDeleteResult(string DeviceId, string FileName);
 /// <param name="Timestamp">When the sample was taken, reconstructed from the device clock.</param>
 /// <param name="DeviceTimestamp">The device's own clock ticks for the sample, verbatim.</param>
 /// <param name="RawValue">
-/// The raw ADC count the value was decoded from, or <c>null</c> when the device sent an
-/// already-scaled value (the USB float path does) or the channel is digital.
+/// The raw ADC count the value was decoded from. Supported firmware streams raw counts on every
+/// transport, so an analog reading carries one; <c>null</c> means the channel is digital, or that
+/// the frame carried an already-scaled value, which no supported firmware sends.
 /// </param>
 public sealed record ChannelReading(
     string Column,


### PR DESCRIPTION
## What was wrong

`IDataSample.RawValue` told you it would be `null` over USB, because (it said) the device hands back
already-scaled volts on that transport. That is backwards. Anyone reading it and concluding "over USB
I can't get raw ADC counts, and calibration already happened on the device" was told the exact
opposite of what the hardware does — the USB path is in fact the *only* live path that runs Core's
calibration formula, and `RawValue` is populated on every streamed analog sample there.

The same USB-vs-WiFi framing was repeated in five internal comments and in `DEVICE_INTERFACES.md`, so
a maintainer reasoning about where calibration happens got misled too.

## How it was fixed

Documentation only — no behaviour change, no API change. The docs now describe the **frame** (does it
carry raw counts or pre-scaled floats) instead of the **transport**, and say plainly that every
supported firmware streams raw counts on every transport.

The one thing worth pushing back on is what we *didn't* do: the `hasFloat` branch in the decoder
stays exactly as it is. `analog_in_data_float` is still a field the protocol defines, so reading it
is harmless defensive handling — it is just never populated today, and the comments now say so rather
than implying a transport picks between the two.

## Why the old text was wrong

The firmware's streaming encoder only ever requests the raw-int field, and the float field's encoder
case explicitly writes nothing. Both are identical at `v3.5.0` and `v3.7.2` — the entire supported
range per ADR 0001 — so `analog_in_data_float` is never populated by any supported firmware, on any
transport.

## Verified

- Bench (from the issue): Nq1 fw 3.7.2, USB CDC, 16 channels at 10 Hz — `frames=62 rawFrames=62
  floatFrames=0`, `RawValue` non-null on every decoded analog sample.
- Full suite green on net9.0 and net10.0: 4092 passed / 3 skipped (Core), 217 passed (Mcp). Release
  build, 0 warnings.

closes #683