### PR TITLE
perf(device): end the connect-time init exchange when its terminator reply arrives

### DIFF
--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -1,4 +1,5 @@
 using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using System.Diagnostics;
@@ -666,6 +667,193 @@ public class DaqifiDeviceStaleTextLineTests
                 () => { finalized = true; return Task.CompletedTask; }));
 
         Assert.False(finalized, "The finalize phase ran for an exchange that never started.");
+    }
+
+    // ── The terminator short-circuit (#667 item 4). Three call sites end their setup action with
+    // SYSTem:ERRor? so the exchange has a reply to finish on; recognising that reply lets it stop
+    // the moment the reply lands instead of waiting out a completion window sized for a device
+    // that might still be talking. The same pre-send boundaries the tests above are about are what
+    // keep a LEFTOVER reply from ending an exchange it does not belong to. ────────────────────
+
+    [Fact]
+    public async Task ExecuteTextCommand_EndsAsSoonAsTheReplyItAskedToFinishOnArrives()
+    {
+        // The completion window is deliberately huge next to the reply, so an exchange that waits
+        // it out cannot be mistaken for one that recognised the terminator. On the real device this
+        // window is 500ms (connect) or 1000ms (SD listing, confirmed commands), and every
+        // millisecond of it used to be spent waiting for lines that by construction never come.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Terminating Device", transport);
+
+        device.Connect();
+
+        var sw = Stopwatch.StartNew();
+        var lines = await device.CallExecuteTextCommandAsync(
+            () =>
+            {
+                device.Send(ScpiMessageProducer.GetSystemError);
+                transport.Release();
+            },
+            responseTimeoutMs: 3000,
+            completionTimeoutMs: 2000);
+        sw.Stop();
+
+        Assert.Contains(lines, l => l.Contains("No error"));
+        Assert.True(
+            sw.ElapsedMilliseconds < 1500,
+            $"Expected the exchange to end on the terminator, not to wait out its 2000ms completion window; took {sw.ElapsedMilliseconds}ms.");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_DoesNotEndEarlyOnAnErrorReplyItNeverAskedFor()
+    {
+        // The command half of the guard. A device can volunteer an error-queue-shaped line
+        // alongside a command's output, and an exchange that never asked for a terminator has no
+        // reason to treat it as one — it may still be mid-dump. Without this half, SYSTem:LOG? on
+        // a device with something to complain about would return a truncated log.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Unasking Device", transport);
+
+        device.Connect();
+
+        var sw = Stopwatch.StartNew();
+        var lines = await device.CallExecuteTextCommandAsync(
+            () =>
+            {
+                device.Send(new ScpiMessage("SYSTem:LOG?"));
+                transport.Release();
+            },
+            responseTimeoutMs: 3000,
+            completionTimeoutMs: 400);
+        sw.Stop();
+
+        Assert.Contains(lines, l => l.Contains("No error"));
+        Assert.True(
+            sw.ElapsedMilliseconds >= 350,
+            $"Expected the exchange to wait out its 400ms completion window for a reply it never asked for; took {sw.ElapsedMilliseconds}ms.");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_IsNotEndedByATerminatorThatArrivedBeforeItSent()
+    {
+        // The failure this guard exists to prevent, and the reason TrySplitAtSdListTerminator
+        // scans from the END: a terminator reply from an earlier, timed-out exchange can lead this
+        // one's response. Stopping on it would cut collection off before the listing arrives and
+        // report an empty SD card for a card with files on it.
+        //
+        // The stale terminator is released at the stale-line boundary and provably collected before
+        // the setup action returns, which puts it inside the capture-to-send window (#553); the
+        // listing line then arrives 150ms after the send boundary, well past the 300ms completion
+        // window an early stop would have ended on. Anchored to the exchange rather than the clock
+        // for the reason the #553 test above records (issue #687).
+        using var transport = new TwoStageReleaseTransport(
+            staleLine: "0,\"No error\"\r\n",
+            contentLine: "/data/log.bin 4096\r\n");
+
+        Thread? releaseContent = null;
+        using var device = new StaleBoundaryHookTestableDevice(
+            "Stale-Terminator Device",
+            transport,
+            onStaleLineBoundaryCaptured: () => transport.ReleaseStale(),
+            onSendBoundaryCaptured: () =>
+            {
+                // One exchange, so one release; guarded so a future extra exchange cannot turn a
+                // second Start() on the same thread into an unrelated failure here.
+                if (releaseContent != null) return;
+
+                releaseContent = new Thread(() =>
+                {
+                    Thread.Sleep(150);
+                    transport.ReleaseContent();
+                })
+                { IsBackground = true, Name = "stale-terminator-test-content-release" };
+                releaseContent.Start();
+            });
+
+        device.Connect();
+
+        var lines = await device.CallExecuteTextCommandAsync(
+            () =>
+            {
+                Assert.True(
+                    transport.WaitForStaleConsumed(TimeSpan.FromSeconds(10)),
+                    "The reader never collected the stale terminator, so the boundary under test was never exercised.");
+                device.Send(ScpiMessageProducer.GetSystemError);
+            },
+            responseTimeoutMs: 5000,
+            completionTimeoutMs: 300);
+
+        // The listing survived: collection did not stop on the leading stale terminator.
+        Assert.Contains(lines, l => l.Contains("/data/log.bin"));
+
+        // And the stale terminator is still handed to the caller, exactly as before. The
+        // short-circuit decides when to stop listening, never what the exchange returns — which is
+        // what leaves TrySplitAtSdListTerminator the authority on which terminator is the real one.
+        Assert.Contains(lines, l => l.Contains("No error"));
+
+        releaseContent?.Join(TimeSpan.FromSeconds(10));
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_IsNotEndedByATerminatorThatArrivesWhileItsCommandIsStillQueued()
+    {
+        // The other half of the same boundary (#593): the setup action returns when the command is
+        // queued, not when it is written, so a leftover reply can arrive after the exchange
+        // believes it has sent and before the device has been asked anything. An earlier command
+        // holds the producer thread, so this exchange's SYSTem:ERRor? provably cannot be on the
+        // wire when the reply lands — nothing has been asked, so nothing can be answering, and the
+        // line-count boundary alone cannot tell.
+        using var transport = new QueuedWriteTransport();
+
+        var terminatorReleased = false;
+        using var device = new StaleLineTestableDevice(
+            "Queued-Terminator Device",
+            transport,
+            onSendBoundaryCaptured: () =>
+            {
+                terminatorReleased = true;
+                transport.ReleaseLine("0,\"No error\"\r\n");
+            });
+
+        device.Connect();
+
+        transport.HoldWrites();
+        device.Send(new ScpiMessage("EARLIER:COMMAND"));
+        Assert.True(
+            transport.WaitForWriteStarted(TimeSpan.FromSeconds(10)),
+            "The producer never picked up the earlier command.");
+
+        // The window is wide, and the bound well inside it, because the two outcomes have to be
+        // unmistakable: an exchange that short-circuits here returns in roughly the time the reader
+        // takes to pick the line up (~350ms observed), one that correctly keeps waiting returns no
+        // earlier than this window. A bound near the window's own length would sit between them.
+        // The write hold is bounded at 30s, so 1500ms cannot expire it.
+        var sw = Stopwatch.StartNew();
+        var lines = await device.CallExecuteTextCommandAsync(
+            () => device.Send(ScpiMessageProducer.GetSystemError),
+            responseTimeoutMs: 3000,
+            completionTimeoutMs: 1500);
+        sw.Stop();
+
+        Assert.True(
+            terminatorReleased,
+            "The exchange never reached its send boundary, so the terminator was never put on the wire.");
+        Assert.True(
+            sw.ElapsedMilliseconds >= 1000,
+            $"Expected the exchange to keep waiting for a terminator that cannot be its own; took {sw.ElapsedMilliseconds}ms.");
+        Assert.Contains(lines, l => l.Contains("No error"));
+
+        transport.ReleaseWrite();
+        Assert.False(
+            transport.HoldExpired,
+            "The write hold expired on its own bound, so the queued-behind-a-held-write window this test needs was not actually held open.");
+
+        device.Disconnect();
     }
 
     /// <summary>

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -682,6 +682,11 @@ public class DaqifiDeviceStaleTextLineTests
         // it out cannot be mistaken for one that recognised the terminator. On the real device this
         // window is 500ms (connect) or 1000ms (SD listing, confirmed commands), and every
         // millisecond of it used to be spent waiting for lines that by construction never come.
+        //
+        // The bound sits halfway between the two outcomes rather than close to either: recognising
+        // the terminator costs the reader's latency and nothing else, while waiting the window out
+        // takes 4000ms, so a loaded runner has 2 full seconds of slack before this says the wrong
+        // thing (issue #687).
         using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
         using var device = new StaleLineTestableDevice("Terminating Device", transport);
 
@@ -695,13 +700,13 @@ public class DaqifiDeviceStaleTextLineTests
                 transport.Release();
             },
             responseTimeoutMs: 3000,
-            completionTimeoutMs: 2000);
+            completionTimeoutMs: 4000);
         sw.Stop();
 
         Assert.Contains(lines, l => l.Contains("No error"));
         Assert.True(
-            sw.ElapsedMilliseconds < 1500,
-            $"Expected the exchange to end on the terminator, not to wait out its 2000ms completion window; took {sw.ElapsedMilliseconds}ms.");
+            sw.ElapsedMilliseconds < 2000,
+            $"Expected the exchange to end on the terminator, not to wait out its 4000ms completion window; took {sw.ElapsedMilliseconds}ms.");
 
         device.Disconnect();
     }
@@ -747,9 +752,15 @@ public class DaqifiDeviceStaleTextLineTests
         //
         // The stale terminator is released at the stale-line boundary and provably collected before
         // the setup action returns, which puts it inside the capture-to-send window (#553); the
-        // listing line then arrives 150ms after the send boundary, well past the 300ms completion
-        // window an early stop would have ended on. Anchored to the exchange rather than the clock
-        // for the reason the #553 test above records (issue #687).
+        // listing line then arrives 150ms after the send boundary, by which point an exchange that
+        // had stopped on the stale terminator would already have returned without it.
+        //
+        // Unlike the #553 test above, the stale line here is CONTENT, not a blank — so it is not
+        // dropped, the wait loop counts it as evidence immediately, and phase 2's completion window
+        // is what has to cover the listing line's arrival rather than phase 1's much longer
+        // first-response timeout. That window is therefore 2000ms against a 150ms release: more
+        // than ten times the delay it has to cover, so a runner that starves the release thread
+        // still lands inside it (issue #687, and the CI failure this replaced).
         using var transport = new TwoStageReleaseTransport(
             staleLine: "0,\"No error\"\r\n",
             contentLine: "/data/log.bin 4096\r\n");
@@ -785,7 +796,7 @@ public class DaqifiDeviceStaleTextLineTests
                 device.Send(ScpiMessageProducer.GetSystemError);
             },
             responseTimeoutMs: 5000,
-            completionTimeoutMs: 300);
+            completionTimeoutMs: 2000);
 
         // The listing survived: collection did not stop on the leading stale terminator.
         Assert.Contains(lines, l => l.Contains("/data/log.bin"));

--- a/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
+++ b/src/Daqifi.Core.Tests/Device/DaqifiDeviceStaleTextLineTests.cs
@@ -700,13 +700,50 @@ public class DaqifiDeviceStaleTextLineTests
                 transport.Release();
             },
             responseTimeoutMs: 3000,
-            completionTimeoutMs: 4000);
+            completionTimeoutMs: 4000,
+            terminatorShortCircuit: true);
         sw.Stop();
 
         Assert.Contains(lines, l => l.Contains("No error"));
         Assert.True(
             sw.ElapsedMilliseconds < 2000,
             $"Expected the exchange to end on the terminator, not to wait out its 4000ms completion window; took {sw.ElapsedMilliseconds}ms.");
+
+        device.Disconnect();
+    }
+
+    [Fact]
+    public async Task ExecuteTextCommand_WaitsOutItsWindowUnlessItOptedIntoTheShortCircuit()
+    {
+        // The gate, and the reason it exists. An exchange that sends the terminator but does not
+        // opt in — the SD listing and the confirming administration commands, every call site but
+        // the connect-time init — must behave exactly as it did before this existed.
+        //
+        // They are held back because a stale reply the device emits AFTER this exchange starts
+        // sending is indistinguishable from its own, and finishing on one truncates the response.
+        // For a directory listing that means caching a partial or empty card silently, since a
+        // listing cut short before its end-of-listing marker reads as Unterminated, which is not an
+        // error. Identical setup to the opted-in test above, minus the opt-in.
+        using var transport = new ReleaseOnStreamAccessMockTransport("0,\"No error\"\r\n");
+        using var device = new StaleLineTestableDevice("Non-Opted-In Device", transport);
+
+        device.Connect();
+
+        var sw = Stopwatch.StartNew();
+        var lines = await device.CallExecuteTextCommandAsync(
+            () =>
+            {
+                device.Send(ScpiMessageProducer.GetSystemError);
+                transport.Release();
+            },
+            responseTimeoutMs: 3000,
+            completionTimeoutMs: 1500);
+        sw.Stop();
+
+        Assert.Contains(lines, l => l.Contains("No error"));
+        Assert.True(
+            sw.ElapsedMilliseconds >= 1000,
+            $"Expected an exchange that did not opt in to wait out its 1500ms completion window; took {sw.ElapsedMilliseconds}ms.");
 
         device.Disconnect();
     }
@@ -731,7 +768,8 @@ public class DaqifiDeviceStaleTextLineTests
                 transport.Release();
             },
             responseTimeoutMs: 3000,
-            completionTimeoutMs: 400);
+            completionTimeoutMs: 400,
+            terminatorShortCircuit: true);
         sw.Stop();
 
         Assert.Contains(lines, l => l.Contains("No error"));
@@ -796,7 +834,8 @@ public class DaqifiDeviceStaleTextLineTests
                 device.Send(ScpiMessageProducer.GetSystemError);
             },
             responseTimeoutMs: 5000,
-            completionTimeoutMs: 2000);
+            completionTimeoutMs: 2000,
+            terminatorShortCircuit: true);
 
         // The listing survived: collection did not stop on the leading stale terminator.
         Assert.Contains(lines, l => l.Contains("/data/log.bin"));
@@ -848,7 +887,8 @@ public class DaqifiDeviceStaleTextLineTests
         var lines = await device.CallExecuteTextCommandAsync(
             () => device.Send(ScpiMessageProducer.GetSystemError),
             responseTimeoutMs: 3000,
-            completionTimeoutMs: 1500);
+            completionTimeoutMs: 1500,
+            terminatorShortCircuit: true);
         sw.Stop();
 
         Assert.True(
@@ -892,17 +932,24 @@ public class DaqifiDeviceStaleTextLineTests
 
         internal override void OnSendBoundaryCaptured() => _onSendBoundaryCaptured?.Invoke();
 
-        public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(
+        /// <param name="terminatorShortCircuit">
+        /// Opts this exchange into finishing on its <c>SYSTem:ERRor?</c> reply, the way the
+        /// connect-time init exchange does. Off by default, matching every other call site.
+        /// </param>
+        public async Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(
             Action setupAction,
             bool keepBlankLines = false,
             int responseTimeoutMs = 500,
-            int completionTimeoutMs = 150)
+            int completionTimeoutMs = 150,
+            bool terminatorShortCircuit = false)
         {
-            return ExecuteTextCommandAsync(
+            using var scope = terminatorShortCircuit ? EnableTerminatorShortCircuit() : null;
+
+            return await ExecuteTextCommandAsync(
                 setupAction,
                 responseTimeoutMs: responseTimeoutMs,
                 completionTimeoutMs: completionTimeoutMs,
-                keepBlankLines: keepBlankLines);
+                keepBlankLines: keepBlankLines).ConfigureAwait(false);
         }
     }
 
@@ -971,17 +1018,24 @@ public class DaqifiDeviceStaleTextLineTests
         /// </summary>
         internal override void OnSendBoundaryCaptured() => _onSendBoundaryCaptured?.Invoke();
 
-        public Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(
+        /// <param name="terminatorShortCircuit">
+        /// Opts this exchange into finishing on its <c>SYSTem:ERRor?</c> reply, the way the
+        /// connect-time init exchange does. Off by default, matching every other call site.
+        /// </param>
+        public async Task<IReadOnlyList<string>> CallExecuteTextCommandAsync(
             Action setupAction,
             bool keepBlankLines = false,
             int responseTimeoutMs = 500,
-            int completionTimeoutMs = 150)
+            int completionTimeoutMs = 150,
+            bool terminatorShortCircuit = false)
         {
-            return ExecuteTextCommandAsync(
+            using var scope = terminatorShortCircuit ? EnableTerminatorShortCircuit() : null;
+
+            return await ExecuteTextCommandAsync(
                 setupAction,
                 responseTimeoutMs: responseTimeoutMs,
                 completionTimeoutMs: completionTimeoutMs,
-                keepBlankLines: keepBlankLines);
+                keepBlankLines: keepBlankLines).ConfigureAwait(false);
         }
 
         public Task<IReadOnlyList<string>> CallWithPrepareAsync(

--- a/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
+++ b/src/Daqifi.Core.Tests/Device/Internal/ConnectionGuardTests.cs
@@ -186,6 +186,7 @@ public class ConnectionGuardTests
         public void ExitOperationLockOwnership() => throw new NotSupportedException();
         public Task DrainOutboundQueueAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
         public OutboundWriterSample? SampleOutboundWriter() => throw new NotSupportedException();
+        public bool IsExchangeTerminatorReply(string line) => throw new NotSupportedException();
         public IDisposable SubscribeConsumerErrors(IMessageConsumer<string> consumer) => throw new NotSupportedException();
         public void OnStaleLineBoundaryCaptured() => throw new NotSupportedException();
         public void OnSendBoundaryCaptured() => throw new NotSupportedException();

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -2053,27 +2053,87 @@ namespace Daqifi.Core.Device
 
         /// <inheritdoc />
         /// <remarks>
-        /// One query terminates an exchange today: <c>SYSTem:ERRor?</c>, which three call sites send
-        /// last for exactly this purpose — the connect-time init (#667 item 2), the SD directory
-        /// listing (#396) and the confirming administration commands. Recognising its reply is what
-        /// lets those exchanges stop the moment it lands instead of waiting out a completion window
-        /// sized for a device that might still be talking.
         /// <para>
-        /// Both halves are load-bearing. The command check keeps an exchange that never asked from
-        /// being ended by an error reply the device volunteered on its own, and the shape check is
-        /// the bare <c>-200,"Execution error"</c> form the query answers with — deliberately not
-        /// <see cref="ScpiResponseClassifier.IsScpiErrorLine"/>, which matches the <c>**ERROR:</c>
-        /// form a device volunteers alongside a command's output and would fire on a complaint that
-        /// is not this exchange's terminator at all.
+        /// One query terminates an exchange: <c>SYSTem:ERRor?</c>. Three call sites send it last for
+        /// exactly this purpose — the connect-time init (#667 item 2), the SD directory listing
+        /// (#396) and the confirming administration commands — but only the init exchange opts into
+        /// finishing early on it, via <see cref="EnableTerminatorShortCircuit"/>. The other two are
+        /// deliberately left on their completion windows; see that method for why.
+        /// </para>
+        /// <para>
+        /// The other two halves are load-bearing too. The command check keeps an exchange that never
+        /// asked from being ended by an error reply the device volunteered on its own, and the shape
+        /// check is the bare <c>-200,"Execution error"</c> form the query answers with — deliberately
+        /// not <see cref="ScpiResponseClassifier.IsScpiErrorLine"/>, which matches the
+        /// <c>**ERROR:</c> form a device volunteers alongside a command's output and would fire on a
+        /// complaint that is not this exchange's terminator at all.
         /// </para>
         /// </remarks>
         bool ITextExchangeHost.IsExchangeTerminatorReply(string line)
         {
-            return string.Equals(
+            return _terminatorShortCircuitEnabled.Value
+                   && string.Equals(
                        _lastExchangeTextCommand,
                        ScpiMessageProducer.GetSystemError.Data,
                        StringComparison.Ordinal)
                    && ScpiResponseClassifier.IsSystemErrorReplyLine(line);
+        }
+
+        /// <summary>
+        /// Whether the exchange running on this flow may finish as soon as its terminator reply
+        /// arrives, rather than waiting out its completion window.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="AsyncLocal{T}"/> so the opt-in reaches the engine and its wait loop — which run
+        /// as callees of the flow that sets it — without leaking to an exchange another thread is
+        /// running at the same time. The direction matters: an AsyncLocal write flows forward to
+        /// callees but never back to the caller, and callees are exactly who has to see this. That is
+        /// the opposite of <see cref="_lastExchangeTextCommand"/>, which is written by a callee (a
+        /// <see cref="Send{T}"/> inside the setup action) and so cannot be one.
+        /// </remarks>
+        private readonly AsyncLocal<bool> _terminatorShortCircuitEnabled = new();
+
+        /// <summary>
+        /// Lets the exchange started on this flow end as soon as its <c>SYSTem:ERRor?</c> reply
+        /// arrives. Dispose the returned scope to put it back.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Opt-in rather than always-on because the terminator cannot be proven to be <i>ours</i>. A
+        /// reply to an earlier, timed-out exchange that the device only emits once this exchange has
+        /// begun sending passes every boundary the engine has, and finishing on it truncates the
+        /// response. Where the response is a directory listing, the caller then caches a partial or
+        /// empty one and answers "is my file on the card?" from it — silently, because a listing cut
+        /// short before its end-of-listing marker reads as <c>Unterminated</c>, which is explicitly
+        /// not an error. That is the failure #396 exists to prevent, and it is not worth a second
+        /// off a listing.
+        /// </para>
+        /// <para>
+        /// The connect-time init exchange is the one place that hazard does not apply. It is the
+        /// first exchange on a freshly opened transport, so there is no earlier exchange of this
+        /// session to have left a reply in flight; a previous session's leftovers are what the
+        /// consumer settle and the stale-line boundary already cover; and its retry only runs once a
+        /// reply has been read, so the retry cannot inherit one either.
+        /// </para>
+        /// <para>
+        /// Widening this to the SD listing or the confirming commands needs the terminator tied to
+        /// the query that asked for it — a correlation SCPI does not offer — or a caller that can
+        /// detect a truncated response and re-run it on the full window. Neither is in scope here.
+        /// </para>
+        /// </remarks>
+        internal IDisposable EnableTerminatorShortCircuit()
+        {
+            _terminatorShortCircuitEnabled.Value = true;
+            return new TerminatorShortCircuitScope(this);
+        }
+
+        private sealed class TerminatorShortCircuitScope : IDisposable
+        {
+            private readonly DaqifiDevice _device;
+
+            internal TerminatorShortCircuitScope(DaqifiDevice device) => _device = device;
+
+            public void Dispose() => _device._terminatorShortCircuitEnabled.Value = false;
         }
 
         /// <inheritdoc />
@@ -3360,6 +3420,12 @@ namespace Daqifi.Core.Device
                     {
                         await Task.Delay(InitScpiErrorRetryDelayMs, cancellationToken).ConfigureAwait(false);
                     }
+
+                    // Scoped to this exchange alone, not to InitializeAsync as a whole: the
+                    // capability-document read and everything after it stay on their completion
+                    // windows. EnableTerminatorShortCircuit explains why this is the one exchange
+                    // that may finish early on its terminator (issue #667 item 4).
+                    using var terminatorShortCircuit = EnableTerminatorShortCircuit();
 
                     // The async setup overload, so the settle delays between commands are awaited
                     // rather than blocking the thread-pool thread in Thread.Sleep for 300ms

--- a/src/Daqifi.Core/Device/DaqifiDevice.cs
+++ b/src/Daqifi.Core/Device/DaqifiDevice.cs
@@ -1658,6 +1658,15 @@ namespace Daqifi.Core.Device
             // and dropped, turning a caller's bug into a silently missing command.
             ArgumentNullException.ThrowIfNull(message);
 
+            // Remember what a running exchange sent last, so the engine can recognise the reply that
+            // ends it (issue #667 item 4). Guarded by the in-exchange flag, which is AsyncLocal: a
+            // send from any other flow — including one being parked by TryDeferSend just below —
+            // reads false there and so cannot overwrite the running exchange's last command.
+            if (_isInsideTextExchange.Value && message is IOutboundMessage<string> textCommand)
+            {
+                _lastExchangeTextCommand = textCommand.Data;
+            }
+
             if (_operations.TryDeferSend(message))
             {
                 return;
@@ -1665,6 +1674,19 @@ namespace Daqifi.Core.Device
 
             SendNow(message);
         }
+
+        /// <summary>
+        /// The last text command a running text exchange enqueued, or <c>null</c> outside one and
+        /// before the first send of each.
+        /// </summary>
+        /// <remarks>
+        /// Written only by the exchange's own flow (see <see cref="Send{T}"/>) and read only by
+        /// <see cref="ITextExchangeHost.IsExchangeTerminatorReply"/> on that same flow, but the two
+        /// sit either side of the awaits the setup action may contain, so the read can land on a
+        /// different thread-pool thread than the write. <c>volatile</c> for that hop; no lock,
+        /// because the seam that reads it is documented as taking none.
+        /// </remarks>
+        private volatile string? _lastExchangeTextCommand;
 
         /// <summary>
         /// Serializes writes on the producer-less path, where <see cref="Send{T}"/> writes to the
@@ -2013,7 +2035,45 @@ namespace Daqifi.Core.Device
         bool ITextExchangeHost.IsInsideTextExchange
         {
             get => _isInsideTextExchange.Value;
-            set => _isInsideTextExchange.Value = value;
+            set
+            {
+                // The engine raises this flag exactly once at the start of each exchange and each
+                // raw capture, which is also the moment command tracking has to start over: without
+                // the reset, an exchange whose setup action sends nothing at all would inherit the
+                // previous exchange's last command and could be ended by a reply to a query it
+                // never sent.
+                if (value)
+                {
+                    _lastExchangeTextCommand = null;
+                }
+
+                _isInsideTextExchange.Value = value;
+            }
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// One query terminates an exchange today: <c>SYSTem:ERRor?</c>, which three call sites send
+        /// last for exactly this purpose — the connect-time init (#667 item 2), the SD directory
+        /// listing (#396) and the confirming administration commands. Recognising its reply is what
+        /// lets those exchanges stop the moment it lands instead of waiting out a completion window
+        /// sized for a device that might still be talking.
+        /// <para>
+        /// Both halves are load-bearing. The command check keeps an exchange that never asked from
+        /// being ended by an error reply the device volunteered on its own, and the shape check is
+        /// the bare <c>-200,"Execution error"</c> form the query answers with — deliberately not
+        /// <see cref="ScpiResponseClassifier.IsScpiErrorLine"/>, which matches the <c>**ERROR:</c>
+        /// form a device volunteers alongside a command's output and would fire on a complaint that
+        /// is not this exchange's terminator at all.
+        /// </para>
+        /// </remarks>
+        bool ITextExchangeHost.IsExchangeTerminatorReply(string line)
+        {
+            return string.Equals(
+                       _lastExchangeTextCommand,
+                       ScpiMessageProducer.GetSystemError.Data,
+                       StringComparison.Ordinal)
+                   && ScpiResponseClassifier.IsSystemErrorReplyLine(line);
         }
 
         /// <inheritdoc />

--- a/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
+++ b/src/Daqifi.Core/Device/Internal/ITextExchangeHost.cs
@@ -144,6 +144,31 @@ namespace Daqifi.Core.Device.Internal
         OutboundWriterSample? SampleOutboundWriter();
 
         /// <summary>
+        /// Whether <paramref name="line"/> is the reply that ends the exchange now running — the
+        /// answer to a query the exchange deliberately sent last so that it would have something to
+        /// finish on, rather than sitting out its whole inactivity window in silence.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The engine asks rather than decides: which query terminates an exchange, and what its
+        /// reply looks like, are SCPI facts that belong to the device. Here they would be the one
+        /// piece of protocol knowledge in an otherwise line-protocol-generic engine.
+        /// </para>
+        /// <para>
+        /// Answering <c>true</c> only shortens the wait; it never changes what the exchange returns,
+        /// and the engine still applies its own staleness boundaries before asking at all. So a
+        /// host that cannot tell should answer <c>false</c> — the exchange then waits out its
+        /// completion window exactly as it did before this seam existed.
+        /// </para>
+        /// <para>
+        /// Called on the exchange's own thread while it holds no gate, but once per newly arrived
+        /// line: it must stay cheap and must not take any lock the exchange holds.
+        /// </para>
+        /// </remarks>
+        /// <param name="line">A line collected after this exchange's commands began going out.</param>
+        bool IsExchangeTerminatorReply(string line);
+
+        /// <summary>
         /// Forwards the temporary text consumer's failures to the device's
         /// <see cref="DaqifiDevice.ErrorOccurred"/> surface for the lifetime of the returned scope.
         /// </summary>

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -640,29 +640,30 @@ namespace Daqifi.Core.Device.Internal
 
                     // Whether any line in [from, to) is the reply that ends this exchange — the
                     // answer to a query the setup action sent last precisely so the exchange would
-                    // have something to finish on (issue #667 item 4). Without this, those exchanges
-                    // sit out their whole completion window after the terminator has already
-                    // arrived: 500ms on every connect, 1000ms on every SD listing and every
-                    // confirmed administration command, all of it spent waiting for lines that by
-                    // construction are never coming.
+                    // have something to finish on (issue #667 item 4). Without this, such an
+                    // exchange sits out its whole completion window after the terminator has already
+                    // arrived, waiting for lines that by construction are never coming: 500ms on
+                    // every connect.
                     //
-                    // Two guards stand in front of the question, and they are what make asking it
-                    // safe. A terminator-shaped line that arrived before this exchange sent anything
-                    // is a leftover from an EARLIER exchange -- the case TrySplitAtSdListTerminator
-                    // scans from the end for, whose comment records that stopping at the first match
+                    // The host decides, and answers no unless the exchange opted in — today only the
+                    // connect-time init does. The reason the SD listing and the confirming commands
+                    // do NOT, though they send the same terminator and would save twice as much, is
+                    // the residual case below; DaqifiDevice.EnableTerminatorShortCircuit records it
+                    // in full.
+                    //
+                    // The guard in front of the question is the exchange's own pre-send boundary. A
+                    // terminator-shaped line that arrived before this exchange sent anything is a
+                    // leftover from an EARLIER exchange -- the case TrySplitAtSdListTerminator scans
+                    // from the end for, whose comment records that stopping at the first match
                     // reports an empty card. Such a line is skipped here, so it cannot end the
                     // exchange, and the projection below still hands the caller every line it
                     // collected: this decides only when to stop listening, never what is returned.
-                    // What the caller does with a response holding two terminator-shaped lines is
-                    // unchanged, and TrySplitAtSdListTerminator remains the authority on which of
-                    // them is real.
                     //
-                    // The residual case, and the reason the completion window stays as a fallback
-                    // rather than being tightened: a stale reply the device only emits AFTER this
-                    // exchange's commands have begun going out is not distinguishable from ours by
-                    // either guard. It has to be read from the buffer more than the 50ms consumer
-                    // settle above plus the send boundary after it, so it is narrow -- but it is not
-                    // impossible, and it is why nothing here is allowed to change the result.
+                    // What the guard cannot catch, and why this stays opt-in rather than becoming
+                    // the default: a stale reply the device only emits AFTER this exchange's
+                    // commands have begun going out is indistinguishable from ours. SCPI replies
+                    // carry no correlation, so there is nothing here that could tell them apart —
+                    // the safety has to come from the caller knowing no such reply can be pending.
                     bool TryFindTerminator(int from, int to)
                     {
                         var candidates = new List<string>();

--- a/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
+++ b/src/Daqifi.Core/Device/Internal/TextExchangeEngine.cs
@@ -420,14 +420,22 @@ namespace Daqifi.Core.Device.Internal
                 // Declared out here rather than beside its first use because both the wait loop
                 // and the projection ask it, and they sit on opposite sides of the consumer swap's
                 // try/finally.
+                //
+                // Split in two because the terminator short-circuit below asks the same question of
+                // a content line (#667 item 4). It may: declining to short-circuit only leaves the
+                // exchange waiting exactly as long as it used to, so applying the narrower rule
+                // there costs a fast reply nothing — unlike applying it to the projection, which
+                // would discard one.
+                bool ArrivedBeforeSend(int index, CollectedLine collected) =>
+                    index < sentBoundaryLineCount
+                    || (writerBoundary.HasValue
+                        && collected.WriterAtArrival.HasValue
+                        && collected.WriterAtArrival.Value.HasWorkOutstanding
+                        && collected.WriterAtArrival.Value.StartedWrites
+                            <= writerBoundary.Value.StartedWrites);
+
                 bool IsPreSendBlank(int index, CollectedLine collected) =>
-                    collected.Text.Length == 0
-                    && (index < sentBoundaryLineCount
-                        || (writerBoundary.HasValue
-                            && collected.WriterAtArrival.HasValue
-                            && collected.WriterAtArrival.Value.HasWorkOutstanding
-                            && collected.WriterAtArrival.Value.StartedWrites
-                                <= writerBoundary.Value.StartedWrites));
+                    collected.Text.Length == 0 && ArrivedBeforeSend(index, collected);
 
                 try
                 {
@@ -630,6 +638,64 @@ namespace Daqifi.Core.Device.Internal
                         }
                     }
 
+                    // Whether any line in [from, to) is the reply that ends this exchange — the
+                    // answer to a query the setup action sent last precisely so the exchange would
+                    // have something to finish on (issue #667 item 4). Without this, those exchanges
+                    // sit out their whole completion window after the terminator has already
+                    // arrived: 500ms on every connect, 1000ms on every SD listing and every
+                    // confirmed administration command, all of it spent waiting for lines that by
+                    // construction are never coming.
+                    //
+                    // Two guards stand in front of the question, and they are what make asking it
+                    // safe. A terminator-shaped line that arrived before this exchange sent anything
+                    // is a leftover from an EARLIER exchange -- the case TrySplitAtSdListTerminator
+                    // scans from the end for, whose comment records that stopping at the first match
+                    // reports an empty card. Such a line is skipped here, so it cannot end the
+                    // exchange, and the projection below still hands the caller every line it
+                    // collected: this decides only when to stop listening, never what is returned.
+                    // What the caller does with a response holding two terminator-shaped lines is
+                    // unchanged, and TrySplitAtSdListTerminator remains the authority on which of
+                    // them is real.
+                    //
+                    // The residual case, and the reason the completion window stays as a fallback
+                    // rather than being tightened: a stale reply the device only emits AFTER this
+                    // exchange's commands have begun going out is not distinguishable from ours by
+                    // either guard. It has to be read from the buffer more than the 50ms consumer
+                    // settle above plus the send boundary after it, so it is narrow -- but it is not
+                    // impossible, and it is why nothing here is allowed to change the result.
+                    bool TryFindTerminator(int from, int to)
+                    {
+                        var candidates = new List<string>();
+                        lock (collectedLinesGate)
+                        {
+                            var start = Math.Max(from, staleLineCount);
+                            var end = Math.Min(to, collectedLines.Count);
+                            for (var i = start; i < end; i++)
+                            {
+                                var collected = collectedLines[i];
+                                if (collected.Text.Length == 0 || ArrivedBeforeSend(i, collected))
+                                {
+                                    continue;
+                                }
+
+                                candidates.Add(collected.Text);
+                            }
+                        }
+
+                        // Asked with the gate released: the host's answer is documented as cheap and
+                        // lock-free, but the reader thread has to be able to take this gate, and
+                        // nothing that calls out of the engine may hold it.
+                        foreach (var candidate in candidates)
+                        {
+                            if (_host.IsExchangeTerminatorReply(candidate))
+                            {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+
                     // Wait for responses using a two-phase inactivity-based timeout:
                     // Phase 1: Wait up to responseTimeoutMs for the first response.
                     // Phase 2: After receiving data, wait completionTimeoutMs of inactivity to finish.
@@ -673,7 +739,18 @@ namespace Daqifi.Core.Device.Internal
                     // loop expressed the same thing by taking its "previous count" from here.
                     var observedLineCount = CollectedLineCount();
 
-                    while (true)
+                    // Checked before the loop as well as inside it, and for the same reason
+                    // hasReceivedAny is seeded above: on a device that answers faster than the
+                    // exchange gets here, the terminator has already landed, and a check that only
+                    // ran on a subsequent arrival would never see it — leaving exactly the wait this
+                    // is meant to remove, on exactly the fast devices it helps most (#592).
+                    var terminatorSeen = TryFindTerminator(0, observedLineCount);
+                    if (terminatorSeen)
+                    {
+                        Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Terminator reply already present entering wait loop"));
+                    }
+
+                    while (!terminatorSeen)
                     {
                         var now = sw.Elapsed;
 
@@ -739,6 +816,7 @@ namespace Daqifi.Core.Device.Internal
                         var currentCount = CollectedLineCount();
                         if (currentCount > observedLineCount)
                         {
+                            var previousLineCount = observedLineCount;
                             observedLineCount = currentCount;
                             lastMessageAt = sw.Elapsed;
 
@@ -751,6 +829,16 @@ namespace Daqifi.Core.Device.Internal
                             {
                                 hasReceivedAny = true;
                                 Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] First response at {ElapsedMs}ms", sw.ElapsedMilliseconds));
+                            }
+
+                            // Only the lines that just arrived are examined: an earlier one that was
+                            // going to end this exchange already did, and re-reading the whole
+                            // response on every arrival would make a long SD listing quadratic in
+                            // the number of lines it collects.
+                            if (TryFindTerminator(previousLineCount, currentCount))
+                            {
+                                terminatorSeen = true;
+                                Log(logger => logger.LogDebug("[ExecuteTextCommandAsync] Terminator reply at {ElapsedMs}ms; ending collection", sw.ElapsedMilliseconds));
                             }
                         }
                     }


### PR DESCRIPTION
## What was wrong

Every connection to a device spent half a second doing nothing but waiting.

The connect-time setup asks the device a question whose answer means "that's everything" — it ends its command sequence with `SYSTem:ERRor?` precisely so there is a reply to finish on. But the code that collects replies had no idea that reply was the end. It just kept listening until the line had gone quiet for half a second. That wait began *after* the answer had already arrived, and nothing was ever going to come during it.

## How it was fixed

The reply collector now asks the device whether the line that just arrived is the one that ends this exchange, and stops as soon as it is. The device answers by remembering what the exchange sent last, so the rule follows from what actually went out rather than from anyone remembering to flag it.

**Only the connect-time init exchange takes this fast path**, and that restriction is the interesting part of the review. The SD listing and the confirming administration commands send the same terminator and would save twice as much, but a reply left over from an *earlier, timed-out* exchange is indistinguishable from ours once our own commands have started going out — SCPI replies carry no correlation. Finishing on a stale one truncates the response, and for a directory listing that means silently caching a partial or empty card: a listing cut short before its end-of-listing marker reads as `Unterminated`, which is explicitly not an error. That is the failure #396 exists to prevent, and it is not worth a second off a listing.

Init is the one place the hazard does not apply. It is the first exchange on a freshly opened transport, so this session has no earlier exchange to have left a reply in flight; a previous session's leftovers are what the consumer settle and the stale-line boundary already cover; and its retry only runs once a reply has been read, so the retry cannot inherit one either.

Widening this later needs the terminator tied to the query that asked for it, or a caller that can detect a truncated response and re-run it on the full window. Both are out of scope here, and the code says so where someone would look.

## Verified

Bench Nq1 (fw 3.7.2, USB/serial), interleaved A/B against `main`, 10 pairs of connect + init + 1 s stream:

| | mean | median |
| --- | ---: | ---: |
| `main` | 5.117 s | 5.102 s |
| branch | 4.756 s | 4.616 s |
| **saving** | **0.360 s** | **0.486 s** |

9 of 10 pairs favour the branch. Interleaved with the leading side alternating, because this device's run-to-run spread is comparable to the effect size — the same discipline #700 needed. SD listing still returns all 55 files and `--lan-chip-info` is unchanged, both re-run after the narrowing.

Five new tests, each verified against a deliberately broken build rather than assumed: the exchange ends on its terminator (4111 ms against a 2000 ms bound when the short-circuit is disabled); an exchange that did **not** opt in waits out its window (111 ms against a 1000 ms bound when the gate is removed); it does not end on an error reply it never asked for; and it is not ended by a terminator that arrived before it sent, by either pre-send boundary — removing that guard makes the listing line vanish outright, which is the empty-card failure reproduced.

Full suite green on net9.0 and net10.0 — 4,134 core + 217 MCP.

No public API change. The new seam is on the internal `ITextExchangeHost`, so the `protected virtual ExecuteTextCommandAsync` overloads and the test doubles that override them are untouched — no `PublicAPI.*.txt` diff, and no source break under ADR 0002.

closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)