### PR TITLE
ci: collect coverage in-process so it cannot fail a green test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,25 @@ jobs:
         # path: src/coverage/<tfm>/<run guid>/coverage.cobertura.xml (see the results
         # directory Daqifi.Core.Tests.csproj sets). Flatten to the framework-labelled names
         # the summary and the uploaded artifact have always used.
+        #
+        # A failed move degrades to a warning and a report missing from the summary. This step
+        # runs under `set -e`, so letting one abort the step would put coverage back in a
+        # position to fail an otherwise green leg — the whole point of #689.
         for report in src/coverage/*/*/coverage.cobertura.xml; do
           framework=$(basename "$(dirname "$(dirname "$report")")")
-          mv -f "$report" "src/coverage/coverage.$framework.cobertura.xml"
+          mv -f "$report" "src/coverage/coverage.$framework.cobertura.xml" \
+            || echo "::warning::Could not move $report into place; $framework will be missing from the coverage summary."
         done
+
+        # Losing one framework's report and not the other's is otherwise invisible: the table
+        # simply renders a row short. The expected list is read from the test project rather
+        # than repeated here, so it cannot drift from the frameworks the tests actually run on.
+        expected=$(sed -n 's:.*<TargetFrameworks>\(.*\)</TargetFrameworks>.*:\1:p' src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj | tr ';' ' ' || true)
+        for framework in $expected; do
+          test -f "src/coverage/coverage.$framework.cobertura.xml" \
+            || echo "::warning::No coverage report was produced for $framework."
+        done
+
         reports=(src/coverage/*.cobertura.xml)
         if [ ${#reports[@]} -eq 0 ]; then
           echo "No coverage reports were produced by this run." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,16 @@ jobs:
 
     # --no-build because the step above already built it. Without that flag every
     # leg compiled the solution a second time, which the matrix would have tripled.
-    # Verified locally that coverlet still writes both cobertura reports under
-    # --no-build: it instruments through its own no-build target.
+    # Coverage rides along with this run: Daqifi.Core.Tests.csproj asks for the
+    # in-process collector, which instruments at load time and so is unaffected by
+    # --no-build. This step can now only fail on a test failure — the post-test
+    # MSBuild step that used to fail it after a fully green run is gone (#689).
     - name: Test
       run: dotnet test --no-build --no-restore Daqifi.Core.sln
 
     # Daqifi.Core.Tests.csproj collects coverage on every run, so the cobertura
-    # report already exists by this point; the next two steps are only about not
-    # throwing it away when the job ends. Reporting only — deliberately no
+    # reports already exist by this point; the next two steps are only about not
+    # throwing them away when the job ends. Reporting only — deliberately no
     # threshold that can fail the build (#641). `always()` so a red test run still
     # publishes whatever coverage was written before the failure.
     - name: Coverage summary
@@ -85,6 +87,15 @@ jobs:
       shell: bash
       run: |
         shopt -s nullglob
+        # The collector names every report coverage.cobertura.xml and buries it under a
+        # per-run GUID directory, so the framework it belongs to is only knowable from the
+        # path: src/coverage/<tfm>/<run guid>/coverage.cobertura.xml (see the results
+        # directory Daqifi.Core.Tests.csproj sets). Flatten to the framework-labelled names
+        # the summary and the uploaded artifact have always used.
+        for report in src/coverage/*/*/coverage.cobertura.xml; do
+          framework=$(basename "$(dirname "$(dirname "$report")")")
+          mv -f "$report" "src/coverage/coverage.$framework.cobertura.xml"
+        done
         reports=(src/coverage/*.cobertura.xml)
         if [ ${#reports[@]} -eq 0 ]; then
           echo "No coverage reports were produced by this run." >> "$GITHUB_STEP_SUMMARY"

--- a/src/Daqifi.Core.Tests/Build/CoverageReportingTests.cs
+++ b/src/Daqifi.Core.Tests/Build/CoverageReportingTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace Daqifi.Core.Tests.Build;
@@ -114,6 +115,34 @@ public class CoverageReportingTests
         var expectedGlob = $"{relative}/*/coverage.cobertura.xml";
 
         Assert.Contains(expectedGlob, WorkflowText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpectedFrameworks_StayReadableTheWayTheWorkflowReadsThem()
+    {
+        // CI warns about a report that went missing for one framework but not the other, and it
+        // reads the list of frameworks to expect straight out of this project rather than
+        // repeating it. That read is a single-line text match, so a reformatted or renamed
+        // element would not break the build - it would just find nothing to expect and warn
+        // about nothing, which is the failure this catches.
+        var declared = TestProject
+            .Descendants("PropertyGroup")
+            .Elements()
+            .Single(e => e.Name.LocalName == "TargetFrameworks")
+            .Value
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var matched = Regex
+            .Match(File.ReadAllText(TestProjectPath), "<TargetFrameworks>(.*)</TargetFrameworks>")
+            .Groups[1]
+            .Value
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        Assert.NotEmpty(declared);
+        Assert.Equal(declared, matched);
+
+        // And that the check is still pointed at this project.
+        Assert.Contains("src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj", WorkflowText, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Build/CoverageReportingTests.cs
+++ b/src/Daqifi.Core.Tests/Build/CoverageReportingTests.cs
@@ -117,14 +117,58 @@ public class CoverageReportingTests
         Assert.Contains(expectedGlob, WorkflowText, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The <c>sed</c> expression CI uses to read the expected frameworks, and the file it reads,
+    /// lifted out of the workflow so the test runs the real thing rather than a copy of it.
+    /// </summary>
+    private static (string Expression, string File) FrameworkReadFromWorkflow()
+    {
+        var invocation = Regex.Match(WorkflowText, @"sed -n 's:(?<expression>.*?):\\1:p' (?<file>\S+)");
+
+        Assert.True(invocation.Success,
+            "The coverage step no longer reads the expected frameworks with the `sed -n 's:...:\\1:p' <project>` " +
+            "form this test knows how to exercise. Either restore it or teach this test the new form - what " +
+            "must not happen is CI reading the frameworks in a way nothing checks.");
+
+        return (invocation.Groups["expression"].Value, invocation.Groups["file"].Value);
+    }
+
+    /// <summary>
+    /// Translates a POSIX basic regular expression - what <c>sed</c> takes - into the equivalent
+    /// .NET pattern, so the workflow's own expression can be run here.
+    /// </summary>
+    /// <remarks>
+    /// Only the grouping difference is translated, because that is the only construct the
+    /// expression uses. Anything else backslash-escaped would mean a rewrite this cannot
+    /// faithfully reproduce, and quietly mistranslating it would be worse than failing.
+    /// </remarks>
+    private static string BasicRegexToDotNet(string expression)
+    {
+        var translated = expression.Replace(@"\(", "(", StringComparison.Ordinal)
+                                   .Replace(@"\)", ")", StringComparison.Ordinal);
+
+        Assert.DoesNotContain(@"\", translated, StringComparison.Ordinal);
+
+        return translated;
+    }
+
     [Fact]
     public void ExpectedFrameworks_StayReadableTheWayTheWorkflowReadsThem()
     {
         // CI warns about a report that went missing for one framework but not the other, and it
         // reads the list of frameworks to expect straight out of this project rather than
-        // repeating it. That read is a single-line text match, so a reformatted or renamed
-        // element would not break the build - it would just find nothing to expect and warn
-        // about nothing, which is the failure this catches.
+        // repeating it. Both halves of that can rot silently: a reformatted <TargetFrameworks>
+        // or an edited sed expression would not break the build, it would just find nothing to
+        // expect and warn about nothing. So run the workflow's own expression over the real
+        // project file and check it still recovers the frameworks the project declares.
+        var (expression, file) = FrameworkReadFromWorkflow();
+
+        Assert.Equal("src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj", file);
+
+        // The workflow splits the match on ';' (`tr ';' ' '`), so a change of separator has to
+        // show up here too.
+        Assert.Contains(@"tr ';' ' '", WorkflowText, StringComparison.Ordinal);
+
         var declared = TestProject
             .Descendants("PropertyGroup")
             .Elements()
@@ -132,17 +176,14 @@ public class CoverageReportingTests
             .Value
             .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        var matched = Regex
-            .Match(File.ReadAllText(TestProjectPath), "<TargetFrameworks>(.*)</TargetFrameworks>")
+        var read = Regex
+            .Match(File.ReadAllText(TestProjectPath), BasicRegexToDotNet(expression))
             .Groups[1]
             .Value
             .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         Assert.NotEmpty(declared);
-        Assert.Equal(declared, matched);
-
-        // And that the check is still pointed at this project.
-        Assert.Contains("src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj", WorkflowText, StringComparison.Ordinal);
+        Assert.Equal(declared, read);
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Build/CoverageReportingTests.cs
+++ b/src/Daqifi.Core.Tests/Build/CoverageReportingTests.cs
@@ -1,0 +1,144 @@
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace Daqifi.Core.Tests.Build;
+
+/// <summary>
+/// Guards the coverage-collection decision from issue #689 and the one relationship it depends
+/// on: where <c>Daqifi.Core.Tests</c> writes its coverage reports has to be where the CI
+/// workflow looks for them.
+/// </summary>
+/// <remarks>
+/// Coverage used to be produced by <c>coverlet.msbuild</c>, whose <c>GenerateCoverageResult</c>
+/// target runs after the test run and could fail the job on an intermittent truncated read of
+/// its own hit file - a red build with 4,063 passing tests and, on a merge-queue run, a
+/// dequeued PR. Coverage is reporting-only and deliberately has no build-failing threshold
+/// (issue #641), so it moved to <c>coverlet.collector</c>, which runs inside the test host and
+/// has no post-test step to fail.
+///
+/// The cost of that move is the report path. <c>coverlet.msbuild</c> put the framework in the
+/// file name; the collector always writes <c>coverage.cobertura.xml</c> under a per-run GUID
+/// directory, so the framework survives only in the results directory the project chooses. That
+/// makes the project and <c>.github/workflows/ci.yml</c> two halves of one arrangement, each
+/// correct in isolation and useless if they disagree - the failure mode being a silent "No
+/// coverage reports were produced by this run.", which by design cannot fail a build and so
+/// would go unnoticed. This test is what notices.
+///
+/// The repository root is captured at build time as an assembly-metadata attribute; see
+/// <c>Daqifi.Core.Tests.csproj</c>.
+/// </remarks>
+public class CoverageReportingTests
+{
+    /// <summary>The collector's friendly name, as VSTest knows it.</summary>
+    private const string CollectorName = "XPlat Code Coverage";
+
+    private static string RepositoryRoot =>
+        Path.GetFullPath(
+            typeof(CoverageReportingTests).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(a => a.Key == "RepositoryRoot")
+                .Value!);
+
+    private static string TestProjectPath =>
+        Path.Combine(RepositoryRoot, "src", "Daqifi.Core.Tests", "Daqifi.Core.Tests.csproj");
+
+    private static XDocument TestProject => XDocument.Load(TestProjectPath);
+
+    private static string WorkflowText =>
+        File.ReadAllText(Path.Combine(RepositoryRoot, ".github", "workflows", "ci.yml"));
+
+    /// <summary>
+    /// The value of an MSBuild property declared in the test project, or <c>null</c>.
+    /// </summary>
+    /// <remarks>
+    /// Matched case-insensitively because MSBuild property names are: a
+    /// <c>&lt;collectcoverage&gt;</c> would set the same property as
+    /// <c>&lt;CollectCoverage&gt;</c>, and an ordinal match would read it as absent.
+    /// </remarks>
+    private static string? Property(string name) =>
+        TestProject
+            .Descendants("PropertyGroup")
+            .Elements()
+            .LastOrDefault(e => e.Name.LocalName.Equals(name, StringComparison.OrdinalIgnoreCase))
+            ?.Value.Trim();
+
+    private static HashSet<string> PackageReferences() =>
+        TestProject
+            .Descendants("PackageReference")
+            .Select(e => e.Attribute("Include")?.Value ?? string.Empty)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Coverage_IsCollectedInProcess()
+    {
+        // Anti-vacuity for the rest of the class: every assertion below is about the collector's
+        // arrangement, and none of them mean anything if the collector is not what runs.
+        Assert.Contains("coverlet.collector", PackageReferences());
+        Assert.Equal(CollectorName, Property("VSTestCollect"));
+    }
+
+    [Fact]
+    public void Coverage_DoesNotRunAsAPostTestMsBuildStep()
+    {
+        var packages = PackageReferences();
+
+        Assert.False(packages.Contains("coverlet.msbuild"),
+            "Daqifi.Core.Tests references coverlet.msbuild again. Its GenerateCoverageResult " +
+            "target runs after the tests have already passed and can still fail the job " +
+            "(issue #689); coverage is reporting-only and must not be able to do that.");
+
+        // CollectCoverage is what switches that target on, so it is the property that brings the
+        // failure mode back even if the package arrived transitively.
+        Assert.Null(Property("CollectCoverage"));
+    }
+
+    [Fact]
+    public void CoverageReports_LandWhereTheWorkflowLooksForThem()
+    {
+        var resultsDirectory = Property("VSTestResultsDirectory");
+        Assert.NotNull(resultsDirectory);
+
+        // Normalize the project-relative results directory to a repo-relative glob: strip the
+        // $(MSBuildThisFileDirectory)../ prefix that anchors it at src/, and stand a wildcard in
+        // for the framework, which expands once per inner build.
+        var relative = resultsDirectory!
+            .Replace("$(MSBuildThisFileDirectory)../", "src/", StringComparison.Ordinal)
+            .Replace("$(TargetFramework)", "*", StringComparison.Ordinal)
+            .Replace('\\', '/');
+
+        Assert.Equal("src/coverage/*", relative);
+
+        // The collector adds one per-run GUID directory of its own under that, then always names
+        // the file coverage.cobertura.xml. This is the glob CI has to walk to recover the
+        // framework from the path.
+        var expectedGlob = $"{relative}/*/coverage.cobertura.xml";
+
+        Assert.Contains(expectedGlob, WorkflowText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CollectorConfiguration_IsTheOneTheProjectPointsAt()
+    {
+        var settingsPath = Property("RunSettingsFilePath");
+        Assert.NotNull(settingsPath);
+
+        var resolved = Path.Combine(
+            RepositoryRoot,
+            "src",
+            "Daqifi.Core.Tests",
+            settingsPath!.Replace("$(MSBuildThisFileDirectory)", string.Empty, StringComparison.Ordinal));
+
+        Assert.True(File.Exists(resolved),
+            $"Daqifi.Core.Tests points RunSettingsFilePath at '{settingsPath}', which does not " +
+            "exist. VSTest ignores a missing run-settings file silently, so the collector would " +
+            "fall back to its own defaults and quietly change what the reported numbers mean.");
+
+        // The settings are only reached through the collector, so they have to name it, and the
+        // format is what the summary script and the uploaded artifact both assume.
+        var configuration = XDocument.Load(resolved)
+            .Descendants("DataCollector")
+            .Single(e => e.Attribute("friendlyName")?.Value == CollectorName);
+
+        Assert.Equal("cobertura", configuration.Descendants("Format").Single().Value.Trim());
+    }
+}

--- a/src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj
+++ b/src/Daqifi.Core.Tests/Daqifi.Core.Tests.csproj
@@ -3,17 +3,29 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <CollectCoverage>true</CollectCoverage>
-    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
-    <CoverletOutput>$(MSBuildThisFileDirectory)../coverage/</CoverletOutput>
-    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+
+    <!-- Coverage is collected in-process by coverlet.collector, not by coverlet.msbuild's
+         post-test MSBuild target (issue #689). That target ran after every test had already
+         passed and could still fail the whole job on an intermittent truncated read of its own
+         hit file, which on a merge-queue run dequeues the PR that is merging. The collector has
+         no post-test step: if it fails, the report is missing and the summary step says so,
+         which is the right blast radius for something that deliberately has no build-failing
+         threshold (issue #641).
+
+         Configured here rather than on CI's command line so a local `dotnet test` collects the
+         same way, and so collection is not requested for Daqifi.Mcp.Tests, which has no
+         collector and would only log "Could not find data collector" for it. -->
+    <VSTestCollect>XPlat Code Coverage</VSTestCollect>
+    <!-- $(TargetFramework) expands once per inner build, so each framework lands in its own
+         directory. That is what lets the solution stay a single `dotnet test` invocation - both
+         frameworks still run in parallel - while keeping the two reports apart and labelled;
+         the collector, unlike coverlet.msbuild, puts no framework in the file name. CI's
+         coverage step reads the framework back out of this layout. -->
+    <VSTestResultsDirectory>$(MSBuildThisFileDirectory)../coverage/$(TargetFramework)</VSTestResultsDirectory>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)coverlet.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <!-- FakeTimeProvider, for the deadlines the production code now reads through
          TimeProvider (issue #637): it makes a multi-second timeout a stepped clock rather than a

--- a/src/Daqifi.Core.Tests/coverlet.runsettings
+++ b/src/Daqifi.Core.Tests/coverlet.runsettings
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Settings for the in-process coverage collector (issue #689). Daqifi.Core.Tests.csproj points
+  RunSettingsFilePath at this file; nothing else in the repo runs with it.
+
+  Both values restate what coverlet.msbuild was configured with before the switch, so the
+  reported numbers stay comparable across the change:
+
+  - Format: coverlet.msbuild defaults to its own JSON, so the old csproj had to ask for
+    cobertura. The collector already defaults to cobertura, but the summary script and the
+    uploaded artifact both depend on the format, so it is stated rather than inherited.
+  - ExcludeByAttribute: keeps generated code - the protobuf message types under
+    Daqifi.Core/Generated - out of the denominator. Naming it here replaces the collector's
+    default list rather than adding to it, which is the same thing the old <ExcludeByAttribute>
+    property did.
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
CI went red on a run where nothing was wrong. Every test passed — 4,060 on each framework, plus the MCP suite — and then the Windows leg failed anyway, in coverlet's post-test MSBuild step, on `Unable to read beyond the end of the stream` while it read back its own hit file. The net9.0 coverage report was lost and the non-zero exit failed the job and the `build` gate with it. Coverage is reporting-only here and deliberately has no threshold that can fail a build, so this failure mode is all cost: a re-run fixes it, and on a merge-queue run it dequeues whatever PR was merging.

Coverage now comes from `coverlet.collector` instead, which runs inside the test host and has no post-test step that can fail. `dotnet test` is still a single solution-wide invocation with both frameworks in parallel, and the job summary and the uploaded artifact look exactly as they did.

**What a reviewer might push back on.** The collector puts no framework in the report name — it always writes `coverage.cobertura.xml` under a per-run GUID directory — so the framework has to survive in the path instead. The test project sets `VSTestResultsDirectory` to `../coverage/$(TargetFramework)`, which expands once per inner build; CI then flattens `<tfm>/<guid>/coverage.cobertura.xml` back to the `coverage.<tfm>.cobertura.xml` names that `coverage-summary.py` and the artifact already expect, so neither of those changed. Doing it this way (a project property, not `--results-directory` on the command line) is what avoids splitting the run into `-f net9.0` and `-f net10.0` steps, which would have serialized the two frameworks and cost about 35s a leg. `coverlet.runsettings` is load-bearing rather than decorative: without it the collector's own default exclusions move the reported line rate from 88.86% to 86.91%.

One real behaviour change for local development: `dotnet test` no longer prints coverlet's console coverage table. It writes cobertura under `src/coverage/<tfm>/` instead.

<details>
<summary>Verification</summary>

- Full suite green on net9.0 and net10.0, both test projects.
- Wall clock measured before and after: 40.9s with coverlet.msbuild, 36.6s with the collector — both frameworks still run in parallel.
- Reported numbers identical to the old configuration on the same tree (net9.0 line-rate 0.8886, 18,165 valid lines).
- Ran CI's coverage step (flatten + `coverage-summary.py`) locally; the rendered table has the same shape and the same `net9.0` / `net10.0` rows.
- `CoverageReportingTests` guards the one relationship that is now split across two files — where the project writes reports vs. where the workflow looks for them — since a mismatch would degrade silently to "No coverage reports were produced by this run." Confirmed it fails when the workflow glob's depth is changed.

</details>

closes #689

Not merging — for review.
