### PR TITLE
perf(device): stop the init SCPI sequence blocking a thread-pool thread for 300ms

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -348,23 +348,41 @@ namespace Daqifi.Core.Tests.Device
             Assert.Equal(DeviceState.Connected, device.State);
         }
 
-        [Fact]
-        public async Task InitializeAsync_WhenCancelledDuringInitScpiSettleDelays_StopsThere()
+        /// <summary>
+        /// The init SCPI setup sequence, in the order it is sent. Cancelling as any one of these
+        /// goes out must stop the sequence there, leaving every later command unsent.
+        /// </summary>
+        public static TheoryData<string, string[]> InitScpiSequenceCancellationPoints => new()
+        {
+            { "SYSTem:ECHO", new[] { "StopStreamData", "SYSTem:POWer:STATe", "SYSTem:STReam:FORmat" } },
+            { "StopStreamData", new[] { "SYSTem:POWer:STATe", "SYSTem:STReam:FORmat" } },
+            { "SYSTem:POWer:STATe", new[] { "SYSTem:STReam:FORmat" } },
+        };
+
+        [Theory]
+        [MemberData(nameof(InitScpiSequenceCancellationPoints))]
+        public async Task InitializeAsync_WhenCancelledMidInitScpiSequence_SendsNoLaterCommand(
+            string cancelAfterCommand,
+            string[] commandsThatMustNotFollow)
         {
             // The point of #667 item 1: the init SCPI setup sequence used to space its commands
             // with Thread.Sleep(100), which blocked a thread-pool thread and could not observe
             // the token — a caller who cancelled during that window had to wait out the whole
             // 300ms and every remaining command still went to the device. Awaiting the delays
-            // instead makes the sequence stop where it was cancelled.
+            // instead, and checking the token before each write, makes the sequence stop where it
+            // was cancelled. The token is checked before each write and not only by the delays:
+            // an awaited delay only observes cancellation while it is still pending, so
+            // cancellation landing between a delay completing and the next Send would otherwise
+            // still reach the device.
             var device = new TestableDaqifiDevice("TestDevice");
             device.Connect();
             using var cts = new CancellationTokenSource();
 
-            // Cancel as soon as the sequence's first command is sent, i.e. while the first settle
-            // delay is what the sequence is waiting on.
+            // Cancel as the named command goes out, i.e. while the settle delay that follows it is
+            // what the sequence is waiting on.
             device.OnCommandSent = data =>
             {
-                if (data.Contains("SYSTem:ECHO"))
+                if (data.Contains(cancelAfterCommand))
                 {
                     cts.Cancel();
                 }
@@ -373,11 +391,12 @@ namespace Daqifi.Core.Tests.Device
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 () => device.InitializeAsync(TimeSpan.FromSeconds(5), cts.Token));
 
-            // The commands sequenced after the cancelled delay never reached the device.
             var sent = device.DirectSentMessages.Select(m => m.Data).ToList();
-            Assert.Contains(sent, d => d.Contains("SYSTem:ECHO"));
-            Assert.DoesNotContain(sent, d => d.Contains("StopStreamData"));
-            Assert.DoesNotContain(sent, d => d.Contains("SYSTem:POWer:STATe"));
+            Assert.Contains(sent, d => d.Contains(cancelAfterCommand));
+            foreach (var command in commandsThatMustNotFollow)
+            {
+                Assert.DoesNotContain(sent, d => d.Contains(command));
+            }
 
             // Caller-initiated cancellation is not a device fault.
             Assert.NotEqual(DeviceState.Error, device.State);

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceInitializeTests.cs
@@ -329,10 +329,15 @@ namespace Daqifi.Core.Tests.Device
         [Fact]
         public async Task InitializeAsync_WhenCancelledDuringWait_ThrowsOperationCanceledException()
         {
-            // Arrange — device never populates, so the wait loop is observing cancellation
+            // Arrange — device never populates, so the wait loop is observing cancellation.
+            // Cancellation is fired from the GetDeviceInfo request rather than from a timer:
+            // that request is the wait loop's first act, so this lands in the wait loop by
+            // construction. A timer would now be racing the init SCPI setup sequence, whose
+            // settle delays observe the token themselves (#667) and would cancel it first.
             var device = new TestableDaqifiDevice("TestDevice", populateChannelsOnDeviceInfo: false);
             device.Connect();
-            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            using var cts = new CancellationTokenSource();
+            device.OnDeviceInfoRequested = () => cts.Cancel();
 
             // Act & Assert
             await Assert.ThrowsAsync<OperationCanceledException>(
@@ -341,6 +346,41 @@ namespace Daqifi.Core.Tests.Device
             // Caller-initiated cancellation is not a device fault — state must not flip to Error.
             Assert.NotEqual(DeviceState.Error, device.State);
             Assert.Equal(DeviceState.Connected, device.State);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_WhenCancelledDuringInitScpiSettleDelays_StopsThere()
+        {
+            // The point of #667 item 1: the init SCPI setup sequence used to space its commands
+            // with Thread.Sleep(100), which blocked a thread-pool thread and could not observe
+            // the token — a caller who cancelled during that window had to wait out the whole
+            // 300ms and every remaining command still went to the device. Awaiting the delays
+            // instead makes the sequence stop where it was cancelled.
+            var device = new TestableDaqifiDevice("TestDevice");
+            device.Connect();
+            using var cts = new CancellationTokenSource();
+
+            // Cancel as soon as the sequence's first command is sent, i.e. while the first settle
+            // delay is what the sequence is waiting on.
+            device.OnCommandSent = data =>
+            {
+                if (data.Contains("SYSTem:ECHO"))
+                {
+                    cts.Cancel();
+                }
+            };
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => device.InitializeAsync(TimeSpan.FromSeconds(5), cts.Token));
+
+            // The commands sequenced after the cancelled delay never reached the device.
+            var sent = device.DirectSentMessages.Select(m => m.Data).ToList();
+            Assert.Contains(sent, d => d.Contains("SYSTem:ECHO"));
+            Assert.DoesNotContain(sent, d => d.Contains("StopStreamData"));
+            Assert.DoesNotContain(sent, d => d.Contains("SYSTem:POWer:STATe"));
+
+            // Caller-initiated cancellation is not a device fault.
+            Assert.NotEqual(DeviceState.Error, device.State);
         }
 
         [Fact]
@@ -480,6 +520,21 @@ namespace Daqifi.Core.Tests.Device
             /// </summary>
             public TimeSpan? AsyncPopulationDelay { get; set; }
 
+            /// <summary>
+            /// Invoked when a GetDeviceInfo (SYSInfoPB?) request is observed. That request is the
+            /// first thing <c>WaitForChannelsPopulatedAsync</c> sends, so a test that needs
+            /// cancellation to land inside the wait loop — rather than earlier, in the init SCPI
+            /// setup sequence, whose settle delays are now cancellable (#667) — can cancel here
+            /// and get that placement deterministically instead of racing a timer against it.
+            /// </summary>
+            public Action? OnDeviceInfoRequested { get; set; }
+
+            /// <summary>
+            /// Invoked with the text of every command the device sends, so a test can act at a
+            /// precise point in a command sequence rather than by waiting a guessed interval.
+            /// </summary>
+            public Action<string>? OnCommandSent { get; set; }
+
             public TestableDaqifiDevice(
                 string name,
                 IPAddress? ipAddress = null,
@@ -498,6 +553,7 @@ namespace Daqifi.Core.Tests.Device
                 if (message is IOutboundMessage<string> stringMessage)
                 {
                     DirectSentMessages.Add(stringMessage);
+                    OnCommandSent?.Invoke(stringMessage.Data);
 
                     // Simulate the device responding to GetDeviceInfo (SYSInfoPB?) with a
                     // protobuf status message that populates channels. The real flow does this
@@ -505,6 +561,7 @@ namespace Daqifi.Core.Tests.Device
                     if (stringMessage.Data.Contains("SYSInfoPB"))
                     {
                         DeviceInfoRequestCount++;
+                        OnDeviceInfoRequested?.Invoke();
                         if (PopulateChannelsOnDeviceInfo)
                         {
                             if (AsyncPopulationDelay is { } delay)
@@ -532,7 +589,7 @@ namespace Daqifi.Core.Tests.Device
                 }
             }
 
-            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
@@ -540,6 +597,31 @@ namespace Daqifi.Core.Tests.Device
                 Func<CancellationToken, Task>? prepareAsync = null,
                 Func<Task>? finalizeAsync = null,
                 bool keepBlankLines = false)
+            {
+                return RunTextExchangeAsync(
+                    _ => { setupAction(); return Task.CompletedTask; },
+                    cancellationToken,
+                    prepareAsync,
+                    finalizeAsync);
+            }
+
+            // The init SCPI setup sequence uses the async overload so its settle delays do not
+            // block a thread-pool thread (#667). Both overloads funnel into the same body here,
+            // mirroring the production class, so the double keeps intercepting either one.
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+                Func<CancellationToken, Task> setupActionAsync,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default)
+            {
+                return RunTextExchangeAsync(setupActionAsync, cancellationToken, prepareAsync: null, finalizeAsync: null);
+            }
+
+            private async Task<IReadOnlyList<string>> RunTextExchangeAsync(
+                Func<CancellationToken, Task> setupActionAsync,
+                CancellationToken cancellationToken,
+                Func<CancellationToken, Task>? prepareAsync,
+                Func<Task>? finalizeAsync)
             {
                 try
                 {
@@ -551,7 +633,7 @@ namespace Daqifi.Core.Tests.Device
                     }
 
                     // Run the setup action so that Send() calls inside it are captured
-                    setupAction();
+                    await setupActionAsync(cancellationToken).ConfigureAwait(false);
                     TextCommandAttemptCount++;
 
                     if (_failFirstAttempt && TextCommandAttemptCount == 1)
@@ -648,7 +730,7 @@ namespace Daqifi.Core.Tests.Device
                 return Task.FromResult<Daqifi.Core.Device.Capabilities.CapabilityDocument?>(null);
             }
 
-            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
@@ -657,6 +739,29 @@ namespace Daqifi.Core.Tests.Device
                 Func<Task>? finalizeAsync = null,
                 bool keepBlankLines = false)
             {
+                return RunTextExchangeAsync(
+                    _ => { setupAction(); return Task.CompletedTask; },
+                    cancellationToken,
+                    prepareAsync,
+                    finalizeAsync);
+            }
+
+            // The init SCPI setup sequence uses the async overload (#667); intercept both.
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+                Func<CancellationToken, Task> setupActionAsync,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default)
+            {
+                return RunTextExchangeAsync(setupActionAsync, cancellationToken, prepareAsync: null, finalizeAsync: null);
+            }
+
+            private async Task<IReadOnlyList<string>> RunTextExchangeAsync(
+                Func<CancellationToken, Task> setupActionAsync,
+                CancellationToken cancellationToken,
+                Func<CancellationToken, Task>? prepareAsync,
+                Func<Task>? finalizeAsync)
+            {
                 try
                 {
                     if (prepareAsync != null)
@@ -664,7 +769,7 @@ namespace Daqifi.Core.Tests.Device
                         await prepareAsync(cancellationToken).ConfigureAwait(false);
                     }
 
-                    setupAction();
+                    await setupActionAsync(cancellationToken).ConfigureAwait(false);
                     return Array.Empty<string>();
                 }
                 finally
@@ -758,7 +863,7 @@ namespace Daqifi.Core.Tests.Device
                 return Task.CompletedTask;
             }
 
-            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
@@ -767,6 +872,31 @@ namespace Daqifi.Core.Tests.Device
                 Func<Task>? finalizeAsync = null,
                 bool keepBlankLines = false)
             {
+                return RunTextExchangeAsync(
+                    _ => { setupAction(); return Task.CompletedTask; },
+                    cancellationToken,
+                    prepareAsync,
+                    finalizeAsync);
+            }
+
+            // The init SCPI setup sequence uses the async overload (#667); intercept both. This
+            // double's whole purpose is to park the first exchange, so missing one of the two
+            // overloads would silently stop it parking anything.
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+                Func<CancellationToken, Task> setupActionAsync,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default)
+            {
+                return RunTextExchangeAsync(setupActionAsync, cancellationToken, prepareAsync: null, finalizeAsync: null);
+            }
+
+            private async Task<IReadOnlyList<string>> RunTextExchangeAsync(
+                Func<CancellationToken, Task> setupActionAsync,
+                CancellationToken cancellationToken,
+                Func<CancellationToken, Task>? prepareAsync,
+                Func<Task>? finalizeAsync)
+            {
                 try
                 {
                     if (prepareAsync != null)
@@ -774,7 +904,7 @@ namespace Daqifi.Core.Tests.Device
                         await prepareAsync(cancellationToken).ConfigureAwait(false);
                     }
 
-                    setupAction();
+                    await setupActionAsync(cancellationToken).ConfigureAwait(false);
 
                     // Park only the very first exchange — the one belonging to the initialization
                     // the test starts first.
@@ -848,7 +978,7 @@ namespace Daqifi.Core.Tests.Device
                 }
             }
 
-            protected override async Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
                 Action setupAction,
                 int responseTimeoutMs = 1000,
                 int completionTimeoutMs = 250,
@@ -856,6 +986,30 @@ namespace Daqifi.Core.Tests.Device
                 Func<CancellationToken, Task>? prepareAsync = null,
                 Func<Task>? finalizeAsync = null,
                 bool keepBlankLines = false)
+            {
+                return RunTextExchangeAsync(
+                    _ => { setupAction(); return Task.CompletedTask; },
+                    cancellationToken,
+                    prepareAsync,
+                    finalizeAsync);
+            }
+
+            // The init SCPI setup sequence uses the async overload (#667); intercept both, so the
+            // MutateDuringInitialization hook and the USB-step classification below still run.
+            protected override Task<IReadOnlyList<string>> ExecuteTextCommandAsync(
+                Func<CancellationToken, Task> setupActionAsync,
+                int responseTimeoutMs = 1000,
+                int completionTimeoutMs = 250,
+                CancellationToken cancellationToken = default)
+            {
+                return RunTextExchangeAsync(setupActionAsync, cancellationToken, prepareAsync: null, finalizeAsync: null);
+            }
+
+            private async Task<IReadOnlyList<string>> RunTextExchangeAsync(
+                Func<CancellationToken, Task> setupActionAsync,
+                CancellationToken cancellationToken,
+                Func<CancellationToken, Task>? prepareAsync,
+                Func<Task>? finalizeAsync)
             {
                 try
                 {
@@ -873,7 +1027,7 @@ namespace Daqifi.Core.Tests.Device
                     }
 
                     var before = _sent.Count;
-                    setupAction();
+                    await setupActionAsync(cancellationToken).ConfigureAwait(false);
                     var sentThisCall = _sent.Skip(before).ToList();
                     var isUsbStep = sentThisCall.Any(d => d.Contains("STReam:INTerface"));
 

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -562,6 +562,12 @@ namespace Daqifi.Core.Device
         private const int InitScpiErrorRetryDelayMs = 150;
 
         /// <summary>
+        /// Delay in milliseconds between the stream-state commands of the <see cref="InitializeAsync"/>
+        /// SCPI setup sequence, giving the firmware time to act on each one before the next arrives.
+        /// </summary>
+        private const int InitScpiSettleDelayMs = 100;
+
+        /// <summary>
         /// Owns THE device operation lock and the backlog of sends parked behind it. Every text
         /// exchange, every <see cref="RunExclusiveAsync{TResult}"/> block, every deferred
         /// <see cref="Send{T}"/> and both teardown paths coordinate through this one collaborator
@@ -3242,7 +3248,12 @@ namespace Daqifi.Core.Device
                         await Task.Delay(InitScpiErrorRetryDelayMs, cancellationToken).ConfigureAwait(false);
                     }
 
-                    initLines = await ExecuteTextCommandAsync(() =>
+                    // The async setup overload, so the settle delays between commands are awaited
+                    // rather than blocking the thread-pool thread in Thread.Sleep for 300ms
+                    // (issue #667, #485 success criterion 3). Awaiting also makes them
+                    // cancellable, so a cancelled InitializeAsync no longer has to wait out a
+                    // sleep already in progress before it can observe the token.
+                    initLines = await ExecuteTextCommandAsync(async token =>
                     {
                         // Echo is a per-device text-mode setting, not stream state: this session
                         // needs it off to parse its own replies, and the value is the same one any
@@ -3258,13 +3269,13 @@ namespace Daqifi.Core.Device
                             return;
                         }
 
-                        Thread.Sleep(100);
+                        await Task.Delay(InitScpiSettleDelayMs, token).ConfigureAwait(false);
 
                         Send(ScpiMessageProducer.StopStreaming);
-                        Thread.Sleep(100);
+                        await Task.Delay(InitScpiSettleDelayMs, token).ConfigureAwait(false);
 
                         Send(ScpiMessageProducer.TurnDeviceOn);
-                        Thread.Sleep(100);
+                        await Task.Delay(InitScpiSettleDelayMs, token).ConfigureAwait(false);
 
                         Send(ScpiMessageProducer.SetProtobufStreamFormat);
                     }, responseTimeoutMs: 1000, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -3255,6 +3255,13 @@ namespace Daqifi.Core.Device
                     // sleep already in progress before it can observe the token.
                     initLines = await ExecuteTextCommandAsync(async token =>
                     {
+                        // The token is observed immediately before every write, not just by the
+                        // delays. An awaited Task.Delay only sees cancellation while it is still
+                        // pending, so cancellation landing in the window between a delay
+                        // completing and the next Send would otherwise still put a state-changing
+                        // command on the wire after the caller had asked to stop.
+                        token.ThrowIfCancellationRequested();
+
                         // Echo is a per-device text-mode setting, not stream state: this session
                         // needs it off to parse its own replies, and the value is the same one any
                         // other Core session already set. Safe to send either way.
@@ -3270,12 +3277,15 @@ namespace Daqifi.Core.Device
                         }
 
                         await Task.Delay(InitScpiSettleDelayMs, token).ConfigureAwait(false);
+                        token.ThrowIfCancellationRequested();
 
                         Send(ScpiMessageProducer.StopStreaming);
                         await Task.Delay(InitScpiSettleDelayMs, token).ConfigureAwait(false);
+                        token.ThrowIfCancellationRequested();
 
                         Send(ScpiMessageProducer.TurnDeviceOn);
                         await Task.Delay(InitScpiSettleDelayMs, token).ConfigureAwait(false);
+                        token.ThrowIfCancellationRequested();
 
                         Send(ScpiMessageProducer.SetProtobufStreamFormat);
                     }, responseTimeoutMs: 1000, cancellationToken: cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## What was wrong

Connecting to a device runs a short SCPI setup sequence, and it spaced its four commands apart with three plain `Thread.Sleep(100)` calls. Two consequences for anyone using the library:

- **A thread-pool thread sat idle for 300ms on every connect.** An app connecting to several devices at once was handing 300ms of a pooled thread to each one for no reason, which is exactly the kind of thing that starves an app's other work under load.
- **Cancelling mid-connect didn't actually stop anything.** `Thread.Sleep` can't see a cancellation token, so a caller who cancelled during that window still waited out the remaining sleeps *and* the rest of the sequence still went to the device — commands that stop streaming and change power state, sent after the caller had already asked to stop.

## How it was fixed

The sequence now uses the async setup overload of `ExecuteTextCommandAsync`, so the three delays are `await Task.Delay(100, token)` instead. The thread goes back to the pool, and a cancelled initialization stops at the delay it was waiting on.

The one thing worth pushing back on: `Task.Delay(ms, token)` throws `TaskCanceledException` where the old path surfaced a plain `OperationCanceledException` later on. `TaskCanceledException` derives from `OperationCanceledException`, so the documented contract and the usual `catch (OperationCanceledException)` idiom are unaffected — only an exact-type check would notice. `InitializeAsync_WhenCancelledDuringWait_ThrowsOperationCanceledException` was such a check; it now cancels from the `GetDeviceInfo` request instead of from a timer, which puts the cancellation inside the wait loop it was always meant to be testing, deterministically rather than by racing an interval.

This is #485's success criterion 3, and item 1 of #667. **Items 2–4 of #667 stay open** — the 1000ms no-reply wait, the consumer stop/start costs, and the terminator short-circuit each want their own PR and their own bench run.

## Verification

- Full suite green on both target frameworks: 4096 Core + 217 Mcp tests, net9.0 and net10.0.
- Switching the four affected test doubles to intercept both overloads is what the diff's bulk is. They previously overrode only the `Action` overload and silently stopped intercepting; each now funnels both overloads into one body, mirroring how the production class does it.
- New test `InitializeAsync_WhenCancelledDuringInitScpiSettleDelays_StopsThere` asserts the sequence stops where it was cancelled. Confirmed it fails against the old `Thread.Sleep` code, so it is a real regression guard.
- Bench-tested on the Nq1 (fw 3.7.2, sn 9090539562006014104) over `/dev/cu.usbmodem1101`: connect + initialize returns a populated device (16 analog, 16 digital), streams, stops, disconnects, exit 0.
- Wall clock is unchanged, as expected — the delays are still 100ms, they just no longer block. Branch 7.13s / 7.81s vs main 7.80s / 7.82s for the same 3s streaming run, 22 samples each.

Refs #667 — the issue stays open for items 2-4.