### PR TITLE
chore(api): check the packaged API against the release on nuget.org, not just against a file in the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,14 +85,26 @@ jobs:
     # Deliberately a failure, not a warning: after a release is published this
     # goes red until the bump lands, which is the point. It costs one unauthenticated
     # HTTP request to the index the pack step already downloads from.
+    #
+    # Stable versions only. release.yml accepts prerelease tags (`1.8.0-beta.1`),
+    # and the flat-container index lists them alongside the rest - but a prerelease
+    # is not what a consumer restores by default, so it must not become the
+    # baseline every other PR is then required to match. Filtering them here is
+    # also what keeps the baseline parseable as a plain three-part version, which
+    # PublicApiTrackingTests asserts.
     - name: Check the package validation baseline is the latest published version
       if: matrix.os == 'ubuntu-latest'
       shell: bash
       run: |
         baseline=$(dotnet msbuild src/Daqifi.Core/Daqifi.Core.csproj \
           -getProperty:PackageValidationBaselineVersion -p:TargetFramework=net10.0 | tr -d '[:space:]')
-        latest=$(curl -sSf https://api.nuget.org/v3-flatcontainer/daqifi.core/index.json | jq -r '.versions[-1]')
+        latest=$(curl -sSf https://api.nuget.org/v3-flatcontainer/daqifi.core/index.json \
+          | jq -r '[.versions[] | select(contains("-") | not)] | last')
         echo "baseline=$baseline latest=$latest"
+        if [ -z "$latest" ] || [ "$latest" = "null" ]; then
+          echo "::error::Could not resolve a stable published version of Daqifi.Core from nuget.org."
+          exit 1
+        fi
         if [ "$baseline" != "$latest" ]; then
           echo "::error::PackageValidationBaselineVersion is $baseline but Daqifi.Core $latest is published." \
                "Everything added since $baseline is outside the ApiCompat comparison." \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,31 @@ jobs:
     - name: Test
       run: dotnet test --no-build --no-restore Daqifi.Core.sln
 
+    # The baseline is only as good as it is current. ApiCompat can only report a
+    # member the baseline package actually contains, so every API added since the
+    # pinned version sits outside the comparison - an out-of-date baseline is a
+    # narrower check, not a stricter one, and the step below would keep passing
+    # while covering less and less. Bumping it is part of cutting a release
+    # (CONTRIBUTING.md); this is what makes forgetting visible instead of silent.
+    #
+    # Deliberately a failure, not a warning: after a release is published this
+    # goes red until the bump lands, which is the point. It costs one unauthenticated
+    # HTTP request to the index the pack step already downloads from.
+    - name: Check the package validation baseline is the latest published version
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        baseline=$(dotnet msbuild src/Daqifi.Core/Daqifi.Core.csproj \
+          -getProperty:PackageValidationBaselineVersion -p:TargetFramework=net10.0 | tr -d '[:space:]')
+        latest=$(curl -sSf https://api.nuget.org/v3-flatcontainer/daqifi.core/index.json | jq -r '.versions[-1]')
+        echo "baseline=$baseline latest=$latest"
+        if [ "$baseline" != "$latest" ]; then
+          echo "::error::PackageValidationBaselineVersion is $baseline but Daqifi.Core $latest is published." \
+               "Everything added since $baseline is outside the ApiCompat comparison." \
+               "Bump it in src/Daqifi.Core/Daqifi.Core.csproj."
+          exit 1
+        fi
+
     # The public API surface is guarded twice (issue #636). RS0016/RS0017 guard it
     # at compile time against the checked-in PublicAPI.*.txt, which the Build step
     # above already covers - but those files are part of the PR, so a PR that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,29 @@ jobs:
     - name: Test
       run: dotnet test --no-build --no-restore Daqifi.Core.sln
 
+    # The public API surface is guarded twice (issue #636). RS0016/RS0017 guard it
+    # at compile time against the checked-in PublicAPI.*.txt, which the Build step
+    # above already covers - but those files are part of the PR, so a PR that
+    # deletes an entry and the member together compiles clean. This step is the
+    # second half: it compares the packaged assemblies against what Daqifi.Core
+    # actually published to nuget.org (the baseline version in Daqifi.Core.csproj),
+    # which a PR cannot edit, and fails on a member the baseline had.
+    #
+    # `--no-build` is deliberately absent: it skips the ApiCompat targets outright,
+    # so a pack that uses it validates nothing. That is also why release.yml's pack
+    # is not the gate - it packs `--no-build` so the assemblies keep the version
+    # stamped from the git tag. Everything reaching a release tag has passed this
+    # step first, on the PR and again on main.
+    #
+    # Ubuntu only: the packaged shape is identical on all three legs, so the other
+    # two would pay to compute the same answer. `dotnet pack` defaults to Release,
+    # so this does compile Daqifi.Core once more rather than reusing the Debug
+    # output above - one project, a few seconds, on one leg. The package itself is
+    # thrown away; only the validation result matters.
+    - name: Validate packaged API against the last published release
+      if: matrix.os == 'ubuntu-latest'
+      run: dotnet pack src/Daqifi.Core/Daqifi.Core.csproj --no-restore --output "${{ runner.temp }}/api-validation"
+
     # Daqifi.Core.Tests.csproj collects coverage on every run, so the cobertura
     # report already exists by this point; the next two steps are only about not
     # throwing it away when the job ends. Reporting only — deliberately no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,30 @@ name in the message is already the exact line to add - those types sit in the gl
 And a *removal* is never automatic: deleting the entry is the deliberate act of declaring a
 breaking change, and ADR 0002 says what that costs.
 
+### The published package is the second opinion
+
+`PublicAPI.*.txt` lives in the repo, so a PR that removes a public member *and* its entry
+compiles clean - the deliberate act above looks identical to an accidental one. So
+`Daqifi.Core` also sets `EnablePackageValidation` with `PackageValidationBaselineVersion`
+pinned to the last version on nuget.org. CI packs the project (`Validate packaged API against
+the last published release` in `ci.yml`) and ApiCompat compares the packaged assemblies, for
+both target frameworks, against that published package - which no PR can edit. A member the
+baseline shipped and this build does not is `CP0002`.
+
+Two things to know:
+
+- Run it locally with `dotnet pack src/Daqifi.Core/Daqifi.Core.csproj`. **Do not** add
+  `--no-build`; it skips the validation targets entirely and the pack passes without checking
+  anything.
+- After a release, bump `PackageValidationBaselineVersion` to the version just published, in
+  the same change that moves `Unshipped` entries into `Shipped`. Forgetting only leaves the
+  check comparing against an older release, which is stricter rather than wrong.
+
+An intentional break needs the entry removed from `PublicAPI.Shipped.txt` *and* an ApiCompat
+suppression (`dotnet pack src/Daqifi.Core/Daqifi.Core.csproj -p:ApiCompatGenerateSuppressionFile=true`),
+which checks in a `CompatibilitySuppressions.xml` naming exactly what was broken. That file
+appearing in a diff is the signal ADR 0002 wants a reviewer to see.
+
 ## Security: how we do and don't accept code
 
 **We only ever accept code changes as pull requests against this repository.** A PR gives

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,8 +91,11 @@ Two things to know:
   `--no-build`; it skips the validation targets entirely and the pack passes without checking
   anything.
 - After a release, bump `PackageValidationBaselineVersion` to the version just published, in
-  the same change that moves `Unshipped` entries into `Shipped`. Forgetting only leaves the
-  check comparing against an older release, which is stricter rather than wrong.
+  the same change that moves `Unshipped` entries into `Shipped`. This is required, not
+  housekeeping. An out-of-date baseline is a *narrower* check, not a stricter one: ApiCompat
+  can only report a member the baseline package actually contains, so everything added since
+  the pinned version falls outside the comparison and could be removed with nothing to report.
+  CI fails when the baseline drifts behind nuget.org, so forgetting is loud rather than silent.
 
 An intentional break needs the entry removed from `PublicAPI.Shipped.txt` *and* an ApiCompat
 suppression (`dotnet pack src/Daqifi.Core/Daqifi.Core.csproj -p:ApiCompatGenerateSuppressionFile=true`),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,8 @@ Two things to know:
   can only report a member the baseline package actually contains, so everything added since
   the pinned version falls outside the comparison and could be removed with nothing to report.
   CI fails when the baseline drifts behind nuget.org, so forgetting is loud rather than silent.
+  The baseline is always the newest *stable* release: a prerelease can be published, but it is
+  not what a consumer restores by default, so CI skips prereleases when deciding what is newest.
 
 An intentional break needs the entry removed from `PublicAPI.Shipped.txt` *and* an ApiCompat
 suppression (`dotnet pack src/Daqifi.Core/Daqifi.Core.csproj -p:ApiCompatGenerateSuppressionFile=true`),

--- a/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
+++ b/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
@@ -6,8 +6,9 @@ namespace Daqifi.Core.Tests.Build;
 
 /// <summary>
 /// Guards the public API surface tracking added for issue #636: the
-/// <c>Microsoft.CodeAnalysis.PublicApiAnalyzers</c> wiring in <c>Daqifi.Core.csproj</c> and the
-/// two <c>PublicAPI.*.txt</c> files it reads.
+/// <c>Microsoft.CodeAnalysis.PublicApiAnalyzers</c> wiring in <c>Daqifi.Core.csproj</c>, the
+/// two <c>PublicAPI.*.txt</c> files it reads, and the package validation that checks the same
+/// surface against the release already on nuget.org.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -91,6 +92,63 @@ public class PublicApiTrackingTests
             .ToList();
 
         Assert.Contains(fileName, additionalFiles);
+    }
+
+    /// <summary>
+    /// The second half of the issue #636 guard: ApiCompat against the package actually on
+    /// nuget.org. RS0016/RS0017 only compare the code to <c>PublicAPI.*.txt</c>, and both live in
+    /// the PR - remove a public member and its entry together and the build is green. Package
+    /// validation compares against a published artifact no PR can edit.
+    /// </summary>
+    [Fact]
+    public void CoreProject_ValidatesThePackageAgainstItsBaseline()
+    {
+        var value = XDocument.Load(CoreProjectPath)
+            .Descendants("EnablePackageValidation")
+            .Select(e => e.Value.Trim())
+            .SingleOrDefault();
+
+        Assert.Equal("true", value);
+    }
+
+    [Fact]
+    public void CoreProject_PinsThePackageValidationBaselineToAPublishedVersion()
+    {
+        var baseline = XDocument.Load(CoreProjectPath)
+            .Descendants("PackageValidationBaselineVersion")
+            .Select(e => e.Value.Trim())
+            .SingleOrDefault();
+
+        // Not a specific version - that has to move with every release. Only that one is pinned:
+        // with EnablePackageValidation on but no baseline, validation still runs and still
+        // passes, checking the package against nothing but itself.
+        Assert.True(
+            baseline is not null && Version.TryParse(baseline, out _),
+            "Daqifi.Core.csproj must pin PackageValidationBaselineVersion to a published version; "
+            + $"found {baseline ?? "<none>"}.");
+    }
+
+    [Fact]
+    public void Ci_PacksTheLibrarySoPackageValidationActuallyRuns()
+    {
+        // The trap this exists for: `dotnet pack --no-build` skips the ApiCompat targets
+        // outright. A pack step carrying that flag succeeds without comparing anything, so the
+        // csproj wiring above would still be present and still be checking nothing. Verified by
+        // running both forms locally against a removed public member: without --no-build it is
+        // CP0002 on both target frameworks, with it the pack is silent.
+        var workflow = File.ReadAllLines(
+            Path.Combine(RepositoryRoot, ".github", "workflows", "ci.yml"));
+
+        var packSteps = workflow
+            .Select(line => line.Trim())
+            .Where(line =>
+                line.StartsWith("run:", StringComparison.Ordinal)
+                && line.Contains("dotnet pack", StringComparison.Ordinal)
+                && line.Contains("Daqifi.Core.csproj", StringComparison.Ordinal))
+            .ToList();
+
+        var packStep = Assert.Single(packSteps);
+        Assert.DoesNotContain("--no-build", packStep, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
+++ b/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
@@ -126,12 +126,15 @@ public class PublicApiTrackingTests
         // all: with EnablePackageValidation on but no baseline, validation still runs and still
         // passes, checking the package against nothing but itself.
         //
-        // Whether the pinned version is still the *newest* published one is a question about
-        // nuget.org, so it is asked in CI rather than here - see the test below.
+        // Version.TryParse rejects a SemVer prerelease such as `1.8.0-beta.1`, which is
+        // deliberate and matches CI: release.yml can publish a prerelease, but the baseline is
+        // always the newest *stable* release, so the CI check filters prereleases out of the
+        // nuget.org query. Whether the pinned version is still the newest one is a question
+        // about nuget.org, so it is asked there rather than here - see the test below.
         Assert.True(
             baseline is not null && Version.TryParse(baseline, out _),
-            "Daqifi.Core.csproj must pin PackageValidationBaselineVersion to a published version; "
-            + $"found {baseline ?? "<none>"}.");
+            "Daqifi.Core.csproj must pin PackageValidationBaselineVersion to a stable published "
+            + $"version; found {baseline ?? "<none>"}.");
     }
 
     [Fact]
@@ -142,14 +145,50 @@ public class PublicApiTrackingTests
         // version is outside the comparison and could be removed with nothing to report - while
         // the pack step keeps passing. Nothing in the repo records which version is current, so
         // CI asks nuget.org, and this asserts it still does.
-        Assert.Contains(
-            "PackageValidationBaselineVersion",
-            CiWorkflowText,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "api.nuget.org/v3-flatcontainer/daqifi.core/index.json",
-            CiWorkflowText,
-            StringComparison.Ordinal);
+        //
+        // Asserted against the step's own `run:` block rather than the whole file, and against
+        // each part the enforcement actually rests on. Checking only that the property name and
+        // the URL appear somewhere would stay green with the comparison or the `exit 1` deleted,
+        // which is precisely the silent disablement this is here to catch.
+        var step = RunBlockOfCiStep("Check the package validation baseline");
+
+        Assert.Contains("PackageValidationBaselineVersion", step, StringComparison.Ordinal);
+        Assert.Contains("api.nuget.org/v3-flatcontainer/daqifi.core/index.json", step, StringComparison.Ordinal);
+
+        // Prereleases are filtered out of the query: release.yml can publish them, and one must
+        // not become the baseline that every other PR is then required to match.
+        Assert.Contains("""select(contains("-") | not)""", step, StringComparison.Ordinal);
+
+        // The comparison itself, and a non-zero exit when it fails. Without both, the step can
+        // report the drift and pass anyway.
+        Assert.Contains("\"$baseline\" != \"$latest\"", step, StringComparison.Ordinal);
+        Assert.Contains("exit 1", step, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The <c>run:</c> block of the first <c>ci.yml</c> step whose name contains
+    /// <paramref name="stepNameFragment"/> - everything from <c>run:</c> to the next step.
+    /// </summary>
+    private static string RunBlockOfCiStep(string stepNameFragment)
+    {
+        var lines = CiWorkflowText.Split('\n');
+
+        var start = Array.FindIndex(
+            lines,
+            line => line.TrimStart().StartsWith("- name:", StringComparison.Ordinal)
+                && line.Contains(stepNameFragment, StringComparison.Ordinal));
+
+        Assert.True(start >= 0, $"ci.yml has no step named like '{stepNameFragment}'.");
+
+        var body = lines
+            .Skip(start + 1)
+            .TakeWhile(line => !line.TrimStart().StartsWith("- name:", StringComparison.Ordinal))
+            .ToList();
+
+        var runAt = body.FindIndex(line => line.TrimStart().StartsWith("run:", StringComparison.Ordinal));
+        Assert.True(runAt >= 0, $"The '{stepNameFragment}' step in ci.yml no longer runs anything.");
+
+        return string.Join("\n", body.Skip(runAt));
     }
 
     [Fact]

--- a/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
+++ b/src/Daqifi.Core.Tests/Build/PublicApiTrackingTests.cs
@@ -51,6 +51,9 @@ public class PublicApiTrackingTests
     private static string ApiFilePath(string fileName) =>
         Path.Combine(RepositoryRoot, "src", "Daqifi.Core", fileName);
 
+    private static string CiWorkflowText =>
+        File.ReadAllText(Path.Combine(RepositoryRoot, ".github", "workflows", "ci.yml"));
+
     private const string ShippedFileName = "PublicAPI.Shipped.txt";
     private const string UnshippedFileName = "PublicAPI.Unshipped.txt";
 
@@ -119,13 +122,34 @@ public class PublicApiTrackingTests
             .Select(e => e.Value.Trim())
             .SingleOrDefault();
 
-        // Not a specific version - that has to move with every release. Only that one is pinned:
-        // with EnablePackageValidation on but no baseline, validation still runs and still
+        // Not a specific version - that moves with every release. Only that one is pinned at
+        // all: with EnablePackageValidation on but no baseline, validation still runs and still
         // passes, checking the package against nothing but itself.
+        //
+        // Whether the pinned version is still the *newest* published one is a question about
+        // nuget.org, so it is asked in CI rather than here - see the test below.
         Assert.True(
             baseline is not null && Version.TryParse(baseline, out _),
             "Daqifi.Core.csproj must pin PackageValidationBaselineVersion to a published version; "
             + $"found {baseline ?? "<none>"}.");
+    }
+
+    [Fact]
+    public void Ci_FailsWhenTheBaselineHasFallenBehindTheLatestRelease()
+    {
+        // An out-of-date baseline is a narrower check, not a stricter one: ApiCompat can only
+        // report a member the baseline package contains, so everything added since the pinned
+        // version is outside the comparison and could be removed with nothing to report - while
+        // the pack step keeps passing. Nothing in the repo records which version is current, so
+        // CI asks nuget.org, and this asserts it still does.
+        Assert.Contains(
+            "PackageValidationBaselineVersion",
+            CiWorkflowText,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "api.nuget.org/v3-flatcontainer/daqifi.core/index.json",
+            CiWorkflowText,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -136,10 +160,8 @@ public class PublicApiTrackingTests
         // csproj wiring above would still be present and still be checking nothing. Verified by
         // running both forms locally against a removed public member: without --no-build it is
         // CP0002 on both target frameworks, with it the pack is silent.
-        var workflow = File.ReadAllLines(
-            Path.Combine(RepositoryRoot, ".github", "workflows", "ci.yml"));
-
-        var packSteps = workflow
+        var packSteps = CiWorkflowText
+            .Split('\n')
             .Select(line => line.Trim())
             .Where(line =>
                 line.StartsWith("run:", StringComparison.Ordinal)

--- a/src/Daqifi.Core/Daqifi.Core.csproj
+++ b/src/Daqifi.Core/Daqifi.Core.csproj
@@ -14,6 +14,30 @@
 
     <!-- Build Configuration -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Binary-shape tracking against the last published package (issue #636).
+         The PublicApiAnalyzers reference below guards the *source* surface as it
+         is written; this guards the *packaged* shape as a consumer restores it -
+         the assemblies actually in the .nupkg, for every target framework it
+         claims to support. It is what reports a framework silently disappearing
+         from the package, or a type that compiles but no longer exists for one
+         of the two TFMs. Runs during `dotnet pack` and fails it (CP0002 and
+         friends) when this build removes something 1.7.0 shipped. Bump the
+         baseline when a release goes out; leaving it behind only makes the
+         check stricter. See CONTRIBUTING.md. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>1.7.0</PackageValidationBaselineVersion>
+    <!-- CP0003 compares assembly *versions*, and this repo carries none: the
+         version is stamped only by release.yml, from the git tag. Every other
+         build - CI, a developer's `dotnet pack` - therefore ships the SDK's
+         1.0.0 placeholder, which CP0003 reports as "lower than the 1.7.0
+         baseline" on a build that has changed no API at all. Suppressed so the
+         rules that do carry signal here (CP0002 for a member the baseline had,
+         CP1002 for a target framework the package no longer offers) are not
+         drowned by a diagnostic that is never about this change. Version
+         ordering is already decided upstream, by which tag the release is cut
+         from. -->
+    <NoWarn>$(NoWarn);CP0003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Daqifi.Core/Daqifi.Core.csproj
+++ b/src/Daqifi.Core/Daqifi.Core.csproj
@@ -22,9 +22,16 @@
          claims to support. It is what reports a framework silently disappearing
          from the package, or a type that compiles but no longer exists for one
          of the two TFMs. Runs during `dotnet pack` and fails it (CP0002 and
-         friends) when this build removes something 1.7.0 shipped. Bump the
-         baseline when a release goes out; leaving it behind only makes the
-         check stricter. See CONTRIBUTING.md. -->
+         friends) when this build removes something the baseline shipped.
+
+         The baseline MUST be bumped to the new version as part of every
+         release. An out-of-date baseline is not a stricter check, it is a
+         narrower one: ApiCompat can only report a member the baseline package
+         actually contains, so everything added since the pinned version falls
+         outside the comparison entirely and can be removed with nothing to
+         report. CI fails when this drifts behind nuget.org - see the
+         `Check the package validation baseline` step in ci.yml, and
+         CONTRIBUTING.md. -->
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>1.7.0</PackageValidationBaselineVersion>
     <!-- CP0003 compares assembly *versions*, and this repo carries none: the


### PR DESCRIPTION
## What was wrong

ADR 0002 promises source compatibility for `Daqifi.Core`'s public API. PR #680 made that promise visible: the surface is checked in as `PublicAPI.Shipped.txt`, and RS0016/RS0017 fail the build whenever the code and that file disagree.

But both files travel in the PR. Delete a public member *and* its line in `PublicAPI.Shipped.txt` in the same change and the build is green — which is precisely the shape of a break ADR 0002 is meant to catch. A deliberate break and an accidental one look identical to the build, and the accidental one reaches a consumer (`daqifi-desktop`, `Daqifi.Mcp`, an external integrator) on their next restore.

I confirmed this on main before changing anything: narrowing `DeviceMetadata.IpAddress`'s setter to `internal` and deleting its one line from `PublicAPI.Shipped.txt` builds clean, 0 warnings, 0 errors.

## How it's fixed

Compare against something the PR cannot edit: the package already on nuget.org.

`Daqifi.Core` now sets `EnablePackageValidation` with `PackageValidationBaselineVersion` pinned to **1.7.0**, the last published version, and CI packs the library so ApiCompat compares the packaged assemblies — both `net9.0` and `net10.0` — against that download. The same removal above now fails with `CP0002` on both frameworks.

That leaves the source analyzer as the fast, precise, everyday check and package validation as the backstop that answers "does this still work for someone who already depends on 1.7.0?"

A second CI step keeps the baseline honest: it resolves the newest stable version from the nuget.org index and fails when the pinned baseline is behind it. Without that, the check quietly narrows over time — ApiCompat can only report a member the baseline package actually contains, so everything added since the pinned version would fall outside the comparison entirely.

## Things a reviewer may want to push back on

**`CP0003` is suppressed.** It compares assembly *versions*, and this repo carries none — the version is stamped only by `release.yml` from the git tag. Every other build ships the SDK's `1.0.0` placeholder, so `CP0003` reports "lower than the 1.7.0 baseline" on every build, including ones that change no API at all. Suppressing it keeps the rules that carry signal here (`CP0002`, `CP1002`) readable. Version ordering is decided upstream by which tag the release is cut from.

**The gate is in `ci.yml`, not `release.yml`.** Package validation only runs inside `dotnet pack`, and `--no-build` skips the ApiCompat targets entirely — verified: with `--no-build` the pack is silent on a break that otherwise produces `CP0002`. `release.yml` packs `--no-build` on purpose, so its assemblies keep the version stamped by the earlier build step; removing that flag would republish the assemblies as `1.0.0.0`. So the PR/main gate is the right place, and everything reaching a release tag has passed it. `PublicApiTrackingTests` asserts the CI pack step never grows a `--no-build`.

**The baseline-freshness check is a failure, not a warning.** After a release is published, CI goes red on every PR until the baseline bump lands. That is the intent — the bump PR itself is green, and the alternative is a check that silently covers less over time. The bump belongs in the same change that moves `Unshipped` entries into `Shipped`.

**Prereleases are excluded when deciding what is "newest".** `release.yml` accepts prerelease tags and the index lists them, but a prerelease is not what a consumer restores by default, so it must not become the version every other PR is required to match.

**It costs one extra compile.** `dotnet pack` defaults to Release, so the step rebuilds `Daqifi.Core` rather than reusing the Debug output. One project, on the ubuntu leg only — the packaged shape is identical on all three. Measured at ~6s in CI.

## Verification

- Mutation proof for package validation: setter narrowed to `internal` **and** its `PublicAPI.Shipped.txt` line deleted → `dotnet build` green, `dotnet pack` red with `CP0002` on `net9.0` and `net10.0`.
- The pre-existing analyzer gate re-verified in both directions: a new public type → `RS0016`; a narrowed setter → `RS0017`.
- Baseline-freshness check: pinning 1.6.0 against the published 1.7.0 exits 1 with the `::error::` annotation. Prerelease filter checked against a simulated index and the live one.
- Every new test checked to fail when its wiring is removed.
- Full suite green on net9.0 + net10.0: 4152 + 217 per framework, 0 failed. CI green on all three OS legs, with both new steps passing.

No bench run — this is a build-configuration change with no device path.

Closes #636

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
