### PR TITLE
perf(benchmarks): add a BenchmarkDotNet harness so the perf numbers are reproducible

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -53,11 +53,19 @@ jobs:
 
     # BenchmarkDotNet builds and launches its own process per benchmark, so this is
     # `dotnet run` rather than a build-then-test split.
+    #
+    # The filter arrives through the environment, not through ${{ }} interpolation into
+    # the script. `filter` is a free-text input, so interpolating it would splice whatever
+    # was typed straight into the shell — a value containing a quote closes the quoting and
+    # the rest runs as commands, on a runner holding this repo's token. `job` is a choice
+    # input with two fixed options, so it has no such freedom and is interpolated directly.
     - name: Run benchmarks
+      env:
+        FILTER: ${{ inputs.filter }}
       run: |
         dotnet run -c Release \
           --project src/Daqifi.Core.Benchmarks/Daqifi.Core.Benchmarks.csproj \
-          -- --filter '${{ inputs.filter }}' \
+          -- --filter "$FILTER" \
              ${{ inputs.job == 'short' && '--job short' || '' }} \
              --exporters github markdown json
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,81 @@
+name: Benchmarks
+
+# On demand only, never on a pull request (issue #640). Timings on a shared GitHub
+# runner are far too noisy to gate a merge on: a perf check that fails a green PR
+# once a week lands straight back in the #634/#632 flake pattern, and the fix for
+# that is not a wider tolerance, it is not gating. Run this before a release, or
+# either side of a change that claims a performance win, and paste the table into
+# the ticket that claims it.
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'BenchmarkDotNet filter, e.g. *Decode* or *SdCard*'
+        required: false
+        default: '*'
+        type: string
+      job:
+        description: 'BenchmarkDotNet job. "short" for a quick look, "default" for numbers worth recording.'
+        required: false
+        default: 'default'
+        type: choice
+        options:
+          - default
+          - short
+
+jobs:
+  benchmark:
+    name: benchmark
+    # Pinned to one OS on purpose. A benchmark number is only meaningful against
+    # another number from the same machine shape, and comparing a run on a Windows
+    # runner with a baseline taken on a Linux one would produce a "regression" that
+    # is nothing but the runner. The cross-platform question CI answers is
+    # correctness (the three-OS test matrix); this answers a different one.
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: |
+          9.0.x
+          10.0.x
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
+
+    # BenchmarkDotNet builds and launches its own process per benchmark, so this is
+    # `dotnet run` rather than a build-then-test split.
+    - name: Run benchmarks
+      run: |
+        dotnet run -c Release \
+          --project src/Daqifi.Core.Benchmarks/Daqifi.Core.Benchmarks.csproj \
+          -- --filter '${{ inputs.filter }}' \
+             ${{ inputs.job == 'short' && '--job short' || '' }} \
+             --exporters github markdown json
+
+    # The whole point of a manual run: the tables have to be readable afterwards
+    # without re-running anything.
+    - name: Summarize
+      if: always()
+      run: |
+        for report in BenchmarkDotNet.Artifacts/results/*-report-github.md; do
+          [ -e "$report" ] || continue
+          cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          printf '\n' >> "$GITHUB_STEP_SUMMARY"
+        done
+
+    - name: Upload reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-reports
+        path: BenchmarkDotNet.Artifacts/results/
+        if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,7 @@ SESSION_LOG.md
 
 # Python bytecode from .github/scripts
 __pycache__/
+
+# BenchmarkDotNet writes its reports and the generated per-benchmark projects here.
+# The baselines worth keeping live in src/Daqifi.Core.Benchmarks/README.md instead.
+BenchmarkDotNet.Artifacts/

--- a/Daqifi.Core.sln
+++ b/Daqifi.Core.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Mcp", "src\Daqifi.Mc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Mcp.Tests", "src\Daqifi.Mcp.Tests\Daqifi.Mcp.Tests.csproj", "{209097AD-D34D-425B-8F22-0936F26C83D3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daqifi.Core.Benchmarks", "src\Daqifi.Core.Benchmarks\Daqifi.Core.Benchmarks.csproj", "{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +73,18 @@ Global
 		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|x64.Build.0 = Release|Any CPU
 		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|x86.ActiveCfg = Release|Any CPU
 		{209097AD-D34D-425B-8F22-0936F26C83D3}.Release|x86.Build.0 = Release|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Debug|x64.Build.0 = Debug|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Debug|x86.Build.0 = Debug|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Release|x64.ActiveCfg = Release|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Release|x64.Build.0 = Release|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Release|x86.ActiveCfg = Release|Any CPU
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -80,5 +94,6 @@ Global
 		{A3E04AD3-E095-48CD-99C7-BD82EF2AB128} = {5412868F-5B63-486D-8EA6-ED8C83418517}
 		{8E836FD9-80B1-4245-8D7A-94D6FAB7021D} = {5412868F-5B63-486D-8EA6-ED8C83418517}
 		{209097AD-D34D-425B-8F22-0936F26C83D3} = {5412868F-5B63-486D-8EA6-ED8C83418517}
+		{BA7A6AF9-CB05-49DE-88F5-D5A95F187ED6} = {5412868F-5B63-486D-8EA6-ED8C83418517}
 	EndGlobalSection
 EndGlobal

--- a/src/Daqifi.Core.Benchmarks/ChannelScalingBenchmarks.cs
+++ b/src/Daqifi.Core.Benchmarks/ChannelScalingBenchmarks.cs
@@ -1,0 +1,103 @@
+using BenchmarkDotNet.Attributes;
+using Daqifi.Core.Channel;
+
+namespace Daqifi.Core.Benchmarks;
+
+/// <summary>
+/// The two per-sample conversions: the device's calibration
+/// (<see cref="AnalogChannel.GetScaledValue"/>, raw ADC count to volts) and the user's transducer
+/// transform (<see cref="ChannelScaling.Apply"/>, volts to engineering units).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both run once per sample per channel, so at 16 channels and 1 kHz they run 16,000 times a
+/// second. Neither should allocate and both should be a handful of nanoseconds; the reason to
+/// measure them is that they are the easiest place in the library for a well-meaning change — a
+/// validity check, a unit lookup, a nullable coefficient — to add a per-sample cost that nothing
+/// else would notice.
+/// </para>
+/// <para>
+/// <see cref="GetScaledValue"/> is measured through the channel, lock included: that lock is what
+/// stops a concurrent status refresh tearing the calibration coefficients, so it is part of what a
+/// sample costs and not an overhead to be measured around.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class ChannelScalingBenchmarks
+{
+    /// <summary>
+    /// Conversions per invocation, so the reported figure is per sample.
+    /// </summary>
+    private const int SampleCount = 1_000;
+
+    private readonly AnalogChannel _channel = new(0);
+
+    private readonly ChannelScaling _transducerScaling = new(gain: 12.5, offset: -1.25, unit: "PSI");
+
+    private readonly ChannelScaling _identityScaling = ChannelScaling.Identity;
+
+    /// <summary>
+    /// Raw ADC counts, pre-generated so the loop measures conversion rather than number generation.
+    /// </summary>
+    private int[] _rawValues = null!;
+
+    private double[] _volts = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawValues = new int[SampleCount];
+        _volts = new double[SampleCount];
+
+        for (var i = 0; i < SampleCount; i++)
+        {
+            _rawValues[i] = i * 37 % 65_536;
+            _volts[i] = _rawValues[i] / 65_535.0 * 5.0;
+        }
+    }
+
+    /// <summary>
+    /// The device calibration as a consumer reaches it, through the channel and its lock.
+    /// </summary>
+    [Benchmark(Baseline = true, OperationsPerInvoke = SampleCount)]
+    public double GetScaledValue()
+    {
+        var total = 0.0;
+        for (var i = 0; i < _rawValues.Length; i++)
+        {
+            total += _channel.GetScaledValue(_rawValues[i]);
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// A configured transducer transform: gain, offset, and the finiteness guard around them.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = SampleCount)]
+    public double ApplyTransducerScaling()
+    {
+        var total = 0.0;
+        for (var i = 0; i < _volts.Length; i++)
+        {
+            total += _transducerScaling.Apply(_volts[i]);
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// The far commoner case — no transducer configured — which every stream pays on every sample.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = SampleCount)]
+    public double ApplyIdentityScaling()
+    {
+        var total = 0.0;
+        for (var i = 0; i < _volts.Length; i++)
+        {
+            total += _identityScaling.Apply(_volts[i]);
+        }
+
+        return total;
+    }
+}

--- a/src/Daqifi.Core.Benchmarks/Daqifi.Core.Benchmarks.csproj
+++ b/src/Daqifi.Core.Benchmarks/Daqifi.Core.Benchmarks.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- ImplicitUsings, Nullable and TreatWarningsAsErrors come from the repo-root
+         Directory.Build.props. Nothing centralized may be restated here; see
+         Daqifi.Core.Tests/Build/DirectoryBuildPropsTests.cs. -->
+
+    <!-- Single-target on purpose, unlike the other three projects. BenchmarkDotNet's
+         toolchain builds and launches the host project itself, and `dotnet run` on a
+         multi-targeted project refuses to pick a framework, so the documented
+         `dotnet run -c Release` would need a -f every time. Measuring the library on
+         net9.0 as well is a job matrix, not a second TargetFramework: add
+         [SimpleJob(RuntimeMoniker.Net90)] to a class and BenchmarkDotNet runs both
+         runtimes from this one host. See the README. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+
+    <!-- Out of the pack path: this is a measuring instrument, not a shipped asset.
+         It also keeps the repo-root Directory.Build.targets package metadata off it. -->
+    <IsPackable>false</IsPackable>
+
+    <!-- Out of the test path. CI runs `dotnet test Daqifi.Core.sln`, which walks every
+         project in the solution; without this the benchmark project is asked for tests
+         it does not have. Benchmark timings on a shared runner are far too noisy to
+         gate a PR on (issue #640 says so explicitly), so this project is only ever run
+         on demand — see .github/workflows/benchmarks.yml. -->
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <ProjectReference Include="..\Daqifi.Core\Daqifi.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Daqifi.Core.Benchmarks/Program.cs
+++ b/src/Daqifi.Core.Benchmarks/Program.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Running;
+
+namespace Daqifi.Core.Benchmarks;
+
+/// <summary>
+/// Entry point for the benchmark harness (issue #640).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="BenchmarkSwitcher"/> rather than a hard-coded run, so the standard BenchmarkDotNet
+/// command line works: <c>--filter *Decode*</c> to run one family, <c>--job short</c> for a quick
+/// look, <c>--list flat</c> to see what is available. With no arguments it prompts for a family.
+/// </para>
+/// <para>
+/// This project is never run by CI on a pull request. See the README for why, and
+/// <c>.github/workflows/benchmarks.yml</c> for the on-demand job.
+/// </para>
+/// </remarks>
+public static class Program
+{
+    /// <summary>
+    /// Runs the benchmarks selected by <paramref name="args"/>.
+    /// </summary>
+    /// <param name="args">BenchmarkDotNet switcher arguments.</param>
+    public static void Main(string[] args) =>
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+}

--- a/src/Daqifi.Core.Benchmarks/ProtobufFramingBenchmarks.cs
+++ b/src/Daqifi.Core.Benchmarks/ProtobufFramingBenchmarks.cs
@@ -1,0 +1,81 @@
+using BenchmarkDotNet.Attributes;
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Messages;
+
+namespace Daqifi.Core.Benchmarks;
+
+/// <summary>
+/// Everything between bytes arriving on the wire and a <see cref="DaqifiOutMessage"/> existing:
+/// the varint length prefix, the frame boundary, and the buffer the consumer accumulates into.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two cases, and the difference between them is the point.
+/// <see cref="ParseWholeFrames"/> is the tidy case — a buffer that happens to end on a frame
+/// boundary. <see cref="ParseWithTrailingPartialFrame"/> is the far commoner one: a USB read
+/// almost never ends where a frame does, so the last bytes are a partial the parser must decline,
+/// leave unconsumed, and re-examine on the next read.
+/// </para>
+/// <para>
+/// Both pass the same buffer every iteration and are pure with respect to it, so the allocation
+/// column is the frames themselves plus whatever the framing adds on top. The consumer loop that
+/// feeds this parser is measured separately in <see cref="StreamConsumerBenchmarks"/>.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class ProtobufFramingBenchmarks
+{
+    /// <summary>
+    /// Frames per buffer. A 4 KB read off a USB CDC port at 16 channels holds roughly this many.
+    /// </summary>
+    private const int FrameCount = 50;
+
+    private readonly ProtobufMessageParser _parser = new();
+
+    private byte[] _wholeFrames = null!;
+    private byte[] _framesWithTrailingPartial = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _wholeFrames = SyntheticFrames.BuildFrameBuffer(FrameCount);
+
+        // FrameCount + 1 frames with the last one truncated, so both cases yield exactly
+        // FrameCount complete frames and OperationsPerInvoke means the same thing in each.
+        _framesWithTrailingPartial = SyntheticFrames.BuildFrameBuffer(FrameCount + 1, truncateLastFrame: true);
+    }
+
+    /// <summary>
+    /// A buffer that ends exactly on a frame boundary: every frame is consumed and nothing is left
+    /// over.
+    /// </summary>
+    [Benchmark(Baseline = true, OperationsPerInvoke = FrameCount)]
+    public int ParseWholeFrames()
+    {
+        var messages = _parser.ParseMessages(_wholeFrames, out _);
+        return Count(messages);
+    }
+
+    /// <summary>
+    /// The same buffer with its last frame cut in half — what a read that lands mid-frame looks
+    /// like. The parser must recognize the tail as incomplete, leave it unconsumed, and still
+    /// return everything before it.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = FrameCount)]
+    public int ParseWithTrailingPartialFrame()
+    {
+        var messages = _parser.ParseMessages(_framesWithTrailingPartial, out _);
+        return Count(messages);
+    }
+
+    private static int Count(IEnumerable<IInboundMessage<DaqifiOutMessage>> messages)
+    {
+        var count = 0;
+        foreach (var _ in messages)
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/src/Daqifi.Core.Benchmarks/README.md
+++ b/src/Daqifi.Core.Benchmarks/README.md
@@ -1,0 +1,138 @@
+# Daqifi.Core.Benchmarks
+
+A BenchmarkDotNet harness for the library's hot paths (issue #640).
+
+Nine performance tickets in this repo each state a specific number — "~700 ms of fixed overhead
+per SCPI exchange", "~1 s per port wasted on teardown" — and every one of those numbers was
+produced by hand, once, on somebody's machine. None of them was reproducible afterwards and
+nothing noticed when one regressed. This project is where those numbers get produced from now on.
+
+## Running it
+
+```bash
+dotnet run -c Release --project src/Daqifi.Core.Benchmarks/Daqifi.Core.Benchmarks.csproj
+```
+
+With no arguments it lists the families and asks which to run. The usual BenchmarkDotNet switches
+all work:
+
+```bash
+# one family
+dotnet run -c Release --project src/Daqifi.Core.Benchmarks/Daqifi.Core.Benchmarks.csproj -- --filter '*Decode*'
+
+# a quick look — fewer iterations, correspondingly less trustworthy
+dotnet run -c Release --project src/Daqifi.Core.Benchmarks/Daqifi.Core.Benchmarks.csproj -- --filter '*' --job short
+
+# what is available
+dotnet run -c Release --project src/Daqifi.Core.Benchmarks/Daqifi.Core.Benchmarks.csproj -- --list flat
+```
+
+Release is not optional — BenchmarkDotNet refuses to measure an unoptimized build.
+
+There is also a `Benchmarks` workflow on GitHub Actions (`workflow_dispatch`) that runs the suite
+on demand and posts the tables to the run summary.
+
+### Measuring on .NET 9
+
+The project targets `net10.0` alone, so that `dotnet run -c Release` needs no `-f`. Measuring the
+library on `net9.0` as well is a BenchmarkDotNet job, not a second target framework — add
+`[SimpleJob(RuntimeMoniker.Net90)]` alongside `[SimpleJob(RuntimeMoniker.Net10_0)]` on the class
+you care about and one run reports both runtimes side by side.
+
+## What is measured, and why
+
+| Family | Covers | The ticket behind it |
+| --- | --- | --- |
+| `StreamDecodeBenchmarks` | A stream frame arriving and becoming per-channel samples: channel-snapshot caching, timestamp reconstruction, gap detection, analog and digital unpacking, event dispatch. | #490 (per-frame allocation), #531 (measuring it with the wrong instrument) |
+| `ProtobufFramingBenchmarks` | Varint length prefixes, frame boundaries, and the partial frame a read almost always ends on. | #490 |
+| `StreamConsumerBenchmarks` | The consumer's read/append/drain loop over a scripted stream that never hands out a whole frame. | #490 |
+| `SdCardParseBenchmarks` | All three log parsers, each measured twice: full drain (throughput) and time to first sample (latency). | #489 (parsers materialized the whole file before yielding anything) |
+| `ChannelScalingBenchmarks` | The two per-sample conversions — device calibration and the user's transducer transform. | #534 |
+
+The decode, framing and consumer families report **per frame** and the scaling family **per
+sample** (`OperationsPerInvoke`), so the figures can be read straight against a sample rate rather
+than divided first. The SD family reports per file.
+
+`StreamConsumerBenchmarks` prints a `MinIterationTime` advisory. That is expected: its iterations
+have to be whole drains of a scripted stream, which is tens of milliseconds rather than the 100 ms
+BenchmarkDotNet would prefer. The measurement is stable regardless — the standard deviation is
+well under 1% of the mean.
+
+**The allocation column is the one to watch.** Timings on a shared runner move with the weather;
+allocation does not. A change that reintroduces a per-frame allocation shows up as bytes-per-frame
+climbing, and that reads the same on any machine.
+
+## Not part of CI
+
+This is deliberately not wired into the pull-request build. Benchmark timings on shared GitHub
+runners are noisy enough that a perf gate would fail green PRs on a regular basis, which is
+exactly the flake pattern (#634, #632) the repo has spent effort getting out of. The suite runs on
+demand: before a release, or either side of a change that claims a performance win, with the table
+pasted into the ticket making the claim.
+
+If a gate is ever wanted, gate on allocation rather than time.
+
+## Baseline
+
+Taken on `main` at `2a59fd1`, so there is a *before* for the open performance tickets to be
+measured against.
+
+```
+BenchmarkDotNet v0.15.8, macOS Tahoe 26.5 (25F71) [Darwin 25.5.0]
+Apple M3 Pro, 1 CPU, 12 logical and 12 physical cores
+.NET SDK 10.0.203, .NET 10.0.7, Arm64 RyuJIT armv8.0-a
+```
+
+**Stream decode** — per frame, 16 analog channels (plus 16 DIO in the combined case):
+
+| Method | Mean | Allocated |
+| --- | ---: | ---: |
+| DecodeAnalogFloatFrame | 257.9 ns | 1.38 KB |
+| DecodeRawAnalogFrame | 332.2 ns | 1.38 KB |
+| DecodeCombinedFrame | 820.5 ns | 2.78 KB |
+
+**Protobuf framing** — per frame:
+
+| Method | Mean | Allocated |
+| --- | ---: | ---: |
+| ParseWholeFrames | 162.4 ns | 1.22 KB |
+| ParseWithTrailingPartialFrame | 166.2 ns | 1.22 KB |
+
+**Stream consumer** — per frame, end to end through the reader loop:
+
+| Method | Mean | Allocated |
+| --- | ---: | ---: |
+| ConsumeScriptedStream | 196.1 ns | 1.33 KB |
+
+**SD-card parsing** — per 10,000-row file, 8 analog channels:
+
+| Method | Mean | Allocated |
+| --- | ---: | ---: |
+| ProtobufDrainAll | 4,800 µs | 16,880 KB |
+| ProtobufTimeToFirstSample | 1,627 µs | 6,754 KB |
+| CsvDrainAll | 5,556 µs | 15,212 KB |
+| CsvTimeToFirstSample | 1.96 µs | 13.6 KB |
+| JsonDrainAll | 7,040 µs | 7,181 KB |
+| JsonTimeToFirstSample | 2.09 µs | 9.9 KB |
+
+**Channel scaling** — per sample:
+
+| Method | Mean | Allocated |
+| --- | ---: | ---: |
+| GetScaledValue | 4.26 ns | – |
+| ApplyTransducerScaling | 0.67 ns | – |
+| ApplyIdentityScaling | 0.67 ns | – |
+
+The absolute numbers are a property of this machine, not of the library. What travels between
+machines is the shape: the ratios between cases, and the allocation figures.
+
+### What the first run already showed
+
+The SD table has an outlier the harness was built to find. The CSV and JSON parsers hand back
+their first sample in about two microseconds; the protobuf parser takes **1.6 ms and 6.7 MB** —
+a third of the time and 40% of the allocation of draining the entire file. That is not the
+configuration pre-scan's message limit: dropping `ConfigurationScanMessageLimit` from 512 to 8
+changed nothing. It is `SdCardParseOptions.BufferSize`. The reader parses every message in a
+64 KB read before yielding the first one, and the configuration pass parses that same first chunk
+a second time. Filed as #697 rather than fixed here — this project's job was to make the number
+visible.

--- a/src/Daqifi.Core.Benchmarks/README.md
+++ b/src/Daqifi.Core.Benchmarks/README.md
@@ -87,39 +87,39 @@ Apple M3 Pro, 1 CPU, 12 logical and 12 physical cores
 
 | Method | Mean | Allocated |
 | --- | ---: | ---: |
-| DecodeAnalogFloatFrame | 257.9 ns | 1.38 KB |
-| DecodeRawAnalogFrame | 332.2 ns | 1.38 KB |
-| DecodeCombinedFrame | 820.5 ns | 2.78 KB |
+| DecodeAnalogFloatFrame | 257.7 ns | 1.38 KB |
+| DecodeRawAnalogFrame | 329.8 ns | 1.38 KB |
+| DecodeCombinedFrame | 814.6 ns | 2.78 KB |
 
 **Protobuf framing** — per frame:
 
 | Method | Mean | Allocated |
 | --- | ---: | ---: |
-| ParseWholeFrames | 162.4 ns | 1.22 KB |
-| ParseWithTrailingPartialFrame | 166.2 ns | 1.22 KB |
+| ParseWholeFrames | 164.4 ns | 1.22 KB |
+| ParseWithTrailingPartialFrame | 163.0 ns | 1.22 KB |
 
 **Stream consumer** — per frame, end to end through the reader loop:
 
 | Method | Mean | Allocated |
 | --- | ---: | ---: |
-| ConsumeScriptedStream | 196.1 ns | 1.33 KB |
+| ConsumeScriptedStream | 197.0 ns | 1.33 KB |
 
 **SD-card parsing** — per 10,000-row file, 8 analog channels:
 
 | Method | Mean | Allocated |
 | --- | ---: | ---: |
-| ProtobufDrainAll | 4,800 µs | 16,880 KB |
-| ProtobufTimeToFirstSample | 1,627 µs | 6,754 KB |
-| CsvDrainAll | 5,556 µs | 15,212 KB |
+| ProtobufDrainAll | 4,636 µs | 16,880 KB |
+| ProtobufTimeToFirstSample | 1,623 µs | 6,754 KB |
+| CsvDrainAll | 5,412 µs | 15,212 KB |
 | CsvTimeToFirstSample | 1.96 µs | 13.6 KB |
-| JsonDrainAll | 7,040 µs | 7,181 KB |
-| JsonTimeToFirstSample | 2.09 µs | 9.9 KB |
+| JsonDrainAll | 7,042 µs | 7,181 KB |
+| JsonTimeToFirstSample | 2.10 µs | 9.9 KB |
 
 **Channel scaling** — per sample:
 
 | Method | Mean | Allocated |
 | --- | ---: | ---: |
-| GetScaledValue | 4.26 ns | – |
+| GetScaledValue | 4.25 ns | – |
 | ApplyTransducerScaling | 0.67 ns | – |
 | ApplyIdentityScaling | 0.67 ns | – |
 

--- a/src/Daqifi.Core.Benchmarks/SdCardParseBenchmarks.cs
+++ b/src/Daqifi.Core.Benchmarks/SdCardParseBenchmarks.cs
@@ -1,0 +1,195 @@
+using System.Globalization;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device.SdCard;
+using Google.Protobuf;
+
+namespace Daqifi.Core.Benchmarks;
+
+/// <summary>
+/// The three SD-card log parsers — protobuf <c>.bin</c>, firmware <c>.csv</c>, and line-delimited
+/// <c>.json</c> — over the same logical recording in each format.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two numbers per format, because issue #489 changed one of them and not the other.
+/// <c>DrainAll</c> is throughput: how long a full export of the file takes.
+/// <c>TimeToFirstSample</c> is latency: how long a caller waits before the first
+/// <see cref="SdCardLogEntry"/> comes back. Before #489 every parser materialized the whole file
+/// first, so the two numbers were the same; they should now be far apart, and a regression that
+/// reintroduces up-front materialization shows up as the latency number climbing towards the
+/// throughput one rather than as anything getting slower.
+/// </para>
+/// <para>
+/// The files are synthetic but real-shaped: the same sample count, channel count and tick rate in
+/// all three formats, built once in <see cref="Setup"/> and re-read from memory per iteration so
+/// the disk is not part of the measurement.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class SdCardParseBenchmarks
+{
+    /// <summary>
+    /// Rows in the synthetic log. About ten seconds of a 1 kHz recording — big enough that the
+    /// per-row work dominates the fixed parse setup, small enough to keep an iteration in the
+    /// milliseconds.
+    /// </summary>
+    private const int RowCount = 10_000;
+
+    private const int AnalogChannelCount = 8;
+
+    private const uint TimestampFrequency = 50_000_000;
+
+    private const uint TicksPerRow = 50_000;
+
+    private byte[] _protobufLog = null!;
+    private byte[] _csvLog = null!;
+    private byte[] _jsonLog = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _protobufLog = BuildProtobufLog();
+        _csvLog = BuildCsvLog();
+        _jsonLog = BuildJsonLog();
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<int> ProtobufDrainAll() => await DrainAllAsync(_protobufLog, "log.bin");
+
+    [Benchmark]
+    public async Task<bool> ProtobufTimeToFirstSample() => await FirstSampleAsync(_protobufLog, "log.bin");
+
+    [Benchmark]
+    public async Task<int> CsvDrainAll() => await DrainAllAsync(_csvLog, "log.csv");
+
+    [Benchmark]
+    public async Task<bool> CsvTimeToFirstSample() => await FirstSampleAsync(_csvLog, "log.csv");
+
+    [Benchmark]
+    public async Task<int> JsonDrainAll() => await DrainAllAsync(_jsonLog, "log.json");
+
+    [Benchmark]
+    public async Task<bool> JsonTimeToFirstSample() => await FirstSampleAsync(_jsonLog, "log.json");
+
+    private static async Task<int> DrainAllAsync(byte[] log, string fileName)
+    {
+        using var stream = new MemoryStream(log, writable: false);
+        var session = await SdCardFileParserFactory.ParseAsync(stream, fileName);
+
+        var count = 0;
+        await foreach (var _ in session.Samples)
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static async Task<bool> FirstSampleAsync(byte[] log, string fileName)
+    {
+        using var stream = new MemoryStream(log, writable: false);
+        var session = await SdCardFileParserFactory.ParseAsync(stream, fileName);
+
+        await foreach (var _ in session.Samples)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static byte[] BuildProtobufLog()
+    {
+        using var buffer = new MemoryStream();
+
+        Append(buffer, new DaqifiOutMessage
+        {
+            AnalogInPortNum = AnalogChannelCount,
+            DigitalPortNum = 0,
+            AnalogInRes = 65535,
+            TimestampFreq = TimestampFrequency,
+            DevicePn = "Nyquist1",
+            DeviceFwRev = "3.7.2",
+            DeviceSn = 9090539562006014104,
+        });
+
+        for (var row = 0; row < RowCount; row++)
+        {
+            var message = new DaqifiOutMessage { MsgTimeStamp = (uint)(row + 1) * TicksPerRow };
+            for (var channel = 0; channel < AnalogChannelCount; channel++)
+            {
+                message.AnalogInData.Add(1_000 + channel + row % 97);
+            }
+
+            Append(buffer, message);
+        }
+
+        return buffer.ToArray();
+
+        static void Append(Stream destination, DaqifiOutMessage message)
+        {
+            var payload = message.ToByteArray();
+            var coded = new CodedOutputStream(destination, leaveOpen: true);
+            coded.WriteLength(payload.Length);
+            coded.Flush();
+            destination.Write(payload, 0, payload.Length);
+        }
+    }
+
+    private static byte[] BuildCsvLog()
+    {
+        // The firmware's own CSV shape: three comment lines, then interleaved per-channel
+        // (timestamp, raw ADC value) column pairs.
+        var text = new StringBuilder();
+        text.Append("# Device: Nyquist 1\n");
+        text.Append("# Serial Number: AABBCCDDEEFF0011\n");
+        text.Append(CultureInfo.InvariantCulture, $"# Timestamp Tick Rate: {TimestampFrequency} Hz\n");
+
+        for (var channel = 0; channel < AnalogChannelCount; channel++)
+        {
+            text.Append(CultureInfo.InvariantCulture, $"ch{channel}_ts,ch{channel}_val");
+            text.Append(channel == AnalogChannelCount - 1 ? '\n' : ',');
+        }
+
+        for (var row = 0; row < RowCount; row++)
+        {
+            var timestamp = (uint)(row + 1) * TicksPerRow;
+            for (var channel = 0; channel < AnalogChannelCount; channel++)
+            {
+                var value = 1_000 + channel + row % 97;
+                text.Append(CultureInfo.InvariantCulture, $"{timestamp},{value}.000000");
+                text.Append(channel == AnalogChannelCount - 1 ? '\n' : ',');
+            }
+        }
+
+        return new UTF8Encoding(false).GetBytes(text.ToString());
+    }
+
+    private static byte[] BuildJsonLog()
+    {
+        // One JSON object per line, which is what the firmware writes.
+        var text = new StringBuilder();
+
+        for (var row = 0; row < RowCount; row++)
+        {
+            var timestamp = (uint)(row + 1) * TicksPerRow;
+            text.Append(CultureInfo.InvariantCulture, $"{{\"ts\":{timestamp},\"analog\":[");
+
+            for (var channel = 0; channel < AnalogChannelCount; channel++)
+            {
+                var value = 1_000 + channel + row % 97;
+                text.Append(CultureInfo.InvariantCulture, $"{value}.000000");
+                if (channel != AnalogChannelCount - 1)
+                {
+                    text.Append(',');
+                }
+            }
+
+            text.Append("],\"digital\":\"00\"}\n");
+        }
+
+        return new UTF8Encoding(false).GetBytes(text.ToString());
+    }
+}

--- a/src/Daqifi.Core.Benchmarks/StreamConsumerBenchmarks.cs
+++ b/src/Daqifi.Core.Benchmarks/StreamConsumerBenchmarks.cs
@@ -1,0 +1,154 @@
+using BenchmarkDotNet.Attributes;
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Messages;
+
+namespace Daqifi.Core.Benchmarks;
+
+/// <summary>
+/// The consumer's own loop: read from the stream, append to the accumulation buffer, parse out
+/// whatever is complete, keep the remainder, dispatch. This is where the cost issue #490 attacked
+/// actually lives — the buffer copy per read, and the byte-at-a-time append that preceded it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The scripted stream hands out 511 bytes per read, which is deliberately not a multiple of the
+/// frame size, so nearly every read ends mid-frame and the partial-frame path runs constantly
+/// rather than once at the end.
+/// </para>
+/// <para>
+/// <b>What the measured window covers.</b> Only <see cref="IMessageConsumer{T}.Start"/> and the
+/// drain: the consumer, the stream and the subscriber are built in
+/// <see cref="IterationSetup"/> and torn down in <see cref="IterationCleanup"/>, neither of which
+/// BenchmarkDotNet measures. That is not tidiness. <c>Stop()</c> joins the reader thread, and by
+/// the time the last frame has been dispatched that thread has gone back for one more read, found
+/// the stream empty, and entered its 10 ms no-data backoff — so a <c>Stop()</c> inside the
+/// measured window contributes a flat ~10 ms that has nothing to do with framing. Measured that
+/// way this case read 43x the per-frame cost of the parser it wraps, essentially all of it the
+/// backoff.
+/// </para>
+/// <para>
+/// <b>What it costs that Core's own path does not.</b> The subscriber here attaches to the public
+/// <see cref="IMessageConsumer{T}.MessageReceived"/>, because that is the only completion signal a
+/// benchmark can see; Core's internals listen on the internal <c>MessageParsed</c> instead. The
+/// difference is not free — with a <c>MessageReceived</c> subscriber attached, every read
+/// snapshots the whole accumulation buffer into a fresh array for the event's <c>RawData</c>. So
+/// read this case as the cost to an application that subscribes, which is a real configuration,
+/// and not as what Core pays internally.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class StreamConsumerBenchmarks
+{
+    /// <summary>
+    /// Frames fed to the consumer per iteration. Sized so one iteration is tens of milliseconds of
+    /// real work: the thread start inside the measured window is then noise rather than the
+    /// measurement.
+    /// </summary>
+    private const int FrameCount = 100_000;
+
+    /// <summary>
+    /// Bytes handed out per read, chosen to be a non-multiple of the frame size so reads land
+    /// mid-frame the way a real USB read does.
+    /// </summary>
+    private const int ChunkSize = 511;
+
+    private byte[] _frames = null!;
+
+    private ChunkedStream _stream = null!;
+    private CountdownEvent _received = null!;
+    private StreamMessageConsumer<DaqifiOutMessage> _consumer = null!;
+
+    [GlobalSetup]
+    public void Setup() => _frames = SyntheticFrames.BuildFrameBuffer(FrameCount);
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _stream = new ChunkedStream(_frames, ChunkSize);
+        _received = new CountdownEvent(FrameCount);
+        _consumer = new StreamMessageConsumer<DaqifiOutMessage>(_stream, new ProtobufMessageParser());
+        _consumer.MessageReceived += OnMessageReceived;
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        _consumer.MessageReceived -= OnMessageReceived;
+        _consumer.Dispose();
+        _received.Dispose();
+        _stream.Dispose();
+    }
+
+    /// <summary>
+    /// Start the reader and wait for every frame to come back out.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = FrameCount)]
+    public void ConsumeScriptedStream()
+    {
+        _consumer.Start();
+
+        // Generous by two orders of magnitude: the work is tens of milliseconds. A timeout here
+        // means the benchmark would be measuring a stall, and reporting that as a number would be
+        // worse than failing.
+        if (!_received.Wait(TimeSpan.FromSeconds(30)))
+        {
+            throw new InvalidOperationException(
+                $"Only {FrameCount - _received.CurrentCount} of {FrameCount} frames were consumed.");
+        }
+    }
+
+    private void OnMessageReceived(object? sender, MessageReceivedEventArgs<DaqifiOutMessage> e)
+    {
+        // Guarded because the countdown must not be signalled past zero: the consumer dispatches
+        // on one thread, but a frame arriving after the last Signal would still throw.
+        if (!_received.IsSet)
+        {
+            _received.Signal();
+        }
+    }
+
+    /// <summary>
+    /// A read-only stream that hands out at most <c>chunkSize</c> bytes per read and then returns
+    /// zero, which the consumer treats as "nothing right now" rather than end-of-stream. Standing
+    /// in for a serial port; the point is that reads land mid-frame.
+    /// </summary>
+    private sealed class ChunkedStream(byte[] data, int chunkSize) : Stream
+    {
+        private int _position;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => data.Length;
+
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var available = Math.Min(Math.Min(count, chunkSize), data.Length - _position);
+            if (available <= 0)
+            {
+                return 0;
+            }
+
+            Array.Copy(data, _position, buffer, offset, available);
+            _position += available;
+            return available;
+        }
+
+        public override void Flush() { }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/Daqifi.Core.Benchmarks/StreamDecodeBenchmarks.cs
+++ b/src/Daqifi.Core.Benchmarks/StreamDecodeBenchmarks.cs
@@ -1,0 +1,197 @@
+using BenchmarkDotNet.Attributes;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using Google.Protobuf;
+
+namespace Daqifi.Core.Benchmarks;
+
+/// <summary>
+/// The library's hot loop: a decoded <see cref="DaqifiOutMessage"/> frame going in and per-channel
+/// <see cref="IChannel.SampleReceived"/> samples coming out.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Measured through <c>OnStreamMessageReceived</c> on a real <see cref="DaqifiStreamingDevice"/>
+/// rather than against the internal decoder directly, because that is the whole path a consumer
+/// pays for: the channel-snapshot cache, timestamp reconstruction, gap detection, the analog and
+/// digital unpacking, and the per-sample event dispatch. Nothing is stubbed except the transport,
+/// which is absent — frames are injected the way the live-stream tests inject them.
+/// </para>
+/// <para>
+/// Every case reports per <em>frame</em>, not per invocation
+/// (<see cref="BenchmarkAttribute.OperationsPerInvoke"/>), so the numbers can be read directly
+/// against a sample rate: at 1 kHz with 16 channels the device emits a frame every millisecond.
+/// The allocation column is the one worth watching. Issue #490 removed per-frame allocation from
+/// this path and #531 showed how badly a correctness test measures it; a regression here shows up
+/// as bytes per frame climbing off zero.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class StreamDecodeBenchmarks
+{
+    /// <summary>
+    /// Frames decoded per invocation. Large enough that the per-invocation overhead BenchmarkDotNet
+    /// cannot subtract is negligible against the work, small enough that the pre-built frame array
+    /// stays in cache-friendly territory.
+    /// </summary>
+    private const int FrameCount = 1_000;
+
+    /// <summary>
+    /// The enabled analog channel count. Sixteen is a fully populated Nyquist.
+    /// </summary>
+    private const int AnalogChannelCount = 16;
+
+    /// <summary>
+    /// The enabled digital channel count for the combined case. Sixteen DIO is a Nyquist, and it
+    /// makes the digital payload two bytes, so the byte-and-bit indexing runs for real.
+    /// </summary>
+    private const int DigitalChannelCount = 16;
+
+    /// <summary>
+    /// Device-clock ticks between frames, at the 50 MHz timestamp frequency the hardware reports.
+    /// 50,000 ticks is 1 ms — a 1 kHz stream, which is what the gap detector is fed here.
+    /// </summary>
+    private const uint TicksPerFrame = 50_000;
+
+    private BenchmarkStreamingDevice _floatDevice = null!;
+    private BenchmarkStreamingDevice _rawDevice = null!;
+    private BenchmarkStreamingDevice _combinedDevice = null!;
+
+    private DaqifiOutMessage[] _floatFrames = null!;
+    private DaqifiOutMessage[] _rawFrames = null!;
+    private DaqifiOutMessage[] _combinedFrames = null!;
+
+    /// <summary>
+    /// Sink for the subscriber below, so the JIT cannot decide the sample never escapes and elide
+    /// the work that produced it.
+    /// </summary>
+    private double _sink;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _floatFrames = BuildFrames(analogFloat: true, digital: false);
+        _rawFrames = BuildFrames(analogFloat: false, digital: false);
+        _combinedFrames = BuildFrames(analogFloat: true, digital: true);
+
+        _floatDevice = CreateDevice(digitalPortCount: 0);
+        _rawDevice = CreateDevice(digitalPortCount: 0);
+        _combinedDevice = CreateDevice(digitalPortCount: DigitalChannelCount);
+    }
+
+    /// <summary>
+    /// The common shape: the firmware's fast streaming encoder sends calibrated floats.
+    /// </summary>
+    [Benchmark(Baseline = true, OperationsPerInvoke = FrameCount)]
+    public void DecodeAnalogFloatFrame() => Decode(_floatDevice, _floatFrames);
+
+    /// <summary>
+    /// The same frame carrying raw ADC counts instead, which routes each value through
+    /// <see cref="IAnalogChannel.GetScaledValue"/> — the per-sample calibration arithmetic.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = FrameCount)]
+    public void DecodeRawAnalogFrame() => Decode(_rawDevice, _rawFrames);
+
+    /// <summary>
+    /// Analog and digital in one frame, the shape a stream with DIO enabled produces.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = FrameCount)]
+    public void DecodeCombinedFrame() => Decode(_combinedDevice, _combinedFrames);
+
+    private static void Decode(BenchmarkStreamingDevice device, DaqifiOutMessage[] frames)
+    {
+        for (var i = 0; i < frames.Length; i++)
+        {
+            device.InjectStreamFrame(frames[i]);
+        }
+    }
+
+    private BenchmarkStreamingDevice CreateDevice(int digitalPortCount)
+    {
+        var device = new BenchmarkStreamingDevice();
+        device.Connect();
+        device.PopulateChannelsFromStatus(StatusMessage(digitalPortCount));
+
+        foreach (var channel in device.Channels)
+        {
+            channel.IsEnabled = true;
+
+            // An honest consumer, not an empty one: a real subscriber reads the value, and the
+            // per-sample event args are allocated for whoever is listening either way.
+            channel.SampleReceived += (_, e) => _sink = e.Sample.Value;
+        }
+
+        device.StartStreaming();
+        return device;
+    }
+
+    private static DaqifiOutMessage StatusMessage(int digitalPortCount)
+    {
+        var status = new DaqifiOutMessage
+        {
+            AnalogInPortNum = AnalogChannelCount,
+            DigitalPortNum = (uint)digitalPortCount,
+            AnalogInRes = 65535,
+            TimestampFreq = 50_000_000,
+        };
+
+        for (var i = 0; i < AnalogChannelCount; i++)
+        {
+            status.AnalogInPortRange.Add(5.0f);
+            status.AnalogInCalM.Add(1.0f);
+            status.AnalogInCalB.Add(0.0f);
+            status.AnalogInIntScaleM.Add(1.0f);
+        }
+
+        return status;
+    }
+
+    private static DaqifiOutMessage[] BuildFrames(bool analogFloat, bool digital)
+    {
+        var frames = new DaqifiOutMessage[FrameCount];
+
+        for (var frame = 0; frame < FrameCount; frame++)
+        {
+            var message = new DaqifiOutMessage
+            {
+                // A real device's tick counter advances between frames, so the gap detector and the
+                // timestamp reconstructor do their real work rather than seeing the same tick twice.
+                MsgTimeStamp = (uint)(frame + 1) * TicksPerFrame,
+            };
+
+            for (var channel = 0; channel < AnalogChannelCount; channel++)
+            {
+                if (analogFloat)
+                {
+                    message.AnalogInDataFloat.Add(1.0f + channel * 0.01f);
+                }
+                else
+                {
+                    message.AnalogInData.Add(1_000 + channel);
+                }
+            }
+
+            if (digital)
+            {
+                message.DigitalData = ByteString.CopyFrom(new[] { (byte)(frame & 0xFF), (byte)0x0F });
+            }
+
+            frames[frame] = message;
+        }
+
+        return frames;
+    }
+
+    /// <summary>
+    /// A streaming device with no transport whose frames are injected directly, mirroring the
+    /// double the live-stream tests use. <c>Send</c> is overridden because there is nothing to
+    /// send to.
+    /// </summary>
+    private sealed class BenchmarkStreamingDevice() : DaqifiStreamingDevice("BenchmarkDevice")
+    {
+        public void InjectStreamFrame(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+
+        public override void Send<T>(IOutboundMessage<T> message) { /* no transport */ }
+    }
+}

--- a/src/Daqifi.Core.Benchmarks/StreamDecodeBenchmarks.cs
+++ b/src/Daqifi.Core.Benchmarks/StreamDecodeBenchmarks.cs
@@ -54,13 +54,9 @@ public class StreamDecodeBenchmarks
     /// </summary>
     private const uint TicksPerFrame = 50_000;
 
-    private BenchmarkStreamingDevice _floatDevice = null!;
-    private BenchmarkStreamingDevice _rawDevice = null!;
-    private BenchmarkStreamingDevice _combinedDevice = null!;
-
-    private DaqifiOutMessage[] _floatFrames = null!;
-    private DaqifiOutMessage[] _rawFrames = null!;
-    private DaqifiOutMessage[] _combinedFrames = null!;
+    private DecodeCase _float = null!;
+    private DecodeCase _raw = null!;
+    private DecodeCase _combined = null!;
 
     /// <summary>
     /// Sink for the subscriber below, so the JIT cannot decide the sample never escapes and elide
@@ -71,41 +67,31 @@ public class StreamDecodeBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        _floatFrames = BuildFrames(analogFloat: true, digital: false);
-        _rawFrames = BuildFrames(analogFloat: false, digital: false);
-        _combinedFrames = BuildFrames(analogFloat: true, digital: true);
-
-        _floatDevice = CreateDevice(digitalPortCount: 0);
-        _rawDevice = CreateDevice(digitalPortCount: 0);
-        _combinedDevice = CreateDevice(digitalPortCount: DigitalChannelCount);
+        _float = new DecodeCase(CreateDevice(digitalPortCount: 0), BuildFrames(analogFloat: true, digital: false));
+        _raw = new DecodeCase(CreateDevice(digitalPortCount: 0), BuildFrames(analogFloat: false, digital: false));
+        _combined = new DecodeCase(
+            CreateDevice(digitalPortCount: DigitalChannelCount),
+            BuildFrames(analogFloat: true, digital: true));
     }
 
     /// <summary>
     /// The common shape: the firmware's fast streaming encoder sends calibrated floats.
     /// </summary>
     [Benchmark(Baseline = true, OperationsPerInvoke = FrameCount)]
-    public void DecodeAnalogFloatFrame() => Decode(_floatDevice, _floatFrames);
+    public void DecodeAnalogFloatFrame() => _float.Replay();
 
     /// <summary>
     /// The same frame carrying raw ADC counts instead, which routes each value through
     /// <see cref="IAnalogChannel.GetScaledValue"/> — the per-sample calibration arithmetic.
     /// </summary>
     [Benchmark(OperationsPerInvoke = FrameCount)]
-    public void DecodeRawAnalogFrame() => Decode(_rawDevice, _rawFrames);
+    public void DecodeRawAnalogFrame() => _raw.Replay();
 
     /// <summary>
     /// Analog and digital in one frame, the shape a stream with DIO enabled produces.
     /// </summary>
     [Benchmark(OperationsPerInvoke = FrameCount)]
-    public void DecodeCombinedFrame() => Decode(_combinedDevice, _combinedFrames);
-
-    private static void Decode(BenchmarkStreamingDevice device, DaqifiOutMessage[] frames)
-    {
-        for (var i = 0; i < frames.Length; i++)
-        {
-            device.InjectStreamFrame(frames[i]);
-        }
-    }
+    public void DecodeCombinedFrame() => _combined.Replay();
 
     private BenchmarkStreamingDevice CreateDevice(int digitalPortCount)
     {
@@ -153,12 +139,9 @@ public class StreamDecodeBenchmarks
 
         for (var frame = 0; frame < FrameCount; frame++)
         {
-            var message = new DaqifiOutMessage
-            {
-                // A real device's tick counter advances between frames, so the gap detector and the
-                // timestamp reconstructor do their real work rather than seeing the same tick twice.
-                MsgTimeStamp = (uint)(frame + 1) * TicksPerFrame,
-            };
+            // The timestamp is not set here: DecodeCase.Replay stamps every frame as it goes, so
+            // the clock keeps advancing across invocations instead of restarting each time.
+            var message = new DaqifiOutMessage();
 
             for (var channel = 0; channel < AnalogChannelCount; channel++)
             {
@@ -181,6 +164,46 @@ public class StreamDecodeBenchmarks
         }
 
         return frames;
+    }
+
+    /// <summary>
+    /// One decode case: a device, the frames replayed into it, and the device clock those frames
+    /// are stamped with.
+    /// </summary>
+    /// <remarks>
+    /// The clock is the reason this is a class rather than two fields. BenchmarkDotNet invokes a
+    /// benchmark many times against the same instance, so a fixed set of timestamps baked into the
+    /// frames would restart the device clock at the top of every invocation — and the decoder is
+    /// stateful. Its timestamp anchor and gap detector would see a large backwards step once per
+    /// invocation, putting the first frame of each invocation down a different path from the other
+    /// 999 and making the first invocation differ from the rest.
+    ///
+    /// Stamping each frame as it is replayed keeps the clock monotonic for the whole run, so the
+    /// device looks like one long 1 kHz acquisition — including the genuine 32-bit tick rollover
+    /// every ~86 seconds of device time, which is a case the decoder is built to handle rather
+    /// than an artefact of the harness. The cost inside the measured loop is one addition and one
+    /// field write per frame, sub-nanosecond against a ~260 ns decode, and it allocates nothing.
+    /// </remarks>
+    private sealed class DecodeCase(BenchmarkStreamingDevice device, DaqifiOutMessage[] frames)
+    {
+        private uint _deviceTicks;
+
+        public void Replay()
+        {
+            for (var i = 0; i < frames.Length; i++)
+            {
+                // Deliberately unchecked: the device's tick counter is a rolling 32-bit value and
+                // wrapping is what it really does.
+                unchecked
+                {
+                    _deviceTicks += TicksPerFrame;
+                }
+
+                var frame = frames[i];
+                frame.MsgTimeStamp = _deviceTicks;
+                device.InjectStreamFrame(frame);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Benchmarks/SyntheticFrames.cs
+++ b/src/Daqifi.Core.Benchmarks/SyntheticFrames.cs
@@ -1,0 +1,58 @@
+using Daqifi.Core.Communication.Messages;
+using Google.Protobuf;
+
+namespace Daqifi.Core.Benchmarks;
+
+/// <summary>
+/// Builds the on-the-wire byte buffers the framing and consumer benchmarks read from: varint32
+/// length-prefixed <see cref="DaqifiOutMessage"/> frames, the way the device sends them.
+/// </summary>
+internal static class SyntheticFrames
+{
+    /// <summary>
+    /// Analog channels per frame. Sixteen is a fully populated Nyquist, and it sets the frame size
+    /// that decides how many frames land in one read.
+    /// </summary>
+    public const int AnalogChannelCount = 16;
+
+    /// <summary>
+    /// Device-clock ticks between frames: 50,000 at the hardware's 50 MHz timestamp frequency, so
+    /// the synthetic stream is a 1 kHz one.
+    /// </summary>
+    private const uint TicksPerFrame = 50_000;
+
+    /// <summary>
+    /// A buffer of <paramref name="frameCount"/> length-prefixed frames.
+    /// </summary>
+    /// <param name="frameCount">How many frames to write.</param>
+    /// <param name="truncateLastFrame">
+    /// When true the final frame's payload is cut in half after its length prefix has been written,
+    /// producing the partial frame a read that lands mid-frame leaves behind. The prefix is
+    /// deliberately intact: a parser must decline the frame because the bytes have not arrived yet,
+    /// not because the prefix is malformed.
+    /// </param>
+    public static byte[] BuildFrameBuffer(int frameCount, bool truncateLastFrame = false)
+    {
+        using var buffer = new MemoryStream();
+
+        for (var frame = 0; frame < frameCount; frame++)
+        {
+            var message = new DaqifiOutMessage { MsgTimeStamp = (uint)(frame + 1) * TicksPerFrame };
+            for (var channel = 0; channel < AnalogChannelCount; channel++)
+            {
+                message.AnalogInDataFloat.Add(1.0f + channel * 0.01f);
+            }
+
+            var payload = message.ToByteArray();
+            var coded = new CodedOutputStream(buffer, leaveOpen: true);
+            coded.WriteLength(payload.Length);
+            coded.Flush();
+
+            var isLast = frame == frameCount - 1;
+            var length = truncateLastFrame && isLast ? payload.Length / 2 : payload.Length;
+            buffer.Write(payload, 0, length);
+        }
+
+        return buffer.ToArray();
+    }
+}

--- a/src/Daqifi.Core.Tests/Build/BenchmarkProjectTests.cs
+++ b/src/Daqifi.Core.Tests/Build/BenchmarkProjectTests.cs
@@ -1,0 +1,78 @@
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace Daqifi.Core.Tests.Build;
+
+/// <summary>
+/// Guards the two things issue #640 asked the benchmark harness to stay out of: the test path and
+/// the pack path.
+/// </summary>
+/// <remarks>
+/// Both are one MSBuild property, and both fail quietly rather than loudly if the property goes
+/// missing. Without <c>IsTestProject=false</c>, CI's <c>dotnet test Daqifi.Core.sln</c> walks into
+/// a console project and asks it for tests; without <c>IsPackable=false</c>, the repo-root
+/// <c>Directory.Build.targets</c> starts attaching package metadata to a measuring instrument and
+/// a <c>dotnet pack</c> of the solution produces a Daqifi.Core.Benchmarks package. Neither would be
+/// noticed by anything else here.
+/// </remarks>
+public class BenchmarkProjectTests
+{
+    private static string RepositoryRoot =>
+        Path.GetFullPath(
+            typeof(BenchmarkProjectTests).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(a => a.Key == "RepositoryRoot")
+                .Value!);
+
+    private static string BenchmarkProjectPath =>
+        Path.Combine(RepositoryRoot, "src", "Daqifi.Core.Benchmarks", "Daqifi.Core.Benchmarks.csproj");
+
+    /// <summary>
+    /// The value of a property in the benchmark project, or <see langword="null"/> if it declares
+    /// none. Element names are matched case-insensitively because MSBuild property names are.
+    /// </summary>
+    private static string? PropertyValue(string name) =>
+        XDocument.Load(BenchmarkProjectPath)
+            .Descendants("PropertyGroup")
+            .Elements()
+            .Where(e => e.Name.LocalName.Equals(name, StringComparison.OrdinalIgnoreCase))
+            .Select(e => e.Value.Trim())
+            .LastOrDefault();
+
+    [Fact]
+    public void TheBenchmarkProjectExists()
+    {
+        // Anti-vacuity: every assertion below reads this file, so a moved or renamed project would
+        // otherwise make them fail for the wrong reason - or, if the reads were made forgiving,
+        // pass by finding nothing.
+        Assert.True(File.Exists(BenchmarkProjectPath),
+            $"Expected the benchmark harness at {BenchmarkProjectPath} (issue #640).");
+    }
+
+    [Fact]
+    public void TheBenchmarkProjectIsExcludedFromTheTestPath()
+    {
+        Assert.Equal("false", PropertyValue("IsTestProject"), ignoreCase: true);
+    }
+
+    [Fact]
+    public void TheBenchmarkProjectIsExcludedFromThePackPath()
+    {
+        Assert.Equal("false", PropertyValue("IsPackable"), ignoreCase: true);
+    }
+
+    [Fact]
+    public void TheBenchmarkProjectReferencesBenchmarkDotNet()
+    {
+        // The harness is only a harness because of this reference: without it the project would
+        // still build, still be excluded from test and pack, and measure nothing.
+        var references = XDocument.Load(BenchmarkProjectPath)
+            .Descendants()
+            .Where(e => e.Name.LocalName.Equals("PackageReference", StringComparison.OrdinalIgnoreCase))
+            .Select(e => e.Attributes()
+                .FirstOrDefault(a => a.Name.LocalName.Equals("Include", StringComparison.OrdinalIgnoreCase))?.Value)
+            .Where(id => id is not null);
+
+        Assert.Contains("BenchmarkDotNet", references);
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
+++ b/src/Daqifi.Core.Tests/Device/AcquisitionStatisticsTests.cs
@@ -529,6 +529,14 @@ namespace Daqifi.Core.Tests.Device
 
         #region Cost
 
+        // The two tests below are coarse guards, not instruments. They answer one yes/no question
+        // each - does this allocate per call, and does attaching the aggregator cost the decode
+        // path anything - and they answer it with a hand-rolled warmup on whatever machine the
+        // suite happens to be running on, which is exactly the arrangement issue #531 was filed
+        // about. The instrument is src/Daqifi.Core.Benchmarks (issue #640): StreamDecodeBenchmarks
+        // reports allocation per frame under [MemoryDiagnoser], with BenchmarkDotNet handling
+        // warmup and tiering. Take a number from there; take a pass/fail from here.
+
         [Fact]
         public void Record_AfterTheFirstSamplePerChannel_AllocatesNothing()
         {


### PR DESCRIPTION
## What was wrong

This repo has nine performance tickets and every one of them states a number — "~700 ms of fixed
overhead per SCPI exchange", "~1 s per port wasted on teardown", "the decode path allocates per
frame". Each of those numbers was produced by hand, once, on whoever's machine was handy. None of
them can be reproduced today, none of the wins has a guard, and the two tickets still open (#485,
#491) have no *before* to prove a fix against. The one attempt at pinning a number in place —
#531's allocation assertion written as a `[Fact]` — went flaky precisely because a correctness
test is the wrong instrument for measuring allocation.

## How it was fixed

A `src/Daqifi.Core.Benchmarks` project running BenchmarkDotNet over the paths those tickets
identified: stream frame decode, protobuf framing, the consumer's read/append/drain loop, all
three SD-card log parsers (each measured twice — full drain and time to first sample), and the two
per-sample scaling conversions. Everything reports under `[MemoryDiagnoser]`, and the decode,
framing and consumer families report per *frame*, so a number can be read straight against a
sample rate. Baseline figures for `main` are in the project README.

It runs on demand only — a new `Benchmarks` workflow with `workflow_dispatch` — and deliberately
does not gate pull requests. Timings on shared GitHub runners are noisy enough that a perf gate
would fail green PRs regularly, which is the exact flake pattern (#634, #632) this repo has spent
real effort escaping. If a gate is ever wanted, allocation is the number to gate on, not
milliseconds.

Two things a reviewer might push back on, so they are stated plainly:

- **It found a bug, and I did not fix it here.** The protobuf SD parser hands back its first
  sample after 1.6 ms and 6.7 MB where CSV and JSON take about 2 µs. That is not the configuration
  pre-scan (dropping its message limit from 512 to 8 changed nothing) — it is `BufferSize`: the
  reader parses every message in a 64 KB read before yielding the first, and the configuration
  pass parses that same chunk again. Filed as **#697**. Fixing it in this PR would have mixed
  "build the instrument" with "act on what it read".
- **The `[Fact]` from #531 stays.** A later PR already stabilized it, and it is a perfectly good
  coarse pass/fail guard. What it was never good at is producing a *number*, so it now carries a
  comment pointing at this project for that. Deleting a green test to satisfy a checkbox seemed
  worse than leaving it and saying what each instrument is for.

The project is out of `dotnet test` (`IsTestProject=false`) and out of pack
(`IsPackable=false`), each guarded by a test, because both would fail quietly: without the first,
CI's `dotnet test Daqifi.Core.sln` starts asking a console project for tests; without the second,
`dotnet pack` starts producing a Daqifi.Core.Benchmarks package.

## Verification

- Full solution green on both frameworks: **4,096 passed / 3 skipped** on net9.0 and net10.0, plus
  217 Mcp tests each. `dotnet test Daqifi.Core.sln` walks past the new project without touching it,
  which is the behaviour the guard test pins.
- The suite itself runs clean end to end (15 benchmarks, ~4.5 min); every table in the README is
  from an actual run on this branch's code.
- No production code changed — the only edit outside the new project is a comment in
  `AcquisitionStatisticsTests` — so no bench validation applies.

closes #640

Not merging — this is for your review.
