### PR TITLE
docs(transport): record what an idle connected serial device actually costs on Unix

### DIFF
--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -38,6 +38,27 @@ namespace Daqifi.Core.Communication.Transport;
 /// An intentional <see cref="Disconnect"/> disarms both detectors first, so it reports a normal
 /// disconnect and never a loss.
 /// </para>
+/// <para>
+/// <b>Idle CPU on Unix.</b> A connected but completely silent device is not free on macOS or Linux.
+/// .NET's Unix <c>SerialStream</c> services a pending read from a helper thread that alternates a
+/// 1 ms sleep with <c>TIOCMGET</c>/<c>FIONREAD</c> ioctls, so it costs roughly <b>2% of one core
+/// for as long as a read is outstanding</b> — and a stream transport keeps exactly one outstanding
+/// at all times, by design. Measured over a 30 s idle window on <c>System.IO.Ports</c> 10.0.11
+/// (issue #673): 0.0% with the port merely open, 2.0% on macOS and 2.3% on Linux with a blocking
+/// read pending, and about 3% for a whole connected <see cref="Device.DaqifiStreamingDevice"/>.
+/// Callers holding many devices open for hours should budget for it. Windows drives reads through
+/// overlapped I/O rather than a poll loop and so is not expected to pay it, but that has not been
+/// measured.
+/// </para>
+/// <para>
+/// Nothing above <see cref="SerialPort"/> reaches that cost: it is unaffected by
+/// <see cref="OperationalReadTimeoutMs"/> (an infinite read timeout measured slightly worse, not
+/// better) and by the shape of the consumer's read loop. The only lever that does reach it is not
+/// having a read outstanding — gating each read on <see cref="SerialPort.BytesToRead"/>, which is a
+/// bare <c>FIONREAD</c> ioctl that does not start the helper thread, measures about 0.1%. That
+/// trade has deliberately not been taken, because it buys the saving with added first-byte latency
+/// after an idle gap on a path whose timing the SCPI exchanges depend on.
+/// </para>
 /// </remarks>
 public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
 {
@@ -64,7 +85,8 @@ public class SerialStreamTransport : IStreamTransport, ITransportHealthSink
     /// <summary>
     /// Blocking-read timeout applied once the port is open. The connection timeout is only
     /// needed for retry/backoff logic, not for reads during normal operation; a short value
-    /// keeps consumer threads stoppable (StopSafely).
+    /// keeps consumer threads stoppable (StopSafely). It is a shutdown-latency knob, not a CPU one
+    /// — see the idle-CPU paragraph on the class for why changing it does not move idle cost.
     /// </summary>
     private const int OperationalReadTimeoutMs = 500;
 

--- a/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
+++ b/src/Daqifi.Core/Communication/Transport/SerialStreamTransport.cs
@@ -42,22 +42,27 @@ namespace Daqifi.Core.Communication.Transport;
 /// <b>Idle CPU on Unix.</b> A connected but completely silent device is not free on macOS or Linux.
 /// .NET's Unix <c>SerialStream</c> services a pending read from a helper thread that alternates a
 /// 1 ms sleep with <c>TIOCMGET</c>/<c>FIONREAD</c> ioctls, so it costs roughly <b>2% of one core
-/// for as long as a read is outstanding</b> — and a stream transport keeps exactly one outstanding
-/// at all times, by design. Measured over a 30 s idle window on <c>System.IO.Ports</c> 10.0.11
-/// (issue #673): 0.0% with the port merely open, 2.0% on macOS and 2.3% on Linux with a blocking
-/// read pending, and about 3% for a whole connected <see cref="Device.DaqifiStreamingDevice"/>.
+/// for as long as a read is outstanding</b>. This transport does not read on its own — an open port
+/// with nobody reading it measures 0.0%. The cost arrives with whoever reads <see cref="Stream"/>:
+/// a <see cref="Consumers.StreamMessageConsumer{T}"/> keeps a blocking read pending the whole time
+/// it is running, which for a connected <see cref="Device.DaqifiStreamingDevice"/> is all of the
+/// time except the brief windows a text exchange suspends it for. Measured over a 30 s idle window
+/// on <c>System.IO.Ports</c> 10.0.11 (issue #673): 0.0% with the port merely open, 2.0% on macOS
+/// and 2.3% on Linux with a blocking read pending, and about 3% for a whole connected device.
 /// Callers holding many devices open for hours should budget for it. Windows drives reads through
 /// overlapped I/O rather than a poll loop and so is not expected to pay it, but that has not been
 /// measured.
 /// </para>
 /// <para>
-/// Nothing above <see cref="SerialPort"/> reaches that cost: it is unaffected by
+/// Because the helper thread polls for the read's <i>duration</i>, the cost follows time spent
+/// inside a read rather than the number of reads. So it is unaffected by
 /// <see cref="OperationalReadTimeoutMs"/> (an infinite read timeout measured slightly worse, not
-/// better) and by the shape of the consumer's read loop. The only lever that does reach it is not
-/// having a read outstanding — gating each read on <see cref="SerialPort.BytesToRead"/>, which is a
-/// bare <c>FIONREAD</c> ioctl that does not start the helper thread, measures about 0.1%. That
-/// trade has deliberately not been taken, because it buys the saving with added first-byte latency
-/// after an idle gap on a path whose timing the SCPI exchanges depend on.
+/// better), and unaffected by any reshaping of the consumer's loop that still leaves a blocking
+/// read continuously pending. The one lever that does reach it is having no read pending while the
+/// line is quiet: gating each read on <see cref="SerialPort.BytesToRead"/> — a bare <c>FIONREAD</c>
+/// ioctl that does not start the helper thread — measures about 0.1%. That trade has deliberately
+/// not been taken, because it buys the saving with added first-byte latency after an idle gap on a
+/// path whose timing the SCPI exchanges depend on.
 /// </para>
 /// </remarks>
 public class SerialStreamTransport : IStreamTransport, ITransportHealthSink


### PR DESCRIPTION
**Not merging — for review.**

## What was wrong

If you connect a DAQiFi over USB serial and then do nothing at all, the library keeps burning CPU. Leave ten devices connected in a desktop app or an MCP server overnight and they idle away a noticeable slice of a core between them, having transferred nothing. Issue #673 recorded this at "about 5% of a core per device" and left three questions open: does it happen off macOS, what exactly is spending the time, and is there anything we can do about it.

## What this changes

Nothing, functionally — this is a documentation-only PR. What it adds is the answer, written down on `SerialStreamTransport` next to the existing drop-detection notes, so the next person to go looking does not repeat the measurement:

- **The real number is ~2%, not ~5%.** An open serial port is free (0.0%). A pending blocking read costs 2.0% of a core on macOS and 2.3% on Linux. A whole connected `DaqifiStreamingDevice` costs about 3%.
- **It is not macOS-specific.** Linux reproduces macOS within noise, which is expected — both go through the same shared Unix `SerialStream`.
- **The mechanism**, from profiler stacks: .NET's Unix `SerialStream` services a pending read from a helper thread that alternates a 1 ms sleep with `TIOCMGET`/`FIONREAD` ioctls. That is a ~1 kHz poll running for as long as a read is outstanding — and a stream transport keeps exactly one outstanding at all times, by design. This is why the cost tracks *time spent inside a read* rather than read count, exactly as #673 suspected.
- **No knob at our layer reaches it.** `OperationalReadTimeoutMs` does not (an *infinite* read timeout measured slightly worse, not better), and neither does the shape of the consumer's read loop. The `OperationalReadTimeoutMs` doc comment now says so, so nobody tunes it hoping for CPU.

## The thing a reviewer will most want to argue with

**There is a fix, and I did not take it.** Gating each read on `SerialPort.BytesToRead` — a bare `FIONREAD` ioctl that does not start the helper thread — drops the transport floor from 2.0% to **0.1%**, a 20x cut, with no P/Invoke and no new dependency. I measured it; it works.

I left it alone for three reasons, and if you disagree with them the change is small:

1. It buys the saving with up to one poll interval of added first-byte latency after an idle gap, on the path whose timing the SCPI exchanges depend on — the same path #700 and #701 just spent effort tightening.
2. It is a change to `StreamMessageConsumer`'s read loop, which #673's own success criteria explicitly rule out on the strength of that issue alone.
3. At 2–3% rather than the 5% the issue was filed on, the problem is materially smaller than it looked.

If you want it, it should be its own ticket with a stated latency budget, not a rider on an investigation.

**Second caveat: Windows was not measured.** I have no Windows machine here. Windows drives reads through overlapped I/O rather than a poll loop, so it should not pay this, but the doc says "not expected to pay it... has not been measured" rather than claiming otherwise. That is the one open item from #673's first success criterion, so you may prefer to keep the issue open for it rather than let this close it.

## Verification

Full suite green on net9.0 and net10.0 (4148 passed, 3 skipped, 0 failed, both TFMs). Bench-validated against the Nq1 on `/dev/cu.usbmodem2101` via a harness built against this worktree's `Daqifi.Core.csproj`; non-destructive (open/read/idle only, no streaming, no SD, no firmware). Linux leg run in a Debian bookworm aarch64 container against a pty, after confirming on macOS that a pty and the real port give identical figures on `System.IO.Ports` 10.0.11. Load conditions: 12-core M3, load average 1.2–2.7 during measurement; CPU read from `Process.TotalProcessorTime` (kernel accounting), not sampled.

Full measurement tables are in the comment on #673.

Refs #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)
