### PR TITLE
perf(sdcard): stop the protobuf log parser decoding a whole 64 KB buffer before its first sample

### DIFF
--- a/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserSteppingTests.cs
+++ b/src/Daqifi.Core.Tests/Communication/Consumers/ProtobufMessageParserSteppingTests.cs
@@ -1,0 +1,197 @@
+using System.Text;
+using Daqifi.Core.Communication.Consumers;
+using Daqifi.Core.Communication.Messages;
+using Google.Protobuf;
+
+namespace Daqifi.Core.Tests.Communication.Consumers;
+
+/// <summary>
+/// Covers <see cref="ProtobufMessageParser.TryReadFrame"/>, the stepping entry point added for
+/// issue #697 so <c>SdCardFileParser</c> can take one frame at a time instead of paying for a
+/// whole 64 KB read buffer before its first sample.
+/// </summary>
+/// <remarks>
+/// Stepping and <see cref="ProtobufMessageParser.ParseMessages(byte[], out int)"/> run the same
+/// frame-boundary code, so the risk this file guards is that they stop doing so: the resync,
+/// gap-gate and leading-noise rules are subtle and were arrived at through four separate field
+/// failures (#268 among them). The equivalence theory below is therefore the important test —
+/// it re-runs the whole existing corpus of awkward buffers through the stepping API and demands
+/// the same frames and the same consumed count.
+/// </remarks>
+public class ProtobufMessageParserSteppingTests
+{
+    [Fact]
+    public void TryReadFrame_WithMultipleFrames_ReturnsOneFramePerStep()
+    {
+        // The property the SD card parser depends on: asking for a frame decodes one frame,
+        // not every frame in the buffer. Before #697 the only entry point parsed the lot.
+        var parser = new ProtobufMessageParser();
+        var data = Frames(7, 9, 11);
+
+        var offset = 0;
+        var timestamps = new List<uint>();
+
+        for (var i = 0; i < 3; i++)
+        {
+            var step = parser.TryReadFrame(data, offset, timestamps.Count > 0, out var frame, out var nextOffset);
+
+            Assert.Equal(ProtobufFrameStep.Frame, step);
+            Assert.NotNull(frame);
+            Assert.True(nextOffset > offset, "A decoded frame must advance the offset.");
+
+            timestamps.Add(frame!.MsgTimeStamp);
+            offset = nextOffset;
+        }
+
+        Assert.Equal(new uint[] { 7, 9, 11 }, timestamps);
+
+        // Exhausted, and the whole buffer was consumed.
+        var end = parser.TryReadFrame(data, offset, anyFrameRead: true, out var none, out var endOffset);
+        Assert.Equal(ProtobufFrameStep.EndOfBuffer, end);
+        Assert.Null(none);
+        Assert.Equal(offset, endOffset);
+        Assert.Equal(data.Length, offset);
+    }
+
+    [Fact]
+    public void TryReadFrame_StoppingEarly_DecodesNothingBeyondTheFrameItWasAskedFor()
+    {
+        // The stepper is only useful if abandoning it costs nothing further. A buffer whose
+        // tail is unparseable garbage still hands back the leading frame, because that tail is
+        // never looked at: had the parser decoded ahead, the garbage would be in its way.
+        var parser = new ProtobufMessageParser();
+        var data = Frames(42).Concat(Enumerable.Repeat((byte)0xFF, 4096)).ToArray();
+
+        var step = parser.TryReadFrame(data, 0, anyFrameRead: false, out var frame, out _);
+
+        Assert.Equal(ProtobufFrameStep.Frame, step);
+        Assert.Equal(42u, frame!.MsgTimeStamp);
+    }
+
+    [Fact]
+    public void TryReadFrame_WithTrailingPartialFrame_PreservesItInsteadOfAdvancing()
+    {
+        // A frame split across reads must be left for the caller to complete, so EndOfBuffer
+        // reports the offset unchanged — that is what makes nextOffset double as the consumed
+        // count for the caller's carry-over buffer.
+        var parser = new ProtobufMessageParser();
+        var whole = Frames(7, 9);
+
+        // One byte short, so the second frame is genuinely incomplete rather than absent.
+        var truncated = whole[..^1];
+
+        var first = parser.TryReadFrame(truncated, 0, anyFrameRead: false, out _, out var offset);
+        Assert.Equal(ProtobufFrameStep.Frame, first);
+
+        var step = parser.TryReadFrame(truncated, offset, anyFrameRead: true, out var frame, out var nextOffset);
+
+        Assert.Equal(ProtobufFrameStep.EndOfBuffer, step);
+        Assert.Null(frame);
+        Assert.Equal(offset, nextOffset);
+        Assert.True(offset < truncated.Length, "The partial frame's bytes must be left unconsumed.");
+    }
+
+    [Fact]
+    public void TryReadFrame_AnyFrameRead_GatesLeadingNoiseRecovery()
+    {
+        // anyFrameRead is not cosmetic: it selects whether the expensive scan-ahead for a real
+        // frame behind leading noise runs (#268). A caller stepping through one buffer must
+        // therefore pass "have I taken a frame from THIS buffer", and reset per buffer — which
+        // is why SdCardFileParser counts frames per chunk rather than for the whole file.
+        var parser = new ProtobufMessageParser();
+        var data = Encoding.ASCII.GetBytes("SYSTem:SYSInfoPB?\r\n").Concat(Frames(42)).ToArray();
+
+        // No frame taken yet: the noise is recognized and skipped.
+        var recovering = parser.TryReadFrame(data, 0, anyFrameRead: false, out _, out var recoveredOffset);
+        Assert.Equal(ProtobufFrameStep.Resync, recovering);
+        Assert.True(recoveredOffset > 0);
+
+        // Told a frame was already taken, the same position reads as a partial frame still
+        // arriving, and is preserved rather than skipped.
+        var waiting = parser.TryReadFrame(data, 0, anyFrameRead: true, out var frame, out var waitingOffset);
+        Assert.Equal(ProtobufFrameStep.EndOfBuffer, waiting);
+        Assert.Null(frame);
+        Assert.Equal(0, waitingOffset);
+    }
+
+    [Theory]
+    [MemberData(nameof(AwkwardBuffers))]
+    public void TryReadFrame_SteppedToExhaustion_AgreesWithParseMessages(string because, byte[] data)
+    {
+        // ParseMessages is itself a loop over the stepper, so this pins that the two stay one
+        // implementation — including for the buffers that motivated the resync rules.
+        var expected = new ProtobufMessageParser().ParseMessages(data, out var expectedConsumed);
+        var expectedTimestamps = expected.Select(m => m.Data.MsgTimeStamp).ToArray();
+
+        var parser = new ProtobufMessageParser();
+        var actualTimestamps = new List<uint>();
+        var offset = 0;
+        var consumed = 0;
+
+        while (true)
+        {
+            var step = parser.TryReadFrame(data, offset, actualTimestamps.Count > 0, out var frame, out var nextOffset);
+            if (step == ProtobufFrameStep.EndOfBuffer)
+            {
+                break;
+            }
+
+            offset = nextOffset;
+            consumed = nextOffset;
+
+            if (step == ProtobufFrameStep.Frame)
+            {
+                actualTimestamps.Add(frame!.MsgTimeStamp);
+            }
+        }
+
+        Assert.True(
+            expectedTimestamps.SequenceEqual(actualTimestamps),
+            $"Stepping disagreed with ParseMessages on the frames of {because}: " +
+            $"expected [{string.Join(", ", expectedTimestamps)}], got [{string.Join(", ", actualTimestamps)}].");
+        Assert.True(
+            expectedConsumed == consumed,
+            $"Stepping disagreed with ParseMessages on the consumed byte count of {because}: " +
+            $"expected {expectedConsumed}, got {consumed}.");
+    }
+
+    public static TheoryData<string, byte[]> AwkwardBuffers()
+    {
+        var frame = Frames(42);
+
+        return new TheoryData<string, byte[]>
+        {
+            { "empty buffer", [] },
+            { "a single clean frame", frame },
+            { "several clean frames", Frames(7, 9, 11) },
+            { "invalid data only", [0xFF, 0xFF, 0xFF, 0xFF] },
+            { "null-byte run then a frame", Enumerable.Repeat((byte)0x00, 20).Concat(frame).ToArray() },
+            { "a frame truncated mid-body", frame[..^1] },
+            { "a length prefix and nothing else", [frame[0]] },
+            {
+                "echoed command text wrapping a frame (#268)",
+                Encoding.ASCII.GetBytes("SYSTem:SYSInfoPB?\r\n")
+                    .Concat(frame)
+                    .Concat(Encoding.ASCII.GetBytes("\r\nDAQIFI>"))
+                    .ToArray()
+            },
+            { "a complete frame followed by a partial one", Frames(7).Concat(Frames(9)[..^2]).ToArray() },
+            { "garbage claiming a multi-KB body", new byte[] { 0xFF, 0xFF, 0x03, 0x08 } },
+            { "trailing garbage after a good frame", frame.Concat(Enumerable.Repeat((byte)0xFF, 64)).ToArray() },
+        };
+    }
+
+    /// <summary>
+    /// Builds a buffer of length-delimited frames, one per supplied timestamp.
+    /// </summary>
+    private static byte[] Frames(params uint[] timestamps)
+    {
+        using var stream = new MemoryStream();
+        foreach (var timestamp in timestamps)
+        {
+            new DaqifiOutMessage { MsgTimeStamp = timestamp }.WriteDelimitedTo(stream);
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/src/Daqifi.Core.Tests/Device/SdCard/SdCardStreamingParseTests.cs
+++ b/src/Daqifi.Core.Tests/Device/SdCard/SdCardStreamingParseTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device.SdCard;
 using Xunit;
 
@@ -147,6 +148,83 @@ public class SdCardStreamingParseTests
 
         // Bounding the config scan must not cost samples.
         Assert.Equal(41, (await ToListAsync(boundedSession.Samples)).Count);
+    }
+
+    [Fact]
+    public async Task ParseAsync_StatusMessageStatesTheClock_ConfigScanStopsAtIt()
+    {
+        // Issue #697. When the log opens with a status message that states the timestamp clock,
+        // that message settles the configuration on its own — the embedded-field scan over the
+        // following messages is skipped, and whatever it would have found is discarded unread.
+        // The scan used to read ConfigurationScanMessageLimit messages (512 by default) anyway,
+        // so opening such a log decoded 512 messages and threw 511 of them away before the
+        // caller saw a single sample.
+        //
+        // A small read buffer turns that into a byte count: stopping at the status message is
+        // one buffer, while grinding through the whole look-ahead window is dozens.
+        var builder = new SdCardTestFileBuilder();
+        builder.AddMessage(SdCardTestFileBuilder.CreateStatusMessage(timestampFreq: 1000));
+        for (var i = 0; i < 2_000; i++)
+        {
+            builder.AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: (uint)((i + 1) * 1000),
+                analogFloatValues: new[] { (float)i }));
+        }
+
+        using var inner = builder.Build();
+        await using var counting = new CountingStream(inner);
+
+        const int bufferSize = 256;
+        var session = await new SdCardFileParser().ParseAsync(
+            counting, "status_first.bin", new SdCardParseOptions { BufferSize = bufferSize });
+
+        var enumerator = session.Samples.GetAsyncEnumerator();
+        await using (enumerator.ConfigureAwait(false))
+        {
+            Assert.True(await enumerator.MoveNextAsync());
+        }
+
+        // The config pass stops at the status message and the sample pass stops at the first
+        // sample: one read buffer each, with room to spare for a straddling frame.
+        Assert.True(
+            counting.BytesRead <= bufferSize * 4,
+            $"Read {counting.BytesRead} bytes to produce one sample; the configuration scan " +
+            "should have stopped at the leading status message.");
+
+        // ...and stopping early cost nothing: the configuration is the one the file states.
+        Assert.Equal(1000u, session.DeviceConfig!.TimestampFrequency);
+        Assert.Equal(8, session.DeviceConfig.AnalogPortCount);
+        Assert.Equal("12345", session.DeviceConfig.DeviceSerialNumber);
+    }
+
+    [Fact]
+    public async Task ParseAsync_StatusMessageWithoutTheClock_ConfigScanKeepsReading()
+    {
+        // The other side of the early exit above: a status message that does NOT state the
+        // clock settles nothing, so the scan must go on reading until it finds one. Pinning
+        // this keeps the #697 optimization from being widened into "stop at the first message",
+        // which would silently drop the timestamp frequency for this firmware shape.
+        var statusMessage = new DaqifiOutMessage { AnalogInPortNum = 4, DigitalPortNum = 2 };
+
+        var builder = new SdCardTestFileBuilder().AddMessage(statusMessage);
+        for (var i = 0; i < 300; i++)
+        {
+            builder.AddMessage(SdCardTestFileBuilder.CreateStreamMessage(
+                timestamp: (uint)((i + 1) * 1000),
+                analogFloatValues: new[] { (float)i }));
+        }
+
+        // The clock only turns up well past the first message.
+        var late = SdCardTestFileBuilder.CreateStreamMessage(301_000, analogFloatValues: new[] { 301f });
+        late.TimestampFreq = 1000;
+        builder.AddMessage(late);
+
+        using var stream = builder.Build();
+        var session = await new SdCardFileParser().ParseAsync(stream, "late_clock.bin");
+
+        Assert.Equal(1000u, session.DeviceConfig!.TimestampFrequency);
+        Assert.Equal(4, session.DeviceConfig.AnalogPortCount);
+        Assert.Equal(2, session.DeviceConfig.DigitalPortCount);
     }
 
     [Fact]

--- a/src/Daqifi.Core/Communication/Consumers/ProtobufFrameStep.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ProtobufFrameStep.cs
@@ -1,0 +1,33 @@
+namespace Daqifi.Core.Communication.Consumers;
+
+/// <summary>
+/// The outcome of a single <see cref="ProtobufMessageParser.TryReadFrame"/> step over a buffer.
+/// </summary>
+/// <remarks>
+/// The stepping form exists for callers that want each frame as it is decoded rather than a whole
+/// buffer's worth at once — see issue #697, where an SD card log's first sample cost a full parse
+/// of the leading 64 KB read buffer.
+/// </remarks>
+internal enum ProtobufFrameStep
+{
+    /// <summary>
+    /// A complete frame was decoded. The caller should take it and step again from the
+    /// reported offset.
+    /// </summary>
+    Frame,
+
+    /// <summary>
+    /// No frame begins at the offset that was stepped from. The parser advanced past bytes it
+    /// has ruled out — a malformed or implausible length prefix, or a body that would not
+    /// deserialize — and the caller should step again from the reported offset. No frame is
+    /// produced for this step.
+    /// </summary>
+    Resync,
+
+    /// <summary>
+    /// The buffer holds no further complete frame; anything left is a partial frame still
+    /// arriving. The offset does not advance, so the caller should read more data and keep the
+    /// bytes from the last advanced offset onwards.
+    /// </summary>
+    EndOfBuffer
+}

--- a/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
+++ b/src/Daqifi.Core/Communication/Consumers/ProtobufMessageParser.cs
@@ -61,157 +61,228 @@ public class ProtobufMessageParser : IMessageParser<DaqifiOutMessage>
         var messages = new List<IInboundMessage<DaqifiOutMessage>>();
         consumedBytes = 0;
 
-        if (data.Length == 0)
-            return messages;
+        var offset = 0;
 
-        var currentIndex = 0;
-
-        while (currentIndex < data.Length)
+        while (true)
         {
-            var remainingData = data.Slice(currentIndex);
-
-            if (!TryReadLengthPrefix(remainingData, out var messageLength, out var prefixBytes, out var prefixIsMalformed))
+            var step = StepFrame(data, offset, anyFrameRead: messages.Count > 0, out var frame, out var nextOffset);
+            if (step == ProtobufFrameStep.EndOfBuffer)
             {
-                if (prefixIsMalformed)
-                {
-                    // Skip this byte and resync; advancing by 1 (not by prefixBytes) is
-                    // important because the malformed run may overlap a valid frame that
-                    // starts mid-way through it.
-                    currentIndex++;
-                    consumedBytes = currentIndex;
-                    continue;
-                }
-
-                break; // Not enough data for length prefix yet — wait for the next read.
-            }
-
-            if (messageLength <= 0 || messageLength > MaxMessageSizeBytes)
-            {
-                currentIndex++;
-                consumedBytes = currentIndex;
-                continue;
-            }
-
-            if (remainingData.Length < prefixBytes + messageLength)
-            {
-                // Not enough buffered data for this frame yet. For a real partial frame
-                // this just means "wait a bit" — streaming messages are well under 1 KB,
-                // so the next read or two will complete it. But a plausible-looking yet
-                // bogus prefix can claim thousands of bytes, and waiting for that much
-                // never-arriving data is exactly the stall that masqueraded as "parser
-                // hung": device LED blinking, buffer growing, zero messages parsed.
-                //
-                // Two recovery gates protect the wait path from garbage while leaving
-                // real partial frames intact for the caller to complete:
-                //
-                //  1. Gap gate: a declared length more than MaxPartialFrameGapBytes
-                //     beyond the *payload* bytes currently buffered (remainingData
-                //     minus the prefix we already consumed when reading it) is almost
-                //     certainly garbage. Real partials for streaming frames leave
-                //     gaps measured in hundreds of bytes, not kilobytes.
-                //
-                //  2. Field-tag gate: when at least one body byte is available, we
-                //     can peek at it. The first body byte of a real DaqifiOutMessage
-                //     is a protobuf field tag — field_number >= 1 and wire_type in
-                //     {0,1,2,5}. A byte that fails both conditions (e.g., wire_type
-                //     of deprecated SGROUP/EGROUP or field_number == 0) is not a
-                //     real frame start; treat it as garbage. A multi-byte tag
-                //     (continuation bit set) can't be fully validated from one byte,
-                //     so we let it through and wait.
-                //
-                // Neither gate advances into a real frame's prefix or payload: only
-                // into bytes already identified as implausible. Callers that trim
-                // consumedBytes from their buffer never lose recoverable data.
-                var availableBodyBytes = remainingData.Length - prefixBytes;
-                var missingPayload = messageLength - availableBodyBytes;
-                var firstBodyByteIsGarbage = availableBodyBytes > 0
-                    && !IsPlausibleFieldTagByte(remainingData[prefixBytes]);
-
-                // Gap gate ONLY applies in the pure-prefix-no-body case
-                // (no body bytes arrived). Once any body byte is buffered,
-                // the field-tag gate above provides positive evidence that
-                // the prefix really is a frame start; a large declared
-                // length at that point is just a multi-chunk read of a
-                // legitimate frame (e.g. a multi-KB initial-status frame
-                // on a transport that returns smaller reads). Including
-                // availableBodyBytes == 1 here would corrupt real frames
-                // whose first body byte arrives alone — a single-byte
-                // mistaken advance is unrecoverable because callers trim
-                // consumedBytes from their buffer.
-                var gapIsSuspicious = availableBodyBytes == 0
-                    && missingPayload > MaxPartialFrameGapBytes;
-
-                if (gapIsSuspicious || firstBodyByteIsGarbage)
-                {
-                    currentIndex++;
-                    consumedBytes = currentIndex;
-                    continue;
-                }
-
-                // The declared frame isn't fully buffered. Normally that means a
-                // genuine frame split across reads — wait for the rest. But the
-                // same condition is reached by leading non-protobuf noise whose
-                // bytes happen to varint-decode to a plausible length with a
-                // plausible first body byte. The motivating case (issue #268): an
-                // echo-on device prefixes its SYSInfoPB? reply with the echoed
-                // ASCII command ("SYSTem:SYSInfoPB?\r\n") and trails it with a
-                // "DAQIFI>" prompt. The leading 'S' (0x53) decodes as length 83
-                // and the next byte 'Y' looks like a field tag, so a plain wait
-                // would block forever on 83 bytes that never arrive while the real
-                // frame sitting further along is never parsed — the device is
-                // silently missed.
-                //
-                // Tell the two apart structurally: a genuine partial frame runs
-                // past the end of the buffer, so nothing parseable can follow it;
-                // noise, by contrast, is followed by the real, complete frame. Scan
-                // ahead for the next fully-buffered, parseable frame. If one exists,
-                // the current position is noise — skip straight to it (everything
-                // before the first parseable frame is, by definition, not a frame
-                // start and holds no recoverable partial, since a partial would
-                // extend past the buffer end and thus past that frame). If none
-                // exists, this really is a partial: preserve it and wait.
-                //
-                // Only do this when no frame has been parsed yet in this call. Once
-                // we've emitted at least one frame from this buffer, a trailing
-                // under-buffered frame is overwhelmingly a genuine split frame to
-                // wait for (the normal streaming case) — not leading noise — so we
-                // skip the linear scan and keep that hot path cheap. Stray bytes
-                // appearing mid-stream are still recovered: the caller trims the
-                // preceding frame and those bytes lead the next call, where no frame
-                // has been parsed yet and the scan runs. Discovery always reaches
-                // here with zero frames parsed, so it recovers on the first reply.
-                if (messages.Count == 0)
-                {
-                    var nextFrameIndex = FindNextParseableFrameStart(data, currentIndex + 1);
-                    if (nextFrameIndex >= 0)
-                    {
-                        currentIndex = nextFrameIndex;
-                        consumedBytes = currentIndex;
-                        continue;
-                    }
-                }
-
+                // Either the buffer is exhausted or what remains is a partial frame the
+                // caller should complete on its next read. Leave consumedBytes where the
+                // last advancing step put it so those bytes are preserved.
                 break;
             }
 
-            try
+            offset = nextOffset;
+            consumedBytes = offset;
+
+            if (step == ProtobufFrameStep.Frame)
             {
-                // ParseFrom(ReadOnlySpan) avoids the per-attempt byte[] copy, which matters
-                // because byte-by-byte resync over a garbage buffer can call this many times
-                // before finding (or failing to find) a valid frame.
-                var message = DaqifiOutMessage.Parser.ParseFrom(remainingData.Slice(prefixBytes, messageLength));
-                currentIndex += prefixBytes + messageLength;
-                consumedBytes = currentIndex;
-                messages.Add(new ProtobufMessage(message));
-            }
-            catch (Exception)
-            {
-                currentIndex++;
-                consumedBytes = currentIndex;
+                messages.Add(new ProtobufMessage(frame!));
             }
         }
 
         return messages;
+    }
+
+    /// <summary>
+    /// Reads at most one frame from <paramref name="data"/>, starting at
+    /// <paramref name="offset"/>, so a caller can take each frame as it is decoded instead of
+    /// waiting for a whole buffer to be parsed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This exists for <c>SdCardFileParser</c>, which reads a log in 64 KB chunks and hands
+    /// samples to the caller as they appear. Going through <see cref="ParseMessages(byte[], out int)"/>
+    /// meant the first sample of a 10,000-row log paid for every frame in that first chunk —
+    /// 1.6 ms and 6.7 MB before anything came back, against about 2 µs for the CSV and JSON
+    /// parsers (issue #697). Stepping decodes exactly as far as the caller asks.
+    /// </para>
+    /// <para>
+    /// The parameter is an array rather than a <see cref="ReadOnlySpan{T}"/> because the SD card
+    /// caller is an async iterator, which cannot hold a ref struct across a <c>yield</c>.
+    /// </para>
+    /// </remarks>
+    /// <param name="data">The buffer to read from.</param>
+    /// <param name="offset">The index to start reading at.</param>
+    /// <param name="anyFrameRead">
+    /// Whether a frame has already been read from this buffer. Leading-noise recovery only runs
+    /// before the first frame — see the wait path in <see cref="StepFrame"/> — so a caller
+    /// stepping through one buffer must pass <c>true</c> once it has taken a frame from it, and
+    /// reset to <c>false</c> for the next buffer.
+    /// </param>
+    /// <param name="frame">The decoded frame, or <c>null</c> when this step produced none.</param>
+    /// <param name="nextOffset">
+    /// The index to step from next. Unchanged from <paramref name="offset"/> when the result is
+    /// <see cref="ProtobufFrameStep.EndOfBuffer"/>, so it doubles as the count of bytes consumed.
+    /// </param>
+    /// <returns>What the step produced.</returns>
+    internal ProtobufFrameStep TryReadFrame(
+        byte[] data,
+        int offset,
+        bool anyFrameRead,
+        out DaqifiOutMessage? frame,
+        out int nextOffset)
+        => StepFrame(new ReadOnlySpan<byte>(data), offset, anyFrameRead, out frame, out nextOffset);
+
+    /// <summary>
+    /// The single frame-boundary implementation, shared by <see cref="ParseMessages(ReadOnlySpan{byte}, out int)"/>
+    /// and <see cref="TryReadFrame"/> so the resync and partial-frame rules below have exactly
+    /// one definition.
+    /// </summary>
+    private static ProtobufFrameStep StepFrame(
+        ReadOnlySpan<byte> data,
+        int offset,
+        bool anyFrameRead,
+        out DaqifiOutMessage? frame,
+        out int nextOffset)
+    {
+        frame = null;
+        nextOffset = offset;
+
+        if (offset >= data.Length)
+        {
+            return ProtobufFrameStep.EndOfBuffer;
+        }
+
+        var remainingData = data.Slice(offset);
+
+        if (!TryReadLengthPrefix(remainingData, out var messageLength, out var prefixBytes, out var prefixIsMalformed))
+        {
+            if (prefixIsMalformed)
+            {
+                // Skip this byte and resync; advancing by 1 (not by prefixBytes) is
+                // important because the malformed run may overlap a valid frame that
+                // starts mid-way through it.
+                nextOffset = offset + 1;
+                return ProtobufFrameStep.Resync;
+            }
+
+            return ProtobufFrameStep.EndOfBuffer; // Not enough data for length prefix yet — wait for the next read.
+        }
+
+        if (messageLength <= 0 || messageLength > MaxMessageSizeBytes)
+        {
+            nextOffset = offset + 1;
+            return ProtobufFrameStep.Resync;
+        }
+
+        if (remainingData.Length < prefixBytes + messageLength)
+        {
+            // Not enough buffered data for this frame yet. For a real partial frame
+            // this just means "wait a bit" — streaming messages are well under 1 KB,
+            // so the next read or two will complete it. But a plausible-looking yet
+            // bogus prefix can claim thousands of bytes, and waiting for that much
+            // never-arriving data is exactly the stall that masqueraded as "parser
+            // hung": device LED blinking, buffer growing, zero messages parsed.
+            //
+            // Two recovery gates protect the wait path from garbage while leaving
+            // real partial frames intact for the caller to complete:
+            //
+            //  1. Gap gate: a declared length more than MaxPartialFrameGapBytes
+            //     beyond the *payload* bytes currently buffered (remainingData
+            //     minus the prefix we already consumed when reading it) is almost
+            //     certainly garbage. Real partials for streaming frames leave
+            //     gaps measured in hundreds of bytes, not kilobytes.
+            //
+            //  2. Field-tag gate: when at least one body byte is available, we
+            //     can peek at it. The first body byte of a real DaqifiOutMessage
+            //     is a protobuf field tag — field_number >= 1 and wire_type in
+            //     {0,1,2,5}. A byte that fails both conditions (e.g., wire_type
+            //     of deprecated SGROUP/EGROUP or field_number == 0) is not a
+            //     real frame start; treat it as garbage. A multi-byte tag
+            //     (continuation bit set) can't be fully validated from one byte,
+            //     so we let it through and wait.
+            //
+            // Neither gate advances into a real frame's prefix or payload: only
+            // into bytes already identified as implausible. Callers that trim
+            // consumedBytes from their buffer never lose recoverable data.
+            var availableBodyBytes = remainingData.Length - prefixBytes;
+            var missingPayload = messageLength - availableBodyBytes;
+            var firstBodyByteIsGarbage = availableBodyBytes > 0
+                && !IsPlausibleFieldTagByte(remainingData[prefixBytes]);
+
+            // Gap gate ONLY applies in the pure-prefix-no-body case
+            // (no body bytes arrived). Once any body byte is buffered,
+            // the field-tag gate above provides positive evidence that
+            // the prefix really is a frame start; a large declared
+            // length at that point is just a multi-chunk read of a
+            // legitimate frame (e.g. a multi-KB initial-status frame
+            // on a transport that returns smaller reads). Including
+            // availableBodyBytes == 1 here would corrupt real frames
+            // whose first body byte arrives alone — a single-byte
+            // mistaken advance is unrecoverable because callers trim
+            // consumedBytes from their buffer.
+            var gapIsSuspicious = availableBodyBytes == 0
+                && missingPayload > MaxPartialFrameGapBytes;
+
+            if (gapIsSuspicious || firstBodyByteIsGarbage)
+            {
+                nextOffset = offset + 1;
+                return ProtobufFrameStep.Resync;
+            }
+
+            // The declared frame isn't fully buffered. Normally that means a
+            // genuine frame split across reads — wait for the rest. But the
+            // same condition is reached by leading non-protobuf noise whose
+            // bytes happen to varint-decode to a plausible length with a
+            // plausible first body byte. The motivating case (issue #268): an
+            // echo-on device prefixes its SYSInfoPB? reply with the echoed
+            // ASCII command ("SYSTem:SYSInfoPB?\r\n") and trails it with a
+            // "DAQIFI>" prompt. The leading 'S' (0x53) decodes as length 83
+            // and the next byte 'Y' looks like a field tag, so a plain wait
+            // would block forever on 83 bytes that never arrive while the real
+            // frame sitting further along is never parsed — the device is
+            // silently missed.
+            //
+            // Tell the two apart structurally: a genuine partial frame runs
+            // past the end of the buffer, so nothing parseable can follow it;
+            // noise, by contrast, is followed by the real, complete frame. Scan
+            // ahead for the next fully-buffered, parseable frame. If one exists,
+            // the current position is noise — skip straight to it (everything
+            // before the first parseable frame is, by definition, not a frame
+            // start and holds no recoverable partial, since a partial would
+            // extend past the buffer end and thus past that frame). If none
+            // exists, this really is a partial: preserve it and wait.
+            //
+            // Only do this when no frame has been read yet from this buffer. Once
+            // one frame has come out of it, a trailing under-buffered frame is
+            // overwhelmingly a genuine split frame to wait for (the normal
+            // streaming case) — not leading noise — so we skip the linear scan and
+            // keep that hot path cheap. Stray bytes appearing mid-stream are still
+            // recovered: the caller trims the preceding frame and those bytes lead
+            // the next buffer, where no frame has been read yet and the scan runs.
+            // Discovery always reaches here with zero frames read, so it recovers
+            // on the first reply.
+            if (!anyFrameRead)
+            {
+                var nextFrameIndex = FindNextParseableFrameStart(data, offset + 1);
+                if (nextFrameIndex >= 0)
+                {
+                    nextOffset = nextFrameIndex;
+                    return ProtobufFrameStep.Resync;
+                }
+            }
+
+            return ProtobufFrameStep.EndOfBuffer;
+        }
+
+        try
+        {
+            // ParseFrom(ReadOnlySpan) avoids the per-attempt byte[] copy, which matters
+            // because byte-by-byte resync over a garbage buffer can call this many times
+            // before finding (or failing to find) a valid frame.
+            frame = DaqifiOutMessage.Parser.ParseFrom(remainingData.Slice(prefixBytes, messageLength));
+            nextOffset = offset + prefixBytes + messageLength;
+            return ProtobufFrameStep.Frame;
+        }
+        catch (Exception)
+        {
+            frame = null;
+            nextOffset = offset + 1;
+            return ProtobufFrameStep.Resync;
+        }
     }
 
     /// <summary>

--- a/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
+++ b/src/Daqifi.Core/Device/SdCard/SdCardFileParser.cs
@@ -127,46 +127,68 @@ public sealed class SdCardFileParser
         var fileCreatedDate = options.SessionStartTime
                               ?? SdCardFileListParser.TryParseDateFromLogFileName(fileName);
 
-        // Only the leading messages are held, never the whole file: firmware states the
+        // Only the leading messages are examined, never the whole file: firmware states the
         // configuration in the status message or in the first handful of stream messages.
         // No progress is reported for this pass — it is not the caller's read of the file.
-        var prefix = new List<DaqifiOutMessage>();
+        //
+        // The scan reads only as far as it has to. It used to read the whole
+        // ConfigurationScanMessageLimit window every time and decide afterwards, so the common
+        // case — a status message that states everything, which is then used on its own —
+        // decoded 512 messages and discarded 511 of them before the caller saw a sample
+        // (issue #697). Each break below is a point at which no later message can change the
+        // configuration that comes out of this pass.
+        SdCardDeviceConfiguration? statusConfig = null;
+        var scanner = new ConfigurationScanner();
+        var messagesScanned = 0;
         var limit = options.ConfigurationScanMessageLimit;
+
         await foreach (var message in openMessages(null, ct).WithCancellation(ct).ConfigureAwait(false))
         {
-            prefix.Add(message);
-            if (limit > 0 && prefix.Count >= limit)
+            // Some firmware versions embed config fields (e.g., AnalogInPortNum/TimestampFreq)
+            // inside stream messages, so we only treat the first message as a dedicated status
+            // message when it has no stream payload.
+            if (messagesScanned == 0 && !HasStreamPayload(message))
+            {
+                statusConfig = ExtractDeviceConfiguration(message);
+            }
+
+            messagesScanned++;
+            scanner.Add(message);
+
+            // A status message that stated the timestamp clock settles it: the embedded-field
+            // scan below is skipped entirely in that case, so what the rest of the file says is
+            // never consulted and there is nothing left to read for.
+            if (statusConfig is { TimestampFrequency: not 0 })
+            {
+                break;
+            }
+
+            // Every field the scan can find has been found.
+            if (scanner.IsComplete)
+            {
+                break;
+            }
+
+            if (limit > 0 && messagesScanned >= limit)
             {
                 break;
             }
         }
 
-        SdCardDeviceConfiguration? config = null;
-
-        // First, check if the first message is a dedicated status message.
-        // Some firmware versions embed config fields (e.g., AnalogInPortNum/TimestampFreq)
-        // inside stream messages, so we only treat the first message as status when it
-        // has no stream payload.
-        if (prefix.Count > 0 && !HasStreamPayload(prefix[0]))
-        {
-            config = ExtractDeviceConfiguration(prefix[0]);
-        }
+        var config = statusConfig;
 
         // If no dedicated status message was found, or the status message had no TimestampFreq,
-        // scan the leading messages for config fields. Device firmware often embeds config fields
-        // (TimestampFreq, DeviceSn, etc.) in streaming data messages rather than writing
-        // a separate status header.
+        // use the config fields scanned out of the leading messages. Device firmware often embeds
+        // config fields (TimestampFreq, DeviceSn, etc.) in streaming data messages rather than
+        // writing a separate status header.
         if (config == null || config.TimestampFrequency == 0)
         {
-            var scannedConfig = ScanMessagesForConfiguration(prefix);
+            var scannedConfig = scanner.ToConfiguration();
             if (scannedConfig != null)
             {
                 config = MergeConfigurations(config, scannedConfig);
             }
         }
-
-        // The prefix has served its purpose; the sample pass re-reads the log from the start.
-        prefix.Clear();
 
         // Whatever the file itself stated, captured before the override is merged in so the
         // two sources stay distinguishable when reporting which one was used.
@@ -227,6 +249,13 @@ public sealed class SdCardFileParser
     /// Deserializes protobuf messages from the stream, holding at most one read buffer plus
     /// the bytes of a straddling frame.
     /// </summary>
+    /// <remarks>
+    /// Each frame is handed on as it is decoded rather than after its whole chunk has been
+    /// parsed. Parsing the chunk first made the caller's first sample cost every frame in the
+    /// leading <see cref="SdCardParseOptions.BufferSize"/> bytes — about 1,300 of them at the
+    /// 64 KB default — which is what made this parser two to three orders of magnitude slower
+    /// to its first sample than the CSV and JSON parsers (issue #697).
+    /// </remarks>
     private static async IAsyncEnumerable<DaqifiOutMessage> ReadMessagesAsync(
         Stream stream,
         SdCardParseOptions options,
@@ -258,10 +287,35 @@ public sealed class SdCardFileParser
             // Strip end-of-file marker if present at the tail
             chunk = StripEndOfFileMarker(chunk);
 
-            var parsed = parser.ParseMessages(chunk, out var consumed);
+            var consumed = 0;
+            var framesFromChunk = 0;
 
-            // Carry unconsumed bytes forward. Computed before yielding so the reader's state
-            // is already consistent when the consumer pauses mid-chunk.
+            while (true)
+            {
+                // The parser only applies its leading-noise recovery before the first frame of
+                // a buffer, so framesFromChunk has to be per-chunk — exactly what the count of
+                // a whole-chunk parse used to say.
+                var step = parser.TryReadFrame(chunk, consumed, framesFromChunk > 0, out var frame, out var nextOffset);
+                if (step == ProtobufFrameStep.EndOfBuffer)
+                {
+                    break;
+                }
+
+                consumed = nextOffset;
+
+                if (step != ProtobufFrameStep.Frame)
+                {
+                    continue;
+                }
+
+                framesFromChunk++;
+                messagesRead++;
+                yield return frame!;
+            }
+
+            // Carry the bytes the parser did not consume — a frame straddling this chunk and
+            // the next. The inner loop has fully drained the chunk by now, so the reader's
+            // state is consistent again before the next read.
             if (consumed < chunk.Length)
             {
                 carry = new byte[chunk.Length - consumed];
@@ -272,23 +326,33 @@ public sealed class SdCardFileParser
                 carry = Array.Empty<byte>();
             }
 
-            foreach (var msg in parsed)
-            {
-                messagesRead++;
-                yield return msg.Data;
-            }
-
             progress?.Report(new SdCardParseProgress(totalBytesRead, totalBytes, messagesRead));
         }
 
         // Try to parse any remaining carry bytes (may contain a partial final message)
         if (carry.Length > 0)
         {
-            var parsed = parser.ParseMessages(carry, out _);
-            foreach (var msg in parsed)
+            var offset = 0;
+            var framesFromCarry = 0;
+
+            while (true)
             {
+                var step = parser.TryReadFrame(carry, offset, framesFromCarry > 0, out var frame, out var nextOffset);
+                if (step == ProtobufFrameStep.EndOfBuffer)
+                {
+                    break;
+                }
+
+                offset = nextOffset;
+
+                if (step != ProtobufFrameStep.Frame)
+                {
+                    continue;
+                }
+
+                framesFromCarry++;
                 messagesRead++;
-                yield return msg.Data;
+                yield return frame!;
             }
 
             progress?.Report(new SdCardParseProgress(totalBytesRead, totalBytes, messagesRead));
@@ -431,56 +495,75 @@ public sealed class SdCardFileParser
     }
 
     /// <summary>
-    /// Scans all messages for device configuration fields that may be embedded in streaming
-    /// data messages. Returns a merged configuration from the first non-zero value found
-    /// for each field, or null if no config fields are found in any message.
+    /// Collects the device configuration fields that firmware may embed in streaming data
+    /// messages, keeping the first non-zero value seen for each, and reporting when there is
+    /// nothing left to look for.
     /// </summary>
-    private static SdCardDeviceConfiguration? ScanMessagesForConfiguration(List<DaqifiOutMessage> messages)
+    /// <remarks>
+    /// Accumulating message by message rather than over a materialized list is what lets
+    /// <see cref="BuildSessionAsync"/> stop reading the moment the answer is settled, instead of
+    /// always reading <see cref="SdCardParseOptions.ConfigurationScanMessageLimit"/> messages
+    /// first (issue #697).
+    /// </remarks>
+    private sealed class ConfigurationScanner
     {
-        uint timestampFreq = 0;
-        uint analogPortNum = 0;
-        uint digitalPortNum = 0;
-        ulong deviceSn = 0;
-        string? devicePn = null;
-        string? fwRev = null;
-        IReadOnlyList<(double Slope, double Intercept)>? calibration = null;
-        uint resolution = 0;
-        IReadOnlyList<double>? portRange = null;
-        IReadOnlyList<double>? internalScaleM = null;
+        private uint _timestampFreq;
+        private uint _analogPortNum;
+        private uint _digitalPortNum;
+        private ulong _deviceSn;
+        private string? _devicePn;
+        private string? _fwRev;
+        private IReadOnlyList<(double Slope, double Intercept)>? _calibration;
+        private uint _resolution;
+        private IReadOnlyList<double>? _portRange;
+        private IReadOnlyList<double>? _internalScaleM;
 
-        foreach (var msg in messages)
+        /// <summary>
+        /// Gets a value indicating whether every field has been found, so no further message
+        /// can change the result.
+        /// </summary>
+        public bool IsComplete =>
+            _timestampFreq != 0 && _analogPortNum != 0 && _digitalPortNum != 0 &&
+            _deviceSn != 0 && _devicePn != null && _fwRev != null && _calibration != null &&
+            _resolution != 0 && _portRange != null && _internalScaleM != null;
+
+        /// <summary>
+        /// Takes whichever configuration fields <paramref name="msg"/> states and that have not
+        /// been seen already.
+        /// </summary>
+        public void Add(DaqifiOutMessage msg)
         {
-            if (timestampFreq == 0 && msg.TimestampFreq != 0)
+            if (_timestampFreq == 0 && msg.TimestampFreq != 0)
             {
-                timestampFreq = msg.TimestampFreq;
+                _timestampFreq = msg.TimestampFreq;
             }
 
-            if (analogPortNum == 0 && msg.AnalogInPortNum != 0)
+            if (_analogPortNum == 0 && msg.AnalogInPortNum != 0)
             {
-                analogPortNum = msg.AnalogInPortNum;
+                _analogPortNum = msg.AnalogInPortNum;
             }
 
-            if (digitalPortNum == 0 && msg.DigitalPortNum != 0)
+            if (_digitalPortNum == 0 && msg.DigitalPortNum != 0)
             {
-                digitalPortNum = msg.DigitalPortNum;
+                _digitalPortNum = msg.DigitalPortNum;
             }
 
-            if (deviceSn == 0 && msg.DeviceSn != 0)
+            if (_deviceSn == 0 && msg.DeviceSn != 0)
             {
-                deviceSn = msg.DeviceSn;
+                _deviceSn = msg.DeviceSn;
             }
 
-            if (devicePn == null && !string.IsNullOrEmpty(msg.DevicePn))
+            if (_devicePn == null && !string.IsNullOrEmpty(msg.DevicePn))
             {
-                devicePn = msg.DevicePn;
+                _devicePn = msg.DevicePn;
             }
 
-            if (fwRev == null && !string.IsNullOrEmpty(msg.DeviceFwRev))
+            if (_fwRev == null && !string.IsNullOrEmpty(msg.DeviceFwRev))
             {
-                fwRev = msg.DeviceFwRev;
+                _fwRev = msg.DeviceFwRev;
             }
 
-            if (calibration == null && msg.AnalogInCalM.Count > 0 && msg.AnalogInCalB.Count > 0)
+            if (_calibration == null && msg.AnalogInCalM.Count > 0 && msg.AnalogInCalB.Count > 0)
             {
                 var count = Math.Min(msg.AnalogInCalM.Count, msg.AnalogInCalB.Count);
                 var cal = new (double, double)[count];
@@ -489,52 +572,50 @@ public sealed class SdCardFileParser
                     cal[i] = (msg.AnalogInCalM[i], msg.AnalogInCalB[i]);
                 }
 
-                calibration = cal;
+                _calibration = cal;
             }
 
-            if (resolution == 0 && msg.AnalogInRes != 0)
+            if (_resolution == 0 && msg.AnalogInRes != 0)
             {
-                resolution = msg.AnalogInRes;
+                _resolution = msg.AnalogInRes;
             }
 
-            if (portRange == null && msg.AnalogInPortRange.Count > 0)
+            if (_portRange == null && msg.AnalogInPortRange.Count > 0)
             {
-                portRange = msg.AnalogInPortRange.Select(v => (double)v).ToArray();
+                _portRange = msg.AnalogInPortRange.Select(v => (double)v).ToArray();
             }
 
-            if (internalScaleM == null && msg.AnalogInIntScaleM.Count > 0)
+            if (_internalScaleM == null && msg.AnalogInIntScaleM.Count > 0)
             {
-                internalScaleM = msg.AnalogInIntScaleM.Select(v => (double)v).ToArray();
-            }
-
-            // If we've found all fields, stop scanning
-            if (timestampFreq != 0 && analogPortNum != 0 && digitalPortNum != 0 &&
-                deviceSn != 0 && devicePn != null && fwRev != null && calibration != null &&
-                resolution != 0 && portRange != null && internalScaleM != null)
-            {
-                break;
+                _internalScaleM = msg.AnalogInIntScaleM.Select(v => (double)v).ToArray();
             }
         }
 
-        // Only return a config if we found at least one meaningful field
-        if (timestampFreq == 0 && analogPortNum == 0 && digitalPortNum == 0 &&
-            deviceSn == 0 && devicePn == null && fwRev == null && calibration == null &&
-            resolution == 0 && portRange == null && internalScaleM == null)
+        /// <summary>
+        /// Returns what was found, or <c>null</c> when no message stated a single field.
+        /// </summary>
+        public SdCardDeviceConfiguration? ToConfiguration()
         {
-            return null;
-        }
+            // Only return a config if we found at least one meaningful field
+            if (_timestampFreq == 0 && _analogPortNum == 0 && _digitalPortNum == 0 &&
+                _deviceSn == 0 && _devicePn == null && _fwRev == null && _calibration == null &&
+                _resolution == 0 && _portRange == null && _internalScaleM == null)
+            {
+                return null;
+            }
 
-        return new SdCardDeviceConfiguration(
-            AnalogPortCount: (int)analogPortNum,
-            DigitalPortCount: (int)digitalPortNum,
-            TimestampFrequency: timestampFreq,
-            DeviceSerialNumber: deviceSn != 0 ? deviceSn.ToString() : null,
-            DevicePartNumber: devicePn,
-            FirmwareRevision: fwRev,
-            CalibrationValues: calibration,
-            Resolution: resolution,
-            PortRange: portRange,
-            InternalScaleM: internalScaleM);
+            return new SdCardDeviceConfiguration(
+                AnalogPortCount: (int)_analogPortNum,
+                DigitalPortCount: (int)_digitalPortNum,
+                TimestampFrequency: _timestampFreq,
+                DeviceSerialNumber: _deviceSn != 0 ? _deviceSn.ToString() : null,
+                DevicePartNumber: _devicePn,
+                FirmwareRevision: _fwRev,
+                CalibrationValues: _calibration,
+                Resolution: _resolution,
+                PortRange: _portRange,
+                InternalScaleM: _internalScaleM);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## What was wrong

Opening an SD card recording and asking for the **first** sample was slow for `.bin` logs and fast
for everything else. On a 10,000-row, 8-channel recording the protobuf parser took **1.6 ms and
allocated 6.7 MB** before handing back one sample. The CSV and JSON parsers answered the same
question in about **2 µs**.

That gap matters for the interactive case — showing the first rows of a recording while the rest
streams in, which is what the lazy parsers were built for in #489. Laziness landed for CSV and JSON
but not for protobuf, and nobody noticed because "lazy" had been checked as "does not load the whole
file" rather than measured as a number.

## How it was fixed

Two independent causes, and neither is the configuration scan limit that the shape of the code
points at:

- The reader pulled a 64 KB buffer, decoded **every one of the ~1,300 frames in it**, and only then
  started handing them over one at a time. Now it decodes one frame at a time and passes each on as
  it appears.
- The configuration pre-scan always read 512 messages before deciding anything. When a log opens
  with a status message that states the timestamp clock — the common case — that message settles the
  configuration by itself and the scan's result is thrown away unread. It now stops as soon as
  nothing later in the file could change the answer.

**Behaviour is unchanged, and that is the part worth checking.** A status message stating the clock
already made the follow-on scan dead code — the `config == null || TimestampFrequency == 0` guard
never fires — so stopping there cannot alter any result. That is exactly the condition the scan
breaks on. Every existing test passed untouched.

The reviewable risk is elsewhere: `ProtobufMessageParser`'s resync, gap-gate and leading-noise rules
are subtle and were arrived at through several field failures (#268 among them). Rather than write a
second decode path beside them, `ParseMessages` is now a thin loop over the new stepper, so there is
still exactly one definition of where a frame begins. A theory test re-runs the whole corpus of
awkward buffers — echo-wrapped frames, null-byte runs, oversized prefixes, trailing partials —
through both entry points and demands identical frames and identical consumed counts.

The stepper is `internal`, so the public API surface is untouched and this does not disturb #680.

## Result

From `src/Daqifi.Core.Benchmarks`, same machine, default job:

| Method | Before | After | |
| --- | ---: | ---: | --- |
| `ProtobufTimeToFirstSample` | 1,565.6 µs | **9.4 µs** | 167× |
| `ProtobufTimeToFirstSample` allocated | 6,753 KB | **263 KB** | 26× |
| `ProtobufDrainAll` | 4,504.4 µs | **2,091.4 µs** | 2.2× |
| `ProtobufDrainAll` allocated | 16,880 KB | **13,170 KB** | 1.3× |

`CsvTimeToFirstSample` is 2.0 µs on the same run, so first-sample latency is now 4.7× CSV rather
than 800× — inside the order of magnitude the issue asked for. Draining the whole file got 2.2×
faster as a side effect, since the per-chunk list and message wrappers are gone.

## Verified

- Full suite green on net9.0 and net10.0: 4,116 passed in `Daqifi.Core.Tests`, 217 in
  `Daqifi.Mcp.Tests`, 0 failures. Release build is warning-clean.
- 17 new tests. The regression guard was checked against unmodified `main`, where it fails as
  intended: 6,144 bytes read to produce one sample, against ≤1,024 with the fix.
- No hardware needed — this is file parsing, so the benchmark is the measurement.

closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)